### PR TITLE
Add Zoom Delete Route

### DIFF
--- a/frontend/app/api/zoom/CreateMeeting/route.ts
+++ b/frontend/app/api/zoom/CreateMeeting/route.ts
@@ -2,10 +2,7 @@ import axios from 'axios'
 import { NextResponse } from "next/server"
 import { NextApiRequest, NextApiResponse } from 'next/types'
 import { GET as getZoomToken }  from '../generateToken'
-import { PrismaClient } from "@prisma/client"
 import  { GET as getZoomMeeting }  from '../GetMeeting/route'
-
-const prisma = new PrismaClient()
 
 // function for POST request to create a zoom meeting
 const createZoomMeeting = async (req : Request, res : NextApiResponse) => {
@@ -30,7 +27,8 @@ const createZoomMeeting = async (req : Request, res : NextApiResponse) => {
     // call get function on the response we got
     const response = request.data;
     const {id : meetingId} = response;
-    const meetingDetails = await getZoomMeeting(meetingId, accessToken);
+    const meetingResponse = await getZoomMeeting(meetingId, accessToken);
+    const meetingDetails = await meetingResponse.json();
 
     return NextResponse.json(meetingDetails, { status: 200 });
   } catch (error) {

--- a/frontend/app/api/zoom/CreateMeeting/route.ts
+++ b/frontend/app/api/zoom/CreateMeeting/route.ts
@@ -8,7 +8,7 @@ import  { GET as getZoomMeeting }  from '../GetMeeting/route'
 const createZoomMeeting = async (req : Request, res : NextApiResponse) => {
   try {
     
-    const token = (await getZoomToken(req,res));
+    const token = await getZoomToken(req, res);
     const tokenJSON = await token.json();
     const accessToken = tokenJSON.access_token;
     const reqBody = await req.json();

--- a/frontend/app/api/zoom/DeleteMeeting/route.ts
+++ b/frontend/app/api/zoom/DeleteMeeting/route.ts
@@ -1,0 +1,33 @@
+import axios from 'axios'
+import { NextRequest, NextResponse } from "next/server"
+import { NextApiRequest, NextApiResponse } from 'next/types'
+import { GET as getZoomToken } from '../generateToken'
+
+// function for deleting a zoom meeting
+const deleteZoomMeeting = async (request: NextRequest, sentResponse: NextApiResponse) => {
+    const zoomMeetingID = request.nextUrl.searchParams.get("id");
+    
+    try {
+        const token = await getZoomToken(request, sentResponse);
+        const tokenJSON = await token.json();
+        const accessToken = tokenJSON.access_token;
+
+        const req = await axios.delete(
+            `${process.env.NEXT_PUBLIC_ZOOM_BASE_API}/meetings/${zoomMeetingID}`,
+            {
+                headers: {
+                    'Authorization': `Bearer ${accessToken}`,
+                    'Content-Type': 'application/json',
+                }
+            }
+        );
+
+        const response = req.data;
+        return NextResponse.json(response, { status: 200 });
+    } catch (error) {
+        console.error(`Error getting Zoom meeting: ${zoomMeetingID}`, error);
+        return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+    }
+}
+
+export { deleteZoomMeeting as DELETE };

--- a/frontend/app/api/zoom/GetMeeting/route.ts
+++ b/frontend/app/api/zoom/GetMeeting/route.ts
@@ -2,9 +2,6 @@ import axios from 'axios'
 import { NextResponse } from "next/server"
 import { NextApiRequest, NextApiResponse } from 'next/types'
 import { GET } from '../generateToken'
-import { PrismaClient } from "@prisma/client"
-
-const prisma = new PrismaClient()
 
 // function for GET request for a meeting
 const getZoomMeeting = async (meetingId : string, accessToken : any) => {

--- a/frontend/app/api/zoom/UpdateMeeting/route.ts
+++ b/frontend/app/api/zoom/UpdateMeeting/route.ts
@@ -29,13 +29,13 @@ const updateZoomMeeting = async (req : Request, res : NextApiResponse) => {
 
     const response = request.data;
 
-    const meetingDetails = await getZoomMeeting(meetingId, accessToken);
+    const meetingResponse = await getZoomMeeting(meetingId, accessToken);
+    const meetingDetails = await meetingResponse.json()
     return NextResponse.json(meetingDetails, { status: 200 });
   } catch (error) {
     console.error(`Error updating Zoom meeting: for ${process.env.NEXT_PUBLIC_ZOOM1_EMAIL}`, error);
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }
-
 }
 
 export { updateZoomMeeting as PATCH };

--- a/frontend/app/api/zoom/generateToken.ts
+++ b/frontend/app/api/zoom/generateToken.ts
@@ -30,7 +30,7 @@ const generateZoomToken = async () => {
       }
     );
 
-    const response = await request.data;
+    const response = request.data;
     const zoomToken = response.access_token;
     return zoomToken;
   } catch (error) {

--- a/frontend/app/api/zoom/generateToken.ts
+++ b/frontend/app/api/zoom/generateToken.ts
@@ -1,10 +1,7 @@
 import axios from 'axios';
 import { NextResponse } from "next/server";
 import { NextApiRequest, NextApiResponse } from 'next/types';
-import { PrismaClient} from "@prisma/client";
 import qs from 'query-string';
-
-const prisma = new PrismaClient();
 
 // function to generate zoom access token 
 const generateZoomToken = async () => {

--- a/frontend/app/createmeeting/page.tsx
+++ b/frontend/app/createmeeting/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+
 import React, { useState } from "react";
 import { DatePicker } from '@mui/x-date-pickers/DatePicker';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
@@ -11,11 +12,12 @@ import styles from "../../styles/CreateMeetingPage.module.scss";
 
 
 const CreateMeetingPage = () => {
+
   const [title, setTitle] = React.useState('');
-  const [value, setValue] = useState<Dayjs | null>(dayjs('2024-04-08'));
+  const [value, setValue] = useState<Dayjs | null>(dayjs('2024-08-24'));
   const [time, setTime] = useState<DateRange<Dayjs>>(() => [
-    dayjs('2024-04-08T15:30'),
-    dayjs('2024-04-08T18:30'),
+    dayjs('2024-08-24T15:30'),
+    dayjs('2024-08-24T18:30'),
   ]);
   const [meetingId, setMeetingId] = React.useState('');
   
@@ -56,7 +58,14 @@ const CreateMeetingPage = () => {
         },
         body: JSON.stringify(createZoomMeetingRequestBody()),
       });
-      console.log('Meeting created:', response);
+
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+
+      const zoomResponse = await response.json();
+      console.log(zoomResponse);
+      alert("Zoom meeting created! Please check the console & the icr Zoom account.");
     } catch (error) {
       console.error('Error creating Zoom meeting:', error);
     }
@@ -76,7 +85,14 @@ const CreateMeetingPage = () => {
         },
         body: JSON.stringify(reqBody),
       });
-      console.log('Meeting updated:', response);
+      
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+
+      const zoomResponse = await response.json();
+      console.log(zoomResponse);
+      alert("Zoom meeting updated! Please check the console & the icr Zoom account.");
     } catch (error) {
       console.error('Error updating Zoom meeting:', error);
     }

--- a/frontend/app/createmeeting/page.tsx
+++ b/frontend/app/createmeeting/page.tsx
@@ -98,6 +98,29 @@ const CreateMeetingPage = () => {
     }
   }
 
+  const handleDeleteMeeting = async () => {
+    try {
+      const url = new URL('/api/zoom/DeleteMeeting', window.location.origin);
+      url.searchParams.append('id', meetingId);
+
+      const response = await fetch(url, {
+        method: 'DELETE',
+        headers: {
+          'Content-Type': 'application/json',
+        }
+      });
+
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+
+      const zoomResponse = await response.json();
+      console.log(zoomResponse);
+      alert("Zoom meeting deleted! Please check the console & the icr Zoom account.");
+    } catch (error) {
+      console.error('Error updating Zoom meeting:', error);
+    }
+  }
 
   return (
     <div className={styles.base}>
@@ -137,6 +160,7 @@ const CreateMeetingPage = () => {
             }}
           />
           <button className={styles.btn} onClick={handleUpdateMeeting}>Update Meeting</button>
+          <button className={styles.btn} onClick={handleDeleteMeeting}>Delete Meeting</button>
         </div>
       </div>
     </div>

--- a/frontend/app/test/page.tsx
+++ b/frontend/app/test/page.tsx
@@ -194,8 +194,14 @@ const App = () => {
   const handleZoomToken = async () => {
     try {
       const response = await fetch('/api/zoom');
-      const data = await response.json();
-      console.log('Access Token:', data.access_token);
+      
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+
+      const zoomResponse = await response.json();
+      console.log(zoomResponse);
+      alert("Zoom token retrieved! Please check the console.");
     } catch (error) {
       console.error('Error generating Zoom token:', error);
     }


### PR DESCRIPTION
## Description

This PR adds the following functionality to the codebase:
- Zoom DELETE route
- Reorganization of code to retrieve zoom access token
- Test button for deleting zoom meeting based on meeting id
- Existing code cleanup of zoom routes

## Verfication

- [x] Zoom Create meeting works as intended
- [x] Zoom Get meeting works as intended (only used after creating a meeting to retrieve the whole meeting object, specifically the meeting id to be stored in the Meeting interface in MongoDB)
- [x] Zoom Update now works an intended (replacing a whole meeting's details for a given meeting id)
- [x] Zoom Delete works as intended