### PR TITLE
Add GET Meetings routes by Day, Week, Month and Change Meeting Schema

### DIFF
--- a/frontend/app/api/retrieve/meeting/day/route.ts
+++ b/frontend/app/api/retrieve/meeting/day/route.ts
@@ -1,0 +1,43 @@
+import { PrismaClient } from '@prisma/client';
+import { start } from 'repl';
+import { IMeeting } from "../../../../../util/models";
+
+const prisma = new PrismaClient();
+
+export const retrieveDayMeetings = async (request: Request) => {
+    try {
+        const { date } = await request.json();
+        const standardDate = new Date(date);
+        const startDate = new Date(Date.UTC(standardDate.getUTCFullYear(), standardDate.getUTCMonth(), standardDate.getUTCDate()));
+        const endDate = new Date(Date.UTC(standardDate.getUTCFullYear(), standardDate.getUTCMonth(), standardDate.getUTCDate(), 23, 59, 59, 999));
+        const meetings = await prisma.meeting.findMany({
+            where: {
+                startDateTime: {
+                    gte: startDate,
+                },
+                endDateTime: {
+                    lte: endDate
+                }
+            }
+        }
+        );
+
+        const typedMeetings: IMeeting[] = meetings.map(meeting => ({ ...meeting }));
+        return new Response(JSON.stringify(typedMeetings), {
+            status: 200,
+            headers: {
+                'Content-Type': 'application/json',
+            },
+        });
+    } catch (error) {
+        console.error("Error retrieving meetings: ", error);
+        return new Response(JSON.stringify({ error: "Error retrieving meetings" }), {
+            status: 500,
+            headers: {
+                'Content-Type': 'application/json',
+            },
+        });
+    }
+}
+
+export { retrieveDayMeetings as GET }

--- a/frontend/app/api/retrieve/meeting/day/route.ts
+++ b/frontend/app/api/retrieve/meeting/day/route.ts
@@ -1,12 +1,13 @@
 import { PrismaClient } from '@prisma/client';
 import { start } from 'repl';
 import { IMeeting } from "../../../../../util/models";
+import { NextRequest } from 'next/server';
 
 const prisma = new PrismaClient();
 
-export const retrieveDayMeetings = async (request: Request) => {
+export const retrieveDayMeetings = async (request: NextRequest) => {
     try {
-        const { date } = await request.json();
+        const date = request.nextUrl.searchParams.get("startDate") ?? new Date().toISOString();
         const standardDate = new Date(date);
         const startDate = new Date(Date.UTC(standardDate.getUTCFullYear(), standardDate.getUTCMonth(), standardDate.getUTCDate()));
         const endDate = new Date(Date.UTC(standardDate.getUTCFullYear(), standardDate.getUTCMonth(), standardDate.getUTCDate(), 23, 59, 59, 999));

--- a/frontend/app/api/retrieve/meeting/month/route.ts
+++ b/frontend/app/api/retrieve/meeting/month/route.ts
@@ -1,11 +1,12 @@
 import { PrismaClient } from '@prisma/client';
 import { IMeeting } from "../../../../../util/models";
+import { NextRequest } from 'next/server';
 
 const prisma = new PrismaClient();
 
-export const retrieveMonthMeetings = async (request: Request) => {
+export const retrieveMonthMeetings = async (request: NextRequest) => {
     try {
-        const { date } = await request.json();
+        const date = request.nextUrl.searchParams.get("startDate") ?? new Date().toISOString();
         const standardDate = new Date(date);
         const month = standardDate.getUTCMonth();
         const nextMonthStart = month + 1;

--- a/frontend/app/api/retrieve/meeting/month/route.ts
+++ b/frontend/app/api/retrieve/meeting/month/route.ts
@@ -1,0 +1,46 @@
+import { PrismaClient } from '@prisma/client';
+import { IMeeting } from "../../../../../util/models";
+
+const prisma = new PrismaClient();
+
+export const retrieveMonthMeetings = async (request: Request) => {
+    try {
+        const { date } = await request.json();
+        const standardDate = new Date(date);
+        const month = standardDate.getUTCMonth();
+        const nextMonthStart = month + 1;
+
+        const startDate = new Date(Date.UTC(standardDate.getUTCFullYear(), month, 1))
+        const endDate = new Date(Date.UTC(standardDate.getUTCFullYear(), nextMonthStart, 0, 23, 59, 59, 999))
+
+        const meetings = await prisma.meeting.findMany({
+            where: {
+                startDateTime: {
+                    gte: startDate,
+                },
+                endDateTime: {
+                    lte: endDate,
+                }
+            }
+        })
+        const typedMeetings: IMeeting[] = meetings.map(meeting => ({ ...meeting }))
+        return new Response(JSON.stringify(typedMeetings), {
+            status: 200,
+            headers: {
+                'Content-Type': 'application/json',
+            },
+        });
+
+    }
+    catch (error) {
+        console.error("Error retrieving meetings: ", error);
+        return new Response(JSON.stringify({ error: "Error retrieving meetings" }), {
+            status: 500,
+            headers: {
+                'Content-Type': 'application/json',
+            },
+        });
+    }
+}
+
+export { retrieveMonthMeetings as GET }

--- a/frontend/app/api/retrieve/meeting/week/route.ts
+++ b/frontend/app/api/retrieve/meeting/week/route.ts
@@ -1,11 +1,12 @@
 import { PrismaClient } from '@prisma/client';
 import { IMeeting } from "../../../../../util/models";
+import { NextRequest } from 'next/server';
 
 const prisma = new PrismaClient();
 
-export const retrieveWeekMeetings = async (request: Request) => {
+export const retrieveWeekMeetings = async (request: NextRequest) => {
     try {
-        const { date } = await request.json();
+        const date = request.nextUrl.searchParams.get("startDate") ?? new Date().toISOString();
         const standardDate = new Date(date)
         const startDate = new Date(Date.UTC(standardDate.getUTCFullYear(), standardDate.getUTCMonth(), (standardDate.getUTCDate() - standardDate.getUTCDay())))
         const endDate = new Date(Date.UTC(standardDate.getUTCFullYear(), standardDate.getUTCMonth(), (standardDate.getUTCDate() + (6 - standardDate.getUTCDay())), 23, 59, 59, 999))

--- a/frontend/app/api/retrieve/meeting/week/route.ts
+++ b/frontend/app/api/retrieve/meeting/week/route.ts
@@ -1,0 +1,42 @@
+import { PrismaClient } from '@prisma/client';
+import { IMeeting } from "../../../../../util/models";
+
+const prisma = new PrismaClient();
+
+export const retrieveWeekMeetings = async (request: Request) => {
+    try {
+        const { date } = await request.json();
+        const standardDate = new Date(date)
+        const startDate = new Date(Date.UTC(standardDate.getUTCFullYear(), standardDate.getUTCMonth(), (standardDate.getUTCDate() - standardDate.getUTCDay())))
+        const endDate = new Date(Date.UTC(standardDate.getUTCFullYear(), standardDate.getUTCMonth(), (standardDate.getUTCDate() + (6 - standardDate.getUTCDay())), 23, 59, 59, 999))
+        const meetings = await prisma.meeting.findMany({
+            where: {
+                startDateTime: {
+                    gte: startDate,
+                },
+                endDateTime: {
+                    lte: endDate
+                }
+            }
+        }
+        );
+
+        const typedMeetings: IMeeting[] = meetings.map(meeting => ({ ...meeting }))
+        return new Response(JSON.stringify(typedMeetings), {
+            status: 200,
+            headers: {
+                'Content-Type': 'application/json',
+            },
+        });
+    } catch (error) {
+        console.error("Error retrieving meetings: ", error);
+        return new Response(JSON.stringify({ error: "Error retrieving meetings" }), {
+            status: 500,
+            headers: {
+                'Content-Type': 'application/json',
+            },
+        });
+    }
+}
+
+export { retrieveWeekMeetings as GET }

--- a/frontend/app/test/page.tsx
+++ b/frontend/app/test/page.tsx
@@ -96,10 +96,11 @@ const App = () => {
         description: 'Meeting Description',
         creator: 'Creator',
         group: 'Group',
-        date: new Date(),
-        startTime: new Date(),
-        fromTime: new Date(),
+        startDateTime: new Date(),
+        endDateTime: new Date(),
         zoomAccount: 'Zoom Account',
+        type: "in-person",
+        room: "sunflower"
       };
       const response = await fetch('/api/write/meeting', {
         method: 'POST',
@@ -189,6 +190,81 @@ const App = () => {
     }
   };
 
+  const getMeetingsDay = async () => {
+    try {
+      const currentDate = new Date('2024-04-14');
+      const response = await fetch('/api/retrieve/meetings/day', {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          date: currentDate.toISOString()
+        })
+      });
+
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+
+      const meetingResponse = await response.json();
+      console.log(meetingResponse);
+      alert(`Daily meetings retrieved successfully for ${currentDate.toISOString()}! Please check the console.`)
+    } catch (error) {
+      console.error('There was an error fetching the data:', error);
+    }
+  };
+
+  const getMeetingsWeek = async () => {
+    try {
+      const currentDate = new Date('2024-04-01');
+      const response = await fetch('/api/retrieve/meeting/week', {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          date: currentDate.toISOString()
+        })
+      })
+      
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+
+      const meetingResponse = await response.json();
+      console.log(meetingResponse);
+      alert(`Weekly meetings retrieved successfully for ${currentDate.toISOString()}! Please check the console.`);
+    } catch (error) {
+      console.error('There was an error fetching the data:', error);
+    }
+  };
+
+  const getMeetingsMonth = async () => {
+    try {
+      const currentDate = new Date('2024-04-14');
+      const response = await fetch('/api/retrieve/meeting/Week', {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          date: currentDate.toISOString()
+        })
+      });
+
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+
+      const meetingResponse = await response.json();
+      console.log(meetingResponse);
+      alert(`Monthly meetings retrieved successfully for ${currentDate.toISOString()}! Please check the console.`);
+    } catch (error) {
+      console.error('There was an error fetching the data:', error);
+    }
+  };
+
   /** ZOOM TESTING FUNCTIONS */
 
   const handleZoomToken = async () => {
@@ -256,9 +332,13 @@ const App = () => {
       </div>
       <div className={styles.section + ' ' + styles.meetings}>
         <h2>Meetings</h2>
-        <TestButton testFunc={createMeeting} text="Call create Meeting /api/write/meeting" />
+        <TestButton testFunc={createMeeting} text="Call Create Meeting /api/write/meeting" />
         <TestButton testFunc={updateMeeting} text="Call Update meeting /api/update/meeting" />
         <TestButton testFunc={deleteMeeting} text="Call Delete meeting /api/delete/meeting" />
+
+        <TestButton testFunc={getMeetingsDay} text="Get Meetings (Day) /api/retrieve/meeting/day" />
+        <TestButton testFunc={getMeetingsWeek} text="Get Meetings (Week) /api/retrieve/meeting/week" />
+        <TestButton testFunc={getMeetingsMonth} text="Get Meetings (Month) /api/retrieve/meeting/month" />
       </div>
       <div className={styles.section + ' ' + styles.zoom}>
         <h2>Zoom Testing</h2>

--- a/frontend/app/test/page.tsx
+++ b/frontend/app/test/page.tsx
@@ -128,7 +128,7 @@ const App = () => {
   const deleteMeeting = async () => {
     try {
       /* Configure to be a real mid */
-      const mid = '96160';
+      const mid = "95992";
 
       const response = await fetch('/api/delete/meeting', {
         method: 'DELETE',
@@ -156,16 +156,17 @@ const App = () => {
   const updateMeeting = async () => {
     try {
       /* mid must correspond to a meeting existing in the collection */
-      const newMeeting = {
+      const newMeeting: IMeeting = {
         title: 'Meeting Title',
-        mid: '96160',
+        mid: '36650',
         description: 'Meeting Description',
         creator: 'Creator',
         group: 'Group',
-        date: new Date(),
-        startTime: new Date(),
-        fromTime: new Date(),
+        startDateTime: new Date(),
+        endDateTime: new Date(),
         zoomAccount: 'Zoom Account',
+        type: "in-person",
+        room: "sunflower"
       };
 
       const response = await fetch('/api/update/meeting', {
@@ -192,16 +193,11 @@ const App = () => {
 
   const getMeetingsDay = async () => {
     try {
-      const currentDate = new Date('2024-04-14');
-      const response = await fetch('/api/retrieve/meetings/day', {
-        method: 'GET',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          date: currentDate.toISOString()
-        })
-      });
+      const currentDate = new Date('2024-09-10');
+
+      const url = new URL('/api/retrieve/meeting/day', window.location.origin);
+      url.searchParams.append('startDate', currentDate.toISOString());
+      const response = await fetch(url);
 
       if (!response.ok) {
         throw new Error(`HTTP error! status: ${response.status}`);
@@ -217,16 +213,11 @@ const App = () => {
 
   const getMeetingsWeek = async () => {
     try {
-      const currentDate = new Date('2024-04-01');
-      const response = await fetch('/api/retrieve/meeting/week', {
-        method: 'GET',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          date: currentDate.toISOString()
-        })
-      })
+      const currentDate = new Date('2024-09-10');
+
+      const url = new URL('/api/retrieve/meeting/week', window.location.origin);
+      url.searchParams.append('startDate', currentDate.toISOString());
+      const response = await fetch(url);
       
       if (!response.ok) {
         throw new Error(`HTTP error! status: ${response.status}`);
@@ -242,16 +233,11 @@ const App = () => {
 
   const getMeetingsMonth = async () => {
     try {
-      const currentDate = new Date('2024-04-14');
-      const response = await fetch('/api/retrieve/meeting/Week', {
-        method: 'GET',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          date: currentDate.toISOString()
-        })
-      });
+      const currentDate = new Date('2024-09-10');
+
+      const url = new URL('/api/retrieve/meeting/month', window.location.origin);
+      url.searchParams.append('startDate', currentDate.toISOString());
+      const response = await fetch(url);
 
       if (!response.ok) {
         throw new Error(`HTTP error! status: ${response.status}`);

--- a/frontend/prisma/schema.prisma
+++ b/frontend/prisma/schema.prisma
@@ -21,14 +21,17 @@ model Admin {
 }
 
 model Meeting {
-  id          String   @id @default(auto()) @map("_id") @db.ObjectId
-  mid         String   @unique
-  title       String
-  description String
-  creator     String
-  group       String
-  date        DateTime
-  startTime   DateTime
-  fromTime    DateTime
-  zoomAccount String
+  id             String   @id @default(auto()) @map("_id") @db.ObjectId
+  mid            String   @unique
+  title          String
+  description    String
+  creator        String   
+  group          String   
+  startDateTime  DateTime
+  endDateTime    DateTime
+  zoomAccount    String?   
+  zoomLink       String?
+  zid            String?
+  type           String
+  room           String
 }

--- a/frontend/util/models.ts
+++ b/frontend/util/models.ts
@@ -16,9 +16,9 @@ interface IMeeting {
   group: string; // group interface later on
   startDateTime: Date;
   endDateTime: Date;
-  zoomAccount?: string;
-  zoomLink?: string;
-  zid?: string;
+  zoomAccount?: string | null;
+  zoomLink?: string | null;
+  zid?: string | null;
   type: string;
   room: string;
 }

--- a/frontend/util/models.ts
+++ b/frontend/util/models.ts
@@ -14,10 +14,13 @@ interface IMeeting {
   description: string;
   creator: string; // admin later on
   group: string; // group interface later on
-  date: Date;
-  startTime: Date;
-  fromTime: Date;
-  zoomAccount: string;
+  startDateTime: Date;
+  endDateTime: Date;
+  zoomAccount?: string;
+  zoomLink?: string;
+  zid?: string;
+  type: string;
+  room: string;
 }
 
 export type { IUser, IMeeting, IAdmin };


### PR DESCRIPTION
Completes #17 with the following difference:

- GET Meeting by Day, Week, Month testing endpoints found in the test page instead of the create meeting page
- Each route accepts a startState in the URL query params instead of adding it to the body

Implementation Notes:
- Week and Month routes get the meetings of the entire week or month of the provided startDate. For example for the month route, passing in "2024-08-29" will get all the meetings of august, while "2024-09-05" will get all the meetings of September. The same applies to the week route; not getting the next 7 days after the startDate but the entire week of which the startDate is included in.