### PR TITLE
Atoms/date time picker fix

### DIFF
--- a/frontend/app/components/atoms/DatePicker/index.tsx
+++ b/frontend/app/components/atoms/DatePicker/index.tsx
@@ -1,170 +1,3 @@
-// // import React, { useState, useEffect } from 'react';
-// // import styles from "../../../../styles/components/atoms/DatePicker.module.scss";
-
-// // interface DatePickerProps {
-// //   label: string | JSX.Element;
-// //   value?: string; // Expect value to be in 'YYYY-MM-DD' format for proper parsing
-// //   onChange: (value: string) => void;
-// //   underlineOnFocus?: boolean;
-// //   error?: string;
-// //   [key: string]: any;
-// // }
-
-// // const DatePicker = ({ label, value: propValue = '', error, onChange, underlineOnFocus = true, ...props }: DatePickerProps) => {
-// //   const [internalValue, setInternalValue] = useState<string>(propValue);
-// //   const [isFocused, setIsFocused] = useState<boolean>(false);
-// //   const [displayValue, setDisplayValue] = useState<string>(propValue); // Store formatted display value
-
-// //   // Format the date for display
-// //   const formatDate = (dateString: string): string => {
-// //     const date = new Date(dateString);
-// //     if (!isNaN(date.getTime())) {
-// //       const options: Intl.DateTimeFormatOptions = { month: 'long', day: 'numeric', year: 'numeric' };
-// //       return date.toLocaleDateString(undefined, options); // Format as "Month Day, Year"
-// //     }
-// //     return dateString; // Return original string if it's invalid
-// //   };
-
-// //   // Update internal value and display value when propValue changes
-// //   useEffect(() => {
-// //     if (propValue !== internalValue) {
-// //       setInternalValue(propValue);
-// //       setDisplayValue(formatDate(propValue)); // Update display value when propValue changes
-// //     }
-// //   }, [propValue]);
-
-// //   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-// //     const newValue = e.target.value;
-// //     setInternalValue(newValue);
-// //     onChange(newValue); // Call onChange with the new input value
-// //   };
-
-// //   const handleFocus = () => {
-// //     setIsFocused(true);
-// //     setInternalValue(propValue); // Reset input to the original value for editing
-// //   };
-
-// //   const handleBlur = () => {
-// //     setIsFocused(false);
-// //     const formattedDate = formatDate(internalValue); // Format date when losing focus
-// //     setDisplayValue(formattedDate); // Set display value to formatted date
-// //     onChange(internalValue); // Keep internal value for prop
-// //   };
-
-// //   return (
-// //     <div className={`${styles['date-picker-wrapper']} ${isFocused && underlineOnFocus ? styles['underline'] : ''}`}>
-// //       <label className={styles['date-picker-label']}>
-// //         {typeof label === 'string' ? <span>{label}</span> : label}
-// //       </label>
-// //       <input
-// //         type="text" // Changed to text to allow custom formatting
-// //         value={isFocused ? internalValue : displayValue} // Show internalValue on focus, else displayValue
-// //         onChange={handleChange}
-// //         onFocus={handleFocus}
-// //         onBlur={handleBlur}
-// //         placeholder="MM/DD/YYYY" // Optional placeholder
-// //         className={styles['date-picker-input']}
-// //         {...props} // Spread the rest of the props
-// //       />
-// //       {error && <div className={styles['error-message']}>{error}</div>}
-// //     </div>
-// //   );
-// // };
-
-// // export default DatePicker;
-
-// import React, { useState, useEffect } from 'react';
-// import styles from "../../../../styles/components/atoms/DatePicker.module.scss";
-
-// interface DatePickerProps {
-//   label: string | JSX.Element;
-//   value?: string; // Expect value to be in 'YYYY-MM-DD' format for proper parsing
-//   onChange: (value: string) => void;
-//   underlineOnFocus?: boolean;
-//   error?: string;
-//   [key: string]: any;
-// }
-
-// const DatePicker = ({ label, value: propValue = '', error, onChange, underlineOnFocus = true, ...props }: DatePickerProps) => {
-//   const [internalValue, setInternalValue] = useState<string>(propValue);
-//   const [isFocused, setIsFocused] = useState<boolean>(false);
-//   const [displayValue, setDisplayValue] = useState<string>(propValue);
-//   const [inputError, setInputError] = useState<string | null>(null); // State for input error message
-
-//   const isValidDate = (dateString: string): boolean => {
-//     const regex = /^(1[0-2]|0?[1-9])\/([1-2][0-9]|3[01]|0?[1-9])\/(\d{1,4})$/;
-//     if (!regex.test(dateString)) {
-//       return false;
-//     }
-
-//     const [month, day, year] = dateString.split('/').map(Number);
-//     if (month < 1 || month > 12) return false;
-
-//     const daysInMonth = [31, (year % 4 === 0 && year % 100 !== 0) || (year % 400 === 0) ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
-//     return day >= 1 && day <= daysInMonth[month - 1];
-//   };
-
-//   const formatDate = (dateString: string): string => {
-//     const [month, day, year] = dateString.split('/').map(Number);
-//     const date = new Date(year, month - 1, day);
-//     const options: Intl.DateTimeFormatOptions = { month: 'long', day: 'numeric', year: 'numeric' };
-//     return date.toLocaleDateString(undefined, options);
-//   };
-
-//   useEffect(() => {
-//     if (propValue !== internalValue) {
-//       setInternalValue(propValue);
-//       setDisplayValue(formatDate(propValue));
-//     }
-//   }, [propValue]);
-
-//   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-//     const newValue = e.target.value;
-//     setInternalValue(newValue);
-//     setInputError(null); // Clear error on input change
-//     onChange(newValue); // Call onChange with the new input value
-//   };
-
-//   const handleFocus = () => {
-//     setIsFocused(true);
-//     setInternalValue(propValue);
-//     setInputError(null); // Clear error on focus
-//   };
-
-//   const handleBlur = () => {
-//     setIsFocused(false);
-//     if (!isValidDate(internalValue)) {
-//       setInputError('Invalid date format. Please enter a valid date in MM/DD/YYYY format.');
-//       setDisplayValue(internalValue); // Keep display value as is
-//     } else {
-//       const formattedDate = formatDate(internalValue);
-//       setDisplayValue(formattedDate);
-//       onChange(internalValue); // Keep internal value for prop
-//     }
-//   };
-
-//   return (
-//     <div className={`${styles['date-picker-wrapper']} ${isFocused && underlineOnFocus ? styles['underline'] : ''}`}>
-//       <label className={styles['date-picker-label']}>
-//         {typeof label === 'string' ? <span>{label}</span> : label}
-//       </label>
-//       <input
-//         type="text"
-//         value={isFocused ? internalValue : displayValue}
-//         onChange={handleChange}
-//         onFocus={handleFocus}
-//         onBlur={handleBlur}
-//         placeholder="MM/DD/YYYY"
-//         className={`${styles['date-picker-input']} ${inputError ? styles['error-input'] : ''}`} // Apply error class conditionally
-//         {...props}
-//       />
-//       {inputError && <div className={styles['error-message']}>{inputError}</div>} {/* Error message for invalid date */}
-//     </div>
-//   );
-// };
-
-// export default DatePicker;
-
 import React, { useState, useEffect } from 'react';
 import styles from "../../../../styles/components/atoms/DatePicker.module.scss";
 
@@ -179,13 +12,11 @@ interface DatePickerProps {
 const DatePicker = ({ label, value: propValue = '', onChange, underlineOnFocus = true, ...props }: DatePickerProps) => {
   const [internalValue, setInternalValue] = useState<string>(propValue);
   const [isFocused, setIsFocused] = useState<boolean>(false);
-  const [inputError, setInputError] = useState<string | null>(null); // State for input error message
+  const [inputError, setInputError] = useState<string | null>(null);
 
   const isValidDate = (dateString: string): boolean => {
     const regex = /^(1[0-2]|0?[1-9])\/([1-2][0-9]|3[01]|0?[1-9])\/(\d{4})$/;
-    if (!regex.test(dateString)) {
-      return false;
-    }
+    if (!regex.test(dateString)) return false;
 
     const [month, day, year] = dateString.split('/').map(Number);
     if (month < 1 || month > 12) return false;
@@ -194,10 +25,10 @@ const DatePicker = ({ label, value: propValue = '', onChange, underlineOnFocus =
     return day >= 1 && day <= daysInMonth[month - 1];
   };
 
-  const formatDateString = (dateString: string): string => {
+  const formatDate = (dateString: string): string => {
     const [month, day, year] = dateString.split('/').map(Number);
-    const date = new Date(year, month - 1, day);
-    return date.toLocaleDateString("en-US", { month: 'long', day: 'numeric', year: 'numeric' });
+    const monthNames = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"];
+    return `${monthNames[month - 1]} ${day}, ${year}`;
   };
 
   useEffect(() => {
@@ -220,8 +51,8 @@ const DatePicker = ({ label, value: propValue = '', onChange, underlineOnFocus =
   const handleBlur = () => {
     setIsFocused(false);
     if (isValidDate(internalValue)) {
-      const formattedDate = formatDateString(internalValue);
-      setInternalValue(formattedDate);
+      const formattedDate = formatDate(internalValue);
+      setInternalValue(formattedDate); // Format and update input with formatted date
       onChange(formattedDate); // Call onChange with the formatted date
     } else {
       setInputError('Invalid date format. Please enter a valid date in MM/DD/YYYY format.');
@@ -247,7 +78,7 @@ const DatePicker = ({ label, value: propValue = '', onChange, underlineOnFocus =
         <div className={styles['error-message']}>
           {inputError}
         </div>
-      )} {/* Error message for invalid date */}
+      )}
     </div>
   );
 };

--- a/frontend/app/components/atoms/DatePicker/index.tsx
+++ b/frontend/app/components/atoms/DatePicker/index.tsx
@@ -1,18 +1,204 @@
+// // import React, { useState, useEffect } from 'react';
+// // import styles from "../../../../styles/components/atoms/DatePicker.module.scss";
+
+// // interface DatePickerProps {
+// //   label: string | JSX.Element;
+// //   value?: string; // Expect value to be in 'YYYY-MM-DD' format for proper parsing
+// //   onChange: (value: string) => void;
+// //   underlineOnFocus?: boolean;
+// //   error?: string;
+// //   [key: string]: any;
+// // }
+
+// // const DatePicker = ({ label, value: propValue = '', error, onChange, underlineOnFocus = true, ...props }: DatePickerProps) => {
+// //   const [internalValue, setInternalValue] = useState<string>(propValue);
+// //   const [isFocused, setIsFocused] = useState<boolean>(false);
+// //   const [displayValue, setDisplayValue] = useState<string>(propValue); // Store formatted display value
+
+// //   // Format the date for display
+// //   const formatDate = (dateString: string): string => {
+// //     const date = new Date(dateString);
+// //     if (!isNaN(date.getTime())) {
+// //       const options: Intl.DateTimeFormatOptions = { month: 'long', day: 'numeric', year: 'numeric' };
+// //       return date.toLocaleDateString(undefined, options); // Format as "Month Day, Year"
+// //     }
+// //     return dateString; // Return original string if it's invalid
+// //   };
+
+// //   // Update internal value and display value when propValue changes
+// //   useEffect(() => {
+// //     if (propValue !== internalValue) {
+// //       setInternalValue(propValue);
+// //       setDisplayValue(formatDate(propValue)); // Update display value when propValue changes
+// //     }
+// //   }, [propValue]);
+
+// //   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+// //     const newValue = e.target.value;
+// //     setInternalValue(newValue);
+// //     onChange(newValue); // Call onChange with the new input value
+// //   };
+
+// //   const handleFocus = () => {
+// //     setIsFocused(true);
+// //     setInternalValue(propValue); // Reset input to the original value for editing
+// //   };
+
+// //   const handleBlur = () => {
+// //     setIsFocused(false);
+// //     const formattedDate = formatDate(internalValue); // Format date when losing focus
+// //     setDisplayValue(formattedDate); // Set display value to formatted date
+// //     onChange(internalValue); // Keep internal value for prop
+// //   };
+
+// //   return (
+// //     <div className={`${styles['date-picker-wrapper']} ${isFocused && underlineOnFocus ? styles['underline'] : ''}`}>
+// //       <label className={styles['date-picker-label']}>
+// //         {typeof label === 'string' ? <span>{label}</span> : label}
+// //       </label>
+// //       <input
+// //         type="text" // Changed to text to allow custom formatting
+// //         value={isFocused ? internalValue : displayValue} // Show internalValue on focus, else displayValue
+// //         onChange={handleChange}
+// //         onFocus={handleFocus}
+// //         onBlur={handleBlur}
+// //         placeholder="MM/DD/YYYY" // Optional placeholder
+// //         className={styles['date-picker-input']}
+// //         {...props} // Spread the rest of the props
+// //       />
+// //       {error && <div className={styles['error-message']}>{error}</div>}
+// //     </div>
+// //   );
+// // };
+
+// // export default DatePicker;
+
+// import React, { useState, useEffect } from 'react';
+// import styles from "../../../../styles/components/atoms/DatePicker.module.scss";
+
+// interface DatePickerProps {
+//   label: string | JSX.Element;
+//   value?: string; // Expect value to be in 'YYYY-MM-DD' format for proper parsing
+//   onChange: (value: string) => void;
+//   underlineOnFocus?: boolean;
+//   error?: string;
+//   [key: string]: any;
+// }
+
+// const DatePicker = ({ label, value: propValue = '', error, onChange, underlineOnFocus = true, ...props }: DatePickerProps) => {
+//   const [internalValue, setInternalValue] = useState<string>(propValue);
+//   const [isFocused, setIsFocused] = useState<boolean>(false);
+//   const [displayValue, setDisplayValue] = useState<string>(propValue);
+//   const [inputError, setInputError] = useState<string | null>(null); // State for input error message
+
+//   const isValidDate = (dateString: string): boolean => {
+//     const regex = /^(1[0-2]|0?[1-9])\/([1-2][0-9]|3[01]|0?[1-9])\/(\d{1,4})$/;
+//     if (!regex.test(dateString)) {
+//       return false;
+//     }
+
+//     const [month, day, year] = dateString.split('/').map(Number);
+//     if (month < 1 || month > 12) return false;
+
+//     const daysInMonth = [31, (year % 4 === 0 && year % 100 !== 0) || (year % 400 === 0) ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+//     return day >= 1 && day <= daysInMonth[month - 1];
+//   };
+
+//   const formatDate = (dateString: string): string => {
+//     const [month, day, year] = dateString.split('/').map(Number);
+//     const date = new Date(year, month - 1, day);
+//     const options: Intl.DateTimeFormatOptions = { month: 'long', day: 'numeric', year: 'numeric' };
+//     return date.toLocaleDateString(undefined, options);
+//   };
+
+//   useEffect(() => {
+//     if (propValue !== internalValue) {
+//       setInternalValue(propValue);
+//       setDisplayValue(formatDate(propValue));
+//     }
+//   }, [propValue]);
+
+//   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+//     const newValue = e.target.value;
+//     setInternalValue(newValue);
+//     setInputError(null); // Clear error on input change
+//     onChange(newValue); // Call onChange with the new input value
+//   };
+
+//   const handleFocus = () => {
+//     setIsFocused(true);
+//     setInternalValue(propValue);
+//     setInputError(null); // Clear error on focus
+//   };
+
+//   const handleBlur = () => {
+//     setIsFocused(false);
+//     if (!isValidDate(internalValue)) {
+//       setInputError('Invalid date format. Please enter a valid date in MM/DD/YYYY format.');
+//       setDisplayValue(internalValue); // Keep display value as is
+//     } else {
+//       const formattedDate = formatDate(internalValue);
+//       setDisplayValue(formattedDate);
+//       onChange(internalValue); // Keep internal value for prop
+//     }
+//   };
+
+//   return (
+//     <div className={`${styles['date-picker-wrapper']} ${isFocused && underlineOnFocus ? styles['underline'] : ''}`}>
+//       <label className={styles['date-picker-label']}>
+//         {typeof label === 'string' ? <span>{label}</span> : label}
+//       </label>
+//       <input
+//         type="text"
+//         value={isFocused ? internalValue : displayValue}
+//         onChange={handleChange}
+//         onFocus={handleFocus}
+//         onBlur={handleBlur}
+//         placeholder="MM/DD/YYYY"
+//         className={`${styles['date-picker-input']} ${inputError ? styles['error-input'] : ''}`} // Apply error class conditionally
+//         {...props}
+//       />
+//       {inputError && <div className={styles['error-message']}>{inputError}</div>} {/* Error message for invalid date */}
+//     </div>
+//   );
+// };
+
+// export default DatePicker;
+
 import React, { useState, useEffect } from 'react';
 import styles from "../../../../styles/components/atoms/DatePicker.module.scss";
 
 interface DatePickerProps {
   label: string | JSX.Element;
-  value?: string;
+  value?: string; // Expect value to be in 'MM/DD/YYYY' format
   onChange: (value: string) => void;
   underlineOnFocus?: boolean;
-  error?: string;
   [key: string]: any;
 }
 
-const DatePicker = ({ label, value: propValue = '', error, onChange, underlineOnFocus = true, ...props }: DatePickerProps) => {
+const DatePicker = ({ label, value: propValue = '', onChange, underlineOnFocus = true, ...props }: DatePickerProps) => {
   const [internalValue, setInternalValue] = useState<string>(propValue);
   const [isFocused, setIsFocused] = useState<boolean>(false);
+  const [inputError, setInputError] = useState<string | null>(null); // State for input error message
+
+  const isValidDate = (dateString: string): boolean => {
+    const regex = /^(1[0-2]|0?[1-9])\/([1-2][0-9]|3[01]|0?[1-9])\/(\d{4})$/;
+    if (!regex.test(dateString)) {
+      return false;
+    }
+
+    const [month, day, year] = dateString.split('/').map(Number);
+    if (month < 1 || month > 12) return false;
+
+    const daysInMonth = [31, (year % 4 === 0 && year % 100 !== 0) || (year % 400 === 0) ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+    return day >= 1 && day <= daysInMonth[month - 1];
+  };
+
+  const formatDateString = (dateString: string): string => {
+    const [month, day, year] = dateString.split('/').map(Number);
+    const date = new Date(year, month - 1, day);
+    return date.toLocaleDateString("en-US", { month: 'long', day: 'numeric', year: 'numeric' });
+  };
 
   useEffect(() => {
     if (propValue !== internalValue) {
@@ -23,24 +209,24 @@ const DatePicker = ({ label, value: propValue = '', error, onChange, underlineOn
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const newValue = e.target.value;
     setInternalValue(newValue);
-    onChange && onChange(newValue);
+    setInputError(null); // Clear error on input change
   };
 
   const handleFocus = () => {
     setIsFocused(true);
+    setInputError(null); // Clear error on focus
   };
 
   const handleBlur = () => {
     setIsFocused(false);
+    if (isValidDate(internalValue)) {
+      const formattedDate = formatDateString(internalValue);
+      setInternalValue(formattedDate);
+      onChange(formattedDate); // Call onChange with the formatted date
+    } else {
+      setInputError('Invalid date format. Please enter a valid date in MM/DD/YYYY format.');
+    }
   };
-
-  const getToday = () => {
-    const today = new Date();
-    return today.toISOString().split('T')[0];
-  };
-
-  // Filter out 'onChange' from props to avoid passing it twice
-  const { onChange: _onChange, ...restProps } = props;
 
   return (
     <div className={`${styles['date-picker-wrapper']} ${isFocused && underlineOnFocus ? styles['underline'] : ''}`}>
@@ -48,18 +234,22 @@ const DatePicker = ({ label, value: propValue = '', error, onChange, underlineOn
         {typeof label === 'string' ? <span>{label}</span> : label}
       </label>
       <input
-        type="date"
+        type="text"
         value={internalValue}
         onChange={handleChange}
         onFocus={handleFocus}
         onBlur={handleBlur}
-        className={styles['date-picker-input']}
-        {...restProps} // Spread the rest of the props, excluding onChange
+        placeholder="MM/DD/YYYY"
+        className={`${styles['date-picker-input']} ${inputError ? styles['error-input'] : ''}`} // Apply error class conditionally
+        {...props}
       />
-      {error && <div className={styles['error-message']}>{error}</div>}
+      {inputError && (
+        <div className={styles['error-message']}>
+          {inputError}
+        </div>
+      )} {/* Error message for invalid date */}
     </div>
   );
 };
 
 export default DatePicker;
-

--- a/frontend/app/components/atoms/DatePicker/index.tsx
+++ b/frontend/app/components/atoms/DatePicker/index.tsx
@@ -36,7 +36,7 @@ const DatePicker = ({ label, value: propValue = '', error, onChange, underlineOn
 
   const getToday = () => {
     const today = new Date();
-    return today.toISOString().split('T')[0]; // Format as YYYY-MM-DD for input
+    return today.toISOString().split('T')[0];
   };
 
   // Filter out 'onChange' from props to avoid passing it twice

--- a/frontend/app/components/atoms/DatePicker/index.tsx
+++ b/frontend/app/components/atoms/DatePicker/index.tsx
@@ -4,30 +4,57 @@ import styles from "../../../../styles/components/atoms/DatePicker.module.scss";
 interface DatePickerProps {
   label: string | JSX.Element;
   value?: string;
+  onChange: (value: string) => void;
+  underlineOnFocus?: boolean;
   error?: string;
   [key: string]: any;
 }
 
-const DatePicker = ({ label, value: propValue = '', error, ...props }: DatePickerProps) => {
-  const [value, setValue] = useState<string>(propValue);
+const DatePicker = ({ label, value: propValue = '', error, onChange, underlineOnFocus = true, ...props }: DatePickerProps) => {
+  const [internalValue, setInternalValue] = useState<string>(propValue);
+  const [isFocused, setIsFocused] = useState<boolean>(false);
 
   useEffect(() => {
-    if (propValue !== value) {
-      setValue(propValue);
+    if (propValue !== internalValue) {
+      setInternalValue(propValue);
     }
   }, [propValue]);
 
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newValue = e.target.value;
+    setInternalValue(newValue);
+    onChange && onChange(newValue);
+  };
+
+  const handleFocus = () => {
+    setIsFocused(true);
+  };
+
+  const handleBlur = () => {
+    setIsFocused(false);
+  };
+
+  const getToday = () => {
+    const today = new Date();
+    return today.toISOString().split('T')[0]; // Format as YYYY-MM-DD for input
+  };
+
+  // Filter out 'onChange' from props to avoid passing it twice
+  const { onChange: _onChange, ...restProps } = props;
+
   return (
-    <div className={styles['date-picker-wrapper']}>
+    <div className={`${styles['date-picker-wrapper']} ${isFocused && underlineOnFocus ? styles['underline'] : ''}`}>
       <label className={styles['date-picker-label']}>
         {typeof label === 'string' ? <span>{label}</span> : label}
       </label>
       <input
         type="date"
-        value={value}
-        onChange={(e) => setValue(e.target.value)}
+        value={internalValue}
+        onChange={handleChange}
+        onFocus={handleFocus}
+        onBlur={handleBlur}
         className={styles['date-picker-input']}
-        {...props}
+        {...restProps} // Spread the rest of the props, excluding onChange
       />
       {error && <div className={styles['error-message']}>{error}</div>}
     </div>
@@ -35,3 +62,4 @@ const DatePicker = ({ label, value: propValue = '', error, ...props }: DatePicke
 };
 
 export default DatePicker;
+

--- a/frontend/app/components/atoms/TimePicker/index.tsx
+++ b/frontend/app/components/atoms/TimePicker/index.tsx
@@ -1,27 +1,41 @@
 import React, { useState, useEffect } from 'react';
 import styles from "../../../../styles/components/atoms/TimePicker.module.scss";
 
-
-// export default TimePicker;
 interface TimePickerProps {
   label: string | JSX.Element;
   value?: string;
+  onChange: (value: string) => void;
+  underlineOnFocus?: boolean;
   error?: string;
   disablePast?: boolean;
   [key: string]: any;
 }
 
-const TimePicker = ({ label, value: propValue = '', error, disablePast, ...props }: TimePickerProps) => {
-  const [startTime, setStartTime] = useState<string>(''); // For start time
-  const [endTime, setEndTime] = useState<string>(''); // For end time
-  const [minTime, setMinTime] = useState<string | undefined>(undefined); // For disabling past times
+// Utility function to add minutes to a given time
+const addMinutes = (time: string, minutesToAdd: number): string => {
+  const [hours, minutes] = time.split(':').map(Number);
+  const date = new Date();
+  date.setHours(hours, minutes, 0, 0);
+  date.setMinutes(date.getMinutes() + minutesToAdd);
+  const newHours = date.getHours().toString().padStart(2, '0');
+  const newMinutes = date.getMinutes().toString().padStart(2, '0');
+  return `${newHours}:${newMinutes}`;
+};
 
-  // Parse the propValue into start and end times when component mounts or propValue changes
-  useEffect(() => {
-    const [start, end] = propValue.split(' - '); // Assuming the propValue is in format "start - end"
-    setStartTime(start || ''); // If no start, set as empty string
-    setEndTime(end || ''); // If no end, set as empty string
-  }, [propValue]);
+// Utility function to calculate the difference in minutes between two times
+const getTimeDifferenceInMinutes = (startTime: string, endTime: string): number => {
+  const [startHours, startMinutes] = startTime.split(':').map(Number);
+  const [endHours, endMinutes] = endTime.split(':').map(Number);
+  const startDate = new Date(1970, 0, 1, startHours, startMinutes);
+  const endDate = new Date(1970, 0, 1, endHours, endMinutes);
+  return (endDate.getTime() - startDate.getTime()) / (1000 * 60);
+};
+
+const TimePicker = ({ label, value: propValue = '', disablePast, onChange, error, ...props }: TimePickerProps) => {
+  const [startTime, setStartTime] = useState<string>(''); // Initially empty
+  const [endTime, setEndTime] = useState<string>(''); // Initially empty
+  const [timeDifference, setTimeDifference] = useState<number>(60); // Default difference is 60 minutes
+  const [minTime, setMinTime] = useState<string | undefined>(undefined);
 
   // Effect to disable past times
   useEffect(() => {
@@ -37,16 +51,50 @@ const TimePicker = ({ label, value: propValue = '', error, disablePast, ...props
   const handleStartTimeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const newStartTime = e.target.value;
     setStartTime(newStartTime);
-    const updatedValue = `${newStartTime} - ${endTime}`;
-    props.onChange && props.onChange(updatedValue); // Call onChange with updated value
+    // Calculate the new end time based on the original time difference
+    if (startTime && endTime) {
+      const newEndTime = addMinutes(newStartTime, timeDifference);
+      setEndTime(newEndTime);
+      onChange && onChange(`${newStartTime} - ${newEndTime}`);
+    } else if (/^\d{2}:\d{2}$/.test(newStartTime) && !endTime) {
+      // If it's the first time setting the start time, set the end time to one hour later
+      const newEndTime = addMinutes(newStartTime, 60);
+      setEndTime(newEndTime);
+      setTimeDifference(60); // Set default time difference to 60 minutes
+      onChange && onChange(`${newStartTime} - ${newEndTime}`);
+    }
   };
 
   // Handle change for end time
   const handleEndTimeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const newEndTime = e.target.value;
+
+    // Allow the value "1" explicitly without performing further validation
+    if (newEndTime === "1" || newEndTime === "01") {
+      setEndTime(newEndTime);
+      return;
+    }
+
+    // Allow temporary setting of the new end time for user input
     setEndTime(newEndTime);
-    const updatedValue = `${startTime} - ${newEndTime}`;
-    props.onChange && props.onChange(updatedValue); // Call onChange with updated value
+
+    // Validate only if the new end time format is a complete HH:mm
+    if (/^\d{2}:\d{2}$/.test(newEndTime)) {
+      const [endHour, endMinute] = newEndTime.split(':').map(Number);
+      const [startHour, startMinute] = startTime.split(':').map(Number);
+
+      // Check if the new end time is strictly later than the start time
+      if (
+        (endHour === 1 || endHour > startHour) ||
+        (endHour === startHour && endMinute > startMinute)
+      ) {
+        // Update the state and trigger the onChange event if valid
+        onChange && onChange(`${startTime} - ${newEndTime}`);
+      } else {
+        // Revert to the previous valid state
+        setEndTime(endTime);
+      }
+    }
   };
 
   return (
@@ -60,16 +108,15 @@ const TimePicker = ({ label, value: propValue = '', error, disablePast, ...props
         min={disablePast ? minTime : undefined}
         onChange={handleStartTimeChange}
         className={styles['time-picker-input']}
-        {...props} // Spread any additional props
+        {...props}
       />
-      <span className={styles['time-range-separator']}> - </span> {/* Separator between start and end */}
+      <span className={styles['time-range-separator']}> - </span>
       <input
         type="time"
         value={endTime}
-        min={startTime} // Ensure the end time is after the start time
         onChange={handleEndTimeChange}
         className={styles['time-picker-input']}
-        {...props} // Spread any additional props
+        {...props}
       />
       {error && <div className={styles['error-message']}>{error}</div>}
     </div>

--- a/frontend/app/test/page.tsx
+++ b/frontend/app/test/page.tsx
@@ -16,6 +16,21 @@ const App = () => {
 
   /** ADMIN TESTING FUNCTIONS  */
 
+  // State for DatePicker
+  const [dateValue, setDateValue] = useState<string>('2024-10-19'); // Example initial date value
+  // State for TimePicker
+  const [timeValue, setTimeValue] = useState<string>('10:00 - 12:00'); // Example initial time range
+
+  // Handlers for DatePicker
+  const handleDateChange = (newDate: string) => {
+    setDateValue(newDate);
+  };
+
+  // Handlers for TimePicker
+  const handleTimeChange = (newTime: string) => {
+    setTimeValue(newTime);
+  };
+
   const createAdmin = async () => {
     try {
       const newAdmin: IAdmin = {
@@ -317,12 +332,12 @@ const App = () => {
   const [inputValue, setInputValue] = useState(''); // State to hold the value
 
   const [selectedOption, setSelectedOption] = useState<string>("Option 1");
-  
-    // Function to handle the change in radio button selection
-    const handleOptionChange = (option: string) => {
-        setSelectedOption(option);
-    };
-  
+
+  // Function to handle the change in radio button selection
+  const handleOptionChange = (option: string) => {
+    setSelectedOption(option);
+  };
+
 
   return (
     <div className={styles['apicontainer']}>
@@ -355,54 +370,76 @@ const App = () => {
       </div>
       <div className={styles.section}>
         <h2>Example Text Field & Radio Buttons</h2>
-          <TextField
-              label="Meeting title"
-              value={inputValue}
-              onChange={setInputValue}
-              underlineOnFocus={false}/>
-          <p>Entered Value: {inputValue}</p>
+        <TextField
+          label="Meeting title"
+          value={inputValue}
+          onChange={setInputValue}
+          underlineOnFocus={false} />
+        <p>Entered Value: {inputValue}</p>
 
-      <div>
+        <div>
           <RadioGroup
-              label="Ends"
-              options={["Never", "On", "After"]}
-              selectedOption={selectedOption}
-              onChange={handleOptionChange}
-              name="preferences"
-              disabledOptions={["On"]}
+            label="Ends"
+            options={["Never", "On", "After"]}
+            selectedOption={selectedOption}
+            onChange={handleOptionChange}
+            name="preferences"
+            disabledOptions={["On"]}
           />
           <p>You have selected: {selectedOption}</p>
-      </div>
+        </div>
       </div>
 
       <div className={styles.section}>
-          <h2>Meeting Block & Room Block</h2>
-          <div className="meeting-blocks">
-            <BoxText boxType="Meeting Block" title="Meeting Name" primaryColor="#b3ea75" time="9am-10am" tags={['Hybrid', 'AA']} />
-            <BoxText boxType="Meeting Block" title="Meeting Name" primaryColor="#f7e57b" time="9am-10am" tags={['Hybrid', 'AA']} />
-            <BoxText boxType="Meeting Block" title="Meeting Name" primaryColor="#96dbfe" time="9am-10am" tags={['Hybrid', 'AA']} />
-            <BoxText boxType="Meeting Block" title="Meeting Name" primaryColor="#ffae73" time="9am-10am" tags={['Hybrid', 'AA']} />
-            <BoxText boxType="Meeting Block" title="Meeting Name" primaryColor="#d2afff" time="9am-10am" tags={['Hybrid', 'AA']} />
-            <BoxText boxType="Meeting Block" title="Meeting Name" primaryColor="#ffa3c2" time="9am-10am" tags={['Hybrid', 'AA']} />
-            <BoxText boxType="Meeting Block" title="Meeting Name" primaryColor="#cecece" time="9am-10am" tags={['Hybrid', 'AA']} />
-          </div>
+        <h2>Meeting Block & Room Block</h2>
+        <div className="meeting-blocks">
+          <BoxText boxType="Meeting Block" title="Meeting Name" primaryColor="#b3ea75" time="9am-10am" tags={['Hybrid', 'AA']} />
+          <BoxText boxType="Meeting Block" title="Meeting Name" primaryColor="#f7e57b" time="9am-10am" tags={['Hybrid', 'AA']} />
+          <BoxText boxType="Meeting Block" title="Meeting Name" primaryColor="#96dbfe" time="9am-10am" tags={['Hybrid', 'AA']} />
+          <BoxText boxType="Meeting Block" title="Meeting Name" primaryColor="#ffae73" time="9am-10am" tags={['Hybrid', 'AA']} />
+          <BoxText boxType="Meeting Block" title="Meeting Name" primaryColor="#d2afff" time="9am-10am" tags={['Hybrid', 'AA']} />
+          <BoxText boxType="Meeting Block" title="Meeting Name" primaryColor="#ffa3c2" time="9am-10am" tags={['Hybrid', 'AA']} />
+          <BoxText boxType="Meeting Block" title="Meeting Name" primaryColor="#cecece" time="9am-10am" tags={['Hybrid', 'AA']} />
+        </div>
 
-          <div className="room-blocks">
-            <BoxText boxType="Room Block" title="Serenity Room" primaryColor="#b3ea75" />
-            <BoxText boxType="Room Block" title="Seeds of Hope" primaryColor="#f7e57b" />
-            <BoxText boxType="Room Block" title="Small but Powerful - Left" primaryColor="#96dbfe" />
-            <BoxText boxType="Room Block" title="Unity Room" primaryColor="#ffae73" />
-            <BoxText boxType="Room Block" title="Room for Improvement" primaryColor="#d2afff" />
-            <BoxText boxType="Room Block" title="Zoom Account" primaryColor="#ffa3c2" />
-            <BoxText boxType="Room Block" title="Zoom Account" primaryColor="#cecece" />
-          </div>
+        <div className="room-blocks">
+          <BoxText boxType="Room Block" title="Serenity Room" primaryColor="#b3ea75" />
+          <BoxText boxType="Room Block" title="Seeds of Hope" primaryColor="#f7e57b" />
+          <BoxText boxType="Room Block" title="Small but Powerful - Left" primaryColor="#96dbfe" />
+          <BoxText boxType="Room Block" title="Unity Room" primaryColor="#ffae73" />
+          <BoxText boxType="Room Block" title="Room for Improvement" primaryColor="#d2afff" />
+          <BoxText boxType="Room Block" title="Zoom Account" primaryColor="#ffa3c2" />
+          <BoxText boxType="Room Block" title="Zoom Account" primaryColor="#cecece" />
+        </div>
       </div>
       <div className={styles.section + ' ' + styles.meetings}>
         <h2>DatePicker and TimePicker</h2>
-        <DatePicker label={<TodayIcon/>} value={"Value"} />
-        <DatePicker label={"string label"} value={"Value"} />
-        <TimePicker label={<AccessTimeIcon/>} value={"Value"} disablePast={true} />
-        <TimePicker label={"string label"} value={"Value"} disablePast={true} />
+        <DatePicker
+          label={<TodayIcon />}
+          value={dateValue}
+          onChange={handleDateChange}
+          error={dateValue === '' ? 'Date is required' : undefined} // Example error handling
+        />
+        <DatePicker
+          label="string label"
+          value={dateValue}
+          onChange={handleDateChange}
+          error={dateValue === '' ? 'Date is required' : undefined} // Example error handling
+        />
+        <TimePicker
+          label={<AccessTimeIcon />}
+          value={timeValue}
+          onChange={handleTimeChange}
+          disablePast={true}
+          error={timeValue === '' ? 'Time is required' : undefined} // Example error handling
+        />
+        <TimePicker
+          label="string label"
+          value={timeValue}
+          onChange={handleTimeChange}
+          disablePast={true}
+          error={timeValue === '' ? 'Time is required' : undefined} // Example error handling
+        />
       </div>
     </div>
   );

--- a/frontend/styles/components/atoms/DatePicker.module.scss
+++ b/frontend/styles/components/atoms/DatePicker.module.scss
@@ -1,6 +1,3 @@
-@import url('https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600&display=swap');
-@import '../../Variables.module.scss';
-
 .date-picker-wrapper {
   display: flex;
   align-items: center;
@@ -9,7 +6,7 @@
   font-family: 'Source Sans Pro', sans-serif;
 
   .date-picker-label {
-    margin-right: 12px;
+    margin-right: 5px;
     display: flex;
     align-items: center;
     font-size: 18px;
@@ -23,14 +20,14 @@
 
   .date-picker-input {
     font-size: 18px;
-    border: none; // Remove border
-    outline: none; // Remove focus outline
+    border: none;
+    outline: none;
     width: 200px;
-    background-color: transparent; // Transparent background
+    background-color: transparent;
     font-family: 'Source Sans Pro', sans-serif;
 
     &:focus {
-      border: none; // Ensure no border appears on focus
+      border: none;
       outline: none;
       background-color: transparent;
       box-shadow: none;
@@ -38,30 +35,27 @@
 
     cursor: text;
 
-    &:underline {
-      border-bottom: 1px solid $dark-pink-color;
-    }
-
-    /* Hide the calendar icon for WebKit browsers (Chrome, Safari, etc.) */
+    // Hide the calendar icon for various browsers
     &::-webkit-calendar-picker-indicator {
       display: none;
-      -webkit-appearance: none;
     }
 
-    /* Hide the calendar icon for Firefox */
     &::-moz-calendar-picker-indicator {
       display: none;
     }
 
-    /* Hide the calendar icon for Internet Explorer and Edge */
     &::-ms-expand {
       display: none;
     }
   }
 
+  .error-input {
+    border: 1px solid red; // Apply red border for error state
+  }
+
   .error-message {
+    margin-left: 10px; // Space between input and error message
     color: red;
-    margin-left: 5px; // Keep error message to the right of the input
     font-size: 14px;
   }
 }

--- a/frontend/styles/components/atoms/DatePicker.module.scss
+++ b/frontend/styles/components/atoms/DatePicker.module.scss
@@ -1,4 +1,5 @@
 @import url('https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600&display=swap');
+@import '../../Variables.module.scss';
 
 .date-picker-wrapper {
   display: flex;
@@ -31,6 +32,14 @@
     &:focus {
       border: none; // Ensure no border appears on focus
       outline: none;
+      background-color: transparent;
+      box-shadow: none;
+    }
+
+    cursor: text;
+
+    &:underline {
+      border-bottom: 1px solid $dark-pink-color;
     }
 
     /* Hide the calendar icon for WebKit browsers (Chrome, Safari, etc.) */

--- a/frontend/styles/components/atoms/TimePicker.module.scss
+++ b/frontend/styles/components/atoms/TimePicker.module.scss
@@ -22,7 +22,7 @@
 
   .time-picker-input {
     font-size: 18px;
-    border: none; // Remove the border
+    border: 1px solid transparent; // Set a transparent border
     outline: none; // Remove the focus outline
     width: 80px; // Adjust the width to be wider
     min-width: 70px; // Set a minimum width
@@ -46,7 +46,7 @@
     }
 
     &:focus {
-      border: none; // No border on focus
+      border: 1px solid transparent; // Keep a transparent border on focus
       outline: none; // No outline on focus
     }
 
@@ -59,9 +59,14 @@
     color: #333;
   }
 
+  .error-input {
+    border: 1px solid red; // Apply red border for error state
+  }
+
   .error-message {
-    color: red;
-    margin-top: 5px;
-    font-size: 14px;
+    color: red; // Set the text color of the error message to red
+    font-size: 14px; // Adjust the font size as needed
+    margin-top: 4px; // Add some space above the error message
+    margin-left: 4px;
   }
 }

--- a/frontend/styles/components/atoms/TimePicker.module.scss
+++ b/frontend/styles/components/atoms/TimePicker.module.scss
@@ -24,11 +24,12 @@
     font-size: 18px;
     border: none; // Remove the border
     outline: none; // Remove the focus outline
-    width: 46px;
+    width: 80px; // Adjust the width to be wider
+    min-width: 70px; // Set a minimum width
     text-align: center;
     background-color: transparent; // Transparent background
     font-family: 'Source Sans Pro', sans-serif;
-
+    padding: 4px; // Add some padding
 
     /* Hide the time picker icon */
     &::-webkit-calendar-picker-indicator {


### PR DESCRIPTION
### Description 
Implemented fixes to TimePicker such as displaying the time on a 12-hour-clock format, setting default times, making the time period stay the same when the starting time changes, and making sure the ending time cannot be set as before the starting time.

### Testing 
1. Navigate to http://localhost:3000/test
2. Scroll to the bottom of the page, and observe the DatePicker/TimePicker section
3. Try to input a time of 14:30 and observe how it will automatically convert 2:30 pm
4. Input any starting time and the ending time will automatically be set to an hour after
5. Try to change the ending time to something earlier than the starting time, it won't let you input it
6. Change the ending time to something valid, then change the starting time, and the ending time will automatically change to retain the same time period

### Notes
related to issue #60 