### PR TITLE
Delete Meeting Fullstack

### DIFF
--- a/frontend/app/components/organisms/ViewMeeting/index.tsx
+++ b/frontend/app/components/organisms/ViewMeeting/index.tsx
@@ -23,7 +23,7 @@ type ViewMeetingDetailsProps = {
   recurrence?: string; // Remains as optional if required
   onBack: () => void;
   onEdit: () => void;
-  onDelete: () => void;
+  onDelete: (mid: string) => void;
 };
 
 const ViewMeetingDetails: React.FC<ViewMeetingDetailsProps> = ({
@@ -46,6 +46,10 @@ const ViewMeetingDetails: React.FC<ViewMeetingDetailsProps> = ({
   onDelete,
 }) => {
 
+  const handleDelete = () => {
+    onDelete(mid);
+  }
+
   return (
     <div className={styles.meetingDetails}>
       <div className={styles.header}>
@@ -56,7 +60,7 @@ const ViewMeetingDetails: React.FC<ViewMeetingDetailsProps> = ({
           <button>⋮</button>
           <div className={styles.optionsMenu}>
             <button onClick={onEdit}>Edit Meeting</button>
-            <button onClick={onDelete}>Delete Meeting</button>
+            <button onClick={handleDelete}>Delete Meeting</button>
           </div>
         </div>
       </div>

--- a/frontend/app/components/organisms/ViewMeeting/index.tsx
+++ b/frontend/app/components/organisms/ViewMeeting/index.tsx
@@ -63,6 +63,29 @@ const ViewMeetingDetails: React.FC<ViewMeetingDetailsProps> = ({
   onEdit,
   onDelete,
 }) => {
+
+  const handleDelete = async (meetingId : string) => {
+    try {
+      const response = await fetch('/api/delete/meeting', {
+        method: 'DELETE',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ meetingId }),
+      });
+
+      if (response.ok) {
+        onDelete();  // Call the onDelete function passed from parent to hide ViewMeeting
+      } else {
+        const result = await response.json();
+        console.error('Failed to delete meeting:', result.error);
+      }
+    } catch (error) {
+      console.error('Error deleting meeting:', error);
+    }
+  };
+
+
   return (
     <div className={styles.meetingDetails}>
       <div className={styles.header}>
@@ -73,27 +96,27 @@ const ViewMeetingDetails: React.FC<ViewMeetingDetailsProps> = ({
           <button>⋮</button>
           <div className={styles.optionsMenu}>
             <button onClick={onEdit}>Edit Meeting</button>
-            <button onClick={onDelete}>Delete Meeting</button>
+            <button onClick={handleDelete}>Delete Meeting</button>
           </div>
         </div>
       </div>
       <div className={styles.details}>
-      <p style={{ color: 'gray' }}>
-  <CalendarTodayIcon />&nbsp;
-  {startDateTime.getDate()} {startDateTime.toLocaleString('default', { month: 'long' })} {startDateTime.getFullYear()}
-  {!(
-    startDateTime.getFullYear() === endDateTime.getFullYear() &&
-    startDateTime.getMonth() === endDateTime.getMonth() &&
-    startDateTime.getDate() === endDateTime.getDate()
-  ) && (
-    <> - {endDateTime.getDate()} {endDateTime.toLocaleString('default', { month: 'long' })} {endDateTime.getFullYear()}</>
-  )}
-</p>
         <p style={{ color: 'gray' }}>
-  <AccessTimeIcon />&nbsp;{`${startDateTime.getHours()}:${startDateTime.getMinutes().toString().padStart(2, '0')}`} 
-  - 
-  {`${endDateTime.getHours()}:${endDateTime.getMinutes().toString().padStart(2, '0')}`}
-</p>
+          <CalendarTodayIcon />&nbsp;
+          {startDateTime.getDate()} {startDateTime.toLocaleString('default', { month: 'long' })} {startDateTime.getFullYear()}
+          {!(
+            startDateTime.getFullYear() === endDateTime.getFullYear() &&
+            startDateTime.getMonth() === endDateTime.getMonth() &&
+            startDateTime.getDate() === endDateTime.getDate()
+          ) && (
+              <> - {endDateTime.getDate()} {endDateTime.toLocaleString('default', { month: 'long' })} {endDateTime.getFullYear()}</>
+            )}
+        </p>
+        <p style={{ color: 'gray' }}>
+          <AccessTimeIcon />&nbsp;{`${startDateTime.getHours()}:${startDateTime.getMinutes().toString().padStart(2, '0')}`}
+          -
+          {`${endDateTime.getHours()}:${endDateTime.getMinutes().toString().padStart(2, '0')}`}
+        </p>
         {recurrence && <p>{recurrence}</p>}
         <hr className={styles.divider} />
 
@@ -101,7 +124,7 @@ const ViewMeetingDetails: React.FC<ViewMeetingDetailsProps> = ({
         <p><strong>Location:</strong>&nbsp;{room}</p>
         {zoomAccount && <p><strong>Zoom Account:</strong>&nbsp;{zoomAccount}</p>}
         {zoomLink && <a href={zoomLink} target="_blank" rel="noopener noreferrer" className={styles.zoomLink}>
-        <VideoCameraFrontIcon /> {zoomLink}
+          <VideoCameraFrontIcon /> {zoomLink}
         </a>}
         <p><strong>PandaDocs Form</strong></p>
         <div className={styles.pandaDocs}>

--- a/frontend/app/components/organisms/ViewMeeting/index.tsx
+++ b/frontend/app/components/organisms/ViewMeeting/index.tsx
@@ -64,28 +64,6 @@ const ViewMeetingDetails: React.FC<ViewMeetingDetailsProps> = ({
   onDelete,
 }) => {
 
-  const handleDelete = async (meetingId : string) => {
-    try {
-      const response = await fetch('/api/delete/meeting', {
-        method: 'DELETE',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ meetingId }),
-      });
-
-      if (response.ok) {
-        onDelete();  // Call the onDelete function passed from parent to hide ViewMeeting
-      } else {
-        const result = await response.json();
-        console.error('Failed to delete meeting:', result.error);
-      }
-    } catch (error) {
-      console.error('Error deleting meeting:', error);
-    }
-  };
-
-
   return (
     <div className={styles.meetingDetails}>
       <div className={styles.header}>
@@ -96,7 +74,7 @@ const ViewMeetingDetails: React.FC<ViewMeetingDetailsProps> = ({
           <button>⋮</button>
           <div className={styles.optionsMenu}>
             <button onClick={onEdit}>Edit Meeting</button>
-            <button onClick={handleDelete}>Delete Meeting</button>
+            <button onClick={onDelete}>Delete Meeting</button>
           </div>
         </div>
       </div>

--- a/frontend/app/components/templates/HomePageLayout.tsx
+++ b/frontend/app/components/templates/HomePageLayout.tsx
@@ -4,6 +4,8 @@ import styles from "../../../styles/HomePageLayout.module.scss";
 import CalendarSidebar from "../organisms/CalendarSidebar";
 import ViewMeetingDetails from "../organisms/ViewMeeting";
 
+import DailyView from "../organisms/DailyView/index";
+
 // Define the type for selectedMeeting to match ViewMeetingDetailsProps
 type MeetingDetails = {
   id: string;
@@ -21,39 +23,8 @@ type MeetingDetails = {
   room: string;
   recurrence?: string;
 };
-import DailyView from "../organisms/DailyView/index";
-const HomePage = () => {
-  const [selectedMeeting, setSelectedMeeting] = useState<string | null>(null); // Track selected meeting or null
-  
-  const handleDelete = async (mid : string) => {
-    try {
-      const response = await fetch('/api/delete/meeting', {
-        method: 'DELETE',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ 
-          mid 
-        }),
-      });
-      console.log("checking if response is ok")
-      if (!response.ok) {
-        alert("Error : Unsuccesful delete")
-        throw new Error(`HTTP error! status: ${response.status}`);
-      }
-      console.log("setting usestate to null 1")
-      setSelectedMeeting(null);
-      console.log("setting usestate to null 2")
 
-      const meetingResponse = await response.json();
-      console.log(meetingResponse);
-      alert("Meeting deleted successfully! Please check the Meeting collection on MongoDB.")
-    
-    } catch (error) {
-      console.error('There was an error fetching the data:', error);
-    }
-  };
-=======
+const HomePage = () => {
   // Define selectedMeeting state with MeetingDetails type or null
   const [selectedMeeting, setSelectedMeeting] = useState<MeetingDetails | null>(null);
   const [selectedMeetingID, setSelectedMeetingID] = useState<string | null>(null);
@@ -64,7 +35,6 @@ const HomePage = () => {
   const [freqValue, setFreqValue] = useState<string>("Never"); // Default frequency value
   const [inputEmailValue, setEmailValue] = useState(""); // Email input value
   const [inputDescriptionValue, setDescriptionValue] = useState(""); // Description input value
-  
   
   const roomOptions = [
     "Serenity Room",
@@ -131,7 +101,34 @@ const HomePage = () => {
   };
 
   const handleEdit = () => console.log("Edit meeting");
-  const handleDelete = () => console.log("Delete meeting");
+  const handleDelete = async (mid : string) => {
+    try {
+      const response = await fetch('/api/delete/meeting', {
+        method: 'DELETE',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ 
+          mid 
+        }),
+      });
+      console.log("checking if response is ok")
+      if (!response.ok) {
+        alert("Error : Unsuccesful delete")
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+      console.log("setting usestate to null 1")
+      setSelectedMeeting(null);
+      console.log("setting usestate to null 2")
+
+      const meetingResponse = await response.json();
+      console.log(meetingResponse);
+      alert("Meeting deleted successfully! Please check the Meeting collection on MongoDB.")
+    
+    } catch (error) {
+      console.error('There was an error fetching the data:', error);
+    }
+  };
 
   return (
     <div className={styles.container}>

--- a/frontend/app/components/templates/HomePageLayout.tsx
+++ b/frontend/app/components/templates/HomePageLayout.tsx
@@ -3,54 +3,45 @@ import React, { useContext, useState } from 'react';
 import styles from "../../../styles/HomePageLayout.module.scss";
 import CalendarSidebar from "../organisms/CalendarSidebar";
 import DailyView from "../organisms/DailyView/index";
-import ViewMeetingDetails from '../../components/organisms/ViewMeeting';
 
 const HomePage = () => {
   const [selectedMeeting, setSelectedMeeting] = useState<string | null>(null); // Track selected meeting or null
-  const [deleteError, setDeleteError] = useState<string | null>(null); // Error state for delete operation
   
-  const handleDelete = () => {
-    setSelectedMeeting(null); // Hide ViewMeeting and show CalendarSidebar
-  };
+  const handleDelete = async (mid : string) => {
+    try {
+      const response = await fetch('/api/delete/meeting', {
+        method: 'DELETE',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ 
+          mid 
+        }),
+      });
+      console.log("checking if response is ok")
+      if (!response.ok) {
+        alert("Error : Unsuccesful delete")
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+      console.log("setting usestate to null 1")
+      setSelectedMeeting(null);
+      console.log("setting usestate to null 2")
 
-  const handleDeleteError = (errorMessage: string) => {
-    setDeleteError(errorMessage); // Set the error message to display in the popup
+      const meetingResponse = await response.json();
+      console.log(meetingResponse);
+      alert("Meeting deleted successfully! Please check the Meeting collection on MongoDB.")
+    
+    } catch (error) {
+      console.error('There was an error fetching the data:', error);
+    }
   };
-
   return (
     <div className={styles.container}>
       <div className={styles.sidebar}>
         <CalendarSidebar />
       </div>
       <div className={styles.primaryCalendar}>
-        {/* Render ViewMeeting if a meeting is selected, else show default view */}
-        {selectedMeeting ? (
-          <ViewMeetingDetails
-            id={selectedMeeting}
-            mid={selectedMeeting}
-            title="Meeting Title"
-            description="Meeting Description"
-            creator="Creator Name"
-            group="Group Name"
-            startDateTime={new Date()}
-            endDateTime={new Date()}
-            zoomAccount="Zoom Account"
-            zoomLink="https://zoom.us"
-            zid="zoomId"
-            type="Meeting Type"
-            room="Room"
-            onBack={() => setSelectedMeeting(null)} // Handle going back
-            onEdit={() => console.log('Edit clicked')}
-            onDelete={handleDelete} // Pass the handleDelete function here
-            // deleteError={deleteError} // Pass the error message to ViewMeeting
-            // setDeleteError={handleDeleteError} // Pass the function to handle error state
-          
-          />
-        ) : (
-          <DailyView />
-
-        )}
-        
+        <DailyView />
       </div>
     </div>
   );

--- a/frontend/app/components/templates/HomePageLayout.tsx
+++ b/frontend/app/components/templates/HomePageLayout.tsx
@@ -3,15 +3,54 @@ import React, { useContext, useState } from 'react';
 import styles from "../../../styles/HomePageLayout.module.scss";
 import CalendarSidebar from "../organisms/CalendarSidebar";
 import DailyView from "../organisms/DailyView/index";
+import ViewMeetingDetails from '../../components/organisms/ViewMeeting';
 
 const HomePage = () => {
+  const [selectedMeeting, setSelectedMeeting] = useState<string | null>(null); // Track selected meeting or null
+  const [deleteError, setDeleteError] = useState<string | null>(null); // Error state for delete operation
+  
+  const handleDelete = () => {
+    setSelectedMeeting(null); // Hide ViewMeeting and show CalendarSidebar
+  };
+
+  const handleDeleteError = (errorMessage: string) => {
+    setDeleteError(errorMessage); // Set the error message to display in the popup
+  };
+
   return (
     <div className={styles.container}>
       <div className={styles.sidebar}>
         <CalendarSidebar />
       </div>
       <div className={styles.primaryCalendar}>
-        <DailyView />
+        {/* Render ViewMeeting if a meeting is selected, else show default view */}
+        {selectedMeeting ? (
+          <ViewMeetingDetails
+            id={selectedMeeting}
+            mid={selectedMeeting}
+            title="Meeting Title"
+            description="Meeting Description"
+            creator="Creator Name"
+            group="Group Name"
+            startDateTime={new Date()}
+            endDateTime={new Date()}
+            zoomAccount="Zoom Account"
+            zoomLink="https://zoom.us"
+            zid="zoomId"
+            type="Meeting Type"
+            room="Room"
+            onBack={() => setSelectedMeeting(null)} // Handle going back
+            onEdit={() => console.log('Edit clicked')}
+            onDelete={handleDelete} // Pass the handleDelete function here
+            // deleteError={deleteError} // Pass the error message to ViewMeeting
+            // setDeleteError={handleDeleteError} // Pass the function to handle error state
+          
+          />
+        ) : (
+          <DailyView />
+
+        )}
+        
       </div>
     </div>
   );

--- a/frontend/app/test/page.tsx
+++ b/frontend/app/test/page.tsx
@@ -26,27 +26,6 @@ import { set } from 'mongoose';
 
 const App = () => {
 
-  const handleDelete = async (meetingId: string) => {
-    try {
-      const response = await fetch('/api/delete/meeting/${meetingId}', {
-        method: 'DELETE',
-        // headers: {
-        //   'Content-Type': 'application/json',
-        // },
-        // body: JSON.stringify({ meetingId }),
-      });
-
-      if (response.ok) {
-        onDelete();  // Call the onDelete function passed from parent to hide ViewMeeting
-      } else {
-        const result = await response.json();
-        console.error('Failed to delete meeting:', result.error);
-      }
-    } catch (error) {
-      console.error('Error deleting meeting:', error);
-    }
-  };
-
   const sampleMeeting = {
     id: '1',
     mid: 'M123',
@@ -64,7 +43,7 @@ const App = () => {
     recurrence: 'Weekly',
     onBack: () => alert('Back button clicked'),
     onEdit: () => alert('Edit button clicked'),
-    onDelete: () => handleDelete,
+    onDelete: () => alert('Delete Button Clicked'),
   };
 
   /** ADMIN TESTING FUNCTIONS  */
@@ -247,7 +226,7 @@ const App = () => {
   const deleteMeeting = async () => {
     try {
       /* Configure to be a real mid */
-      const mid = "95992";
+      const mid = "84143";
 
       const response = await fetch('/api/delete/meeting', {
         method: 'DELETE',

--- a/frontend/app/test/page.tsx
+++ b/frontend/app/test/page.tsx
@@ -26,6 +26,26 @@ import { set } from 'mongoose';
 
 const App = () => {
 
+  const handleDelete = async (meetingId: string) => {
+    try {
+      const response = await fetch('/api/delete/meeting/${meetingId}', {
+        method: 'DELETE',
+        // headers: {
+        //   'Content-Type': 'application/json',
+        // },
+        // body: JSON.stringify({ meetingId }),
+      });
+
+      if (response.ok) {
+        onDelete();  // Call the onDelete function passed from parent to hide ViewMeeting
+      } else {
+        const result = await response.json();
+        console.error('Failed to delete meeting:', result.error);
+      }
+    } catch (error) {
+      console.error('Error deleting meeting:', error);
+    }
+  };
 
   const sampleMeeting = {
     id: '1',
@@ -44,7 +64,7 @@ const App = () => {
     recurrence: 'Weekly',
     onBack: () => alert('Back button clicked'),
     onEdit: () => alert('Edit button clicked'),
-    onDelete: () => alert('Delete button clicked'),
+    onDelete: () => handleDelete,
   };
 
   /** ADMIN TESTING FUNCTIONS  */


### PR DESCRIPTION
## Description

We used the `onDelete` prop and passed in a function that calls the appropriate backend API endpoint to delete a meeting from MongoDB. When there is a successful delete, the ViewMeeting component immediately closes and is replaced with the calendar sidebar. When there is an unsuccessful delete, the ViewMeeting component remains rendered, and a message indicating that the delete failed is shown to the user. In `frontend/app/components/templates/HomePageLayout.tsx`, we tested that these functionalities properly worked. 

## Testing

Create a BoxText component in `frontend/app/components/templates/HomePageLayout.tsx` to test that the delete meeting functionalities actually work with a meeting id that exists in MongoDB. Navigate to http://localhost:3000/ after running `yarn run dev`. After clicking the box, having the sidebar come, and clicking the "delete meeting" button, that meeting will be deleted from the backend properly. When setting the meeting id to one that doesn't exist in the `BoxText` component, and then attempting to delete it, a popup is shown to the user indicating that their delete failed.

## Notes

- We tested these functionalities in `frontend/app/components/templates/HomePageLayout.tsx`. The current code in that file has just the handleDelete fetch call.
- In `HomePageLayout`, added a handleDelete fetch call, but nothing else to avoid merge conflicts. Line 8 is repetitive with our code from the last ticket, which hasn't been merged yet.