### PR TITLE
Atoms/date picker fix

### DIFF
--- a/frontend/app/about/page.tsx
+++ b/frontend/app/about/page.tsx
@@ -1,0 +1,8 @@
+import React from "react";
+
+/** An About page */
+const About = () => {
+  return <>Hello there</>;
+};
+
+export default About;

--- a/frontend/app/about/page.tsx
+++ b/frontend/app/about/page.tsx
@@ -1,5 +1,16 @@
+"use client";
 import React from "react";
 import Button from "../components/button"; 
+
+const getCatFact = async () => {
+    const response = await fetch("https://catfact.ninja/fact");
+    const data = await response.json(); 
+    console.log("Cat Fact:", data.fact); 
+  };
+  
+  const handleClick = () => {
+    getCatFact();
+  };
 
 /** An About page */
 const About = () => {
@@ -7,6 +18,7 @@ const About = () => {
     <>
      <Button text="hello" />
       Hello there
+      <button onClick={handleClick}>cat fact</button>
     </>
   );
 };

--- a/frontend/app/about/page.tsx
+++ b/frontend/app/about/page.tsx
@@ -1,8 +1,14 @@
 import React from "react";
+import Button from "../components/button"; 
 
 /** An About page */
 const About = () => {
-  return <>Hello there</>;
+  return (
+    <>
+      <Button />
+      Hello there
+    </>
+  );
 };
 
 export default About;

--- a/frontend/app/about/page.tsx
+++ b/frontend/app/about/page.tsx
@@ -5,7 +5,7 @@ import Button from "../components/button";
 const About = () => {
   return (
     <>
-      <Button />
+     <Button text="hello" />
       Hello there
     </>
   );

--- a/frontend/app/api/update/meeting/admin/route.ts
+++ b/frontend/app/api/update/meeting/admin/route.ts
@@ -1,0 +1,26 @@
+import { PrismaClient } from "@prisma/client";
+import { NextResponse } from "next/server";
+
+const prisma = new PrismaClient();
+
+const updateAdmin = async (request: Request): Promise<Response> => {
+    try {
+      const { uid, name, email } = await request.json();
+    
+      const updatedAdmin = await prisma.admin.update({
+        where: { uid },
+        data: {
+          name,
+          email
+        },
+      });
+      
+      return NextResponse.json(updatedAdmin);
+  
+    } catch (error) {
+        console.error(error);
+        return NextResponse.json({ error: "Meeting not found or update failed" }, { status: 500 });
+    }
+  };
+  
+export { updateAdmin as PUT };

--- a/frontend/app/components/atoms/DatePicker/index.tsx
+++ b/frontend/app/components/atoms/DatePicker/index.tsx
@@ -32,6 +32,12 @@ const DatePicker = ({ label, value: propValue = '', onChange, underlineOnFocus =
     return `${monthNames[month - 1]} ${day}, ${year}`;
   };
 
+  /**
+ * stringToDate translates a given string text to MM/DD/YYYY form. If the year is not specified, the current year is used.
+ * @param dateString is a string in the form of either "Month day, Year", "Month day Year", "Month day", or MM/DD
+ * @returns string in the form of MM/DD/YYYY
+ */
+
   const stringToDate = (dateString: string): string => {
     const currentYear = new Date().getFullYear();
     const monthNames = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"];

--- a/frontend/app/components/atoms/DatePicker/index.tsx
+++ b/frontend/app/components/atoms/DatePicker/index.tsx
@@ -32,6 +32,52 @@ const DatePicker = ({ label, value: propValue = '', onChange, underlineOnFocus =
     return `${monthNames[month - 1]} ${day}, ${year}`;
   };
 
+  const stringToDate = (dateString: string): string => {
+    const currentYear = new Date().getFullYear();
+    const monthNames = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"];
+    const monthAbbr = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+  
+    const getMonthIndex = (month: string): number => {
+      let monthIndex = monthNames.indexOf(month);
+      if (monthIndex === -1) {
+        monthIndex = monthAbbr.indexOf(month);
+      }
+      return monthIndex;
+    };
+  
+    // "Month day, Year" or "Month day Year" -> MM/DD/YYYY
+    const matchFullDate = dateString.match(/([a-zA-Z]+)\s(\d{1,2})\s*,?\s*(\d{4})/);
+    if (matchFullDate) {
+      const month = matchFullDate[1];
+      const day = matchFullDate[2];
+      const year = matchFullDate[3];
+      const monthIndex = getMonthIndex(month);
+      
+      return `${monthNames[monthIndex]} ${Number(day)}, ${Number(year)}`;
+    }
+  
+    // "Month day" -> MM/DD/YYYY
+    const matchMonthDay = dateString.match(/([a-zA-Z]+)\s(\d{1,2})/);
+    if (matchMonthDay) {
+      const month = matchMonthDay[1];
+      const day = matchMonthDay[2];
+      const monthIndex = getMonthIndex(month);
+
+      return `${monthNames[monthIndex]} ${Number(day)}, ${currentYear}`;
+    }
+  
+    // MM/DD -> MM/DD/YYYY
+    const matchMMDD = dateString.match(/(\d{2})\/(\d{2})/);
+    if (matchMMDD) {
+      const month = matchMMDD[1];
+      const day = matchMMDD[2];
+      return `${Number(month)}/${Number(day)}/${currentYear}`;
+    }
+
+    return "";
+  };  
+  
+
   useEffect(() => {
     if (propValue !== internalValue) {
       setInternalValue(propValue);

--- a/frontend/app/components/button/index.tsx
+++ b/frontend/app/components/button/index.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+
+/** A simple Button component */
+const Button = () => {
+  return (
+    <button>Press me</button>
+  );
+};
+
+export default Button;

--- a/frontend/app/components/button/index.tsx
+++ b/frontend/app/components/button/index.tsx
@@ -1,10 +1,16 @@
 import React from "react";
 
-/** A simple Button component */
-const Button = () => {
-  return (
-    <button>Press me</button>
-  );
+/**
+ * Component for a general button
+ * @param text is the text on the button
+ */
+
+interface Props {
+  text: string;
+}
+
+const Button = ({ text }: Props) => {
+  return <button>{text}</button>;
 };
 
 export default Button;

--- a/frontend/app/test/page.tsx
+++ b/frontend/app/test/page.tsx
@@ -108,11 +108,35 @@ const App = () => {
     setSelectedZoomAccount(email);
   };
 
+  const updateAdmin = async () => {
+    try {
+      const hardcodedUid = "101"; 
+      const newName = "Victoria Yu"; 
+      const newEmail = "vwy5@cornell.edu";
+  
+      const response = await fetch("/api/update/meeting/admin", {
+        method: "PUT", 
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ uid: hardcodedUid, name: newName, email: newEmail }),
+      });
+  
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+  
+      const updatedAdmin = await response.json();
+    } catch (error) {
+      console.error("There was an error updating the admin:", error);
+    }
+  };  
 
+  
   const createAdmin = async () => {
     try {
       const newAdmin: IAdmin = {
-        uid: `${Math.floor(Math.random() * 100000) + 1}`, // Most likely will be Microsoft ID
+        uid: "101",
         name: "Joseph Ugarte",
         email: "jeu9@cornell.edu"
       }
@@ -446,6 +470,7 @@ const App = () => {
       </div>
       <div className={styles.section}>
         <h2>Admins</h2>
+        <TestButton testFunc={updateAdmin} text="Update admin" />
         <TestButton testFunc={createAdmin} text="Call create admin post /api/write/admin" />
         <TestButton testFunc={getAdmin} text="Call get admin /api/retrieve/admin" />
         <TestButton testFunc={deleteAdmin} text="Call delete admin /api/delete/admin" />

--- a/frontend/app/test/page.tsx
+++ b/frontend/app/test/page.tsx
@@ -453,7 +453,6 @@ const App = () => {
     }
   }
 
-
   return (
     <div className={styles['apicontainer']}>
       <div>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -51,5 +51,6 @@
     "postcss": "^8",
     "tailwindcss": "^3.3.0",
     "typescript": "5.3.3"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }


### PR DESCRIPTION
**Description**
Translates a given string text to MM/DD/YYYY form. If the year is not specified, the current year is used. Implemented in /DatePicker/index.tsx.

**Testing**
Tested locally on my computer; added Console.log statements that called the stringToDate and validated the output was as expected.

**Notes**
This ticket is the inverse of a previous DatePicker function that translates a MM/DD/YYYY to a string text. Improves user experience by preventing errors when a user accidentally clicks on a previously inputted date in the DatePicker.

Closes #84