### PR TITLE
Finished Overlapping Days

### DIFF
--- a/frontend/app/api/retrieve/meeting/day/route.ts
+++ b/frontend/app/api/retrieve/meeting/day/route.ts
@@ -22,14 +22,15 @@ const retrieveDayMeetings = async (request: NextRequest) => {
             localDate.getUTCFullYear(),
             localDate.getUTCMonth(),
             localDate.getUTCDate(),
-            0, 0, 0, 0
+            4, 0, 0, 0 //this is 12:00am in EST
         ));
         
         const endOfDay = new Date(Date.UTC(
             localDate.getUTCFullYear(),
             localDate.getUTCMonth(),
-            localDate.getUTCDate(),
-            23, 59, 59, 999
+            localDate.getUTCDate()+1,
+            // 23, 59, 59, 999
+            3, 59, 59, 999 // this is 11:59pm in EST
         ));
 
         const dayOfWeek = localDate.getUTCDay();
@@ -38,8 +39,8 @@ const retrieveDayMeetings = async (request: NextRequest) => {
         
         const directlyScheduledMeetings = await prisma.meeting.findMany({
             where: {
-                startDateTime: { gte: startOfDay },
-                endDateTime: { lte: endOfDay }
+                startDateTime: { lte: endOfDay },
+                endDateTime: { gte: startOfDay }
             },
             include: { 
                 recurrencePattern: true 

--- a/frontend/app/components/atoms/TimePicker/index.tsx
+++ b/frontend/app/components/atoms/TimePicker/index.tsx
@@ -88,7 +88,7 @@ const TimePicker = ({ label, value: propValue = '', disablePast, onChange, error
 
     // Validate end time against start time
     const newTimeDifference = getTimeDifferenceInMinutes(startTime, newEndTime);
-    if (newTimeDifference <= 0) {
+    if (newTimeDifference == 0) {
       setEndTimeError(true); // Set error state if end time is not later than start time
     } else {
       setEndTimeError(false); // Clear error state if valid
@@ -118,7 +118,7 @@ const TimePicker = ({ label, value: propValue = '', disablePast, onChange, error
         className={`${styles['time-picker-input']} ${endTimeError ? styles['error-input'] : ''}`} // Apply error class conditionally
         {...props}
       />
-      {endTimeError && <div className={styles['error-message']}>End time must be later than start time.</div>} {/* Display error message */}
+      {endTimeError && <div className={styles['error-message']}>End time cannot equal start time.</div>} {/* Display error message */}
       {error && <div className={styles['error-message']}>{error}</div>}
     </div>
   );

--- a/frontend/app/components/organisms/DailyView/index.tsx
+++ b/frontend/app/components/organisms/DailyView/index.tsx
@@ -32,9 +32,41 @@ const fetchMeetingsByDay = async (date: Date): Promise<Room[]> => {
     const data = await response.json();
     console.log("Raw API response:", data);
 
+    const dayStart = new Date(date);
+    dayStart.setHours(0, 0, 0, 0);
+    const dayEnd = new Date(date);
+    dayEnd.setHours(23, 59, 59, 999);
+
+    const clipped: IMeeting[] = data.flatMap(meeting => {
+      const start = new Date(meeting.startDateTime);
+      const end   = new Date(meeting.endDateTime);
+
+      // Case 1: meeting spans into today from before; start it at 12:00 AM today
+      if (start < dayStart && end > dayStart) {
+        return [{
+          ...meeting,
+          startDateTime: dayStart.toISOString(),
+          endDateTime:   end < dayEnd ? meeting.endDateTime : dayEnd.toISOString(),
+        }];
+      }
+      // Case 2: starts today, goes past midnight; end it at 11:59 PM today
+      if (start < dayEnd && end > dayEnd) {
+        return [{
+          ...meeting,
+          startDateTime: meeting.startDateTime,
+          endDateTime:   dayEnd.toISOString(),
+        }];
+      }
+      // Case 3: fully inside today
+      if (start >= dayStart && end <= dayEnd) {
+        return [meeting];
+      }
+      return [];
+    });
+
     const groupedRooms: { [key: string]: Meeting[] } = {};
 
-    data.forEach((meeting: any) => {
+    clipped.forEach((meeting: any) => {
       const roomName = meeting.room;
       if (!groupedRooms[roomName]) {
         groupedRooms[roomName] = [];
@@ -65,8 +97,6 @@ const fetchMeetingsByDay = async (date: Date): Promise<Room[]> => {
       };
     });
 
-    // Cache result
-    meetingCache.set(formattedDate, structuredData);
     return structuredData;
   } catch (error) {
     console.error("Error fetching meetings:", error);

--- a/frontend/app/components/organisms/NewMeeting.tsx
+++ b/frontend/app/components/organisms/NewMeeting.tsx
@@ -121,10 +121,10 @@ const NewMeetingSidebar: React.FC<NewMeetingSidebarProps> =
           console.error("Invalid timeValue format");
           return;
         }
-
+      
         // in EST
         const startDateString = `${isoDateValue}T${startTime}`;
-        const endDateString = `${isoDateValue}T${endTime}`;
+        let endDateString = `${isoDateValue}T${endTime}`;
 
         if (!startDateString || !endDateString) {
           console.error("Start or end date string could not be constructed");
@@ -136,6 +136,11 @@ const NewMeetingSidebar: React.FC<NewMeetingSidebarProps> =
 
         const startDateTimeUTC = new Date(startDateTimeUTCString);
         const endDateTimeUTC = new Date(endDateTimeUTCString);
+
+         // If endTime < startTime, add one calendar day to endDateTime (e.g., 10:00 PM - 2:00 AM)
+        if (endDateTimeUTC <= startDateTimeUTC) {
+          endDateTimeUTC.setUTCDate(endDateTimeUTC.getUTCDate() + 1);
+        }
 
         const newMeeting: IMeeting = {
           mid: generateMeetingId(),


### PR DESCRIPTION
1. First we allowed users to input end times that were numerically less than the start time
    1. For example before we couldn’t create the a meeting from 11:00 PM to 2:00AM because the input thought 2AM < 11PM. 
    2. We fixed this by adding an extra day to the end time if the end time < start time
    3. So the aforementioned meeting starts at 11PM on 05/18 and ends at 2am on 05/19
    4. We made this change in frontend/app/components/organisms/NewMeeting.tsx
2. Next we changed the error message in the TimePicker component
    1. Now if you choose a meeting from 11PM to 2AM there is no red error message
    2. There is only an error if you try to create a meeting that starts and ends at the same exact time (e.g start is 12:00AM and end is 12:00AM)
    3. We made this change in frontend/app/components/atoms/TimePicker/index.tsx
3. Next we needed to change how the backend was fetching the meetings for the current calendar day
    1. Since start and end times are stored in UTC in the database, our backend was returning meetings whose UTC start date matched our EST calendar start date
        1. The issue was that if we were looking at calendar day 05/18 and wanted the meeting that started at 8:01PM on 05/18 in EST (which is  12:01AM on 05/19 in UTC) then our meeting wouldn’t be returned in the calendar view for 05/18 but instead in the calendar view for 05/19
    2. We fixed this by changing what was defined as the start and end of day (START: 12:00AM → 04:00AM UTC and END: 23:59:59 → 3:59:59 UTC)
    3. We made also changed the where condition for fetching our meetings so we could fetch meetings that 1) start and end on the same day and 2)  overlap days 
    4. So if a meeting starts at 11:00pm EST on 05/18 and end at 2:00am EST on 05/19, this meeting gets returned to our calendar view on both 05/18 and 05/19 which is what we want
    5. We made these changes in frontend/app/api/retrieve/meeting/day/route.ts
4. Lastly we needed to clip meetings on the frontend
    1. We mapped all the meetings to 3 cases which you can see in the commits
    2. We made these changes in the DailyView component: frontend/app/components/organisms/DailyView/index.tsx
    
   

https://github.com/user-attachments/assets/7b5753ca-9daa-4f92-8676-e5721b3906fb

