### PR TITLE
Fix weekly view navigation

### DIFF
--- a/frontend/app/components/organisms/CalendarNavbar.tsx
+++ b/frontend/app/components/organisms/CalendarNavbar.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
-import styles from "../../../../styles/components/organisms/CalendarNavbar.module.scss";
-import PandaDocButton from '../../../components/molecules/PandaDocButton';
+import styles from "../../../styles/components/organisms/CalendarNavbar.module.scss";
+import PandaDocButton from '../molecules/PandaDocButton';
 
 type CalendarNavbarProps = {
     selectedDate: Date;
@@ -86,8 +86,6 @@ const CalendarNavbar: React.FC<CalendarNavbarProps> = ({ selectedDate, onDateCha
         default:
           break;
       }
-      console.log("Selected Date:", selectedDate);
-      console.log("New Date:", newDate);
       onDateChange(newDate);
     };
   
@@ -106,8 +104,6 @@ const CalendarNavbar: React.FC<CalendarNavbarProps> = ({ selectedDate, onDateCha
         default:
           break;
       }
-      console.log("Selected Date:", selectedDate);
-      console.log("New Date:", newDate);
       onDateChange(newDate);
     };
 

--- a/frontend/app/components/organisms/CalendarNavbar/index.tsx
+++ b/frontend/app/components/organisms/CalendarNavbar/index.tsx
@@ -9,7 +9,6 @@ type CalendarNavbarProps = {
   };
   
 const CalendarNavbar: React.FC<CalendarNavbarProps> = ({ selectedDate, onDateChange, onViewChange }) => {
-    const [currentDate, setCurrentDate] = useState(new Date());
     const [selectedView, setSelectedView] = useState('Day');
   
     const getDateRange = (date: Date) => {
@@ -69,8 +68,7 @@ const CalendarNavbar: React.FC<CalendarNavbarProps> = ({ selectedDate, onDateCha
   
     const handleToday = () => {
       setSelectedView("Day");
-      setCurrentDate(new Date());
-      onDateChange(currentDate); // Call the external function as well
+      onDateChange(new Date()); // Call the external function as well
     };
 
     const handlePrevious = () => {
@@ -88,7 +86,8 @@ const CalendarNavbar: React.FC<CalendarNavbarProps> = ({ selectedDate, onDateCha
         default:
           break;
       }
-      setCurrentDate(newDate);
+      console.log("Selected Date:", selectedDate);
+      console.log("New Date:", newDate);
       onDateChange(newDate);
     };
   
@@ -107,7 +106,8 @@ const CalendarNavbar: React.FC<CalendarNavbarProps> = ({ selectedDate, onDateCha
         default:
           break;
       }
-      setCurrentDate(newDate);
+      console.log("Selected Date:", selectedDate);
+      console.log("New Date:", newDate);
       onDateChange(newDate);
     };
 
@@ -124,7 +124,7 @@ const CalendarNavbar: React.FC<CalendarNavbarProps> = ({ selectedDate, onDateCha
             </select>
           </div>
           <div className={styles.box}>
-            <a href="#" onClick={() => handleToday()}>Today</a>
+            <a href="#" onClick={handleToday}>Today</a>
           </div>
           <div className={styles.dateToggle}>
             <img src="/left-arrow.svg" alt="Left Arrow" width={24} height={24} onClick={handlePrevious} />

--- a/frontend/app/components/organisms/CalendarNavbar/index.tsx
+++ b/frontend/app/components/organisms/CalendarNavbar/index.tsx
@@ -4,14 +4,11 @@ import PandaDocButton from '../../../components/molecules/PandaDocButton';
 
 type CalendarNavbarProps = {
     selectedDate: Date;
-    onPreviousDay: () => void;
-    onNextDay: () => void;
     onDateChange: (date : Date) => void;
-    onToday: () => void;
     onViewChange: (view: string) => void;
   };
   
-const CalendarNavbar: React.FC<CalendarNavbarProps> = ({ selectedDate, onPreviousDay, onNextDay, onDateChange, onToday, onViewChange }) => {
+const CalendarNavbar: React.FC<CalendarNavbarProps> = ({ selectedDate, onDateChange, onViewChange }) => {
     const [currentDate, setCurrentDate] = useState(new Date());
     const [selectedView, setSelectedView] = useState('Day');
   
@@ -64,6 +61,18 @@ const CalendarNavbar: React.FC<CalendarNavbarProps> = ({ selectedDate, onPreviou
       }
     };
   
+    const handleViewChange: React.ChangeEventHandler<HTMLSelectElement> = (event) => {
+      setSelectedView(event.target.value);
+      onViewChange(event.target.value); // Call the external function
+      onDateChange(new Date());
+    };
+  
+    const handleToday = () => {
+      setSelectedView("Day");
+      setCurrentDate(new Date());
+      onDateChange(currentDate); // Call the external function as well
+    };
+
     const handlePrevious = () => {
       const newDate = new Date(selectedDate);
       switch (selectedView) {
@@ -79,8 +88,8 @@ const CalendarNavbar: React.FC<CalendarNavbarProps> = ({ selectedDate, onPreviou
         default:
           break;
       }
+      setCurrentDate(newDate);
       onDateChange(newDate);
-
     };
   
     const handleNext = () => {
@@ -98,29 +107,8 @@ const CalendarNavbar: React.FC<CalendarNavbarProps> = ({ selectedDate, onPreviou
         default:
           break;
       }
+      setCurrentDate(newDate);
       onDateChange(newDate);
-    };
-  
-    const handleViewChange: React.ChangeEventHandler<HTMLSelectElement> = (event) => {
-      setSelectedView(event.target.value);
-      onViewChange(event.target.value); // Call the external function
-      onDateChange(new Date());
-    };
-  
-    const handleToday = () => {
-      setSelectedView("Day");
-      setCurrentDate(new Date());
-      onToday(); // Call the external function as well
-    };
-  
-    const handleCombinedPrevious = () => {
-      handlePrevious(); // Local function logic
-      onPreviousDay(); // External function from DailyView
-    };
-  
-    const handleCombinedNext = () => {
-      handleNext(); // Local function logic
-      onNextDay(); // External function from DailyView
     };
 
     return (
@@ -133,15 +121,14 @@ const CalendarNavbar: React.FC<CalendarNavbarProps> = ({ selectedDate, onPreviou
             <select id="view-select" value={selectedView} onChange={handleViewChange}>
               <option value="Day">Day</option>
               <option value="Week">Week</option>
-              {/* <option value="Month">Month</option> */}
             </select>
           </div>
           <div className={styles.box}>
-            <a href="#" onClick={() => onDateChange(new Date())}>Today</a>
+            <a href="#" onClick={() => handleToday()}>Today</a>
           </div>
           <div className={styles.dateToggle}>
-            <img src="/left-arrow.svg" alt="Left Arrow" width={24} height={24} onClick={handleCombinedPrevious} />
-            <img src="/right-arrow.svg" alt="Right Arrow" width={24} height={24} onClick={handleCombinedNext} />
+            <img src="/left-arrow.svg" alt="Left Arrow" width={24} height={24} onClick={handlePrevious} />
+            <img src="/right-arrow.svg" alt="Right Arrow" width={24} height={24} onClick={handleNext} />
           </div>
         </div>
       </div>

--- a/frontend/app/components/templates/HomePageLayout.tsx
+++ b/frontend/app/components/templates/HomePageLayout.tsx
@@ -247,9 +247,6 @@ const HomePage = () => {
       <div className={styles.primaryCalendar}>
         <CalendarNavbar
           selectedDate={selectedDate}
-          onPreviousDay={() => setSelectedDate(new Date(selectedDate.setDate(selectedDate.getDate() - 1)))}
-          onNextDay={() => setSelectedDate(new Date(selectedDate.setDate(selectedDate.getDate() + 1)))}
-          onToday={() => (setSelectedDate(new Date()))}
           onDateChange={setSelectedDate}
           onViewChange={setSelectedView}
         />


### PR DESCRIPTION
### Description
This ticket covers fixing issues with regarding to navigating weekly view.

### Testing
1. Navigate to [http://localhost:3000/](url)
2. Navigate forward and backward with Daily View, observe that it works as intended.
3. Switch to Weekly View, navigate forward and backward, observe that it works as intended.
4. Switch to Daily View again, observe that it takes us back to current date, and navigation works as intended.

### Notes
- Currently, when navigating Weekly View using navigation arrows, the Mini Calendar on the Sidebar selected first day of the week instead of CurrentDate plus/minus 7 days (for example, if today is a Thursday, clicking a backward arrow will take us to the Sunday of last week instead of the Thursday of last week). Not impacting other functionalities however.
- I also refactor CalendarNavbar for cleaner directory navigation (bigger repo refactor is WIP).

Closes #156 

