### PR TITLE
Connect Google Auth to MongoDB database

### DIFF
--- a/frontend/app/api/auth/authConfig.ts
+++ b/frontend/app/api/auth/authConfig.ts
@@ -25,16 +25,29 @@ export const authOptions: NextAuthOptions = {
         }),
     ],
     callbacks: {
-        async jwt({ token, account }) {
+        async jwt({ token, account, profile }) {
             if (account) {
                 token.accessToken = account.access_token;
                 token.refreshToken = account.refresh_token;
                 token.expiresAt = account.expires_at;
 
-                if (account.refresh_token && token.email) {
-                    await prisma.admin.updateMany({
+                if (token.email) {
+                    await prisma.admin.upsert({
                         where: { email: token.email },
-                        data: { refreshToken: account.refresh_token },
+                        update: {
+                            googleId: account.providerAccountId,
+                            refreshToken: account.refresh_token ?? undefined,
+                            accessToken: account.access_token ?? undefined,
+                            tokenExpiresAt: account.expires_at ?? undefined,
+                        },
+                        create: {
+                            email: token.email,
+                            name: token.name ?? (profile as { name?: string })?.name ?? "",
+                            googleId: account.providerAccountId,
+                            refreshToken: account.refresh_token ?? undefined,
+                            accessToken: account.access_token ?? undefined,
+                            tokenExpiresAt: account.expires_at ?? undefined,
+                        },
                     });
                 }
             }

--- a/frontend/app/api/microsoft/calendars/getCalendars/route.ts
+++ b/frontend/app/api/microsoft/calendars/getCalendars/route.ts
@@ -1,5 +1,4 @@
 export const dynamic = 'force-dynamic';
-import { authProvider } from "../../../../../services/auth";
 import getAccessToken from "../../AccessToken";
 
 const getCalendars = async (req: Request) => {

--- a/frontend/app/api/microsoft/groups/route.ts
+++ b/frontend/app/api/microsoft/groups/route.ts
@@ -1,5 +1,4 @@
 export const dynamic = 'force-dynamic';
-import { authProvider } from "../../../../services/auth";
 import getAccessToken from '../AccessToken';
 
 const getGroups = async (req: Request) => {

--- a/frontend/prisma/schema.prisma
+++ b/frontend/prisma/schema.prisma
@@ -8,12 +8,14 @@ datasource db {
 }
 
 model Admin {
-  id            String  @id @default(auto()) @map("_id") @db.ObjectId
-  email         String  @unique
-  name          String
-  privilegeMode String?
-  uid           String  @unique
-  refreshToken  String?
+  id             String   @id @default(auto()) @map("_id") @db.ObjectId
+  email          String   @unique
+  name           String
+  privilegeMode  String?
+  googleId       String? 
+  refreshToken   String?
+  accessToken    String?
+  tokenExpiresAt Int?
 }
 
 model Meeting {

--- a/frontend/util/models.ts
+++ b/frontend/util/models.ts
@@ -1,11 +1,14 @@
 // Please add models here
 interface IUser {
-  uid: string;
   name: string;
 }
 
 interface IAdmin extends IUser {
   email: string;
+  googleId?: string | null;
+  refreshToken?: string | null;
+  accessToken?: string | null;
+  tokenExpiresAt?: number | null;
 }
 
 interface IMeeting {


### PR DESCRIPTION
### Description
This update completes the beginning of the Google OAuth migration. The jwt callback now upserts admin records on sign-in, writing googleId and token fields that were previously never populated.

### Changes

- Updated jwt callback in authConfig.ts to use upsert instead of updateMany, so googleId and all token fields are written on every sign-in
- Added googleId, accessToken, and tokenExpiresAt to the Admin schema; removed deprecated uid unique index (legacy Azure AD OID from MSAL migration)

### Testing
Navigate to the app and sign in with Google
Check the database and verify the admin record has googleId, accessToken, and tokenExpiresAt populated

Fixes [#173](https://github.com/cornellh4i/ithaca-recovery/issues/173)