### PR TITLE
Stop leaking meeting PII and Zoom join links from public retrieval endpoints

### DIFF
--- a/frontend/app/api/retrieve/meeting/[id]/route.ts
+++ b/frontend/app/api/retrieve/meeting/[id]/route.ts
@@ -1,7 +1,14 @@
 import { NextRequest } from "next/server";
+import { getAuth } from "../../../../../services/auth";
 import { prisma } from "../../../../../lib/prisma";
+import { toPublicMeeting } from "../../../../../util/publicMeeting";
 const getMeeting = async(request: NextRequest) => {
   try {
+    // Intentionally public (see routeGuards.test.ts PUBLIC_ROUTES) -- backs the
+    // unauthenticated calendar's detail panel. Callers without a session get only the
+    // public-safe fields; a valid session (any role) gets the full record, same as before.
+    const session = await getAuth();
+
     const mid = request.nextUrl.pathname.split('/').pop() as string;
     console.log("Requested meeting ID:", mid);
 
@@ -23,7 +30,11 @@ const getMeeting = async(request: NextRequest) => {
       });
     }
 
-    return new Response(JSON.stringify(meeting), {
+    const body = session?.user?.role
+      ? meeting
+      : toPublicMeeting({ ...meeting, recurrencePattern: meeting.recurrencePattern ?? null });
+
+    return new Response(JSON.stringify(body), {
       status: 200,
       headers: {
         'Content-Type': 'application/json',

--- a/frontend/app/api/retrieve/meeting/month/route.ts
+++ b/frontend/app/api/retrieve/meeting/month/route.ts
@@ -1,8 +1,8 @@
 export const dynamic = 'force-dynamic';
-import { IMeeting } from "../../../../../util/models";
 import { getETDayBounds, toETDateString } from "../../../../../util/timeUtils";
 import { NextRequest } from 'next/server';
 import { prisma } from "../../../../../lib/prisma";
+import { toPublicMeeting } from "../../../../../util/publicMeeting";
 
 const notDeleted = { OR: [{ deletedAt: null }, { deletedAt: { isSet: false } }] };
 
@@ -33,11 +33,8 @@ const retrieveMonthMeetings = async (request: NextRequest) => {
                 }
             }
         })
-        const typedMeetings: IMeeting[] = meetings.map(meeting => ({
-            ...meeting,
-            googleCalendarEventIds: (meeting.googleCalendarEventIds ?? {}) as Record<string, string>,
-        }))
-        return new Response(JSON.stringify(typedMeetings), {
+        const publicMeetings = meetings.map(toPublicMeeting);
+        return new Response(JSON.stringify(publicMeetings), {
             status: 200,
             headers: {
                 'Content-Type': 'application/json',

--- a/frontend/app/api/retrieve/meeting/route.ts
+++ b/frontend/app/api/retrieve/meeting/route.ts
@@ -1,16 +1,13 @@
-import { IMeeting } from "../../../../util/models";
 import { prisma } from "../../../../lib/prisma";
+import { toPublicMeeting } from "../../../../util/publicMeeting";
 
 const notDeleted = { OR: [{ deletedAt: null }, { deletedAt: { isSet: false } }] };
 
 const retrieveMeetings = async () => {
   try {
     const meetings = await prisma.meeting.findMany({ where: notDeleted });
-    const typedMeetings: IMeeting[] = meetings.map(meeting => ({
-      ...meeting,
-      googleCalendarEventIds: (meeting.googleCalendarEventIds ?? {}) as Record<string, string>,
-    }))
-    return new Response(JSON.stringify(typedMeetings), {
+    const publicMeetings = meetings.map(toPublicMeeting);
+    return new Response(JSON.stringify(publicMeetings), {
       status: 200,
       headers: {
         'Content-Type': 'application/json',

--- a/frontend/util/meetingOccurrences.ts
+++ b/frontend/util/meetingOccurrences.ts
@@ -1,6 +1,6 @@
-import { IMeeting } from "./models";
 import { getETDayBounds, convertETToUTC } from "./timeUtils";
 import { prisma } from "../lib/prisma";
+import { PublicMeeting, toPublicMeeting } from "./publicMeeting";
 
 const notDeleted = { OR: [{ deletedAt: null }, { deletedAt: { isSet: false } }] };
 
@@ -106,7 +106,7 @@ export const matchesRecurrencePattern = (
  * ET calendar date, with recurring occurrences' start/end times adjusted onto that date.
  * Shared by the day and week retrieval routes so recurrence rules are only implemented once.
  */
-export const getMeetingsForDate = async (etDateStr: string): Promise<IMeeting[]> => {
+export const getMeetingsForDate = async (etDateStr: string): Promise<PublicMeeting[]> => {
     const [startOfDay, endOfDay] = getETDayBounds(etDateStr);
 
     // localDate is used only for day-of-week and recurring-pattern comparisons;
@@ -177,13 +177,8 @@ export const getMeetingsForDate = async (etDateStr: string): Promise<IMeeting[]>
         ...adjustedPatternMeetings
     ];
 
-    return allMeetings.map((meeting) => {
-        const { recurrencePattern, ...meetingDetails } = meeting;
-
-        return {
-            ...meetingDetails,
-            googleCalendarEventIds: (meeting.googleCalendarEventIds ?? {}) as Record<string, string>,
-            recurrencePattern: recurrencePattern ?? null,
-        };
-    });
+    return allMeetings.map((meeting) => toPublicMeeting({
+        ...meeting,
+        recurrencePattern: meeting.recurrencePattern ?? null,
+    }));
 };

--- a/frontend/util/publicMeeting.ts
+++ b/frontend/util/publicMeeting.ts
@@ -1,0 +1,36 @@
+import { IMeeting } from "./models";
+
+// Fields safe to serve from unauthenticated meeting endpoints (public calendar + signage
+// kiosk). Deliberately an allowlist, not a blacklist -- a new sensitive column added to the
+// Meeting model (e.g. another contact/credential field) is excluded by default here instead
+// of leaking until someone remembers to blacklist it.
+export type PublicMeeting = Pick<
+  IMeeting,
+  | "mid"
+  | "title"
+  | "startDateTime"
+  | "endDateTime"
+  | "calType"
+  | "modeType"
+  | "room"
+  | "zoomRoom"
+  | "isRecurring"
+  | "recurrencePattern"
+  | "syncStatus"
+  | "zoomSyncStatus"
+>;
+
+export const toPublicMeeting = (meeting: PublicMeeting): PublicMeeting => ({
+  mid: meeting.mid,
+  title: meeting.title,
+  startDateTime: meeting.startDateTime,
+  endDateTime: meeting.endDateTime,
+  calType: meeting.calType,
+  modeType: meeting.modeType,
+  room: meeting.room,
+  zoomRoom: meeting.zoomRoom,
+  isRecurring: meeting.isRecurring,
+  recurrencePattern: meeting.recurrencePattern,
+  syncStatus: meeting.syncStatus,
+  zoomSyncStatus: meeting.zoomSyncStatus,
+});


### PR DESCRIPTION
## Description

- **`frontend/util/publicMeeting.ts`** (new): adds a `toPublicMeeting()` allowlist mapper that keeps only the fields the public calendar/signage UI actually renders (`mid`, `title`, times, `calType`, `modeType`, `room`, `zoomRoom`, `isRecurring`, `recurrencePattern`, `syncStatus`, `zoomSyncStatus`) and drops everything else — most notably `email`, `zoomLink`, `zid`, and internal Google/Zoom sync bookkeeping fields.
- **`frontend/app/api/retrieve/meeting/route.ts`**, **`frontend/app/api/retrieve/meeting/month/route.ts`**, **`frontend/util/meetingOccurrences.ts`** (shared by the `day` and `week` routes): these four fully-unauthenticated endpoints now map their Prisma results through `toPublicMeeting()` before returning, instead of serializing the raw record.
- **`frontend/app/api/retrieve/meeting/[id]/route.ts`**: stays reachable without auth — it's on `routeGuards.test.ts`'s `PUBLIC_ROUTES` allowlist by design, and the admin edit sidebar reuses this same fetch to prefill the edit form — but now checks for a session and only returns the full record (including `email`/`zoomLink`) when one exists; anonymous callers get the same public-safe shape as the other four routes.

Previously, an anonymous request to any of these five endpoints (e.g. `curl /api/retrieve/meeting/day`) returned every field of every meeting in the system, including organizer contact emails and live Zoom join links/IDs — letting anyone scrape a contact directory or silently join/disrupt a Zoom meeting they were never invited to.

## Testing

- [x] `node_modules/.bin/tsc --noEmit -p tsconfig.json` — clean, no type errors
- [x] `yarn test:unit` (57 tests, 7 suites) — all passing, including `routeGuards.test.ts` and `proxy.test.ts`
- [x] Manually verify: signed-out request to `/api/retrieve/meeting/day` (or `/week`, `/month`, `/[id]`) no longer includes `email`/`zoomLink`/`zid` in the response
- [x] Manually verify: signed-in admin clicking a meeting in the calendar still sees email/Zoom link in the detail sidebar and can still prefill/edit those fields
- [x] `yarn test:e2e` against a real dev DB