### PR TITLE
Fix meeting modal-switch UX bugs; scope Dependabot auto-merge

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,10 +7,12 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 10
     groups:
-      # Majors stay ungrouped -- those need a human to read the changelog.
-      minor-and-patch:
+      # Only patch-level devDependency bumps are safe to auto-merge unattended (see
+      # dependabot-auto-merge.yml) -- everything else (prod deps at any semver level,
+      # dev deps at minor/major) stays its own PR so a human reads the diff/changelog.
+      dev-patch:
+        dependency-type: "development"
         update-types:
-          - "minor"
           - "patch"
 
   # .github/workflows/test.yml — actions/checkout, actions/setup-node, actions/upload-artifact

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -17,12 +17,17 @@ jobs:
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
-      # dependabot.yml only groups minor/patch updates -- majors stay ungrouped so a human
-      # reads the changelog. Mirror that split here: enabling auto-merge doesn't bypass
-      # required status checks, it just lets the PR merge itself once lint/unit/integration/e2e
-      # all pass, same as a human clicking "merge" would.
-      - name: Enable auto-merge for minor/patch updates
-        if: steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.update-type == 'version-update:semver-patch'
+      # dependabot.yml's "dev-patch" group is the only group scoped to
+      # dependency-type: development + update-types: patch -- membership in it is itself
+      # the safety guarantee, so gate on the group rather than re-deriving semver/type here.
+      # Everything else (prod deps at any semver level, github-actions bumps, dev deps at
+      # minor/major) is left as an individual PR for manual review + CI green -- a version
+      # bump can change runtime/build behavior in ways this repo's CI doesn't always catch,
+      # so those get a human read of the diff/changelog rather than an unattended merge.
+      # Auto-merge still doesn't bypass required status checks -- it just lets the PR merge
+      # itself once lint/unit/integration/e2e all pass.
+      - name: Enable auto-merge for patch-level devDependency updates
+        if: steps.metadata.outputs.dependency-group == 'dev-patch'
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: "${{ github.event.pull_request.html_url }}"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,29 @@
+name: Dependabot auto-merge
+
+on: pull_request_target
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  auto-merge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      # dependabot.yml only groups minor/patch updates -- majors stay ungrouped so a human
+      # reads the changelog. Mirror that split here: enabling auto-merge doesn't bypass
+      # required status checks, it just lets the PR merge itself once lint/unit/integration/e2e
+      # all pass, same as a human clicking "merge" would.
+      - name: Enable auto-merge for minor/patch updates
+        if: steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: "${{ github.event.pull_request.html_url }}"
+          GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/frontend/app/(main)/page.tsx
+++ b/frontend/app/(main)/page.tsx
@@ -58,6 +58,8 @@ export default function HomePage() {
       const response = await fetch(`/api/retrieve/meeting/${meetingId}`, { method: 'GET' });
       if (response.ok) {
         const data: IMeeting = await response.json();
+        // Batched: keeps the old panel on screen until the new meeting is ready.
+        setShowEditMeeting(false);
         setSelectedMeeting(data);
         // Store the date that was clicked when the meeting was selected
         setLastClickedDate(new Date(selectedDate));
@@ -74,10 +76,10 @@ export default function HomePage() {
   };
 
   useEffect(() => {
-    setShowEditMeeting(false);
     if (selectedMeetingID) {
       fetchMeetingDetails(selectedMeetingID);
     } else {
+      setShowEditMeeting(false);
       setSelectedMeeting(null);
       setLastClickedDate(null);
     }

--- a/frontend/app/(main)/page.tsx
+++ b/frontend/app/(main)/page.tsx
@@ -74,6 +74,7 @@ export default function HomePage() {
   };
 
   useEffect(() => {
+    setShowEditMeeting(false);
     if (selectedMeetingID) {
       fetchMeetingDetails(selectedMeetingID);
     } else {
@@ -174,6 +175,7 @@ export default function HomePage() {
             />) :
             selectedMeeting ? (
               <ViewMeetingDetails
+                key={selectedMeeting.mid}
                 mid={selectedMeeting.mid}
                 title={selectedMeeting.title}
                 description={selectedMeeting.description}

--- a/frontend/app/components/organisms/DailyView.tsx
+++ b/frontend/app/components/organisms/DailyView.tsx
@@ -177,12 +177,12 @@ const DailyView: React.FC<DailyViewProps> = ({
     if (requestId === fetchRequestIdRef.current) {
       setMeetings(data);
       updateTimePosition();
-      scrollToCurrentTime();
     }
   };
 
   useEffect(() => {
     fetchData();
+    scrollToCurrentTime();
 
     const intervalId = setInterval(updateTimePosition, 60000);
 

--- a/frontend/test/e2e/03-meeting-editing.spec.ts
+++ b/frontend/test/e2e/03-meeting-editing.spec.ts
@@ -2,6 +2,19 @@ import { test, expect } from "./support/fixtures";
 import { fillTimeRange } from "./support/formHelpers";
 import { seedMeeting } from "../factories/meeting";
 import { getTestPrismaClient } from "../factories/db";
+import { convertETToUTC, formatETDateString } from "../../util/timeUtils";
+
+// seedMeeting defaults every meeting to the same 18:00-19:00 ET slot in the same room, so two
+// seeded in one test would render as fully overlapping, unclickable calendar cards in Day view
+// (which — unlike Week view — has no overlap-splitting layout). Give the second meeting a
+// distinct time to keep both cards independently clickable.
+function laterSlot() {
+  const etDate = formatETDateString(new Date());
+  return {
+    startDateTime: new Date(convertETToUTC(`${etDate}T20:00:00`)),
+    endDateTime: new Date(convertETToUTC(`${etDate}T21:00:00`)),
+  };
+}
 
 // Manual script §3 (Meeting Editing). §3.5/3.6 (Zoom-room mode switches) live in
 // 06-zoom-integration.spec.ts.
@@ -87,5 +100,39 @@ test.describe("meeting editing", () => {
     const all = await prisma.meeting.findMany({ where: { mid: meeting.mid } });
     expect(all).toHaveLength(1);
     expect(all[0].title).toBe("Recurring Series Renamed");
+  });
+
+  test("3.6 opening a different meeting closes an in-progress edit panel", async ({ adminPage }) => {
+    const { page } = adminPage;
+    await seedMeeting({ title: "Edit Panel A" });
+    await seedMeeting({ title: "Edit Panel B", ...laterSlot() });
+    await page.goto("/");
+
+    await openMeeting(page, "Edit Panel A");
+    await openEditFromDetails(page);
+    await expect(page.getByRole("heading", { name: "Edit Meeting" })).toBeVisible();
+
+    // level: 3 disambiguates the calendar card from ViewMeeting's <h1>.
+    await page.getByRole("heading", { name: "Edit Panel B", exact: true, level: 3 }).click();
+
+    await expect(page.getByRole("heading", { name: "Edit Meeting" })).toHaveCount(0);
+    await expect(page.getByRole("heading", { level: 1, name: "Edit Panel B" })).toBeVisible();
+  });
+
+  test("3.7 opening a different meeting doesn't carry over a stale sync-error banner", async ({ adminPage }) => {
+    const { page } = adminPage;
+    await seedMeeting({ title: "Sync Error Meeting", syncStatus: "error" });
+    await seedMeeting({ title: "Synced Meeting", ...laterSlot() });
+    await page.goto("/");
+
+    await openMeeting(page, "Sync Error Meeting");
+    await expect(page.getByText("Google Calendar sync failed")).toBeVisible();
+    await expect(page.getByRole("button", { name: "Retry sync" })).toBeVisible();
+
+    await page.getByRole("heading", { name: "Synced Meeting", exact: true, level: 3 }).click();
+
+    await expect(page.getByText("Google Calendar sync failed")).toHaveCount(0);
+    await expect(page.getByRole("button", { name: "Retry sync" })).toHaveCount(0);
+    await expect(page.getByRole("heading", { level: 1, name: "Synced Meeting" })).toBeVisible();
   });
 });

--- a/frontend/test/e2e/03-meeting-editing.spec.ts
+++ b/frontend/test/e2e/03-meeting-editing.spec.ts
@@ -4,10 +4,7 @@ import { seedMeeting } from "../factories/meeting";
 import { getTestPrismaClient } from "../factories/db";
 import { convertETToUTC, formatETDateString } from "../../util/timeUtils";
 
-// seedMeeting defaults every meeting to the same 18:00-19:00 ET slot in the same room, so two
-// seeded in one test would render as fully overlapping, unclickable calendar cards in Day view
-// (which — unlike Week view — has no overlap-splitting layout). Give the second meeting a
-// distinct time to keep both cards independently clickable.
+// Avoids overlapping the default 18:00-19:00 seeded slot, which Day view can't visually split.
 function laterSlot() {
   const etDate = formatETDateString(new Date());
   return {


### PR DESCRIPTION
## Description
- **frontend/app/(main)/page.tsx**: clicking a different meeting while one was already open
  (in view or edit mode) left stale UI behind — `showEditMeeting` never reset, so the edit panel
  could stay open showing the newly clicked meeting's data still in edit mode; `ViewMeetingDetails`
  reused the same component instance across meetings, so its local sync-status banner could leak
  from the previous meeting. Fixed by resetting `showEditMeeting` and adding
  `key={selectedMeeting.mid}`, batched together with the new meeting's data once fetched so the
  previous panel stays on screen unchanged until the new one is ready (no flash of stale data or a
  blank sidebar in between).
- **frontend/app/components/organisms/DailyView.tsx**: `scrollToCurrentTime()` ran on every
  `refreshTrigger` bump, not just initial load/date navigation — so every meeting create/update/
  delete (and the 30s auto-refresh) snapped Day View's horizontal scroll back to "now," discarding
  wherever the user had scrolled. Now only runs on mount/date change.
- **frontend/test/e2e/03-meeting-editing.spec.ts**: added tests 3.6/3.7 covering the two
  modal-switch fixes above (verified both fail without the fix, pass with it).
- **.github/dependabot.yml, .github/workflows/dependabot-auto-merge.yml**: added a `dev-patch`
  Dependabot group (devDependencies, patch-level only) and a workflow that auto-merges PRs in that
  group once all CI checks pass. Production dependencies, majors, and GitHub Actions bumps are
  left as individual PRs for manual review — auto-merge doesn't bypass required status checks, it
  only removes the manual click once CI is green for the narrow, low-risk group.

## Testing
- [x] `yarn tsc --noEmit`
- [x] `yarn playwright test test/e2e/03-meeting-editing.spec.ts test/e2e/04-meeting-deletion.spec.ts test/e2e/05-calendar-display.spec.ts`
- [x] Manually: open a meeting, click Edit, then click a different meeting on the calendar —
      confirm it opens in view mode (not edit) with no flash of the previous meeting
- [x] Manually: delete a meeting after scrolling Day View away from the current-time position —
      confirm the scroll position isn't reset
- [x] Confirm branch protection on `master` has "require status checks" and "allow auto-merge"
      enabled (needed for the Dependabot workflow to actually merge anything)