### PR TITLE
Suppress hydration warning from browser-extension-injected attributes

### DIFF
--- a/frontend/app/ClientLayout.tsx
+++ b/frontend/app/ClientLayout.tsx
@@ -20,7 +20,10 @@ export default function ClientLayout({
         <html lang="en">
             <head>
             </head>
-            <body className={inter.className}>
+            {/* suppressHydrationWarning: some browser extensions (e.g. security/wallet
+                extensions) inject attributes like bis_register onto <body> before React
+                hydrates — a real mismatch, but not one our code can control or should warn on. */}
+            <body className={inter.className} suppressHydrationWarning>
                 <div className={styles.mainlayout}>
                     <div className={styles.navigation}>
                         <AppNavbar session={session} />


### PR DESCRIPTION
## Summary
- Adds `suppressHydrationWarning` to `<body>` — browser extensions (e.g. security/wallet extensions) inject attributes like `bis_register` before React hydrates, producing a hydration-mismatch warning that isn't caused by or actionable in our code.

## Test plan
- [x] `yarn tsc --noEmit` clean
- [ ] Confirm the hydration warning no longer appears in the console with an extension that injects body attributes installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented misleading hydration warnings caused by browser extensions modifying page attributes before the app loads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->