### PR TITLE
Fix Category/Location Type export showing raw pseudo-enum values

### DIFF
--- a/frontend/app/api/export/meetings/route.ts
+++ b/frontend/app/api/export/meetings/route.ts
@@ -6,17 +6,6 @@ import { prisma } from "../../../../lib/prisma";
 
 const notDeleted = { OR: [{ deletedAt: null }, { deletedAt: { isSet: false } }] };
 
-const CATEGORY_LABELS: Record<string, string> = {
-  "Al-Anon": "AL_ANON",
-  Other: "OTHER",
-};
-
-const LOCATION_TYPE_LABELS: Record<string, string> = {
-  Hybrid: "HYBRID",
-  Remote: "ONLINE_ONLY",
-  "In Person": "IN_PERSON",
-};
-
 type MeetingWithRecurrence = Awaited<ReturnType<typeof loadMeetings>>[number];
 
 function formatETDate(date: Date): string {
@@ -72,14 +61,14 @@ export const GET = async () => {
       "Meeting ID": `M${String(i + 1).padStart(3, "0")}`,
       "Meeting Name": meeting.title,
       Status: meeting.status ?? "Active",
-      Category: meeting.calType.map((c) => CATEGORY_LABELS[c] ?? c).join(", "),
+      Category: meeting.calType.join(", "),
       Day: formatDayColumn(meeting.recurrencePattern),
       Frequency: formatFrequencyColumn(meeting.recurrencePattern),
       "Start Date": formatETDate(meeting.startDateTime),
       "Start Time": formatETTime(meeting.startDateTime),
       "End Date": formatETDate(meeting.endDateTime),
       "End Time": formatETTime(meeting.endDateTime),
-      "Location Type": LOCATION_TYPE_LABELS[meeting.modeType] ?? meeting.modeType,
+      "Location Type": meeting.modeType,
       "Physical Room": meeting.room,
       "Zoom Room": meeting.zoomRoom ?? "",
       "Contact Email": meeting.email,


### PR DESCRIPTION
## Summary
- `CATEGORY_LABELS`/`LOCATION_TYPE_LABELS` in `export/meetings/route.ts` were keyed backwards — keyed by the already-correct human-readable value (e.g. `"Al-Anon"`), mapping to a pseudo-enum string (`"AL_ANON"`) that's never actually stored anywhere in the DB.
- `calType`/`modeType` are stored as the human-readable label directly (see `hooks/useMeetingForm.ts`'s `CAL_TYPE_OPTIONS = ["AA", "Al-Anon", "Other"]` and `ModeTypeButtons.tsx`'s `"Hybrid"`/`"In Person"`/`"Remote"`) — there's no enum-style DB representation at all.
- Export was mangling already-correct data into `AL_ANON`/`OTHER`/`HYBRID`/`ONLINE_ONLY`/`IN_PERSON` on the way out. Removed the mistaken translation layer entirely; values now pass through unchanged.

## Test plan
- [x] `yarn tsc --noEmit` clean
- [ ] Export meetings, confirm Category/Location Type columns show human-readable values (`Al-Anon`, `Other`, `Hybrid`, `Remote`, `In Person`) instead of pseudo-enum strings