### PR TITLE
Add XLSX bulk import for meetings

### DIFF
--- a/docs/testing/manual-test-script-template.md
+++ b/docs/testing/manual-test-script-template.md
@@ -124,12 +124,14 @@
 
 ## 11. Admin Panel — Roles & Tabs
 
-> **Automated:** `frontend/test/e2e/11-admin-panel.spec.ts` — the case below needs live Zoom/Google
-> reachability checks against the real services.
+> **Automated:** `frontend/test/e2e/11-admin-panel.spec.ts` — 11.1 needs live Zoom/Google
+> reachability checks against the real services; 11.2/11.3 (import) don't.
 
 | # | Step | Expected Result | Pass/Fail | Notes |
 |---|------|-----------------|-----------|-------|
 | 11.1 | Diagnostics tab | System Status card shows DB latency, Google Calendar reachability per category (AA/Al-Anon/Other), and Zoom account reachability + per-room calendar status + per-host pool status | | |
+| 11.2 | Import a spreadsheet (Admin → Import) with a valid new meeting row | Row shows "✓ Created", and the meeting appears on the live calendar | | |
+| 11.3 | Import a spreadsheet with one row duplicating an existing meeting (same title + schedule) and one row that conflicts with an existing meeting's room/time | Duplicate row shows "⊘ Skipped"; conflicting row shows "⚠ Created with conflict" and is still created; both the conflict note under the results table and the Diagnostics Conflicts panel reflect it | | |
 
 ---
 

--- a/docs/testing/manual-test-script-template.md
+++ b/docs/testing/manual-test-script-template.md
@@ -72,7 +72,8 @@
 
 > **Automated (fail-soft path + auto-pairing logic):** `frontend/test/e2e/06-zoom-integration.spec.ts`
 > — most cases below require live Zoom/Google credentials to verify against the real services.
-> 6.11 (host-pool exhaustion) doesn't — see `frontend/test/integration/write-meeting-route.test.ts`.
+> 6.10/6.11 (conflicts, host-pool exhaustion) don't — they're covered by
+> `frontend/test/e2e/11-admin-panel.spec.ts`'s conflict-detection cases with zero real network calls.
 
 | # | Step | Expected Result | Pass/Fail | Notes |
 |---|------|-----------------|-----------|-------|
@@ -85,6 +86,7 @@
 | 6.7 | On `/admin` → Diagnostics, check the Zoom status row | Shows account reachability, a per-room Zoom Calendar breakdown, and a separate per-host breakdown of the shared host pool (resolves + whether Licensed) | | |
 | 6.8 | Temporarily remove one email from `ZOOM_HOSTS`, reload Diagnostics | That host no longer appears in the pool breakdown and the "N/M pooled hosts OK" count drops by one; other hosts/rooms are unaffected | | |
 | 6.9 | Force a Zoom sync failure (e.g. temporarily use an invalid `ZOOM_CLIENT_SECRET`) | Meeting shows a Zoom-specific ⚠ status separate from the Google Calendar one; Diagnostics' Meeting Counts card shows a nonzero Zoom sync-error count; **Retry sync** clears both once credentials are fixed | | |
+| 6.10 | Create two meetings in the same room (or same Zoom Room) at overlapping times, then check Diagnostics' Conflicts panel | Both meetings appear together in a conflict row, grouped by the shared room/Zoom Room; meetings in different rooms or non-overlapping times are not flagged | | |
 | 6.11 | Set `ZOOM_HOSTS` to a single email, then create two Zoom-enabled meetings at overlapping times (different rooms) | The first gets a real Zoom meeting; the second is still created but shows "Zoom sync failed ⚠: No Zoom host available…" with a working **Retry sync** button | | |
 
 ---

--- a/frontend/app/api/admin/diagnostics/route.ts
+++ b/frontend/app/api/admin/diagnostics/route.ts
@@ -3,6 +3,7 @@ import { NextResponse } from "next/server";
 import { requireRole } from "../../../../services/auth";
 import { calendarIdForCategory, checkCalendarReachable } from "../../../../services/googleCalendar";
 import { checkZoomReachable, zoomRoomCalendarId, checkZoomHostPool } from "../../../../services/zoom";
+import { computeConflicts } from "../../../../util/resourceOverlap";
 import { prisma } from "../../../../lib/prisma";
 
 const notDeleted = { OR: [{ deletedAt: null }, { deletedAt: { isSet: false } }] };
@@ -10,8 +11,7 @@ const notDeleted = { OR: [{ deletedAt: null }, { deletedAt: { isSet: false } }] 
 // Diagnostics for the Admin page's Diagnostics tab: DB health, GCal reachability per
 // category, Zoom account reachability, per-room Zoom calendar validity, per-host Zoom pool
 // validity (host existence and licensed-vs-basic status), meeting counts (incl. sync-error
-// counts), and a list of currently suspended meetings. Conflict detection is stubbed (empty)
-// until the overlap-detection endpoint lands.
+// counts), room/Zoom-room conflicts, and a list of currently suspended meetings.
 export const GET = async () => {
   try {
     const auth = await requireRole(Role.ADMIN);
@@ -47,7 +47,11 @@ export const GET = async () => {
 
     const meetings = await prisma.meeting.findMany({
       where: notDeleted,
-      select: { status: true, calType: true, isRecurring: true, syncStatus: true, zoomRoom: true, zoomSyncStatus: true },
+      select: {
+        mid: true, title: true, status: true, calType: true, isRecurring: true,
+        syncStatus: true, zoomRoom: true, zoomSyncStatus: true, room: true,
+        startDateTime: true, endDateTime: true, recurrencePattern: true,
+      },
     });
 
     const byCategory: Record<string, number> = {};
@@ -89,7 +93,7 @@ export const GET = async () => {
         gcalSyncErrors,
         zoomSyncErrors,
       },
-      conflicts: [],
+      conflicts: computeConflicts(meetings),
       suspendedMeetings,
     });
   } catch (error) {

--- a/frontend/app/api/export/meetings/route.ts
+++ b/frontend/app/api/export/meetings/route.ts
@@ -6,17 +6,6 @@ import { prisma } from "../../../../lib/prisma";
 
 const notDeleted = { OR: [{ deletedAt: null }, { deletedAt: { isSet: false } }] };
 
-const CATEGORY_LABELS: Record<string, string> = {
-  "Al-Anon": "AL_ANON",
-  Other: "OTHER",
-};
-
-const LOCATION_TYPE_LABELS: Record<string, string> = {
-  Hybrid: "HYBRID",
-  Remote: "ONLINE_ONLY",
-  "In Person": "IN_PERSON",
-};
-
 type MeetingWithRecurrence = Awaited<ReturnType<typeof loadMeetings>>[number];
 
 function formatETDate(date: Date): string {
@@ -72,14 +61,14 @@ export const GET = async () => {
       "Meeting ID": `M${String(i + 1).padStart(3, "0")}`,
       "Meeting Name": meeting.title,
       Status: meeting.status ?? "Active",
-      Category: meeting.calType.map((c) => CATEGORY_LABELS[c] ?? c).join(", "),
+      Category: meeting.calType.join(", "),
       Day: formatDayColumn(meeting.recurrencePattern),
       Frequency: formatFrequencyColumn(meeting.recurrencePattern),
       "Start Date": formatETDate(meeting.startDateTime),
       "Start Time": formatETTime(meeting.startDateTime),
       "End Date": formatETDate(meeting.endDateTime),
       "End Time": formatETTime(meeting.endDateTime),
-      "Location Type": LOCATION_TYPE_LABELS[meeting.modeType] ?? meeting.modeType,
+      "Location Type": meeting.modeType,
       "Physical Room": meeting.room,
       "Zoom Room": meeting.zoomRoom ?? "",
       "Contact Email": meeting.email,

--- a/frontend/app/api/import/meetings/route.ts
+++ b/frontend/app/api/import/meetings/route.ts
@@ -1,0 +1,241 @@
+import * as XLSX from "xlsx";
+import { Role } from "@prisma/client";
+import { NextResponse, after } from "next/server";
+import { requireRole } from "../../../../services/auth";
+import { createCalendarEvent, calendarIdsForMeeting } from "../../../../services/googleCalendar";
+import { createZoomMeeting, resolveZoomHost, zoomRoomCalendarId } from "../../../../services/zoom";
+import { findResourceConflicts, ConflictRow, OccupiedClaim } from "../../../../util/resourceOverlap";
+import { parseImportRow } from "../../../../util/importParsing";
+import { IMeeting } from "../../../../util/models";
+import { prisma } from "../../../../lib/prisma";
+
+const notDeleted = { OR: [{ deletedAt: null }, { deletedAt: { isSet: false } }] };
+
+type ImportStatus = "created" | "conflict" | "skipped" | "errored";
+
+interface ImportResultRow {
+  meeting: string;
+  status: ImportStatus;
+  note?: string;
+}
+
+// A row that was created and still needs the slow GCal/Zoom sync half, run after the response
+// is sent — mirrors write/meeting/route.ts's syncNewMeeting, but batched, and reusing the Zoom
+// host this row already claimed in the sequential loop below instead of re-resolving it (that
+// resolution happening sequentially, before any DB writes race, is what avoids two rows in the
+// same batch grabbing the same host).
+type PendingSync = {
+  mid: string;
+  meetingData: IMeeting;
+  resolvedHost: string | null;
+};
+
+const toClaim = (meeting: IMeeting, value: string): OccupiedClaim => ({
+  mid: meeting.mid,
+  title: meeting.title,
+  value,
+  startDateTime: meeting.startDateTime,
+  endDateTime: meeting.endDateTime,
+  isRecurring: meeting.isRecurring,
+  recurrencePattern: meeting.recurrencePattern,
+});
+
+async function syncImportedRow(pending: PendingSync, accessToken: string | undefined): Promise<void> {
+  const { mid, meetingData, resolvedHost } = pending;
+
+  if (accessToken && meetingData.status !== "Suspended") {
+    const calendarIds = calendarIdsForMeeting(meetingData.calType ?? []);
+    const eventIds: Record<string, string> = {};
+    for (const [cat, calId] of Object.entries(calendarIds)) {
+      const id = await createCalendarEvent(accessToken, meetingData, calId);
+      if (id) eventIds[cat] = id;
+    }
+    const synced = Object.keys(eventIds).length === Object.keys(calendarIds).length && Object.keys(calendarIds).length > 0;
+    await prisma.meeting.update({
+      where: { mid },
+      data: { googleCalendarEventIds: eventIds, syncStatus: synced ? "synced" : "error" },
+    });
+  }
+
+  if (meetingData.zoomRoom && meetingData.status !== "Suspended") {
+    let zid: string | null = null;
+    let zoomLink: string | null = null;
+    let zoomCalendarEventId: string | null = null;
+    let zoomHost = resolvedHost;
+    let zoomSynced = true;
+    let zoomSyncError: string | null = null;
+
+    if (!resolvedHost) {
+      zoomSynced = false;
+      zoomSyncError = "No Zoom host available for this meeting's schedule (pool exhausted).";
+    } else {
+      const created = await createZoomMeeting(meetingData, resolvedHost);
+      if (created) {
+        zid = created.zid;
+        zoomLink = created.zoomLink;
+      } else {
+        zoomSynced = false;
+        zoomHost = null;
+        zoomSyncError = "Failed to create the Zoom meeting.";
+      }
+    }
+
+    if (accessToken && zoomLink) {
+      const calId = zoomRoomCalendarId[meetingData.zoomRoom];
+      if (calId) {
+        const eventId = await createCalendarEvent(accessToken, { ...meetingData, zoomLink }, calId, zoomLink);
+        if (eventId) zoomCalendarEventId = eventId;
+        else {
+          zoomSynced = false;
+          zoomSyncError = zoomSyncError ?? "Zoom meeting created but its calendar event failed to sync.";
+        }
+      }
+    }
+
+    await prisma.meeting.update({
+      where: { mid },
+      data: {
+        zid, zoomLink, zoomHost, zoomCalendarEventId,
+        zoomSyncStatus: zoomSynced ? "synced" : "error",
+        zoomSyncError: zoomSynced ? null : zoomSyncError,
+      },
+    });
+  }
+}
+
+// Host collisions were already avoided sequentially in the POST handler below — safe to run
+// the slow network half in parallel per row now.
+async function syncImportedRows(pending: PendingSync[], accessToken: string | undefined): Promise<void> {
+  await Promise.all(pending.map((p) => syncImportedRow(p, accessToken)));
+}
+
+const duplicateKey = (title: string, start: Date, end: Date) => `${title}|${start.toISOString()}|${end.toISOString()}`;
+
+const importMeetings = async (request: Request): Promise<Response> => {
+  try {
+    const auth = await requireRole(Role.SUPER_ADMIN);
+    if (auth instanceof Response) return auth;
+
+    const formData = await request.formData();
+    const file = formData.get("file");
+    if (!(file instanceof Blob)) {
+      return NextResponse.json({ error: "No file uploaded" }, { status: 400 });
+    }
+
+    const buffer = Buffer.from(await file.arrayBuffer());
+    const workbook = XLSX.read(buffer, { type: "buffer", cellDates: true });
+    const sheetName = workbook.SheetNames[0];
+    if (!sheetName) {
+      return NextResponse.json({ error: "Spreadsheet has no sheets" }, { status: 400 });
+    }
+    const rawRows = XLSX.utils.sheet_to_json(workbook.Sheets[sheetName]);
+
+    const results: ImportResultRow[] = [];
+    const conflicts: ConflictRow[] = [];
+    const pendingSync: PendingSync[] = [];
+
+    const seenInBatch = new Set<string>();
+    const roomClaims: OccupiedClaim[] = [];
+    const zoomRoomClaims: OccupiedClaim[] = [];
+    const zoomHostClaims: OccupiedClaim[] = [];
+
+    // Sequential, not Promise.all: two rows needing a Zoom host in the same batch must not
+    // race for the same one — findResourceConflicts/resolveZoomHost see each prior row's claim
+    // via extraOccupied immediately, before it's committed to the DB.
+    for (let i = 0; i < rawRows.length; i++) {
+      const parsedRow = parseImportRow(rawRows[i], i);
+
+      if (!parsedRow.ok) {
+        results.push({ meeting: "—", status: "errored", note: parsedRow.error });
+        continue;
+      }
+
+      const { meeting } = parsedRow.row;
+
+      const dupKey = duplicateKey(meeting.title, meeting.startDateTime, meeting.endDateTime);
+      const isDuplicate = seenInBatch.has(dupKey) || (await prisma.meeting.findFirst({
+        where: {
+          ...notDeleted,
+          title: meeting.title,
+          startDateTime: meeting.startDateTime,
+          endDateTime: meeting.endDateTime,
+        },
+        select: { mid: true },
+      })) !== null;
+      if (isDuplicate) {
+        results.push({ meeting: meeting.title, status: "skipped", note: "already exists (matched by title + schedule)" });
+        continue;
+      }
+
+      const rowConflicts: { mid: string; title: string }[] = [];
+
+      const roomConflicts = await findResourceConflicts("room", meeting.room, meeting, { extraOccupied: roomClaims });
+      if (roomConflicts.length > 0) {
+        rowConflicts.push(...roomConflicts);
+        conflicts.push({
+          field: "room", value: meeting.room,
+          meetings: [{ mid: meeting.mid, title: meeting.title }, ...roomConflicts],
+        });
+      }
+
+      if (meeting.zoomRoom) {
+        const zoomRoomConflicts = await findResourceConflicts("zoomRoom", meeting.zoomRoom, meeting, { extraOccupied: zoomRoomClaims });
+        if (zoomRoomConflicts.length > 0) {
+          rowConflicts.push(...zoomRoomConflicts);
+          conflicts.push({
+            field: "zoomRoom", value: meeting.zoomRoom,
+            meetings: [{ mid: meeting.mid, title: meeting.title }, ...zoomRoomConflicts],
+          });
+        }
+      }
+
+      const needsZoom = !!meeting.zoomRoom && meeting.status !== "Suspended";
+      const resolvedHost = needsZoom ? await resolveZoomHost(meeting, { extraOccupied: zoomHostClaims }) : null;
+
+      const { recurrencePattern, ...meetingFields } = meeting;
+      const newMeeting = await prisma.meeting.create({ data: meetingFields });
+
+      if (recurrencePattern) {
+        await prisma.recurrencePattern.create({
+          data: {
+            mid: newMeeting.mid,
+            type: recurrencePattern.type,
+            startDate: recurrencePattern.startDate,
+            endDate: recurrencePattern.endDate ?? undefined,
+            daysOfWeek: recurrencePattern.daysOfWeek ?? [],
+            firstDayOfWeek: recurrencePattern.firstDayOfWeek || "Sunday",
+            interval: recurrencePattern.interval || 1,
+            weekOfMonth: recurrencePattern.weekOfMonth ?? null,
+            dayOfMonth: recurrencePattern.dayOfMonth ?? null,
+          },
+        });
+      }
+
+      seenInBatch.add(dupKey);
+      roomClaims.push(toClaim(meeting, meeting.room));
+      if (meeting.zoomRoom) zoomRoomClaims.push(toClaim(meeting, meeting.zoomRoom));
+      if (resolvedHost) zoomHostClaims.push(toClaim(meeting, resolvedHost));
+
+      pendingSync.push({ mid: newMeeting.mid, meetingData: meeting, resolvedHost });
+
+      results.push({
+        meeting: meeting.title,
+        status: rowConflicts.length > 0 ? "conflict" : "created",
+        note: rowConflicts.length > 0
+          ? `conflicts with ${rowConflicts.map((c) => c.title).join(", ")}`
+          : undefined,
+      });
+    }
+
+    if (pendingSync.length > 0) {
+      after(syncImportedRows(pendingSync, auth.accessToken));
+    }
+
+    return NextResponse.json({ results, conflicts });
+  } catch (error) {
+    console.error("Error importing meetings:", error);
+    return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+  }
+};
+
+export { importMeetings as POST };

--- a/frontend/app/components/molecules/ConflictList.tsx
+++ b/frontend/app/components/molecules/ConflictList.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import React from "react";
+import styles from "../../../styles/components/molecules/ConflictList.module.scss";
+
+export interface ConflictListRow {
+  field: "room" | "zoomRoom";
+  value: string;
+  meetings: { mid: string; title: string }[];
+}
+
+interface ConflictListProps {
+  conflicts: ConflictListRow[];
+  emptyLabel?: string;
+}
+
+const fieldLabel = (field: "room" | "zoomRoom"): string => (field === "room" ? "Room" : "Zoom Room");
+
+// Shared by DiagnosticsTab's Conflicts panel and ImportTab's post-import results — same
+// resource-conflict shape (see util/resourceOverlap.ts's ConflictRow), rendered the same way
+// in both places so a Super Admin importing meetings sees exactly what Diagnostics would flag.
+const ConflictList: React.FC<ConflictListProps> = ({ conflicts, emptyLabel = "No conflicts detected." }) => {
+  if (conflicts.length === 0) {
+    return <div className={styles.emptyState}>{emptyLabel}</div>;
+  }
+
+  return (
+    <div data-testid="conflict-list">
+      {conflicts.map((conflict, i) => (
+        <div key={`${conflict.field}-${conflict.value}-${i}`} className={styles.conflictRow}>
+          <div className={styles.conflictMeta}>
+            {fieldLabel(conflict.field)}: <span className={styles.conflictValue}>{conflict.value}</span>
+          </div>
+          <div className={styles.conflictTitles}>
+            {conflict.meetings.map((m) => m.title).join(" ↔ ")}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default ConflictList;

--- a/frontend/app/components/organisms/DiagnosticsTab.tsx
+++ b/frontend/app/components/organisms/DiagnosticsTab.tsx
@@ -3,6 +3,7 @@
 import React, { useEffect, useState } from "react";
 import type { Role } from "@prisma/client";
 import StatCounter from "../atoms/StatCounter";
+import ConflictList, { ConflictListRow } from "../molecules/ConflictList";
 import styles from "../../../styles/components/organisms/DiagnosticsTab.module.scss";
 
 interface DiagnosticsTabProps {
@@ -29,7 +30,7 @@ interface DiagnosticsData {
     gcalSyncErrors: number;
     zoomSyncErrors: number;
   };
-  conflicts: unknown[];
+  conflicts: ConflictListRow[];
   suspendedMeetings: {
     mid: string;
     title: string;
@@ -173,11 +174,9 @@ const DiagnosticsTab: React.FC<DiagnosticsTabProps> = ({ email, role }) => {
       <div className={styles.card} data-testid="diagnostics-conflicts-panel">
         <div className={styles.panelHeader}>⚠ Conflicts ({data.conflicts.length})</div>
         <div className={styles.panelSubhead}>
-          These meetings share a room or Zoom account at overlapping times. Review and edit one to resolve.
+          These meetings share a room or Zoom room at overlapping times. Review and edit one to resolve.
         </div>
-        {data.conflicts.length === 0 && (
-          <div className={styles.emptyState}>No conflicts detected.</div>
-        )}
+        <ConflictList conflicts={data.conflicts} />
       </div>
 
       <div className={styles.card} data-testid="diagnostics-suspended-panel">

--- a/frontend/app/components/organisms/ImportTab.tsx
+++ b/frontend/app/components/organisms/ImportTab.tsx
@@ -4,6 +4,7 @@ import React, { useState } from "react";
 import UploadFileIcon from "@mui/icons-material/UploadFile";
 import CardHeader from "../molecules/CardHeader";
 import StatusPill, { StatusPillVariant } from "../atoms/StatusPill";
+import ConflictList, { ConflictListRow } from "../molecules/ConflictList";
 import styles from "../../../styles/components/organisms/ImportTab.module.scss";
 
 type ImportStatus = "created" | "conflict" | "skipped" | "errored";
@@ -30,18 +31,6 @@ const STATUS_VARIANT: Record<ImportStatus, StatusPillVariant> = {
   errored: "error",
 };
 
-// Stands in for a parsed spreadsheet so the Results UI can be reviewed before the
-// real endpoint exists — replace with the POST /api/import/meetings response in Ticket B.
-const MOCK_RESULTS: ImportResultRow[] = [
-  { meeting: "Serenity Fellowship", status: "created" },
-  { meeting: "Seeds of Hope Group", status: "created" },
-  { meeting: "Unity Big Book Study", status: "conflict", note: "conflicts with Unity Fellowship (Tue 7PM)" },
-  { meeting: "Gratitude Group", status: "created" },
-  { meeting: "Acceptance Speaker Meeting", status: "skipped", note: "already exists (matched by title + schedule)" },
-  { meeting: "—", status: "errored", note: "invalid email" },
-  { meeting: "Improvement Step Study", status: "created" },
-];
-
 const formatMeetingId = (index: number) => `M${String(index + 1).padStart(3, "0")}`;
 
 const ImportTab: React.FC = () => {
@@ -49,21 +38,38 @@ const ImportTab: React.FC = () => {
   const [dragOver, setDragOver] = useState(false);
   const [importing, setImporting] = useState(false);
   const [results, setResults] = useState<ImportResultRow[] | null>(null);
+  const [conflicts, setConflicts] = useState<ConflictListRow[]>([]);
+  const [error, setError] = useState<string | null>(null);
 
   const chooseFile = (next: File | null) => {
     setFile(next);
     setResults(null);
+    setConflicts([]);
+    setError(null);
   };
 
-  const handleImport = () => {
+  const handleImport = async () => {
     if (!file) return;
     setImporting(true);
     setResults(null);
-    // TODO (Import XLSX): replace this timeout with a real POST /api/import/meetings call.
-    setTimeout(() => {
-      setResults(MOCK_RESULTS);
+    setConflicts([]);
+    setError(null);
+    try {
+      const formData = new FormData();
+      formData.append("file", file);
+      const res = await fetch("/api/import/meetings", { method: "POST", body: formData });
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data.error ?? "Import failed.");
+        return;
+      }
+      setResults(data.results ?? []);
+      setConflicts(data.conflicts ?? []);
+    } catch {
+      setError("Import failed.");
+    } finally {
       setImporting(false);
-    }, 800);
+    }
   };
 
   const counts = results && STATUS_ORDER.reduce((acc, status) => {
@@ -109,6 +115,7 @@ const ImportTab: React.FC = () => {
             {importing ? "Importing…" : "Upload & Import"}
           </button>
         </div>
+        {error && <div className={styles.resultNote} data-testid="import-error">{error}</div>}
       </div>
 
       {results && counts && (
@@ -142,6 +149,13 @@ const ImportTab: React.FC = () => {
               ))}
             </tbody>
           </table>
+        </div>
+      )}
+
+      {conflicts.length > 0 && (
+        <div className={styles.card} data-testid="import-conflicts-panel">
+          <div className={styles.resultsHeader}>⚠ Conflicts found during import ({conflicts.length})</div>
+          <ConflictList conflicts={conflicts} />
         </div>
       )}
     </div>

--- a/frontend/styles/components/molecules/ConflictList.module.scss
+++ b/frontend/styles/components/molecules/ConflictList.module.scss
@@ -1,0 +1,31 @@
+@import '../../Variables.module.scss';
+
+.emptyState {
+  color: $medium-grey-color;
+  font-size: 14px;
+}
+
+.conflictRow {
+  border-top: 1px solid #F1F1F1;
+  padding: 10px 0;
+
+  &:first-of-type {
+    border-top: none;
+  }
+}
+
+.conflictMeta {
+  font-size: 13px;
+  color: #555;
+}
+
+.conflictValue {
+  font-weight: 600;
+  color: $black-color;
+}
+
+.conflictTitles {
+  font-size: 14px;
+  color: $black-color;
+  margin-top: 2px;
+}

--- a/frontend/test/e2e/11-admin-panel.spec.ts
+++ b/frontend/test/e2e/11-admin-panel.spec.ts
@@ -4,9 +4,9 @@ import { seedAdmin } from "../factories/admin";
 import { loginAs } from "./support/auth";
 import { Role } from "@prisma/client";
 
-// Manual script §11 (Admin Panel — Roles & Tabs). §11.3/§11.7 are the same
-// known-gap stubs covered in more detail by provisional.spec.ts (conflict detection,
-// XLSX import) — this file just confirms the panel renders their current stub state.
+// Manual script §11 (Admin Panel — Roles & Tabs). XLSX import (11.8) is still a known-gap
+// stub, covered in more detail by provisional.spec.ts — this file just confirms the panel
+// renders its current stub state until that lands too.
 
 test.describe("admin panel", () => {
   test("11.2 SUPER_ADMIN sees all four tabs accessible", async ({ superAdminPage }) => {
@@ -29,10 +29,22 @@ test.describe("admin panel", () => {
     await expect(page.getByText("AA: 2")).toBeVisible();
   });
 
-  test("11.4 double-booked meetings in the same room are not flagged as conflicts", async ({ superAdminPage }) => {
+  test("11.4 double-booked meetings in the same room are flagged as conflicts", async ({ superAdminPage }) => {
     const { page } = superAdminPage;
     await seedMeeting({ title: "Double Book A", room: "Serenity Room" });
     await seedMeeting({ title: "Double Book B", room: "Serenity Room" });
+    await page.goto("/admin");
+
+    const panel = page.getByTestId("diagnostics-conflicts-panel");
+    await expect(panel.getByText("⚠ Conflicts (1)")).toBeVisible();
+    await expect(panel.getByText("Double Book A", { exact: false })).toBeVisible();
+    await expect(panel.getByText("Double Book B", { exact: false })).toBeVisible();
+  });
+
+  test("11.4b meetings in different rooms are not flagged as conflicts", async ({ superAdminPage }) => {
+    const { page } = superAdminPage;
+    await seedMeeting({ title: "No Conflict A", room: "Serenity Room" });
+    await seedMeeting({ title: "No Conflict B", room: "Unity Room" });
     await page.goto("/admin");
 
     await expect(page.getByTestId("diagnostics-conflicts-panel").getByText("No conflicts detected.")).toBeVisible();

--- a/frontend/test/e2e/11-admin-panel.spec.ts
+++ b/frontend/test/e2e/11-admin-panel.spec.ts
@@ -1,12 +1,18 @@
+import * as XLSX from "xlsx";
 import { test, expect } from "./support/fixtures";
 import { seedMeeting } from "../factories/meeting";
 import { seedAdmin } from "../factories/admin";
 import { loginAs } from "./support/auth";
 import { Role } from "@prisma/client";
 
-// Manual script §11 (Admin Panel — Roles & Tabs). XLSX import (11.8) is still a known-gap
-// stub, covered in more detail by provisional.spec.ts — this file just confirms the panel
-// renders its current stub state until that lands too.
+// Manual script §11 (Admin Panel — Roles & Tabs).
+
+function buildImportWorkbook(rows: Record<string, string>[]): Buffer {
+  const worksheet = XLSX.utils.json_to_sheet(rows);
+  const workbook = XLSX.utils.book_new();
+  XLSX.utils.book_append_sheet(workbook, worksheet, "Meetings");
+  return XLSX.write(workbook, { type: "buffer", bookType: "xlsx" }) as Buffer;
+}
 
 test.describe("admin panel", () => {
   test("11.2 SUPER_ADMIN sees all four tabs accessible", async ({ superAdminPage }) => {
@@ -83,21 +89,75 @@ test.describe("admin panel", () => {
     await expect(page.getByText("Can't change the last Super Admin's role.")).toBeVisible();
   });
 
-  test("11.8 Import tab shows hardcoded mock results, not a real parse", async ({ superAdminPage }) => {
+  test("11.8 Import tab parses and creates a real meeting from an uploaded spreadsheet", async ({ superAdminPage }) => {
     const { page } = superAdminPage;
+    const workbook = buildImportWorkbook([{
+      "Meeting Name": "Imported Test Meeting",
+      Status: "Active",
+      Category: "AA",
+      Day: "One-time",
+      Frequency: "",
+      "Start Date": "12/01/2026",
+      "Start Time": "7:00 PM",
+      "End Time": "8:00 PM",
+      "Location Type": "In Person",
+      "Physical Room": "Serenity Room",
+      "Zoom Room": "",
+      "Contact Email": "import-test@icr.org",
+      Description: "",
+    }]);
+
     await page.goto("/admin");
     await page.getByTestId("admin-tab-import").click();
 
     await page.getByTestId("import-file-input").setInputFiles({
       name: "meetings.xlsx",
       mimeType: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-      buffer: Buffer.from("not a real spreadsheet"),
+      buffer: workbook,
     });
     await page.getByTestId("import-upload-button").click();
 
     await expect(page.getByTestId("import-results-table")).toBeVisible();
-    // MOCK_RESULTS in ImportTab.tsx — same regardless of the file's actual content.
-    await expect(page.getByText("Serenity Fellowship")).toBeVisible();
+    await expect(page.getByText("Imported Test Meeting")).toBeVisible();
+    await expect(page.getByText("✓ Created (1)")).toBeVisible();
+  });
+
+  test("11.8b Import tab skips a row that duplicates an existing meeting", async ({ superAdminPage }) => {
+    const { page } = superAdminPage;
+    // EST (UTC-5, no DST in December) — 8:00-9:00 PM ET on 12/01/2026 is 01:00-02:00 UTC on
+    // 12/02/2026; must match exactly for the duplicate-skip rule (title + exact schedule) to fire.
+    await seedMeeting({
+      title: "Already Exists",
+      startDateTime: new Date("2026-12-02T01:00:00.000Z"),
+      endDateTime: new Date("2026-12-02T02:00:00.000Z"),
+    });
+    const workbook = buildImportWorkbook([{
+      "Meeting Name": "Already Exists",
+      Status: "Active",
+      Category: "AA",
+      Day: "One-time",
+      Frequency: "",
+      "Start Date": "12/01/2026",
+      "Start Time": "8:00 PM",
+      "End Time": "9:00 PM",
+      "Location Type": "In Person",
+      "Physical Room": "Serenity Room",
+      "Zoom Room": "",
+      "Contact Email": "import-test@icr.org",
+      Description: "",
+    }]);
+
+    await page.goto("/admin");
+    await page.getByTestId("admin-tab-import").click();
+    await page.getByTestId("import-file-input").setInputFiles({
+      name: "meetings.xlsx",
+      mimeType: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+      buffer: workbook,
+    });
+    await page.getByTestId("import-upload-button").click();
+
+    await expect(page.getByTestId("import-results-table")).toBeVisible();
+    await expect(page.getByText("⊘ Skipped (1)")).toBeVisible();
   });
 
   test("11.9 exporting meetings downloads a real file", async ({ superAdminPage }) => {

--- a/frontend/test/e2e/provisional.spec.ts
+++ b/frontend/test/e2e/provisional.spec.ts
@@ -8,18 +8,9 @@ import { seedMeeting } from "../factories/meeting";
 // regression to revert — it means the real feature landed; delete/rewrite the test.
 
 test.describe("provisional — unimplemented features", () => {
-  test('[PROVISIONAL:conflict-detection] double-booked meetings are never flagged as conflicts', async ({ superAdminPage }) => {
-    const { page } = superAdminPage;
-    // app/api/admin/diagnostics/route.ts hardcodes `conflicts: []` — no overlap
-    // query exists yet, regardless of how many meetings actually collide.
-    await seedMeeting({ title: "Conflict Stub A", room: "Serenity Room" });
-    await seedMeeting({ title: "Conflict Stub B", room: "Serenity Room" });
-    await page.goto("/admin");
-
-    const panel = page.getByTestId("diagnostics-conflicts-panel");
-    await expect(panel.getByText("⚠ Conflicts (0)")).toBeVisible();
-    await expect(panel.getByText("No conflicts detected.")).toBeVisible();
-  });
+  // [PROVISIONAL:conflict-detection] was removed here — the feature landed (see
+  // test/e2e/11-admin-panel.spec.ts's 11.4, which now asserts the real behavior instead of
+  // the old stub).
 
   test("[PROVISIONAL:xlsx-import] Import always returns the same hardcoded mock results", async ({ superAdminPage }) => {
     const { page } = superAdminPage;

--- a/frontend/test/e2e/provisional.spec.ts
+++ b/frontend/test/e2e/provisional.spec.ts
@@ -8,29 +8,9 @@ import { seedMeeting } from "../factories/meeting";
 // regression to revert — it means the real feature landed; delete/rewrite the test.
 
 test.describe("provisional — unimplemented features", () => {
-  // [PROVISIONAL:conflict-detection] was removed here — the feature landed (see
-  // test/e2e/11-admin-panel.spec.ts's 11.4, which now asserts the real behavior instead of
-  // the old stub).
-
-  test("[PROVISIONAL:xlsx-import] Import always returns the same hardcoded mock results", async ({ superAdminPage }) => {
-    const { page } = superAdminPage;
-    // ImportTab.tsx's handleImport() has a `// TODO (Import XLSX): replace this
-    // timeout with a real POST /api/import/meetings call` — MOCK_RESULTS is
-    // returned unconditionally after an 800ms setTimeout, regardless of what (or
-    // whether) a file was actually uploaded. No app/api/import/ route exists.
-    await page.goto("/admin");
-    await page.getByTestId("admin-tab-import").click();
-    await page.getByTestId("import-file-input").setInputFiles({
-      name: "anything.xlsx",
-      mimeType: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-      buffer: Buffer.from("this content is never read"),
-    });
-    await page.getByTestId("import-upload-button").click();
-
-    await expect(page.getByText("Results: 7 rows processed")).toBeVisible();
-    await expect(page.getByText("Serenity Fellowship")).toBeVisible();
-    await expect(page.getByText("⚠ Created with conflict (1)")).toBeVisible();
-  });
+  // [PROVISIONAL:conflict-detection] and [PROVISIONAL:xlsx-import] were removed here —
+  // both features landed (see test/e2e/11-admin-panel.spec.ts's 11.4 and 11.8, which now
+  // assert the real behavior instead of the old stubs).
 
   test("[PROVISIONAL:suspend-workflow] a Suspended meeting is only reachable via direct DB write, never through the UI", async ({ superAdminPage }) => {
     const { page } = superAdminPage;

--- a/frontend/test/integration/import-meetings-route.test.ts
+++ b/frontend/test/integration/import-meetings-route.test.ts
@@ -1,0 +1,178 @@
+import { randomUUID } from "crypto";
+import * as XLSX from "xlsx";
+import { getTestPrismaClient, disconnectTestPrismaClient } from "../factories/db";
+
+// Next's after() throws when called outside a real request scope, which route handlers
+// invoked directly (not through the Next server) always are. Let the passed promise run to
+// completion in the background instead of awaiting it here (see write-meeting-route.test.ts).
+jest.mock("next/server", () => ({
+  ...jest.requireActual("next/server"),
+  after: (p: Promise<unknown>) => { p.catch(() => {}); },
+}));
+
+jest.mock("../../services/auth", () => ({
+  requireRole: jest.fn().mockResolvedValue({
+    user: { role: "SUPER_ADMIN" },
+    accessToken: undefined,
+  }),
+}));
+
+jest.mock("../../services/googleCalendar", () => ({
+  calendarIdsForMeeting: jest.fn().mockReturnValue({}),
+  createCalendarEvent: jest.fn(),
+}));
+
+// Only the network-calling half of services/zoom is mocked — resolveZoomHost (and the
+// zoomHostPool it reads) stay real, since the whole point of this suite is to exercise real
+// sequential host-collision avoidance against the in-memory test DB.
+jest.mock("../../services/zoom", () => {
+  const actual = jest.requireActual("../../services/zoom");
+  return {
+    ...actual,
+    createZoomMeeting: jest.fn().mockResolvedValue({ zid: "fake-zid", zoomLink: "https://zoom.example/fake" }),
+  };
+});
+
+function buildImportRequest(rows: Record<string, string>[]): Request {
+  const worksheet = XLSX.utils.json_to_sheet(rows);
+  const workbook = XLSX.utils.book_new();
+  XLSX.utils.book_append_sheet(workbook, worksheet, "Meetings");
+  const buffer = XLSX.write(workbook, { type: "buffer", bookType: "xlsx" }) as Buffer;
+
+  const formData = new FormData();
+  formData.append("file", new Blob([new Uint8Array(buffer)]), "meetings.xlsx");
+  return new Request("http://localhost/api/import/meetings", { method: "POST", body: formData });
+}
+
+// zoomHostPool (services/zoom.ts) is computed once at module-load time from
+// process.env.ZOOM_HOSTS, so it must be set before that module is first required —
+// dynamic require() after setting the env var, not a static import, guarantees the order.
+let POST: typeof import("../../app/api/import/meetings/route").POST;
+
+beforeAll(() => {
+  process.env.ZOOM_HOSTS = "only-host@icr.org";
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  POST = require("../../app/api/import/meetings/route").POST;
+});
+
+afterAll(async () => {
+  await disconnectTestPrismaClient();
+});
+
+test("two rows in the same batch needing a Zoom host at the same time don't collide", async () => {
+  const suffix = randomUUID().slice(0, 8);
+  const rowA = `Host Pool Row A ${suffix}`;
+  const rowB = `Host Pool Row B ${suffix}`;
+
+  const request = buildImportRequest([
+    {
+      "Meeting Name": rowA,
+      Status: "Active",
+      Category: "AA",
+      Day: "One-time",
+      Frequency: "",
+      "Start Date": "12/03/2026",
+      "Start Time": "7:00 PM",
+      "End Time": "8:00 PM",
+      "Location Type": "In Person",
+      "Physical Room": "Serenity Room",
+      "Zoom Room": "Serenity Room - Zoom",
+      "Contact Email": "a@icr.org",
+      Description: "",
+    },
+    {
+      "Meeting Name": rowB,
+      Status: "Active",
+      Category: "AA",
+      Day: "One-time",
+      Frequency: "",
+      "Start Date": "12/03/2026",
+      "Start Time": "7:00 PM",
+      "End Time": "8:00 PM",
+      "Location Type": "In Person",
+      "Physical Room": "Unity Room",
+      "Zoom Room": "Unity Room - Zoom",
+      "Contact Email": "b@icr.org",
+      Description: "",
+    },
+  ]);
+
+  const response = await POST(request);
+  expect(response.status).toBe(200);
+  const body = await response.json();
+  expect(body.results).toEqual([
+    { meeting: rowA, status: "created" },
+    { meeting: rowB, status: "created" },
+  ]);
+  // Different rooms and different Zoom rooms — only the shared host pool is contended, so no
+  // room/zoomRoom conflict should be reported.
+  expect(body.conflicts).toEqual([]);
+
+  // The Zoom half of each row syncs in the background (after()) — give it time to finish.
+  await new Promise((resolve) => setTimeout(resolve, 400));
+
+  const prisma = getTestPrismaClient();
+  const createdA = await prisma.meeting.findFirst({ where: { title: rowA } });
+  const createdB = await prisma.meeting.findFirst({ where: { title: rowB } });
+
+  const hosts = [createdA?.zoomHost, createdB?.zoomHost];
+  // Exactly one row got the pool's only host; the other found it already claimed.
+  expect(hosts.filter((h) => h === "only-host@icr.org")).toHaveLength(1);
+  expect(hosts.filter((h) => h == null)).toHaveLength(1);
+
+  const synced = [createdA, createdB].find((m) => m?.zoomHost === "only-host@icr.org");
+  const exhausted = [createdA, createdB].find((m) => m?.zoomHost == null);
+  expect(synced?.zid).toBe("fake-zid");
+  expect(synced?.zoomSyncStatus).toBe("synced");
+  expect(exhausted?.zoomSyncStatus).toBe("error");
+  expect(exhausted?.zoomSyncError).toMatch(/pool exhausted/i);
+});
+
+test("an unparseable row is reported as errored without aborting the batch", async () => {
+  const suffix = randomUUID().slice(0, 8);
+  const goodRow = `Good Row ${suffix}`;
+
+  const request = buildImportRequest([
+    {
+      "Meeting Name": "",
+      Status: "Active",
+      Category: "AA",
+      Day: "One-time",
+      Frequency: "",
+      "Start Date": "12/04/2026",
+      "Start Time": "7:00 PM",
+      "End Time": "8:00 PM",
+      "Location Type": "In Person",
+      "Physical Room": "Serenity Room",
+      "Zoom Room": "",
+      "Contact Email": "a@icr.org",
+      Description: "",
+    },
+    {
+      "Meeting Name": goodRow,
+      Status: "Active",
+      Category: "AA",
+      Day: "One-time",
+      Frequency: "",
+      "Start Date": "12/04/2026",
+      "Start Time": "7:00 PM",
+      "End Time": "8:00 PM",
+      "Location Type": "In Person",
+      "Physical Room": "Seeds of Hope Room",
+      "Zoom Room": "",
+      "Contact Email": "b@icr.org",
+      Description: "",
+    },
+  ]);
+
+  const response = await POST(request);
+  expect(response.status).toBe(200);
+  const body = await response.json();
+
+  expect(body.results[0].status).toBe("errored");
+  expect(body.results[1]).toEqual({ meeting: goodRow, status: "created" });
+
+  const prisma = getTestPrismaClient();
+  const created = await prisma.meeting.findFirst({ where: { title: goodRow } });
+  expect(created).not.toBeNull();
+});

--- a/frontend/test/unit/importParsing.test.ts
+++ b/frontend/test/unit/importParsing.test.ts
@@ -1,0 +1,200 @@
+import { parseImportRow } from "../../util/importParsing";
+
+const baseRow = {
+  "Meeting Name": "Test Meeting",
+  Status: "Active",
+  Category: "AA",
+  Day: "M-W, F",
+  Frequency: "Weekly",
+  "Start Date": "07/06/2026", // a Monday
+  "Start Time": "7:00 PM",
+  "End Time": "8:00 PM",
+  "Location Type": "In Person",
+  "Physical Room": "Serenity Room",
+  "Zoom Room": "",
+  "Contact Email": "test@icr.org",
+  Description: "",
+};
+
+describe("parseImportRow — general rules", () => {
+  it("parses a straightforward weekly row", () => {
+    const result = parseImportRow(baseRow, 0);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.row.meeting.calType).toEqual(["AA"]);
+    expect(result.row.meeting.room).toBe("Serenity Room");
+    expect(result.row.meeting.modeType).toBe("In Person");
+    expect(result.row.meeting.isRecurring).toBe(true);
+    expect(result.row.recurrencePattern).toMatchObject({
+      type: "weekly",
+      daysOfWeek: ["Monday", "Tuesday", "Wednesday", "Friday"],
+      interval: 1,
+    });
+  });
+
+  it("treats a time without AM/PM as AM", () => {
+    const result = parseImportRow({
+      ...baseRow, Day: "", Frequency: "", "Start Time": "9:00", "End Time": "10:00",
+    }, 0);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    // 9:00 AM ET on 07/06/2026 = 13:00 UTC (EDT, UTC-4)
+    expect(result.row.meeting.startDateTime.toISOString()).toBe("2026-07-06T13:00:00.000Z");
+    expect(result.row.meeting.endDateTime.toISOString()).toBe("2026-07-06T14:00:00.000Z");
+  });
+
+  it("treats 12:00 PM as noon", () => {
+    const result = parseImportRow({
+      ...baseRow, Day: "", Frequency: "", "Start Time": "12:00 PM", "End Time": "1:00 PM",
+    }, 0);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    // Noon ET on 07/06/2026 = 16:00 UTC (EDT, UTC-4)
+    expect(result.row.meeting.startDateTime.toISOString()).toBe("2026-07-06T16:00:00.000Z");
+  });
+
+  it('expands "Daily" to all 7 days', () => {
+    const result = parseImportRow({ ...baseRow, Day: "Daily" }, 0);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.row.recurrencePattern?.daysOfWeek).toHaveLength(7);
+  });
+
+  it("falls back to Zoom Room when Physical Room is blank", () => {
+    const result = parseImportRow({ ...baseRow, "Physical Room": "", "Zoom Room": "Serenity Room - Zoom" }, 0);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.row.meeting.room).toBe("Serenity Room - Zoom");
+    expect(result.row.meeting.zoomRoom).toBe("Serenity Room - Zoom");
+  });
+
+  it("uses the first email when multiple are listed", () => {
+    const result = parseImportRow({ ...baseRow, "Contact Email": "first@icr.org, second@icr.org" }, 0);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.row.meeting.email).toBe("first@icr.org");
+  });
+
+  it("parses a fixed day-of-month monthly pattern", () => {
+    const result = parseImportRow({ ...baseRow, Day: "Day 15", Frequency: "Monthly" }, 0);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.row.recurrencePattern).toMatchObject({ type: "monthly", dayOfMonth: 15 });
+  });
+
+  it("parses a one-time (non-recurring) row", () => {
+    const result = parseImportRow({ ...baseRow, Day: "One-time", Frequency: "" }, 0);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.row.meeting.isRecurring).toBe(false);
+    expect(result.row.recurrencePattern).toBeNull();
+  });
+
+  it("prefixes errors with the row number", () => {
+    const result = parseImportRow({ ...baseRow, "Meeting Name": "" }, 4);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toMatch(/^Row 5: /);
+  });
+
+  it("errors when End Time is before Start Time", () => {
+    const result = parseImportRow({ ...baseRow, "Start Time": "8:00 PM", "End Time": "7:00 PM" }, 0);
+    expect(result.ok).toBe(false);
+  });
+
+  it("errors when neither Physical Room nor Zoom Room is set", () => {
+    const result = parseImportRow({ ...baseRow, "Physical Room": "", "Zoom Room": "" }, 0);
+    expect(result.ok).toBe(false);
+  });
+
+  it("errors on an unrecognized Day value", () => {
+    const result = parseImportRow({ ...baseRow, Day: "Someday" }, 0);
+    expect(result.ok).toBe(false);
+  });
+});
+
+describe("parseImportRow — notable spreadsheet rows", () => {
+  it("M006 Woman's Double Winners — two categories, two emails", () => {
+    const result = parseImportRow({
+      ...baseRow,
+      "Meeting Name": "Woman's Double Winners",
+      Category: "Al-Anon, AA",
+      "Contact Email": "host1@icr.org, host2@icr.org",
+    }, 0);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.row.meeting.calType).toEqual(["Al-Anon", "AA"]);
+    expect(result.row.meeting.email).toBe("host1@icr.org");
+  });
+
+  it("M011 Al-Anon Intergroup — monthly (1st Tuesday), online-only, no physical room", () => {
+    const result = parseImportRow({
+      ...baseRow,
+      "Meeting Name": "Al-Anon Intergroup",
+      Category: "Al-Anon",
+      Day: "1st Tu",
+      Frequency: "Monthly",
+      "Location Type": "Remote",
+      "Physical Room": "",
+      "Zoom Room": "Unity Room - Zoom",
+    }, 0);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.row.meeting.modeType).toBe("Remote");
+    expect(result.row.meeting.room).toBe("Unity Room - Zoom");
+    expect(result.row.recurrencePattern).toMatchObject({
+      type: "monthly", weekOfMonth: 1, daysOfWeek: ["Tuesday"],
+    });
+  });
+
+  it("M017 11th Step — two categories, no Zoom room", () => {
+    const result = parseImportRow({
+      ...baseRow,
+      "Meeting Name": "11th Step",
+      Category: "AA, Other",
+      "Zoom Room": "",
+    }, 0);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.row.meeting.calType).toEqual(["AA", "Other"]);
+    expect(result.row.meeting.zoomRoom).toBeNull();
+  });
+
+  it("M022 Recovering Couples — two categories, two emails", () => {
+    const result = parseImportRow({
+      ...baseRow,
+      "Meeting Name": "Recovering Couples",
+      Category: "AA, Other",
+      "Contact Email": "host1@icr.org; host2@icr.org",
+    }, 0);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.row.meeting.calType).toEqual(["AA", "Other"]);
+    expect(result.row.meeting.email).toBe("host1@icr.org");
+  });
+
+  it('M028 Daily Ithaca Group — "Daily" expands to all 7 days', () => {
+    const result = parseImportRow({ ...baseRow, "Meeting Name": "Daily Ithaca Group", Day: "Daily" }, 0);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.row.recurrencePattern?.daysOfWeek).toEqual([
+      "Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday",
+    ]);
+  });
+
+  it("M029 AA District — monthly (1st Wednesday), Room for Improvement", () => {
+    const result = parseImportRow({
+      ...baseRow,
+      "Meeting Name": "AA District",
+      Day: "1st W",
+      Frequency: "Monthly",
+      "Physical Room": "Room for Improvement",
+    }, 0);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.row.meeting.room).toBe("Room for Improvement");
+    expect(result.row.recurrencePattern).toMatchObject({
+      type: "monthly", weekOfMonth: 1, daysOfWeek: ["Wednesday"],
+    });
+  });
+});

--- a/frontend/util/importParsing.ts
+++ b/frontend/util/importParsing.ts
@@ -1,0 +1,283 @@
+import { z } from "zod";
+import { randomUUID } from "crypto";
+import { convertETToUTC } from "./timeUtils";
+import { IMeeting, IRecurrencePattern } from "./models";
+
+const DAY_ORDER = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
+const WEEK_OF_MONTH_ORDINALS = ["1st", "2nd", "3rd", "4th"];
+
+const DAY_NAME_BY_ABBREVIATION: Record<string, string> = {
+  Su: "Sunday", M: "Monday", Tu: "Tuesday", W: "Wednesday", Th: "Thursday", F: "Friday", Sa: "Saturday",
+};
+
+// Accepts either the abbreviated form the Export tab produces ("M", "Tu") or a spelled-out
+// day name/prefix from a manually-authored sheet ("Monday", "Mon").
+function resolveDayName(token: string): string | null {
+  const trimmed = token.trim();
+  if (DAY_NAME_BY_ABBREVIATION[trimmed]) return DAY_NAME_BY_ABBREVIATION[trimmed];
+  const match = DAY_ORDER.find((day) => day.toLowerCase() === trimmed.toLowerCase()
+    || day.toLowerCase().startsWith(trimmed.toLowerCase()));
+  return match ?? null;
+}
+
+function expandDayRange(token: string): string[] | null {
+  const parts = token.split("-").map((p) => p.trim());
+  if (parts.length === 1) {
+    const day = resolveDayName(parts[0]);
+    return day ? [day] : null;
+  }
+  if (parts.length === 2) {
+    const startDay = resolveDayName(parts[0]);
+    const endDay = resolveDayName(parts[1]);
+    if (!startDay || !endDay) return null;
+    const startIndex = DAY_ORDER.indexOf(startDay);
+    const endIndex = DAY_ORDER.indexOf(endDay);
+    if (startIndex === -1 || endIndex === -1 || endIndex < startIndex) return null;
+    return DAY_ORDER.slice(startIndex, endIndex + 1);
+  }
+  return null;
+}
+
+type ParsedDay =
+  | { kind: "weekly"; daysOfWeek: string[] }
+  | { kind: "monthlyWeekday"; weekOfMonth: number; daysOfWeek: string[] }
+  | { kind: "monthlyDayOfMonth"; dayOfMonth: number }
+  | { kind: "oneTime" };
+
+// Inverse of util/recurrenceDisplay.ts's formatDayColumn — same grammar, read backwards.
+function parseDayColumn(dayRaw: string, frequency: string): ParsedDay | { error: string } {
+  const day = dayRaw.trim();
+  const freq = frequency.trim().toLowerCase();
+
+  if (day.toLowerCase() === "one-time" || (!freq && !day)) return { kind: "oneTime" };
+
+  if (freq === "monthly") {
+    const dayOfMonthMatch = day.match(/^Day\s+(\d{1,2})$/i);
+    if (dayOfMonthMatch) return { kind: "monthlyDayOfMonth", dayOfMonth: parseInt(dayOfMonthMatch[1], 10) };
+
+    const nthMatch = day.match(/^(1st|2nd|3rd|4th|Last)\s+(\S+)$/i);
+    if (nthMatch) {
+      const [, ordinalRaw, dayToken] = nthMatch;
+      const weekOfMonth = ordinalRaw.toLowerCase() === "last"
+        ? -1
+        : WEEK_OF_MONTH_ORDINALS.indexOf(
+            WEEK_OF_MONTH_ORDINALS.find((o) => o.toLowerCase() === ordinalRaw.toLowerCase()) ?? "",
+          ) + 1;
+      const dayName = resolveDayName(dayToken);
+      if (!dayName || weekOfMonth === 0) return { error: `Unrecognized monthly Day value "${dayRaw}"` };
+      return { kind: "monthlyWeekday", weekOfMonth, daysOfWeek: [dayName] };
+    }
+
+    return { error: `Unrecognized monthly Day value "${dayRaw}"` };
+  }
+
+  if (freq === "weekly") {
+    if (day.toLowerCase() === "daily") return { kind: "weekly", daysOfWeek: [...DAY_ORDER] };
+    if (!day) return { error: "Weekly meeting is missing a Day value" };
+
+    const tokens = day.split(",").map((t) => t.trim()).filter(Boolean);
+    const days = new Set<string>();
+    for (const token of tokens) {
+      const expanded = expandDayRange(token);
+      if (!expanded) return { error: `Unrecognized Day value "${token}"` };
+      expanded.forEach((d) => days.add(d));
+    }
+    if (days.size === 0) return { error: `Unrecognized Day value "${dayRaw}"` };
+    return { kind: "weekly", daysOfWeek: [...days].sort((a, b) => DAY_ORDER.indexOf(a) - DAY_ORDER.indexOf(b)) };
+  }
+
+  return { error: `Unrecognized Frequency value "${frequency}"` };
+}
+
+// "Times without AM/PM are treated as AM; 12:00 PM = noon" — standard 12-hour parsing, with a
+// missing meridiem defaulting to AM (so a bare "12:00" is midnight, matching that rule).
+function parseTimeOfDay(raw: string | Date): { hour: number; minute: number } | null {
+  // A time-only Excel cell can come back from xlsx as a Date (epoch date + wall-clock time)
+  // when read with cellDates:true — read the ET wall-clock hour/minute directly off it.
+  if (raw instanceof Date) {
+    return { hour: raw.getHours(), minute: raw.getMinutes() };
+  }
+
+  const match = raw.trim().match(/^(\d{1,2}):(\d{2})\s*(AM|PM)?$/i);
+  if (!match) return null;
+  let hour = parseInt(match[1], 10);
+  const minute = parseInt(match[2], 10);
+  const meridiem = match[3]?.toUpperCase();
+  if (hour < 1 || hour > 12 || minute < 0 || minute > 59) return null;
+
+  if (meridiem === "PM" && hour !== 12) hour += 12;
+  if ((meridiem === "AM" || !meridiem) && hour === 12) hour = 0;
+
+  return { hour, minute };
+}
+
+// Accepts "MM/DD/YYYY" (what the Export tab writes) or "YYYY-MM-DD", or a real Date (xlsx
+// returns one when the source cell is Excel-formatted as a date and read with cellDates:true).
+function parseCalendarDate(raw: string | Date): { year: number; month: number; day: number } | null {
+  if (raw instanceof Date) {
+    return { year: raw.getFullYear(), month: raw.getMonth() + 1, day: raw.getDate() };
+  }
+  const trimmed = raw.trim();
+  const slash = trimmed.match(/^(\d{1,2})\/(\d{1,2})\/(\d{4})$/);
+  if (slash) return { year: Number(slash[3]), month: Number(slash[1]), day: Number(slash[2]) };
+  const iso = trimmed.match(/^(\d{4})-(\d{1,2})-(\d{1,2})$/);
+  if (iso) return { year: Number(iso[1]), month: Number(iso[2]), day: Number(iso[3]) };
+  return null;
+}
+
+function toETInstant(date: { year: number; month: number; day: number }, time: { hour: number; minute: number }): Date {
+  const pad = (n: number) => String(n).padStart(2, "0");
+  const etDateTime = `${date.year}-${pad(date.month)}-${pad(date.day)}T${pad(time.hour)}:${pad(time.minute)}:00`;
+  return new Date(convertETToUTC(etDateTime));
+}
+
+const cellValue = z.union([z.string(), z.number(), z.date()]).transform((v) => (v instanceof Date ? v : String(v)));
+
+export const importRowSchema = z.object({
+  "Meeting Name": z.string().min(1, "Meeting Name is required"),
+  Status: z.string().optional(),
+  Category: z.string().min(1, "Category is required"),
+  Day: cellValue.optional(),
+  Frequency: cellValue.optional(),
+  "Start Date": cellValue,
+  "Start Time": cellValue,
+  "End Time": cellValue,
+  "Location Type": z.string().min(1, "Location Type is required"),
+  "Physical Room": z.string().optional(),
+  "Zoom Room": z.string().optional(),
+  "Contact Email": z.string().min(1, "Contact Email is required"),
+  Description: z.string().optional(),
+});
+
+export type ImportRow = z.infer<typeof importRowSchema>;
+
+export type ParsedImportRow = {
+  meeting: IMeeting;
+  recurrencePattern: IRecurrencePattern | null;
+};
+
+export type ParseImportRowResult =
+  | { ok: true; row: ParsedImportRow }
+  | { ok: false; error: string };
+
+// Parses one raw spreadsheet row (already shaped by importRowSchema) into an IMeeting +
+// optional IRecurrencePattern, implementing the parsing rules from the Ticket B spec: category
+// split, Day/Frequency recurrence decoding (see parseDayColumn above), AM/PM-less time
+// defaulting to AM, Location Type relabeling, room fallback, first-listed email.
+export function parseImportRow(rawRow: unknown, rowIndex: number): ParseImportRowResult {
+  const fail = (message: string): { ok: false; error: string } => ({ ok: false, error: `Row ${rowIndex + 1}: ${message}` });
+
+  const parsed = importRowSchema.safeParse(rawRow);
+  if (!parsed.success) {
+    return fail(parsed.error.issues.map((i) => i.message).join("; "));
+  }
+  const row = parsed.data;
+
+  const calType = row.Category.split(",")
+    .map((c) => c.trim())
+    .filter(Boolean);
+  if (calType.length === 0) {
+    return fail("Category is required");
+  }
+
+  const modeType = row["Location Type"];
+
+  const physicalRoom = (row["Physical Room"] ?? "").trim();
+  const zoomRoomRaw = (row["Zoom Room"] ?? "").trim();
+  const room = physicalRoom || zoomRoomRaw;
+  if (!room) {
+    return fail("Row has neither a Physical Room nor a Zoom Room");
+  }
+
+  const email = (row["Contact Email"] ?? "")
+    .split(/[,;]/)
+    .map((e) => e.trim())
+    .filter(Boolean)[0];
+  if (!email) {
+    return fail("Contact Email is required");
+  }
+
+  const startDate = parseCalendarDate(row["Start Date"]);
+  if (!startDate) {
+    return fail(`Unrecognized Start Date "${String(row["Start Date"])}"`);
+  }
+  const startTime = parseTimeOfDay(row["Start Time"]);
+  const endTime = parseTimeOfDay(row["End Time"]);
+  if (!startTime || !endTime) {
+    return fail("Unrecognized Start Time or End Time");
+  }
+
+  const startDateTime = toETInstant(startDate, startTime);
+  const endDateTime = toETInstant(startDate, endTime);
+  if (endDateTime <= startDateTime) {
+    return fail("End Time must be after Start Time");
+  }
+
+  const dayStr = typeof row.Day === "string" ? row.Day : "";
+  const frequencyStr = typeof row.Frequency === "string" ? row.Frequency : "";
+  const parsedDay = parseDayColumn(dayStr, frequencyStr);
+  if ("error" in parsedDay) {
+    return fail(parsedDay.error);
+  }
+
+  const mid = randomUUID();
+  const baseMeeting: Omit<IMeeting, "isRecurring" | "recurrencePattern"> = {
+    title: row["Meeting Name"],
+    mid,
+    description: row.Description ?? "",
+    creator: "Import",
+    group: "Group", // matches the placeholder value the New Meeting form itself submits
+    startDateTime,
+    endDateTime,
+    email,
+    zoomRoom: zoomRoomRaw || null,
+    room,
+    calType,
+    modeType,
+    status: row.Status?.trim() || "Active",
+  };
+
+  if (parsedDay.kind === "oneTime") {
+    return {
+      ok: true,
+      row: { meeting: { ...baseMeeting, isRecurring: false, recurrencePattern: null }, recurrencePattern: null },
+    };
+  }
+
+  const recurrencePattern: IRecurrencePattern =
+    parsedDay.kind === "weekly"
+      ? {
+          type: "weekly",
+          startDate: startDateTime,
+          endDate: null,
+          daysOfWeek: parsedDay.daysOfWeek,
+          firstDayOfWeek: "Sunday",
+          interval: 1,
+        }
+      : parsedDay.kind === "monthlyWeekday"
+        ? {
+            type: "monthly",
+            startDate: startDateTime,
+            endDate: null,
+            daysOfWeek: parsedDay.daysOfWeek,
+            weekOfMonth: parsedDay.weekOfMonth,
+            firstDayOfWeek: "Sunday",
+            interval: 1,
+          }
+        : {
+            type: "monthly",
+            startDate: startDateTime,
+            endDate: null,
+            dayOfMonth: parsedDay.dayOfMonth,
+            firstDayOfWeek: "Sunday",
+            interval: 1,
+          };
+
+  return {
+    ok: true,
+    row: {
+      meeting: { ...baseMeeting, isRecurring: true, recurrencePattern },
+      recurrencePattern,
+    },
+  };
+}


### PR DESCRIPTION
## Summary
**3 of 3 in a stack** — builds on #240 (conflict detection), which builds on #238 (Zoom host pool). Base branch is `pr2-b5-conflict-detection`, not `master` — merge the first two in order first.

- Super-Admin-only `POST /api/import/meetings`: upload a spreadsheet to create many meetings at once.
- Per row: parse → skip if it exactly duplicates an existing meeting (title + schedule) → flag but still create if it conflicts with an existing meeting's room/Zoom room (via `findResourceConflicts` from #238) → resolve a Zoom host synchronously in a sequential loop so two rows in the same batch can't race for the same host.
- Results and any conflicts render in the Import tab via the same `ConflictList` component Diagnostics uses (#240), so what a Super Admin sees after importing matches what Diagnostics would independently flag.
- Also fixes Category/Location Type values in the parser: the DB stores human-readable labels directly (e.g. `"Al-Anon"`, not `"AL_ANON"`) rather than a pseudo-enum that was never actually stored anywhere — sheet values now pass through unchanged instead of being run through a translation that was never correct.

## Test plan
- [x] `yarn tsc --noEmit` clean
- [x] `yarn test:unit`, `yarn test:integration` passing (`util/importParsing.test.ts`, `test/integration/import-meetings-route.test.ts` incl. batch host-collision avoidance)
- [ ] Run a sample XLSX import covering a few special-case rows plus one intentionally-conflicting and one intentionally-duplicate row, confirm per-row statuses and that conflicts render both in Diagnostics and under the Import results
- [ ] `yarn build` clean

Resolves #191 