### PR TITLE
Loosen dependabot auto-merge to cover minor bumps, not just dev-patch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,15 +7,20 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 10
     groups:
-      # Only patch-level devDependency bumps are safe to auto-merge unattended (see
-      # dependabot-auto-merge.yml) -- everything else (prod deps at any semver level,
-      # dev deps at minor/major) stays its own PR so a human reads the diff/changelog.
-      dev-patch:
-        dependency-type: "development"
+      # Patch and minor bumps (prod or dev) are safe to auto-merge unattended once CI is
+      # green (see dependabot-auto-merge.yml) -- only major bumps are left as individual
+      # PRs for manual review, since those are the ones most likely to carry breaking
+      # changes a semver-respecting package wouldn't ship otherwise.
+      safe-updates:
         update-types:
           - "patch"
+          - "minor"
 
   # .github/workflows/test.yml — actions/checkout, actions/setup-node, actions/upload-artifact
+  # Never auto-merged, regardless of semver level: Action version bumps don't reliably
+  # follow semver for breaking changes (e.g. actions/checkout v7 broke fork-PR checkout
+  # under pull_request_target despite looking like a routine bump), so every bump here
+  # gets a human read of the diff.
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -17,17 +17,15 @@ jobs:
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
-      # dependabot.yml's "dev-patch" group is the only group scoped to
-      # dependency-type: development + update-types: patch -- membership in it is itself
-      # the safety guarantee, so gate on the group rather than re-deriving semver/type here.
-      # Everything else (prod deps at any semver level, github-actions bumps, dev deps at
-      # minor/major) is left as an individual PR for manual review + CI green -- a version
-      # bump can change runtime/build behavior in ways this repo's CI doesn't always catch,
-      # so those get a human read of the diff/changelog rather than an unattended merge.
+      # dependabot.yml's "safe-updates" group is scoped to update-types: patch + minor --
+      # membership in it is itself the safety guarantee, so gate on the group rather than
+      # re-deriving semver/type here. Major bumps and all github-actions bumps are left as
+      # individual PRs for manual review + CI green -- those are the ones most likely to
+      # carry breaking changes this repo's CI doesn't always catch.
       # Auto-merge still doesn't bypass required status checks -- it just lets the PR merge
       # itself once lint/unit/integration/e2e all pass.
-      - name: Enable auto-merge for patch-level devDependency updates
-        if: steps.metadata.outputs.dependency-group == 'dev-patch'
+      - name: Enable auto-merge for patch/minor updates
+        if: steps.metadata.outputs.dependency-group == 'safe-updates'
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: "${{ github.event.pull_request.html_url }}"


### PR DESCRIPTION
## Summary
- Auto-merge now covers patch **and minor** dependency bumps, for both prod and dev deps (renamed group `dev-patch` → `safe-updates`)
- Major bumps still get an individual PR for manual review
- `github-actions` ecosystem bumps are still never auto-merged regardless of semver level — Action version bumps don't reliably respect semver for breaking changes (e.g. `actions/checkout` v7 broke fork-PR checkout under `pull_request_target` despite looking like a routine bump)

## Why
Prompted by PRs #244–246 (patch bumps to `sass`/`@mui/x-date-pickers*`, all prod deps) sitting unmerged under the old `dev-patch`-only rule even though they're low-risk. Extending to minor-level prod/dev bumps cuts manual-review overhead without touching the two riskiest categories (major bumps, Actions bumps).

## Test plan
- [ ] Confirm a future patch/minor npm PR gets grouped under `safe-updates` and auto-merges once CI is green
- [ ] Confirm a major npm PR still opens as an individual PR requiring manual merge
- [ ] Confirm github-actions PRs (any level) still require manual merge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency update policies to allow qualifying patch and minor updates to merge automatically after successful CI checks.
  * Major dependency updates and GitHub Actions updates continue to require manual review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->