### PR TITLE
Skip CodeRabbit auto-review on Dependabot PRs

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,8 @@
+reviews:
+  auto_review:
+    # Dependency bumps from these bots are already gated by CI + the auto-merge
+    # policy in dependabot.yml/dependabot-auto-merge.yml -- a CodeRabbit review
+    # adds no signal there and just generates noise. Comment `@coderabbitai review`
+    # on a specific PR to force one anyway.
+    ignore_usernames:
+      - "dependabot[bot]"


### PR DESCRIPTION
## Summary
- Add `.coderabbit.yaml` with `reviews.auto_review.ignore_usernames: ["dependabot[bot]"]` so CodeRabbit silently skips Dependabot PRs instead of reviewing them
- A specific PR can still get a review on demand via `@coderabbitai review`

## Why
Dependabot PRs (e.g. #242–248) are already gated by CI plus the patch/minor auto-merge policy added in #247. A CodeRabbit review of a version-bump diff adds no real signal and just adds noise to every dependency PR.

## Test plan
- [ ] Confirm the next Dependabot PR gets no CodeRabbit review comment
- [ ] Confirm `@coderabbitai review` still works on a Dependabot PR if forced


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled automated code reviews.
  * Excluded automated dependency-update pull requests from triggering reviews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->