### PR TITLE
Document yarn test:all in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Opens at [http://localhost:3000](http://localhost:3000). See [`docs/project-stru
 yarn test:unit          # pure functions, seconds, no setup
 yarn test:integration   # route handlers against an in-memory Mongo replica set
 yarn test:e2e           # full Playwright E2E suite (needs `npx playwright install --with-deps chromium` once)
+yarn test:all           # unit + integration + e2e, in that order
 ```
 
 See [`docs/testing/README.md`](docs/testing/README.md) for how the suite and CI work.


### PR DESCRIPTION
## Summary
- Add `yarn test:all` to the README's "Running Tests" section, alongside the existing `test:unit`/`test:integration`/`test:e2e` entries

## Why
The script already exists in `frontend/package.json` (`test:unit && test:integration && test:e2e`) but wasn't documented.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added instructions for running all unit, integration, and end-to-end tests sequentially with a single command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->