### PR TITLE
Add area labels auto-applied from PR/issue checkboxes

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -32,13 +32,19 @@ labels: bug
 ## Area(s) Touched
 <!-- Check all that apply — automatically applies matching labels, re-synced on every edit.
 A best guess is fine; this gets corrected during triage if wrong. -->
-- [ ] auth
-- [ ] admin
-- [ ] google-calendar
-- [ ] zoom-api
-- [ ] documentation
-- [ ] cleanup
-- [ ] billing
-- [ ] ui/ux
-- [ ] security
-- [ ] testing
+**Product areas**
+- [ ] auth — sign-in, sessions, NextAuth, role-based access
+- [ ] admin — /admin shell (Diagnostics, Users, Import, Export tabs)
+- [ ] billing — lease export, XLSX import, anything affecting invoicing
+- [ ] ui/ux — frontend layout/styling not tied to a specific integration
+
+**Integrations**
+- [ ] google-calendar — Google Calendar sync
+- [ ] zoom-api — Zoom meeting/host sync
+
+**Engineering**
+- [ ] security — auth hardening, data exposure, dependency/security scanning
+- [ ] testing — test suite (Jest/Playwright) changes
+- [ ] github-actions — workflows, Dependabot config, other .github/ CI tooling
+- [ ] cleanup — refactor or dead-code removal, no behavior change
+- [ ] documentation — docs/ or README changes only

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -28,3 +28,17 @@ labels: bug
 ## Additional context
 
 <!-- Add any other context about the problem here. -->
+
+## Area(s) Touched
+<!-- Check all that apply — automatically applies matching labels, re-synced on every edit.
+A best guess is fine; this gets corrected during triage if wrong. -->
+- [ ] auth
+- [ ] admin
+- [ ] google-calendar
+- [ ] zoom-api
+- [ ] documentation
+- [ ] cleanup
+- [ ] billing
+- [ ] ui/ux
+- [ ] security
+- [ ] testing

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -25,3 +25,17 @@ description is fine if it's one cohesive change. Each piece should:
 log output, or before/after comparison — not vague ("works correctly") unless paired with
 what "correctly" actually means here. -->
 - [ ]
+
+## Area(s) Touched
+<!-- Check all that apply — automatically applies matching labels, re-synced on every edit.
+A best guess is fine; this gets corrected during triage if wrong. -->
+- [ ] auth
+- [ ] admin
+- [ ] google-calendar
+- [ ] zoom-api
+- [ ] documentation
+- [ ] cleanup
+- [ ] billing
+- [ ] ui/ux
+- [ ] security
+- [ ] testing

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -29,13 +29,19 @@ what "correctly" actually means here. -->
 ## Area(s) Touched
 <!-- Check all that apply — automatically applies matching labels, re-synced on every edit.
 A best guess is fine; this gets corrected during triage if wrong. -->
-- [ ] auth
-- [ ] admin
-- [ ] google-calendar
-- [ ] zoom-api
-- [ ] documentation
-- [ ] cleanup
-- [ ] billing
-- [ ] ui/ux
-- [ ] security
-- [ ] testing
+**Product areas**
+- [ ] auth — sign-in, sessions, NextAuth, role-based access
+- [ ] admin — /admin shell (Diagnostics, Users, Import, Export tabs)
+- [ ] billing — lease export, XLSX import, anything affecting invoicing
+- [ ] ui/ux — frontend layout/styling not tied to a specific integration
+
+**Integrations**
+- [ ] google-calendar — Google Calendar sync
+- [ ] zoom-api — Zoom meeting/host sync
+
+**Engineering**
+- [ ] security — auth hardening, data exposure, dependency/security scanning
+- [ ] testing — test suite (Jest/Playwright) changes
+- [ ] github-actions — workflows, Dependabot config, other .github/ CI tooling
+- [ ] cleanup — refactor or dead-code removal, no behavior change
+- [ ] documentation — docs/ or README changes only

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -31,4 +31,7 @@
   description: Auth hardening, data exposure, dependency/security scanning
 - name: testing
   color: "0E8A16"
-  description: Test suite (Jest/Playwright) or CI workflow changes
+  description: Test suite (Jest/Playwright) changes
+- name: github-actions
+  color: "24292E"
+  description: Workflows, Dependabot config, other .github/ CI tooling

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,34 @@
+# Area labels applied automatically from the "Area(s) Touched" checklist in the PR/issue
+# templates -- see .github/workflows/label-from-checklist.yml. This file only owns those
+# area labels, not GitHub's/Dependabot's defaults (bug, enhancement, dependencies, etc.) --
+# the sync workflow runs with skip-delete so it never touches labels outside this list.
+- name: auth
+  color: "5319E7"
+  description: Sign-in, sessions, NextAuth, role-based access
+- name: admin
+  color: "0052CC"
+  description: "/admin shell — Diagnostics, Users, Import, Export tabs"
+- name: google-calendar
+  color: "4285F4"
+  description: Google Calendar sync (services/googleCalendar.ts)
+- name: zoom-api
+  color: "2D8CFF"
+  description: Zoom meeting/host sync (services/zoom.ts)
+- name: documentation
+  color: "0075CA"
+  description: docs/ or README changes only
+- name: cleanup
+  color: "C5DEF5"
+  description: Refactor or dead-code removal, no behavior change
+- name: billing
+  color: "B60205"
+  description: Lease export, XLSX import, anything affecting invoicing
+- name: ui/ux
+  color: "D93F0B"
+  description: Frontend layout/styling not tied to a specific integration
+- name: security
+  color: "E99695"
+  description: Auth hardening, data exposure, dependency/security scanning
+- name: testing
+  color: "0E8A16"
+  description: Test suite (Jest/Playwright) or CI workflow changes

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,6 +14,19 @@ Group related files under one bullet when they're part of the same change, e.g.:
 <!-- Concrete steps a reviewer can actually run — specific commands or repro steps, not "tested thoroughly". -->
 - [ ]
 
+## Area(s) Touched
+<!-- Check all that apply — automatically applies matching labels, re-synced on every edit. -->
+- [ ] auth
+- [ ] admin
+- [ ] google-calendar
+- [ ] zoom-api
+- [ ] documentation
+- [ ] cleanup
+- [ ] billing
+- [ ] ui/ux
+- [ ] security
+- [ ] testing
+
 ## Pre-merge Checklist
 <!-- Check every box below before merging to master. -->
 - [ ] Code follows current formatting conventions and passes lint (`yarn lint`).

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,16 +16,22 @@ Group related files under one bullet when they're part of the same change, e.g.:
 
 ## Area(s) Touched
 <!-- Check all that apply — automatically applies matching labels, re-synced on every edit. -->
-- [ ] auth
-- [ ] admin
-- [ ] google-calendar
-- [ ] zoom-api
-- [ ] documentation
-- [ ] cleanup
-- [ ] billing
-- [ ] ui/ux
-- [ ] security
-- [ ] testing
+**Product areas**
+- [ ] auth — sign-in, sessions, NextAuth, role-based access
+- [ ] admin — /admin shell (Diagnostics, Users, Import, Export tabs)
+- [ ] billing — lease export, XLSX import, anything affecting invoicing
+- [ ] ui/ux — frontend layout/styling not tied to a specific integration
+
+**Integrations**
+- [ ] google-calendar — Google Calendar sync
+- [ ] zoom-api — Zoom meeting/host sync
+
+**Engineering**
+- [ ] security — auth hardening, data exposure, dependency/security scanning
+- [ ] testing — test suite (Jest/Playwright) changes
+- [ ] github-actions — workflows, Dependabot config, other .github/ CI tooling
+- [ ] cleanup — refactor or dead-code removal, no behavior change
+- [ ] documentation — docs/ or README changes only
 
 ## Pre-merge Checklist
 <!-- Check every box below before merging to master. -->

--- a/.github/workflows/label-from-checklist.yml
+++ b/.github/workflows/label-from-checklist.yml
@@ -1,0 +1,57 @@
+name: Label from checklist
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+  issues:
+    types: [opened, edited]
+
+permissions:
+  pull-requests: write
+  issues: write
+
+jobs:
+  sync-area-labels:
+    runs-on: ubuntu-latest
+    steps:
+      # Checked boxes under "Area(s) Touched" drive labels directly from the PR/issue body --
+      # re-run on every edit (not just open) so unchecking a box removes its label too. Only
+      # ever adds/removes labels from the fixed AREAS list below, never touches type labels
+      # (bug/enhancement) or anything else already on the issue/PR.
+      - name: Sync area labels from checklist
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const AREAS = [
+              'auth', 'admin', 'google-calendar', 'zoom-api', 'documentation',
+              'cleanup', 'billing', 'ui/ux', 'security', 'testing',
+            ];
+
+            const item = context.payload.pull_request ?? context.payload.issue;
+            const body = item.body ?? '';
+            const number = item.number;
+            const { owner, repo } = context.repo;
+
+            const checked = AREAS.filter((area) => {
+              const escaped = area.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+              return new RegExp(`^\\s*[-*]\\s*\\[[xX]\\]\\s*${escaped}\\b`, 'mi').test(body);
+            });
+
+            const { data: current } = await github.rest.issues.listLabelsOnIssue({
+              owner,
+              repo,
+              issue_number: number,
+            });
+            const currentAreaLabels = current.map((l) => l.name).filter((n) => AREAS.includes(n));
+
+            const toAdd = checked.filter((a) => !currentAreaLabels.includes(a));
+            const toRemove = currentAreaLabels.filter((a) => !checked.includes(a));
+
+            if (toAdd.length) {
+              await github.rest.issues.addLabels({ owner, repo, issue_number: number, labels: toAdd });
+            }
+            for (const name of toRemove) {
+              await github.rest.issues
+                .removeLabel({ owner, repo, issue_number: number, name })
+                .catch(() => {});
+            }

--- a/.github/workflows/label-from-checklist.yml
+++ b/.github/workflows/label-from-checklist.yml
@@ -24,7 +24,7 @@ jobs:
           script: |
             const AREAS = [
               'auth', 'admin', 'google-calendar', 'zoom-api', 'documentation',
-              'cleanup', 'billing', 'ui/ux', 'security', 'testing',
+              'cleanup', 'billing', 'ui/ux', 'security', 'testing', 'github-actions',
             ];
 
             const item = context.payload.pull_request ?? context.payload.issue;

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -1,0 +1,26 @@
+name: Sync labels
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - .github/labels.yml
+  workflow_dispatch:
+
+permissions:
+  issues: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      # skip-delete: labels.yml only owns the "area touched" labels, not GitHub's/Dependabot's
+      # defaults (bug, enhancement, dependencies, ...) -- without this the labeler would delete
+      # every label not listed in the file.
+      - name: Sync area labels
+        uses: crazy-max/ghaction-github-labeler@v5
+        with:
+          yaml-file: .github/labels.yml
+          skip-delete: true


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an **Area(s) Touched** checklist to bug reports, feature requests, and pull requests for consistent triage.
  * Introduced a standardized set of labels covering product areas, integrations, and engineering work.
  * Implemented automatic labeling driven by the selected checklist items.
  * Added label synchronization from a central label definition while preserving unrelated labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description
- **.github/labels.yml**: defines 11 area labels — auth, admin, billing, ui/ux, google-calendar, zoom-api, security, testing, github-actions, cleanup, documentation — each with a color and description.
- **.github/workflows/sync-labels.yml**: creates/updates those labels on push to master when `labels.yml` changes (or via manual dispatch), using `crazy-max/ghaction-github-labeler` with `skip-delete: true` so it never removes GitHub's/Dependabot's existing labels (`bug`, `enhancement`, `dependencies`, ...).
- **.github/workflows/label-from-checklist.yml**: parses the new "Area(s) Touched" checklist on PRs and issues and adds matching labels; re-runs on every edit so unchecking a box removes its label too. Only ever touches labels within the fixed area list, never anything else already on the issue/PR.
- **.github/pull_request_template.md**, **.github/ISSUE_TEMPLATE/bug_report.md**, **.github/ISSUE_TEMPLATE/feature_request.md**: each gets the new "Area(s) Touched" checklist, grouped into Product areas / Integrations / Engineering with each item's description inlined next to it (not just in the label's GitHub tooltip).
- `github-actions` was split out of `testing` mid-review — this PR itself only touches workflow files with no test-suite changes, which is what surfaced that `testing`'s original description ("or CI workflow changes") was too broad.

## Testing
- [x] Validated all three YAML files parse cleanly (`ruby -ryaml`)
- [x] Simulated the checkbox-parsing regex against the grouped template locally (Node), confirmed it correctly extracts checked areas around the bold group headers
- [x] Confirm `sync-labels.yml` creates all 11 labels cleanly on first run against `master`
- [x] Open a test PR/issue, check a couple of area boxes, confirm matching labels get applied; uncheck one, confirm it gets removed on the next edit

## Area(s) Touched
**Product areas**
- [ ] auth — sign-in, sessions, NextAuth, role-based access
- [ ] admin — /admin shell (Diagnostics, Users, Import, Export tabs)
- [ ] billing — lease export, XLSX import, anything affecting invoicing
- [ ] ui/ux — frontend layout/styling not tied to a specific integration

**Integrations**
- [ ] google-calendar — Google Calendar sync
- [ ] zoom-api — Zoom meeting/host sync

**Engineering**
- [ ] security — auth hardening, data exposure, dependency/security scanning
- [ ] testing — test suite (Jest/Playwright) changes
- [x] github-actions — workflows, Dependabot config, other .github/ CI tooling
- [ ] cleanup — refactor or dead-code removal, no behavior change
- [ ] documentation — docs/ or README changes only

<!-- github-actions checked above for accuracy, but note this PR's own workflow additions can't
self-label -- pull_request-triggered workflows run from the base branch's version, and this one
doesn't exist on master until this PR merges. -->

## Pre-merge Checklist
- [x] Code follows current formatting conventions and passes lint (`yarn lint`).
- [x] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
- [x] All test suites pass, both run locally and green in GitHub CI. **Do not merge if any test suite is failing.**
- [ ] A test suite was added or updated for the feature/fix in this PR.
- [x] Only files relevant to this change are committed — no stray or unrelated files.
- [x] If this branch has a merge conflict with master, master was merged into this branch first (not the other way around).
- [x] The rest of this PR description (Description, Testing) is filled out, not left as template placeholders.