### PR TITLE
Resize Main Calendar sidebar, add hamburger toggle, swap CalendarNavbar to in-house Dropdown

### DIFF
--- a/frontend/app/(main)/page.module.scss
+++ b/frontend/app/(main)/page.module.scss
@@ -4,7 +4,7 @@
 }
 
 .sidebar {
-  width: 350px;
+  width: 280px;
   background-color: #ffffff;
   padding: 10px;
   min-height: 0; // lets the flex item shrink so overflow-y actually scrolls

--- a/frontend/app/(main)/page.tsx
+++ b/frontend/app/(main)/page.tsx
@@ -137,11 +137,9 @@ export default function HomePage() {
     if (!isSidebarOpen && showEditMeeting) {
       // eslint-disable-next-line react-hooks/set-state-in-effect
       handleBack();
-      // eslint-disable-next-line react-hooks/set-state-in-effect
       setShowEditMeeting(false);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isSidebarOpen]);
+  }, [isSidebarOpen, showEditMeeting]);
 
   // Switching Day/Week view backs out to neutral (CalendarSidebar, no popup) entirely --
   // not just closing Edit, since the clicked box's anchorEl also goes stale across the

--- a/frontend/app/(main)/page.tsx
+++ b/frontend/app/(main)/page.tsx
@@ -12,8 +12,10 @@ import WeeklyView from "../components/organisms/WeeklyView";
 import { convertUTCToET } from "../../util/timeUtils";
 import { IMeeting } from "../../util/models";
 import { createDefaultFilters } from "../../util/meetingFilters";
+import { useSidebar } from "../context/SidebarContext";
 
 export default function HomePage() {
+  const { isSidebarOpen, openSidebar } = useSidebar();
   const [isLoggedIn, setIsLoggedIn] = useState<boolean | null>(null);
   const [refreshTrigger, setRefreshTrigger] = useState(0);
 
@@ -125,6 +127,22 @@ export default function HomePage() {
     setAnchorEl(null);
   };
 
+  // NewMeeting's own open/closed state lives inside CalendarSidebar itself, so it already
+  // resets for free when the sidebar unmounts. showEditMeeting lives up here instead, so
+  // hiding the sidebar while Edit is open needs an explicit reset -- and since Edit only
+  // exists as a follow-on from ViewMeeting's popup (see handleOpenEdit below), backing out
+  // of Edit here backs all the way out of ViewMeeting too, same as handleBack elsewhere,
+  // rather than leaving the popup to reappear underneath once the sidebar reopens.
+  useEffect(() => {
+    if (!isSidebarOpen && showEditMeeting) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      handleBack();
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setShowEditMeeting(false);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isSidebarOpen]);
+
   // Switching Day/Week view backs out to neutral (CalendarSidebar, no popup) entirely --
   // not just closing Edit, since the clicked box's anchorEl also goes stale across the
   // switch (Day view's boxes aren't in the DOM once Week view renders, and vice versa),
@@ -143,6 +161,9 @@ export default function HomePage() {
   }, [selectedView]);
 
   const handleOpenEdit = () => {
+    // EditMeetingSidebar renders inside the .sidebar column, so Edit needs it open --
+    // unlike just viewing a meeting, which shows its own popup regardless of sidebar state.
+    openSidebar();
     setShowEditMeeting(true);
   };
 
@@ -214,30 +235,40 @@ export default function HomePage() {
     return new Date(isoDateString);
   };
 
+  // ViewMeeting's popup is anchored to the clicked box's on-screen position -- scrolling
+  // either the sidebar or the calendar grid underneath it while it's open just fights that
+  // anchoring instead of being useful, so both are locked while it's showing.
+  const isViewMeetingOpen = !!(selectedMeeting && !showEditMeeting);
+
   return (
     <div className={styles.container}>
-      <div className={styles.sidebar}>
-        {isLoggedIn === null ? null : !isLoggedIn ? (
-          <SignInPrompt />
-        ) : showEditMeeting && selectedMeeting ? (
-            <EditMeetingSidebar
-              meeting={selectedMeeting}
-              onClose={handleCloseEdit}
-              onUpdateSuccess={() => {
-                console.log("Meeting updated!");
-                triggerCalendarRefresh();
-              }}
-            />) : (
-              <CalendarSidebar
-                filters={filters}
-                setFilters={setFilters}
-                selectedDate={selectedDate}
-                setSelectedDate={setSelectedDate}
-                selectedView={selectedView}
-                triggerCalendarRefresh={triggerCalendarRefresh}
-              />
-            )}
-      </div>
+      {isSidebarOpen && (
+        <div
+          className={styles.sidebar}
+          style={isViewMeetingOpen ? { overflowY: 'hidden' } : undefined}
+        >
+          {isLoggedIn === null ? null : !isLoggedIn ? (
+            <SignInPrompt />
+          ) : showEditMeeting && selectedMeeting ? (
+              <EditMeetingSidebar
+                meeting={selectedMeeting}
+                onClose={handleCloseEdit}
+                onUpdateSuccess={() => {
+                  console.log("Meeting updated!");
+                  triggerCalendarRefresh();
+                }}
+              />) : (
+                <CalendarSidebar
+                  filters={filters}
+                  setFilters={setFilters}
+                  selectedDate={selectedDate}
+                  setSelectedDate={setSelectedDate}
+                  selectedView={selectedView}
+                  triggerCalendarRefresh={triggerCalendarRefresh}
+                />
+              )}
+        </div>
+      )}
       {selectedMeeting && !showEditMeeting && (
         <ViewMeetingDetails
           key={selectedMeeting.mid}
@@ -303,6 +334,7 @@ export default function HomePage() {
             setSelectedNewMeeting={setSelectedNewMeeting}
             setAnchorEl={setAnchorEl}
             refreshTrigger={refreshTrigger}
+            scrollLocked={isViewMeetingOpen}
           />
         ) : (
           <WeeklyView
@@ -314,6 +346,7 @@ export default function HomePage() {
             setSelectedNewMeeting={setSelectedNewMeeting}
             setAnchorEl={setAnchorEl}
             refreshTrigger={refreshTrigger}
+            scrollLocked={isViewMeetingOpen}
           />
         )}
       </div>

--- a/frontend/app/ClientLayout.tsx
+++ b/frontend/app/ClientLayout.tsx
@@ -5,6 +5,7 @@ import AppNavbar from "./components/organisms/AppNavbar";
 import { Inter } from "next/font/google";
 import styles from "../styles/MainLayout.module.scss";
 import type { Session } from "next-auth";
+import { SidebarProvider } from "./context/SidebarContext";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -24,14 +25,16 @@ export default function ClientLayout({
                 extensions) inject attributes like bis_register onto <body> or <html> before React
                 hydrates — a real mismatch, but not one our code can control or should warn on. */}
             <body className={inter.className} suppressHydrationWarning>
-                <div className={styles.mainlayout}>
-                    <div className={styles.navigation}>
-                        <AppNavbar session={session} />
+                <SidebarProvider>
+                    <div className={styles.mainlayout}>
+                        <div className={styles.navigation}>
+                            <AppNavbar session={session} />
+                        </div>
+                        <div className={styles.content}>
+                            {children}
+                        </div>
                     </div>
-                    <div className={styles.content}>
-                        {children}
-                    </div>
-                </div>
+                </SidebarProvider>
             </body>
         </html>
     );

--- a/frontend/app/components/atoms/CheckBox.tsx
+++ b/frontend/app/components/atoms/CheckBox.tsx
@@ -9,11 +9,15 @@ interface LabeledCheckBoxProps {
     // Background when unchecked -- defaults to transparent (FilterGroup's look); the Meeting
     // Form's checkboxes opt into a white fill instead.
     uncheckedBg?: string;
+    // Scales font-size to ~80% for narrow embedding contexts (the 280px Main Calendar
+    // sidebar) -- used by RecurringMeeting's "This meeting is recurring" checkbox, not
+    // FilterGroup's (Location/Zoom Rooms filters sit in the sidebar directly, unaffected).
+    compact?: boolean;
 }
 
-const LabeledCheckbox: React.FC<LabeledCheckBoxProps> = ({ label, checked, onChange, color, uncheckedBg = 'transparent' }) => {
+const LabeledCheckbox: React.FC<LabeledCheckBoxProps> = ({ label, checked, onChange, color, uncheckedBg = 'transparent', compact = false }) => {
     return (
-        <label className={styles.checkbox}>
+        <label className={`${styles.checkbox} ${compact ? styles.compact : ''}`}>
             <input
                 type="checkbox"
                 checked={checked}

--- a/frontend/app/components/atoms/CheckButton.tsx
+++ b/frontend/app/components/atoms/CheckButton.tsx
@@ -5,13 +5,16 @@ interface CheckButtonProps {
   label: string;
   checked?: boolean;
   onClick: () => void;
+  // Smaller diameter for narrow embedding contexts (e.g. the 280px calendar sidebar), where
+  // the full-size button would get squished into an ellipse by flexbox's default shrink.
+  compact?: boolean;
 }
 
-const CheckButton: React.FC<CheckButtonProps> = ({ label, checked = false, onClick }) => {
+const CheckButton: React.FC<CheckButtonProps> = ({ label, checked = false, onClick, compact = false }) => {
   return (
     <button
       type="button"
-      className={`${styles.checkButton} ${checked ? styles.active : ''}`}
+      className={`${styles.checkButton} ${compact ? styles.compact : ''} ${checked ? styles.active : ''}`}
       onClick={onClick}
     >
       {label}

--- a/frontend/app/components/atoms/DatePicker.tsx
+++ b/frontend/app/components/atoms/DatePicker.tsx
@@ -8,10 +8,12 @@ interface DatePickerProps {
   value?: string; // Expect value to be in 'MM/DD/YYYY' format
   onChange: (value: string) => void;
   underlineOnFocus?: boolean;
+  // Scales font-size to ~80% for narrow embedding contexts (the 280px Main Calendar sidebar).
+  compact?: boolean;
   [key: string]: unknown;
 }
 
-const DatePicker = ({ label, value: propValue = '', onChange, underlineOnFocus = true, ...props }: DatePickerProps) => {
+const DatePicker = ({ label, value: propValue = '', onChange, underlineOnFocus = true, compact = false, ...props }: DatePickerProps) => {
   const [internalValue, setInternalValue] = useState<string>(propValue);
   const [isFocused, setIsFocused] = useState<boolean>(false);
   const [showCalendar, setShowCalendar] = useState<boolean>(false);
@@ -226,7 +228,7 @@ const DatePicker = ({ label, value: propValue = '', onChange, underlineOnFocus =
 };
 
   return (
-    <div className={`${styles['date-picker-wrapper']} ${isFocused && underlineOnFocus ? styles['underline'] : ''}`} ref={datePickerRef}>
+    <div className={`${styles['date-picker-wrapper']} ${compact ? styles.compact : ''} ${isFocused && underlineOnFocus ? styles['underline'] : ''}`} ref={datePickerRef}>
       <label className={styles['date-picker-label']}>
         {typeof label === 'string' ? <span>{label}</span> : label}
       </label>

--- a/frontend/app/components/atoms/Dropdown.tsx
+++ b/frontend/app/components/atoms/Dropdown.tsx
@@ -25,16 +25,30 @@ const Dropdown: React.FC<DropdownProps> = ({
   const [selectedElement, setselectedElement] = useState<string | null>(value ?? null);
 
   const [activeDropdown, setActiveDropdown] = useState<string | null>(null);
+  const buttonRef = React.useRef<HTMLButtonElement>(null);
 
   React.useEffect(() => {
     // Intentionally mount-only: notifies the parent once with the initial value. Call
-    // sites needing continuous sync as `value` changes later already remount this
-    // component via `key={...}` (see EditMeeting/NewMeeting's zoom-room dropdowns).
+    // sites needing continuous sync as `value` changes later either remount this
+    // component via `key={...}` (see EditMeeting/NewMeeting's zoom-room dropdowns) or
+    // rely on the value-sync effect below (see CalendarNavbar's view dropdown, which
+    // stays mounted -- remounting it would re-fire this onChange on every selection).
     if (value) {
       onChange(value);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  // Keeps a non-remounting Dropdown's displayed selection in sync when the parent
+  // changes `value` out from under it. Deliberately doesn't call onChange -- that
+  // would re-notify the parent of a value it just told us about, right back where the
+  // key-remount pattern's duplicate-onChange problem started.
+  React.useEffect(() => {
+    if (value !== undefined) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setselectedElement(value);
+    }
+  }, [value]);
 
   if (!isVisible) return null;
 
@@ -45,13 +59,25 @@ const Dropdown: React.FC<DropdownProps> = ({
   const handleElementClick = (element: string) => {
     setselectedElement(element);
     onChange(element);
-    setActiveDropdown(null); 
+    setActiveDropdown(null);
   };
 
+  const handleOptionKeyDown = (e: React.KeyboardEvent<HTMLLIElement>, element: string) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      handleElementClick(element);
+      buttonRef.current?.focus();
+    } else if (e.key === 'Escape') {
+      setActiveDropdown(null);
+      buttonRef.current?.focus();
+    }
+  };
 
   // String labels (e.g. "Repeats") stay outside the button as a plain text caption; icon
   // labels move inside the button so the icon and value read as one field, not two boxes.
-  const isStringLabel = typeof label === 'string';
+  // An empty string ("" -- passed when a call site wants neither) must count as no label,
+  // same as omitting the prop entirely.
+  const isStringLabel = typeof label === 'string' && label.trim().length > 0;
 
   return (
     <div className={`${styles.dropdown} ${compact ? styles.compact : ''}`}>
@@ -62,8 +88,11 @@ const Dropdown: React.FC<DropdownProps> = ({
           </label>
         )}
         <button
+          ref={buttonRef}
           className={`${styles.DropdownButton} ${activeDropdown === "element" ? styles.activeDropdown : ''}`}
           onClick={() => handleDropdownToggle("element")}
+          aria-haspopup="listbox"
+          aria-expanded={activeDropdown === "element"}
         >
           <span className={styles.DropdownButtonContent}>
             {!isStringLabel && label && <span className={styles.DropdownIcon}>{label}</span>}
@@ -72,12 +101,20 @@ const Dropdown: React.FC<DropdownProps> = ({
           <img src="/svg/drop-down-arrow.svg" alt="" className={styles.dropdownArrow} />
         </button>
         {activeDropdown === "element" && (
-          <ul className={`${styles.elementList} ${!isStringLabel ? styles.elementListFullWidth : ''}`}>
+          <ul
+            className={`${styles.elementList} ${!isStringLabel ? styles.elementListFullWidth : ''}`}
+            role="listbox"
+            aria-label={name}
+          >
             {elements.map((element, index) => (
               <li
                 key={index}
+                role="option"
+                aria-selected={selectedElement === element}
+                tabIndex={0}
                 className={`${styles.dropdownItem} ${selectedElement === element ? styles.selected : ''}`}
                 onClick={() => handleElementClick(element)}
+                onKeyDown={(e) => handleOptionKeyDown(e, element)}
               >
                 {element}
               </li>

--- a/frontend/app/components/atoms/Dropdown.tsx
+++ b/frontend/app/components/atoms/Dropdown.tsx
@@ -5,19 +5,23 @@ interface DropdownProps {
   label: string | React.ReactNode;
   value?: string;
   isVisible: boolean;
-  elements: string[]; 
-  name: string; 
+  elements: string[];
+  name: string;
   onChange: (value: string) => void;
+  // Scales font-size to ~80% for narrow embedding contexts (the 280px Main Calendar sidebar).
+  compact?: boolean;
 }
 
 
-const Dropdown: React.FC<DropdownProps> = ({ 
-  label, 
+const Dropdown: React.FC<DropdownProps> = ({
+  label,
   value,
-  isVisible, 
-  elements, 
-  name, 
-  onChange,}) => {
+  isVisible,
+  elements,
+  name,
+  onChange,
+  compact = false,
+}) => {
   const [selectedElement, setselectedElement] = useState<string | null>(value ?? null);
 
   const [activeDropdown, setActiveDropdown] = useState<string | null>(null);
@@ -50,7 +54,7 @@ const Dropdown: React.FC<DropdownProps> = ({
   const isStringLabel = typeof label === 'string';
 
   return (
-    <div className={styles.dropdown}>
+    <div className={`${styles.dropdown} ${compact ? styles.compact : ''}`}>
       <div className={styles.DropdownContainer}>
         {isStringLabel && (
           <label className={styles.DropdownLabel}>
@@ -65,6 +69,7 @@ const Dropdown: React.FC<DropdownProps> = ({
             {!isStringLabel && label && <span className={styles.DropdownIcon}>{label}</span>}
             <span className={styles.DropdownButtonText}>{selectedElement ? selectedElement : name}</span>
           </span>
+          <img src="/svg/drop-down-arrow.svg" alt="" className={styles.dropdownArrow} />
         </button>
         {activeDropdown === "element" && (
           <ul className={`${styles.elementList} ${!isStringLabel ? styles.elementListFullWidth : ''}`}>

--- a/frontend/app/components/atoms/ModeTypeButtons.tsx
+++ b/frontend/app/components/atoms/ModeTypeButtons.tsx
@@ -4,25 +4,30 @@ import styles from '../../../styles/components/atoms/ModeTypeButtons.module.scss
 interface ModeButtonsProps {
   selectedMode: string;
   onModeSelect: (mode: string) => void;
+  // Scales font-size to ~80% for narrow embedding contexts (the 280px Main Calendar sidebar).
+  compact?: boolean;
 }
 
-const ModeButtons: React.FC<ModeButtonsProps> = ({ selectedMode, onModeSelect }) => {
+const ModeButtons: React.FC<ModeButtonsProps> = ({ selectedMode, onModeSelect, compact = false }) => {
+  const buttonClassName = (mode: string) =>
+    `${styles.button} ${compact ? styles.compact : ""} ${selectedMode === mode ? styles.selected : ""}`;
+
   return (
     <div className={styles.meetingButtons}>
       <button
-        className={`${styles.button} ${selectedMode === "Hybrid" ? styles.selected : ""}`}
+        className={buttonClassName("Hybrid")}
         onClick={() => onModeSelect("Hybrid")}
       >
         Hybrid
       </button>
       <button
-        className={`${styles.button} ${selectedMode === "In Person" ? styles.selected : ""}`}
+        className={buttonClassName("In Person")}
         onClick={() => onModeSelect("In Person")}
       >
         In Person
       </button>
       <button
-        className={`${styles.button} ${selectedMode === "Remote" ? styles.selected : ""}`}
+        className={buttonClassName("Remote")}
         onClick={() => onModeSelect("Remote")}
       >
         Remote

--- a/frontend/app/components/atoms/TextField.tsx
+++ b/frontend/app/components/atoms/TextField.tsx
@@ -28,10 +28,12 @@ const TextField: React.FC<TextFieldProps> = ({
 
   const toggleFocus = () => setUnderlineOnFocus((prev) => !prev);
 
-  // Determine font size based on label presence
+  // Determine font size based on label presence -- "" (passed for description fields
+  // that intentionally render no label) must count as unlabeled, same as undefined/null.
+  const hasLabel = Boolean(label);
   const fontSize = compact
-    ? (label == null ? "19.2px" : "14.4px")
-    : (label == null ? "24px" : "18px");
+    ? (hasLabel ? "14.4px" : "19.2px")
+    : (hasLabel ? "18px" : "24px");
   const labelFontSize = compact ? "14.4px" : "18px";
 
   const inputClassName = `${styles.textfieldinput} ${multiline ? styles.multiline : ''} ${underlineOnFocus ? styles.focused : styles.default}`;

--- a/frontend/app/components/atoms/TextField.tsx
+++ b/frontend/app/components/atoms/TextField.tsx
@@ -8,6 +8,9 @@ interface TextFieldProps {
   underlineOnFocus?: boolean;
   label?: string | React.JSX.Element; // Label can now be either a string or an SVG element
   multiline?: boolean; // Renders a wrapping <textarea> instead of a single-line <input>
+  // Scales font-size to ~80% for narrow embedding contexts (the 280px Main Calendar
+  // sidebar) -- set via inline style below, so a CSS override can't win over it.
+  compact?: boolean;
   [key: string]: unknown; // Allow for additional props
 }
 
@@ -17,6 +20,7 @@ const TextField: React.FC<TextFieldProps> = ({
   onChange,
   label,
   multiline = false,
+  compact = false,
   ...props
 }) => {
   const [underlineOnFocus, setUnderlineOnFocus] = useState(false);
@@ -25,7 +29,10 @@ const TextField: React.FC<TextFieldProps> = ({
   const toggleFocus = () => setUnderlineOnFocus((prev) => !prev);
 
   // Determine font size based on label presence
-  const fontSize = label == null ? "24px" : "18px";
+  const fontSize = compact
+    ? (label == null ? "19.2px" : "14.4px")
+    : (label == null ? "24px" : "18px");
+  const labelFontSize = compact ? "14.4px" : "18px";
 
   const inputClassName = `${styles.textfieldinput} ${multiline ? styles.multiline : ''} ${underlineOnFocus ? styles.focused : styles.default}`;
 
@@ -41,7 +48,7 @@ const TextField: React.FC<TextFieldProps> = ({
       {label && (
         <label
           className={styles.textfieldlabel}
-          style={{ fontSize: "18px" }} // Label is always 18px
+          style={{ fontSize: labelFontSize }}
         >
           {typeof label === "string" ? <span>{label}</span> : label}
         </label>

--- a/frontend/app/components/atoms/TimePicker.tsx
+++ b/frontend/app/components/atoms/TimePicker.tsx
@@ -7,6 +7,8 @@ interface TimePickerProps {
   onChange: (value: string) => void;
   underlineOnFocus?: boolean;
   disablePast?: boolean;
+  // Scales font-size to ~80% for narrow embedding contexts (the 280px Main Calendar sidebar).
+  compact?: boolean;
   [key: string]: unknown;
 }
 
@@ -30,7 +32,7 @@ const getTimeDifferenceInMinutes = (startTime: string, endTime: string): number 
   return (endDate.getTime() - startDate.getTime()) / (1000 * 60);
 };
 
-const TimePicker = ({ label, value: propValue = '', disablePast, onChange, ...props }: TimePickerProps) => {
+const TimePicker = ({ label, value: propValue = '', disablePast, onChange, compact = false, ...props }: TimePickerProps) => {
 
   // Parse the initial value when component mounts
   const parseTimeRange = (value: string): { startTime: string, endTime: string } => {
@@ -105,7 +107,7 @@ const TimePicker = ({ label, value: propValue = '', disablePast, onChange, ...pr
   };
 
   return (
-    <div className={styles['time-picker-wrapper']}>
+    <div className={`${styles['time-picker-wrapper']} ${compact ? styles.compact : ''}`}>
       <label className={styles['time-picker-label']}>
         {typeof label === 'string' ? <span>{label}</span> : label}
       </label>

--- a/frontend/app/components/molecules/MeetingsFilter.tsx
+++ b/frontend/app/components/molecules/MeetingsFilter.tsx
@@ -20,11 +20,11 @@ const LOCATION_ITEMS: FilterGroupItem[] = [
 ];
 
 const ZOOM_ITEMS: FilterGroupItem[] = [
-    { key: 'SerenityRoomZoom', label: 'Serenity Room - Zoom', color: ZOOM_ROOM_COLOR },
-    { key: 'SeedsofHopeRoomZoom', label: 'Seeds of Hope Room - Zoom', color: ZOOM_ROOM_COLOR },
-    { key: 'UnityRoomZoom', label: 'Unity Room - Zoom', color: ZOOM_ROOM_COLOR },
-    { key: 'RoomforImprovementZoom', label: 'Room for Improvement - Zoom', color: ZOOM_ROOM_COLOR },
-    { key: "Children'sRoom@518Zoom", label: "Children's Room @ 518 - Zoom", color: ZOOM_ROOM_COLOR },
+    { key: 'SerenityRoomZoom', label: 'Serenity Room', color: ZOOM_ROOM_COLOR },
+    { key: 'SeedsofHopeRoomZoom', label: 'Seeds of Hope Room', color: ZOOM_ROOM_COLOR },
+    { key: 'UnityRoomZoom', label: 'Unity Room', color: ZOOM_ROOM_COLOR },
+    { key: 'RoomforImprovementZoom', label: 'Room for Improvement', color: ZOOM_ROOM_COLOR },
+    { key: "Children'sRoom@518Zoom", label: "Children's Room @ 518", color: ZOOM_ROOM_COLOR },
 ];
 
 const CALENDAR_ITEMS: FilterGroupItem[] = [

--- a/frontend/app/components/molecules/RecurringMeeting.tsx
+++ b/frontend/app/components/molecules/RecurringMeeting.tsx
@@ -264,6 +264,7 @@ const RecurringMeetingForm: React.FC<RecurringMeetingFormProps> = ({
           onChange={handleRecurringChange}
           color="#848484"
           uncheckedBg="#fff"
+          compact={layout === "sidebar"}
         />
       </div>
 
@@ -285,6 +286,7 @@ const RecurringMeetingForm: React.FC<RecurringMeetingFormProps> = ({
                     if (opts.length > 0) setMonthlyOption(opts[0]);
                   }
                 }}
+                compact={layout === "sidebar"}
               />
             </div>
 
@@ -315,6 +317,7 @@ const RecurringMeetingForm: React.FC<RecurringMeetingFormProps> = ({
                       label={day.label}
                       checked={selectedDays.includes(day.id)}
                       onClick={() => toggleDay(day.id)}
+                      compact={layout === "sidebar"}
                     />
                   ))}
                 </div>
@@ -337,6 +340,7 @@ const RecurringMeetingForm: React.FC<RecurringMeetingFormProps> = ({
                   elements={monthlyOptions}
                   name="Select recurrence"
                   onChange={setMonthlyOption}
+                  compact={layout === "sidebar"}
                 />
               </div>
             )}
@@ -353,6 +357,7 @@ const RecurringMeetingForm: React.FC<RecurringMeetingFormProps> = ({
                     label={""}
                     value={endDate}
                     onChange={(val) => setEndDate(val)}
+                    compact={layout === "sidebar"}
                   />
                 ),
                 After: (

--- a/frontend/app/components/organisms/AppNavbar.tsx
+++ b/frontend/app/components/organisms/AppNavbar.tsx
@@ -6,6 +6,8 @@ import { usePathname } from "next/navigation";
 import Logo from "../atoms/Logo";
 import type { Session } from "next-auth";
 import { signOut } from "next-auth/react";
+import IconButton from "@mui/material/IconButton";
+import { useSidebar } from "../../context/SidebarContext";
 import styles from "../../../styles/components/organisms/AppNavbar.module.scss";
 
 interface AppNavbarProps {
@@ -16,11 +18,26 @@ const AppNavbar: React.FC<AppNavbarProps> = ({ session }) => {
     const isAdmin = session?.user?.role === "ADMIN" || session?.user?.role === "SUPER_ADMIN";
     const pathname = usePathname();
     const navItemClass = (isActive: boolean) => `btn btn-ghost ${isActive ? styles.active : ""}`;
+    const { isSidebarOpen, toggleSidebar } = useSidebar();
 
     return (
         <div className={styles.navbar}>
             <div className={styles.navcontainer}>
-                <Logo />
+                <div className={styles.navLeft}>
+                    <span className={styles.sidebarToggleWrapper}>
+                        <IconButton
+                            className={styles.sidebarToggleButton}
+                            onClick={toggleSidebar}
+                            aria-label={isSidebarOpen ? "Hide calendar sidebar" : "Show calendar sidebar"}
+                        >
+                            <img src="/svg/menu-icon.svg" alt="" className={styles.menuIcon} />
+                        </IconButton>
+                        <span className={styles.tooltip}>
+                            Show/Hide calendar sidebar
+                        </span>
+                    </span>
+                    <Logo />
+                </div>
                 <ul className={styles.navigationlist}>
                     <li className={`${navItemClass(pathname === "/")} ${styles.navTooltipWrapper}`}>
                         <Link href="/">

--- a/frontend/app/components/organisms/CalendarNavbar.tsx
+++ b/frontend/app/components/organisms/CalendarNavbar.tsx
@@ -76,7 +76,6 @@ const CalendarNavbar: React.FC<CalendarNavbarProps> = ({ selectedDate, onDateCha
         <div className={styles.navbarContainerLeft}>
           <div className={styles.viewDropdown}>
             <Dropdown
-              key={selectedView}
               label=""
               value={selectedView}
               isVisible={true}

--- a/frontend/app/components/organisms/CalendarNavbar.tsx
+++ b/frontend/app/components/organisms/CalendarNavbar.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import Dropdown from '../atoms/Dropdown';
 import styles from "../../../styles/components/organisms/CalendarNavbar.module.scss";
 import { formatMeetingDateLine, monthNameForETDateString, formatMeetingWeekLine } from "../../../util/timeFormat";
 import {
@@ -32,9 +33,9 @@ const CalendarNavbar: React.FC<CalendarNavbarProps> = ({ selectedDate, onDateCha
       return `${monthNameForETDateString(etDateStr)} ${year}`;
     };
   
-    const handleViewChange: React.ChangeEventHandler<HTMLSelectElement> = (event) => {
-      setSelectedView(event.target.value);
-      onViewChange(event.target.value); // Call the external function
+    const handleViewChange = (value: string) => {
+      setSelectedView(value);
+      onViewChange(value); // Call the external function
       onDateChange(new Date());
     };
   
@@ -73,12 +74,16 @@ const CalendarNavbar: React.FC<CalendarNavbarProps> = ({ selectedDate, onDateCha
       <div className={styles.navbarContainer}>
         <h2 className={styles.navbarContainerRight}>{getDateRange(selectedDate)}</h2>
         <div className={styles.navbarContainerLeft}>
-          <div className={styles.box}>
-            {/* Temporary dropdown component */}
-            <select id="view-select" value={selectedView} onChange={handleViewChange}>
-              <option value="Day">Day</option>
-              <option value="Week">Week</option>
-            </select>
+          <div className={styles.viewDropdown}>
+            <Dropdown
+              key={selectedView}
+              label=""
+              value={selectedView}
+              isVisible={true}
+              elements={['Day', 'Week']}
+              name="Select view"
+              onChange={handleViewChange}
+            />
           </div>
           <div className={styles.box}>
             <a href="#" onClick={handleToday}>Today</a>

--- a/frontend/app/components/organisms/DailyView.tsx
+++ b/frontend/app/components/organisms/DailyView.tsx
@@ -152,6 +152,10 @@ interface DailyViewProps {
   setSelectedNewMeeting: (newMeetingExists: boolean) => void;
   setAnchorEl: (el: HTMLElement) => void;
   refreshTrigger?: number;
+  // Disables scrolling this view while the ViewMeeting popup is open -- it's anchored to
+  // the clicked box's on-screen position, so scrolling underneath it while open just
+  // fights the popup's own reposition-on-scroll logic instead of being useful.
+  scrollLocked?: boolean;
 }
 
 const DailyView: React.FC<DailyViewProps> = ({
@@ -161,7 +165,8 @@ const DailyView: React.FC<DailyViewProps> = ({
   setSelectedMeetingID,
   setSelectedNewMeeting,
   setAnchorEl,
-  refreshTrigger = 0
+  refreshTrigger = 0,
+  scrollLocked = false,
 }) => {
   const [currentTimePosition, setCurrentTimePosition] = useState(0);
   const [meetings, setMeetings] = useState<Room[]>([]);
@@ -249,7 +254,11 @@ const DailyView: React.FC<DailyViewProps> = ({
 
   return (
     <div className={styles.outerContainer}>
-      <div ref={scrollContainerRef} className={styles.viewContainer}>
+      <div
+        ref={scrollContainerRef}
+        className={styles.viewContainer}
+        style={scrollLocked ? { overflow: 'hidden' } : undefined}
+      >
         <div className={styles.roomContainer}>
           <div className={styles.roomCorner} />
           {combinedRooms.map((room, index) => (

--- a/frontend/app/components/organisms/EditMeeting.tsx
+++ b/frontend/app/components/organisms/EditMeeting.tsx
@@ -47,6 +47,9 @@ const EditMeetingSidebar: React.FC<EditMeetingSidebarProps> =
     } = useMeetingForm(meeting);
 
     const [isSubmitting, setIsSubmitting] = useState(false);
+    // Narrow Main Calendar sidebar gets ~80%-scaled field fonts; the "wide" embed (e.g.
+    // Diagnostics Conflicts panel) has room to spare and keeps full size.
+    const compact = layout === "sidebar";
 
     const updateMeeting = async () => {
       // Guards against duplicate/racing updates from rapid/double clicks — the
@@ -100,22 +103,26 @@ const EditMeetingSidebar: React.FC<EditMeetingSidebarProps> =
             input="Meeting title"
             value={inputMeetingTitleValue}
             onChange={setMeetingTitleValue}
+            compact={compact}
           />}
           modeTypeButtons={<ModeTypeButtons
             selectedMode={selectedMode}
             onModeSelect={handleModeSelect}
+            compact={compact}
           />}
           selectedMode={selectedMode}
           DatePicker={<DatePicker
             label={<img src='/svg/calendar-icon.svg' alt="Calendar Icon" />}
             value={dateValue}
             onChange={setDateValue}
+            compact={compact}
           />}
           TimePicker={<TimePicker
             label={<img src='/svg/clock-icon.svg' alt="Clock Icon" />}
             value={timeValue}
             onChange={setTimeValue}
             disablePast={true}
+            compact={compact}
           />}
           RecurringMeeting={
             <RecurringMeetingForm
@@ -136,6 +143,7 @@ const EditMeetingSidebar: React.FC<EditMeetingSidebarProps> =
               elements={physicalRoomOptions}
               name="Select Room"
               onChange={handleRoomChange}
+              compact={compact}
             />
           }
           meetingTypeDropdown={
@@ -155,6 +163,7 @@ const EditMeetingSidebar: React.FC<EditMeetingSidebarProps> =
                     onChange={(_e) => handleCalTypeToggle(type)}
                     color={CAL_TYPE_COLOR}
                     uncheckedBg="#fff"
+                    compact={compact}
                   />
                 ))}
               </div>
@@ -169,6 +178,7 @@ const EditMeetingSidebar: React.FC<EditMeetingSidebarProps> =
               elements={zoomRoomOptions}
               name="Select Zoom Room"
               onChange={setSelectedZoomRoom}
+              compact={compact}
             />
           }
           emailTextField={<TextField
@@ -176,6 +186,7 @@ const EditMeetingSidebar: React.FC<EditMeetingSidebarProps> =
             label={<img src="svg/mail-icon.svg" alt="Mail Icon" />}
             value={inputEmailValue}
             onChange={setEmailValue}
+            compact={compact}
           />}
           descriptionTextField={<TextField
             input="Description"
@@ -184,6 +195,7 @@ const EditMeetingSidebar: React.FC<EditMeetingSidebarProps> =
             onChange={setDescriptionValue}
             multiline
             maxLength={DESCRIPTION_MAX_LENGTH}
+            compact={compact}
           />}
           handleMeetingSubmit={updateMeeting}
           buttonText={isSubmitting ? "Updating…" : "Update Meeting"}

--- a/frontend/app/components/organisms/NewMeeting.tsx
+++ b/frontend/app/components/organisms/NewMeeting.tsx
@@ -110,11 +110,13 @@ const NewMeetingSidebar: React.FC<NewMeetingSidebarProps> = ({
             input="Meeting title"
             value={inputMeetingTitleValue}
             onChange={setMeetingTitleValue}
+            compact
           />}
           modeTypeButtons={
             <ModeTypeButtons
               selectedMode={selectedMode}
               onModeSelect={handleModeSelect}
+              compact
             />
           }
           selectedMode={selectedMode}
@@ -122,12 +124,14 @@ const NewMeetingSidebar: React.FC<NewMeetingSidebarProps> = ({
             label={<img src='/svg/calendar-icon.svg' alt="Calendar Icon" />}
             value={dateValue}
             onChange={setDateValue}
+            compact
           />}
           TimePicker={<TimePicker
             label={<img src='/svg/clock-icon.svg' alt="Clock Icon" />}
             value={timeValue}
             onChange={setTimeValue}
             disablePast={true}
+            compact
           />}
           RecurringMeeting={
             <RecurringMeetingForm
@@ -142,6 +146,7 @@ const NewMeetingSidebar: React.FC<NewMeetingSidebarProps> = ({
               elements={physicalRoomOptions}
               name="Select Room"
               onChange={handleRoomChange}
+              compact
             />
           }
           meetingTypeDropdown={
@@ -161,6 +166,7 @@ const NewMeetingSidebar: React.FC<NewMeetingSidebarProps> = ({
                     onChange={(_e) => handleCalTypeToggle(type)}
                     color={CAL_TYPE_COLOR}
                     uncheckedBg="#fff"
+                    compact
                   />
                 ))}
               </div>
@@ -175,6 +181,7 @@ const NewMeetingSidebar: React.FC<NewMeetingSidebarProps> = ({
               elements={zoomRoomOptions}
               name="Select Zoom Room"
               onChange={setSelectedZoomRoom}
+              compact
             />
           }
           emailTextField={<TextField
@@ -182,6 +189,7 @@ const NewMeetingSidebar: React.FC<NewMeetingSidebarProps> = ({
             label={<img src="svg/mail-icon.svg" alt="Mail Icon" />}
             value={inputEmailValue}
             onChange={setEmailValue}
+            compact
           />}
           descriptionTextField={<TextField
             input="Description"
@@ -190,6 +198,7 @@ const NewMeetingSidebar: React.FC<NewMeetingSidebarProps> = ({
             onChange={setDescriptionValue}
             multiline
             maxLength={DESCRIPTION_MAX_LENGTH}
+            compact
           />}
           handleMeetingSubmit={createMeeting}
           buttonText={isSubmitting ? "Creating…" : "Create Meeting"}

--- a/frontend/app/components/organisms/ViewMeeting.tsx
+++ b/frontend/app/components/organisms/ViewMeeting.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useLayoutEffect, useRef } from 'react';
+import React, { useState, useEffect, useLayoutEffect, useCallback, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import styles from '../../../styles/components/organisms/ViewMeeting.module.scss';
 import DeleteRecurringModal from '../molecules/DeleteRecurringModal';
@@ -105,6 +105,28 @@ const ViewMeetingDetails: React.FC<ViewMeetingDetailsProps> = ({
   const [descNode, setDescNode] = useState<HTMLParagraphElement | null>(null);
   const [popupPosition, setPopupPosition] = useState<{ top: number; left: number } | null>(null);
 
+  // Before the popup has ever mounted, popupRef.current is null, so the first calculation
+  // below falls back to a capped estimate (min(80% of viewport, 600px)) for its height --
+  // real popups are usually much shorter (e.g. ~350-400px for a non-recurring meeting with
+  // no description), so that estimate over-clamps `top` upward far more than necessary,
+  // landing the popup well away from the anchor box that was actually clicked. The
+  // useLayoutEffect below corrects this once the real height is known post-mount.
+  const updatePosition = useCallback(() => {
+    if (!anchorEl) return;
+    const rect = anchorEl.getBoundingClientRect();
+    let left = rect.right + ANCHOR_GAP;
+    if (left + POPUP_WIDTH > window.innerWidth - POPUP_MARGIN) {
+      left = rect.left - POPUP_WIDTH - ANCHOR_GAP;
+    }
+    left = Math.max(POPUP_MARGIN, Math.min(left, window.innerWidth - POPUP_WIDTH - POPUP_MARGIN));
+    // Clamp against the popup's own (measured, or capped-height-estimated pre-mount) height --
+    // window.innerHeight alone is the viewport's bottom edge, not the popup's, so an anchor low
+    // in the day grid would otherwise render the popup mostly off-screen.
+    const popupHeight = popupRef.current?.offsetHeight ?? Math.min(0.8 * window.innerHeight, 600);
+    const top = Math.max(POPUP_MARGIN, Math.min(rect.top, window.innerHeight - popupHeight - POPUP_MARGIN));
+    setPopupPosition({ top, left });
+  }, [anchorEl]);
+
   // Tracks the clicked box's on-screen position while the popup is open, so the portaled
   // popup (position:fixed) stays anchored beside it -- recomputed on scroll (capture:true
   // catches scrolling within any nested scroll container, not just the window) and resize.
@@ -112,21 +134,6 @@ const ViewMeetingDetails: React.FC<ViewMeetingDetailsProps> = ({
   // recomputing there would just churn popupPosition with an equivalent-but-new object.
   useEffect(() => {
     if (!anchorEl) return;
-
-    const updatePosition = () => {
-      const rect = anchorEl.getBoundingClientRect();
-      let left = rect.right + ANCHOR_GAP;
-      if (left + POPUP_WIDTH > window.innerWidth - POPUP_MARGIN) {
-        left = rect.left - POPUP_WIDTH - ANCHOR_GAP;
-      }
-      left = Math.max(POPUP_MARGIN, Math.min(left, window.innerWidth - POPUP_WIDTH - POPUP_MARGIN));
-      // Clamp against the popup's own (measured, or capped-height-estimated pre-mount) height --
-      // window.innerHeight alone is the viewport's bottom edge, not the popup's, so an anchor low
-      // in the day grid would otherwise render the popup mostly off-screen.
-      const popupHeight = popupRef.current?.offsetHeight ?? Math.min(0.8 * window.innerHeight, 600);
-      const top = Math.max(POPUP_MARGIN, Math.min(rect.top, window.innerHeight - popupHeight - POPUP_MARGIN));
-      setPopupPosition({ top, left });
-    };
 
     const handleScroll = (event: Event) => {
       if (popupRef.current?.contains(event.target as Node)) return;
@@ -140,7 +147,19 @@ const ViewMeetingDetails: React.FC<ViewMeetingDetailsProps> = ({
       window.removeEventListener('scroll', handleScroll, true);
       window.removeEventListener('resize', updatePosition);
     };
-  }, [anchorEl]);
+  }, [anchorEl, updatePosition]);
+
+  // Runs once the popup's real DOM node exists (right after the first render above sets
+  // popupPosition and the portal actually mounts) and corrects `top` using its real
+  // offsetHeight in place of the pre-mount estimate -- see the comment on updatePosition.
+  useLayoutEffect(() => {
+    if (!popupPosition || !popupRef.current) return;
+    updatePosition();
+    // Deliberately excludes updatePosition/popupPosition to run only on the transition to
+    // mounted, not on every position update updatePosition itself causes (which would still
+    // be harmless/idempotent, just redundant).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [!!popupPosition]);
 
   // Closes the whole popup on an outside click -- clicks on the anchor box itself are left
   // alone since that box's own onClick already handles re-selecting/toggling it.

--- a/frontend/app/components/organisms/WeeklyView.tsx
+++ b/frontend/app/components/organisms/WeeklyView.tsx
@@ -114,6 +114,10 @@ interface WeeklyViewProps {
     setSelectedNewMeeting: (newMeetingExists: boolean) => void;
     setAnchorEl: (el: HTMLElement) => void;
     refreshTrigger?: number;
+    // Disables scrolling this view while the ViewMeeting popup is open -- it's anchored to
+    // the clicked box's on-screen position, so scrolling underneath it while open just
+    // fights the popup's own reposition-on-scroll logic instead of being useful.
+    scrollLocked?: boolean;
 }
 
 const WeeklyView: React.FC<WeeklyViewProps> = ({
@@ -124,7 +128,8 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
     setSelectedMeetingID,
     setSelectedNewMeeting,
     setAnchorEl,
-    refreshTrigger = 0
+    refreshTrigger = 0,
+    scrollLocked = false,
 }) => {
     const [currentTimePosition, setCurrentTimePosition] = useState(0);
     const [weekStartDate, setWeekStartDate] = useState<Date>(() => getFirstDayOfWeek(selectedDate));
@@ -258,7 +263,11 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
 
     return (
         <div className={styles.outerContainer}>
-            <div className={styles.viewContainer} ref={viewContainerRef}>
+            <div
+                className={styles.viewContainer}
+                ref={viewContainerRef}
+                style={scrollLocked ? { overflow: 'hidden' } : undefined}
+            >
                 {/* Time column */}
                 <div className={styles.timeColumn}>
                     <div className={styles.timeHeader}>

--- a/frontend/app/context/SidebarContext.tsx
+++ b/frontend/app/context/SidebarContext.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import React, { createContext, useCallback, useContext, useState } from "react";
+
+interface SidebarContextValue {
+    isSidebarOpen: boolean;
+    toggleSidebar: () => void;
+    openSidebar: () => void;
+}
+
+const SidebarContext = createContext<SidebarContextValue | undefined>(undefined);
+
+export const SidebarProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
+    const [isSidebarOpen, setIsSidebarOpen] = useState(true);
+
+    const toggleSidebar = useCallback(() => setIsSidebarOpen((prev) => !prev), []);
+    const openSidebar = useCallback(() => setIsSidebarOpen(true), []);
+
+    return (
+        <SidebarContext.Provider value={{ isSidebarOpen, toggleSidebar, openSidebar }}>
+            {children}
+        </SidebarContext.Provider>
+    );
+};
+
+export const useSidebar = (): SidebarContextValue => {
+    const context = useContext(SidebarContext);
+    if (!context) {
+        throw new Error("useSidebar must be used within a SidebarProvider");
+    }
+    return context;
+};

--- a/frontend/config/playwright.config.ts
+++ b/frontend/config/playwright.config.ts
@@ -11,6 +11,12 @@ export default defineConfig({
   globalTeardown: require.resolve("../test/e2e/global-teardown.ts"),
   fullyParallel: false,
   workers: 1,
+  // CI runners are shared/throttled, and next dev (see global-setup.ts) can still
+  // have a stray lazy-compile latency spike despite pre-warming -- one retry
+  // absorbs that without masking a real logic bug (a genuinely broken test fails
+  // twice). Local runs stay retry-free so a real failure isn't hidden behind a
+  // silent pass on attempt 2.
+  retries: process.env.CI ? 1 : 0,
   reporter: "list",
   use: {
     baseURL: TEST_BASE_URL,

--- a/frontend/public/svg/menu-icon.svg
+++ b/frontend/public/svg/menu-icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="#848484"><path d="M120-240v-80h720v80H120Zm0-200v-80h720v80H120Zm0-200v-80h720v80H120Z"/></svg>

--- a/frontend/styles/components/atoms/CheckButton.module.scss
+++ b/frontend/styles/components/atoms/CheckButton.module.scss
@@ -3,6 +3,10 @@
 .checkButton {
     width: 32px;
     height: 32px;
+
+    // Fixed dimensions only stay circular if flex children are stopped from shrinking below
+    // them -- a flex row narrower than its content otherwise squishes width but not height.
+    flex-shrink: 0;
     border-radius: 50%; // <-- this makes the button circular
     border: 1px solid $grey-border-color;
     background-color: #fff;
@@ -14,6 +18,12 @@
     align-items: center;
     justify-content: center;
     padding: 0;
+  }
+
+  .compact {
+    width: 22px;
+    height: 22px;
+    font-size: 11px;
   }
 
   .checkButton:hover {

--- a/frontend/styles/components/atoms/Checkbox.module.scss
+++ b/frontend/styles/components/atoms/Checkbox.module.scss
@@ -28,5 +28,14 @@
     .checkmark {
         color: white;
     }
+
+    // Scales font-size to ~80% for narrow embedding contexts (the 280px Main Calendar sidebar).
+    &.compact {
+        font-size: 12.8px;
+
+        .checkboxLabel {
+            font-size: 14.4px;
+        }
+    }
 }
   

--- a/frontend/styles/components/atoms/DatePicker.module.scss
+++ b/frontend/styles/components/atoms/DatePicker.module.scss
@@ -30,6 +30,16 @@
     flex: 1;
   }
 
+  &.compact {
+    .date-picker-label {
+      font-size: 14.4px;
+    }
+
+    .date-picker-input {
+      font-size: 12px;
+    }
+  }
+
   .date-picker-input {
     font-size: 15px;
     border: none;

--- a/frontend/styles/components/atoms/Dropdown.module.scss
+++ b/frontend/styles/components/atoms/Dropdown.module.scss
@@ -9,6 +9,15 @@
     width: 100%;
 }
 
+// Scales font-size to ~80% for narrow embedding contexts (the 280px Main Calendar sidebar).
+.dropdown.compact .DropdownLabel {
+    font-size: 14.4px;
+}
+
+.dropdown.compact .DropdownButton {
+    font-size: 12px;
+}
+
 .meetingTitleInput {
     width: 100%;
 
@@ -51,14 +60,22 @@
 
 .elementList {
     position: absolute;
-    top: calc(100% + 5px); 
+    top: calc(100% + 5px);
     left: 30px;
-    width: calc(100% - 30px); 
+    width: calc(100% - 30px);
     background-color: white;
-    border: 1px solid #ccc;
-    box-shadow: 0 4px 8px rgb(0 0 0 / 20%); 
-    z-index: 10; 
-    border-radius: 4px;
+
+    // Same bordered field-box language as MeetingForm's own fields (TextField, DatePicker,
+    // .DropdownButton above all use $grey-border-color + 6px radius) instead of a hardcoded
+    // #ccc/4px that didn't match anything else in the form.
+    border: 1px solid $grey-border-color;
+    border-radius: 6px;
+    box-shadow: 0 4px 8px rgb(0 0 0 / 20%);
+
+    // Above any page content that establishes its own stacking context with a competing
+    // z-index -- e.g. DailyView/WeeklyView's sticky headers go up to 20/21, which used to
+    // render on top of this list (CalendarNavbar's view-switcher dropdown, confirmed 2026-07-25).
+    z-index: 100;
     list-style: none;
     padding: 8px 0;
     margin: 0;
@@ -114,15 +131,15 @@
     white-space: nowrap;
 }
 
+.dropdownArrow {
+    width: 8px;
+    height: 5px;
+    flex-shrink: 0;
+}
+
 .elementListFullWidth {
     left: 0;
     width: 100%;
-}
-
-.DropdownButton::after {
-    content: '\25BC'; /* Downward arrow icon (Unicode) */
-    font-size: 0.7rem; /* Adjust the icon size */
-    color: $medium-grey-color; /* Lighter gray color for the icon */
 }
 
 /* Add active class for when the dropdown is clicked */
@@ -146,25 +163,29 @@
 }
 
 .dropdownItem {
-    padding: 10px 12px;
+    // Matches MeetingForm's field typography (TextField/DatePicker/.DropdownButton above
+    // all use this same family + $black-color) instead of falling back to the browser's
+    // default UI font and a bespoke #333.
+    font-family: 'Source Sans Pro', sans-serif;
+    font-size: 15px;
+    color: $black-color;
+    padding: 14px 12px;
+
+    // Insets each row from the list's own border, and rounds it to match -- reads as its
+    // own field-box-like row highlighting on hover, rather than a flat, undifferentiated strip.
+    margin: 2px 6px;
+    border-radius: 4px;
     cursor: pointer;
-    color: #333; /* Darker text color */
     display: flex;
     align-items: center;
-    justify-content: space-between; /* Space between the text and icon */
 }
 
 .dropdownItem:hover {
-    background-color: #f0f0f0;
+    background-color: $grey-lightest-color;
 }
 
-.dropdownItem::after {
-    content: '\2713'; /* Checkmark icon (Unicode) */
-    font-size: 0.9rem; /* Adjust icon size */
-    color: #d22e55; /* Red color for checkmark */
-    opacity: 0; /* Hide by default */
-}
-
-.dropdownItem.selected::after {
-    opacity: 1; /* Show checkmark if selected */
+// Selected state is a persistent row highlight instead of a checkmark -- reads at a
+// glance without needing to scan each row's trailing edge for a small glyph.
+.dropdownItem.selected {
+    background-color: $grey-lightest-color;
 }

--- a/frontend/styles/components/atoms/MiniCalendar.module.scss
+++ b/frontend/styles/components/atoms/MiniCalendar.module.scss
@@ -11,7 +11,13 @@
 
     // box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
     z-index: 999; // Increased z-index to ensure visibility
-    width: 325px; // Explicit width
+    // .sidebar (page.module.scss) uses the default content-box sizing, so its own
+    // `width: 280px` already *is* its content area -- sibling cards (New Meeting button,
+    // Location/Zoom Rooms filter panel) are plain width:auto blocks that fill exactly that
+    // 280px. Matching it here with a fixed width (rather than width: 100%, which depends on
+    // whatever this happens to be nested inside) is what actually lines this up with them.
+    width: 280px;
+    box-sizing: border-box;
 
     span {
         font-size: 20px;
@@ -27,11 +33,30 @@
         font-size: 14px;
     }
     
-    /* Global styles nested inside the local .container class */
-    :global(.rdp) {
-        --rdp-cell-size: 36px;
+    // Global styles nested inside the local .container class -- react-day-picker v10 API:
+    // sizing comes from the --rdp-day-... and --rdp-day_button-... custom properties on
+    // .rdp-root, and the table itself is .rdp-month_grid (not .rdp-month, which is now just
+    // a wrapper div). These class/variable names don't match v8-era naming (.rdp, .rdp-month,
+    // .rdp-button, --rdp-cell-size) still used elsewhere in older docs/examples -- confirmed
+    // the actual rendered DOM directly against the installed v10 package before writing these.
+    :global(.rdp-root) {
+        // Sized to fit the 280px sidebar: 7 columns must fit inside this .container's own
+        // content width (280px - 24px .container padding = 256px). Library defaults are
+        // 44px/42px, which is what was making this look oversized.
+        --rdp-day-width: 32px;
+        --rdp-day-height: 32px;
+
+        // These two are react-day-picker's own variable names (underscore, not kebab-case) --
+        // can't be renamed, the library reads them verbatim.
+        /* stylelint-disable custom-property-pattern */
+        --rdp-day_button-width: 32px;
+        --rdp-day_button-height: 32px;
+        --rdp-nav-height: 28px;
+        --rdp-nav_button-width: 24px;
+        --rdp-nav_button-height: 24px;
+        /* stylelint-enable custom-property-pattern */
         --rdp-accent-color: #{$dark-pink-color};
-        --rdp-background-color: #f5f5f5;
+        --rdp-accent-background-color: #f5f5f5;
 
         margin: 0;
     }
@@ -39,14 +64,22 @@
     :global(.rdp-months) {
         display: flex;
         justify-content: center;
+
+        // Library default is max-width: fit-content, which lets the table's intrinsic width
+        // win over this container's width instead of being constrained by it.
+        max-width: 100%;
     }
 
-    :global(.rdp-month) {
-        display: table;
+    :global(.rdp-month_grid) {
         width: 100%;
+
+        // Without this, table-layout defaults to auto, which lets a column grow past its
+        // --rdp-day-width if content needs more room than that -- forcing the whole table
+        // (and this box) wider than the sidebar, instead of respecting the fixed size.
+        table-layout: fixed;
     }
 
-    :global(.rdp-caption) {
+    :global(.rdp-month_caption) {
         display: flex;
         justify-content: space-between;
         padding: 0 8px;
@@ -57,18 +90,19 @@
         display: flex;
     }
 
-    :global(.rdp-button) {
+    :global(.rdp-button_previous),
+    :global(.rdp-button_next) {
         cursor: pointer;
-        
+
         &:hover {
             background-color: color.adjust($dark-pink-color, $lightness: 35%);
         }
     }
 
-    :global(.rdp-day) {
+    :global(.rdp-day_button) {
         cursor: pointer;
-        
-        &:hover:not(.rdp-selected, .rdp-disabled) {
+
+        &:hover:not(:disabled) {
             background-color: color.adjust($dark-pink-color, $lightness: 35%);
         }
     }
@@ -91,8 +125,8 @@
         left: 50%;
         transform: translate(-50%, -50%);
         z-index: -1;
-        width: 28px;
-        height: 28px;
+        width: 25px;
+        height: 25px;
     }
 }
 

--- a/frontend/styles/components/atoms/ModeTypeButtons.module.scss
+++ b/frontend/styles/components/atoms/ModeTypeButtons.module.scss
@@ -54,3 +54,7 @@
 .button.selected:hover {
   background: $dark-pink-color;
 }
+
+.button.compact {
+  font-size: 12px;
+}

--- a/frontend/styles/components/atoms/TimePicker.module.scss
+++ b/frontend/styles/components/atoms/TimePicker.module.scss
@@ -18,6 +18,20 @@
     border-color: $dark-pink-color;
   }
 
+  &.compact {
+    .time-picker-label {
+      font-size: 14.4px;
+    }
+
+    .time-picker-input {
+      font-size: 12px;
+    }
+
+    .time-range-separator {
+      font-size: 11.2px;
+    }
+  }
+
   .time-picker-label {
     display: flex;
     align-items: center;

--- a/frontend/styles/components/molecules/RecurringMeeting.module.scss
+++ b/frontend/styles/components/molecules/RecurringMeeting.module.scss
@@ -34,7 +34,9 @@
 
   .dayButtons {
     display: flex;
-    gap: 8px;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 4px;
     margin-bottom: 16px;
 
     .dayButton {

--- a/frontend/styles/components/organisms/AppNavbar.module.scss
+++ b/frontend/styles/components/organisms/AppNavbar.module.scss
@@ -30,6 +30,47 @@
     box-sizing: border-box;
 }
 
+.navLeft {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 8px;
+}
+
+.sidebarToggleWrapper {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+
+    &:hover .tooltip,
+    &:focus-within .tooltip {
+        opacity: 1;
+        visibility: visible;
+    }
+
+    // This trigger sits at the far left edge of the screen, so the shared .tooltip rule's
+    // centered left:50%/translateX(-50%) would push it off-screen -- anchor to the left
+    // edge of the button instead of centering under it.
+    .tooltip {
+        left: 0;
+        transform: none;
+    }
+}
+
+.sidebarToggleButton {
+    color: $black-color;
+
+    &:hover,
+    &:focus {
+        background-color: $grey-lightest-color;
+    }
+}
+
+.menuIcon {
+    width: 24px;
+    height: 24px;
+}
+
 .navigationlist {
     display: contents;
     color: #000;

--- a/frontend/styles/components/organisms/CalendarNavbar.module.scss
+++ b/frontend/styles/components/organisms/CalendarNavbar.module.scss
@@ -63,24 +63,45 @@
     color: $black-color;
     text-decoration: none;
   }
+}
 
-  select {
-    font-size: 18px;
-    border: none;
-    background: transparent;
-    color: $black-color;
-    cursor: pointer;
+// The in-house Dropdown atom (app/components/atoms/Dropdown.tsx) brings its own bordered
+// button chrome and defaults to width: 100%, which would otherwise stretch to fill this
+// flex row -- constrain it to fit "Day"/"Week" instead, alongside the .box pill buttons,
+// and override its default look (fixed 42px height, 6px radius, lighter border, native
+// button font) to mirror .box/.box a's exact styling so the two sit consistently side by side.
+.viewDropdown {
+  width: 110px;
+  flex-shrink: 0;
+
+  button {
+    height: auto;
+    padding: 12px 18px;
+    justify-content: center;
+    gap: 8px;
+    border-radius: 8px;
+    border: 1.5px solid $medium-grey-color;
     font-family: 'Source Sans Pro', sans-serif;
-    appearance: none;
-    padding-right: 24px;
-    background-image: url('/svg/drop-down-arrow.svg');
-    background-repeat: no-repeat;
-    background-position: right 10px center;
+    font-size: 18px;
+    font-weight: 400;
   }
-  
-  select:focus {
-    outline: none;
-    border-color: $medium-grey-color;
+
+  // No visible caption label here (label=""), so the list doesn't need the 30px offset
+  // .elementList reserves for a real text caption sitting to its left -- align it flush
+  // under the button instead, matching .elementListFullWidth's behavior. Rounded to match
+  // the button's own 8px radius (its default is a subtler 6px).
+  ul {
+    left: 0;
+    width: 100%;
+    border-radius: 8px;
+    overflow: hidden;
   }
-  
+
+  // Dropdown's default list item is left-aligned (suited to a form field's option list) --
+  // centered here instead, to read as one consistent visual language with the centered
+  // button text above it.
+  li {
+    justify-content: center;
+    font-size: 18px;
+  }
 }

--- a/frontend/test/e2e/05-calendar-display.spec.ts
+++ b/frontend/test/e2e/05-calendar-display.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from "./support/fixtures";
 import { seedMeeting } from "../factories/meeting";
 import { convertETToUTC, formatETDateString } from "../../util/timeUtils";
+import { selectView, toggleFilter } from "./support/formHelpers";
 
 // Manual script §5 (Calendar Display). §5.9 (2+ overlapping meetings sharing space
 // with a "+N more" indicator) is WeeklyViewColumn-specific behavior — DailyView lays
@@ -19,11 +20,11 @@ test.describe("calendar display", () => {
     const { page } = adminPage;
     await seedMeeting({ title: "Week View Meeting", room: "Serenity Room" });
     await page.goto("/");
-    await page.locator("select").selectOption("Week");
+    await selectView(page, "Week");
 
     // Week defaults rooms unchecked (opt-in) — nothing shows until one is picked.
     await expect(page.getByText("Week View Meeting")).toHaveCount(0);
-    await page.getByText("Serenity Room", { exact: true }).click();
+    await toggleFilter(page, "Serenity Room");
     await expect(page.getByText("Week View Meeting")).toBeVisible();
   });
 

--- a/frontend/test/e2e/06-zoom-integration.spec.ts
+++ b/frontend/test/e2e/06-zoom-integration.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "./support/fixtures";
-import { fillDatePicker, fillTimeRange, selectFromDropdown, toggleCalType, todayMMDDYYYY } from "./support/formHelpers";
+import { fillDatePicker, fillTimeRange, selectFromDropdown, selectView, toggleCalType, toggleFilter, todayMMDDYYYY } from "./support/formHelpers";
 import { seedMeeting } from "../factories/meeting";
 import { seedAdmin } from "../factories/admin";
 import { getTestPrismaClient } from "../factories/db";
@@ -36,8 +36,8 @@ test.describe("zoom integration", () => {
     await page.goto("/");
     // The zoomTag mismatch badge (util/rooms.ts isZoomRoomMismatched) is rendered by
     // WeeklyViewColumn only — DailyView's BoxText usage doesn't pass a zoomTag at all.
-    await page.locator("select").selectOption("Week");
-    await page.getByText("Serenity Room", { exact: true }).click();
+    await selectView(page, "Week");
+    await toggleFilter(page, "Serenity Room");
     await expect(page.getByTitle("Zoom room: Unity Room")).toBeVisible();
   });
 

--- a/frontend/test/e2e/08-filters.spec.ts
+++ b/frontend/test/e2e/08-filters.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from "./support/fixtures";
 import { seedMeeting } from "../factories/meeting";
-import { toggleFilter } from "./support/formHelpers";
+import { toggleFilter, selectView } from "./support/formHelpers";
 
 // Manual script §8 (Room and Meeting Filters).
 
@@ -18,7 +18,7 @@ test.describe("filters", () => {
   test("8.2 Week view starts with room filters unchecked", async ({ adminPage }) => {
     const { page } = adminPage;
     await page.goto("/");
-    await page.locator("select").selectOption("Week");
+    await selectView(page, "Week");
     const serenityCheckbox = page.locator('label:has-text("Serenity Room")').first().locator('input[type="checkbox"]');
     await expect(serenityCheckbox).not.toBeChecked();
   });

--- a/frontend/test/e2e/10-recurring-meetings.spec.ts
+++ b/frontend/test/e2e/10-recurring-meetings.spec.ts
@@ -59,13 +59,13 @@ test.describe("recurring meetings", () => {
     // The frequency dropdown already shows "Weekly" (its own default selection), so
     // it can't be opened by the "Select frequency" placeholder text.
     await page.getByRole("button", { name: "Weekly" }).click();
-    await page.getByRole("listitem").filter({ hasText: "Monthly" }).click();
+    await page.getByRole("option").filter({ hasText: "Monthly" }).click();
 
     // Switching to Monthly auto-selects "Monthly on day 11" (day-of-month is always
     // first in RecurringMeeting.tsx's getMonthlyOptions()) — explicitly pick the
     // Nth-weekday option instead.
     await page.getByRole("button", { name: "Monthly on day 11" }).click();
-    await page.getByRole("listitem").filter({ hasText: "Monthly on the 2nd Tuesday" }).click();
+    await page.getByRole("option").filter({ hasText: "Monthly on the 2nd Tuesday" }).click();
     await expect(page.getByRole("button", { name: "Monthly on the 2nd Tuesday" })).toBeVisible();
 
     const dialogPromise = page.waitForEvent("dialog");

--- a/frontend/test/e2e/12-weekly-view.spec.ts
+++ b/frontend/test/e2e/12-weekly-view.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from "./support/fixtures";
 import { seedMeeting, seedRecurringMeeting } from "../factories/meeting";
-import { toggleFilter } from "./support/formHelpers";
+import { toggleFilter, selectView } from "./support/formHelpers";
 import { convertETToUTC, formatETDateString } from "../../util/timeUtils";
 
 // Manual script §12 (Weekly View). §12.5 (Zoom-room mismatch indicator) is also
@@ -12,7 +12,7 @@ test.describe("weekly view", () => {
     const { page } = adminPage;
     await seedMeeting({ title: "Hidden Until Filtered", room: "Serenity Room" });
     await page.goto("/");
-    await page.locator("select").selectOption("Week");
+    await selectView(page, "Week");
     await expect(page.getByText("Hidden Until Filtered")).toHaveCount(0);
   });
 
@@ -20,7 +20,7 @@ test.describe("weekly view", () => {
     const { page } = adminPage;
     await seedMeeting({ title: "Week Room Meeting", room: "Serenity Room" });
     await page.goto("/");
-    await page.locator("select").selectOption("Week");
+    await selectView(page, "Week");
     await toggleFilter(page, "Serenity Room");
     await expect(page.getByText("Week Room Meeting")).toBeVisible();
   });
@@ -43,7 +43,7 @@ test.describe("weekly view", () => {
       { type: "weekly", daysOfWeek: ["Sunday", "Wednesday"], interval: 1, startDate: twoWeeksAgo },
     );
     await page.goto("/");
-    await page.locator("select").selectOption("Week");
+    await selectView(page, "Week");
     await toggleFilter(page, "Serenity Room");
     await expect(page.getByText("Multi Day Recurring")).toHaveCount(2);
   });
@@ -57,7 +57,7 @@ test.describe("weekly view", () => {
       await seedMeeting({ title, room: "Serenity Room", startDateTime: start, endDateTime: end });
     }
     await page.goto("/");
-    await page.locator("select").selectOption("Week");
+    await selectView(page, "Week");
     await toggleFilter(page, "Serenity Room");
 
     // layoutOverlappingMeetings shows up to 2 cards side-by-side plus a "+N" pill.
@@ -73,7 +73,7 @@ test.describe("weekly view", () => {
       zoomRoom: "Unity Room - Zoom",
     });
     await page.goto("/");
-    await page.locator("select").selectOption("Week");
+    await selectView(page, "Week");
     await toggleFilter(page, "Serenity Room");
     await expect(page.getByTitle("Zoom room: Unity Room")).toBeVisible();
   });

--- a/frontend/test/e2e/global-setup.ts
+++ b/frontend/test/e2e/global-setup.ts
@@ -71,7 +71,17 @@ export default async function globalSetup(): Promise<void> {
   // Triggering every route the suite ever page.goto()s to, once, up front,
   // moves that latency into setup instead of a random test.
   await Promise.all(
-    ["/", "/admin", "/signage"].map((route) => fetch(`${TEST_BASE_URL}${route}`)),
+    ["/", "/admin", "/signage"].map(async (route) => {
+      try {
+        const res = await fetch(`${TEST_BASE_URL}${route}`, { signal: AbortSignal.timeout(20_000) });
+        await res.arrayBuffer(); // drain the body so the connection closes cleanly
+      } catch {
+        // Best-effort: a route still compiling past 20s just compiles lazily on its
+        // first real page.goto() instead -- the CI-only retry (playwright.config.ts)
+        // is the backstop for that, and this timeout is what keeps a stuck route from
+        // hanging global setup (and the whole suite) indefinitely.
+      }
+    }),
   );
 
   // The rest of the suite (fixtures.ts, factories) also runs in this same

--- a/frontend/test/e2e/global-setup.ts
+++ b/frontend/test/e2e/global-setup.ts
@@ -63,6 +63,17 @@ export default async function globalSetup(): Promise<void> {
     3000,
   );
 
+  // next dev compiles each route lazily on its first request. Left alone, that
+  // first compile happens mid-suite instead of here, competing with whatever
+  // test is running at the time for CPU on the same (often shared/throttled)
+  // CI runner -- e.g. a test's create-meeting round-trip missing its 30s
+  // timeout because an unrelated route started compiling in the background.
+  // Triggering every route the suite ever page.goto()s to, once, up front,
+  // moves that latency into setup instead of a random test.
+  await Promise.all(
+    ["/", "/admin", "/signage"].map((route) => fetch(`${TEST_BASE_URL}${route}`)),
+  );
+
   // The rest of the suite (fixtures.ts, factories) also runs in this same
   // Playwright test-runner process and needs DATABASE_URL to talk to the
   // same Mongo instance the server is using.

--- a/frontend/test/e2e/support/formHelpers.ts
+++ b/frontend/test/e2e/support/formHelpers.ts
@@ -25,7 +25,7 @@ export async function selectFromDropdown(page: Page, buttonName: string, optionT
   // Not `exact` — Dropdown.tsx's button has a CSS-generated "▼" suffix appended
   // to its accessible name.
   await page.getByRole("button", { name: buttonName }).click();
-  await page.getByRole("listitem").filter({ hasText: optionText }).click();
+  await page.getByRole("option").filter({ hasText: optionText }).click();
 }
 
 // Toggles one of the AA/Al-Anon/Other checkboxes, scoped to the meeting form's
@@ -54,7 +54,7 @@ export async function toggleFilter(page: Page, label: string): Promise<void> {
 export async function selectView(page: Page, view: "Day" | "Week"): Promise<void> {
   const dropdown = page.locator('[class*="viewDropdown"]');
   await dropdown.getByRole("button").click();
-  await dropdown.getByRole("listitem").filter({ hasText: view }).click();
+  await dropdown.getByRole("option").filter({ hasText: view }).click();
 }
 
 // Today's date in MM/DD/YYYY, for form fixtures that need to land on a real day

--- a/frontend/test/e2e/support/formHelpers.ts
+++ b/frontend/test/e2e/support/formHelpers.ts
@@ -38,9 +38,23 @@ export async function toggleCalType(page: Page, type: string): Promise<void> {
 // Toggles a MeetingsFilter checkbox by its visible label, scoped to the sidebar's
 // filter panel — Day view also renders a same-named <h3> room-column header on the
 // calendar itself (e.g. "Unity Room" is both a filter label and a room header), so
-// an unscoped text match is ambiguous there.
+// an unscoped text match is ambiguous there. Room names are also reused verbatim as
+// Zoom Room filter labels (MeetingsFilter.tsx's ZOOM_ITEMS), so within the panel
+// itself `.first()` picks the Location group's checkbox -- it always renders before
+// the Zoom Rooms group -- matching what every current caller actually intends.
 export async function toggleFilter(page: Page, label: string): Promise<void> {
-  await page.locator('[class*="meetingsFilter"]').getByText(label, { exact: true }).click();
+  await page.locator('[class*="meetingsFilter"]').getByText(label, { exact: true }).first().click();
+}
+
+// Switches the CalendarNavbar Day/Week view via its atoms/Dropdown.tsx view-switcher.
+// Scoped to the navbar's own dropdown wrapper (not the meeting form's Dropdown
+// instances) so the button can be clicked without knowing which view is currently
+// selected -- unlike selectFromDropdown's callers, this button's accessible name
+// changes with the current view instead of staying a fixed placeholder.
+export async function selectView(page: Page, view: "Day" | "Week"): Promise<void> {
+  const dropdown = page.locator('[class*="viewDropdown"]');
+  await dropdown.getByRole("button").click();
+  await dropdown.getByRole("listitem").filter({ hasText: view }).click();
 }
 
 // Today's date in MM/DD/YYYY, for form fixtures that need to land on a real day


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added coordinated sidebar control with context-driven toggle behavior.
  * Introduced “compact” variants across meeting form controls.
  * Updated the Day/Week selector to use the shared dropdown UI.
* **Bug Fixes**
  * Locked calendar scrolling when meeting detail popups are open.
  * Improved popup positioning accuracy after it renders.
* **Style**
  * Refreshed compact styling and aligned sidebar/mini-calendar to a 280px layout.
  * Refined dropdown and filter label presentation.
* **Tests**
  * Updated E2E tests to use shared view/filter helpers; improved CI reliability with route pre-warming and conditional retries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description
- **app/(main)/page.module.scss, page.tsx, app/context/SidebarContext.tsx, app/ClientLayout.tsx**: Main Calendar sidebar resized 350px→280px; added a `SidebarContext` (`isSidebarOpen`/`toggleSidebar`/`openSidebar`) so a new hamburger button can show/hide it. Hiding the sidebar resets out of New/Edit Meeting and backs out of ViewMeeting; only Edit re-opens a hidden sidebar (plain viewing does not). Day/Week views get a `scrollLocked` prop to prevent background scroll while ViewMeeting is open.
- **app/components/organisms/AppNavbar.tsx, styles/.../AppNavbar.module.scss, public/svg/menu-icon.svg**: New hamburger icon toggling the sidebar, with a tooltip fixed to no longer render off the left edge of the screen.
- **app/components/atoms/MiniCalendar (styles)**: Fixed MiniCalendar rendering oversized — its CSS was still targeting react-day-picker v8 class/variable names after a past library bump to v10; rewritten against the real v10 API (`.rdp-root`, `.rdp-month_grid`, `--rdp-day_button-width`, etc.).
- **app/components/molecules/RecurringMeeting.tsx (+ styles), CheckButton.tsx (+ styles)**: Fixed day-of-week buttons losing their round shape (flexbox `flex-shrink` squish) in the narrower sidebar.
- **TextField, ModeTypeButtons, DatePicker, TimePicker, Dropdown, CheckBox (components + styles)**: Added a `compact` prop scaling font sizes to ~80%, used only inside the sidebar's New/Edit Meeting forms to match the 280/350 width ratio.
- **app/components/organisms/ViewMeeting.tsx**: Fixed the popup not re-anchoring correctly when opened near the bottom of the screen (stale position on mount; now corrected via `useLayoutEffect`).
- **app/components/organisms/CalendarNavbar.tsx, Dropdown.tsx (+ styles)**: Replaced CalendarNavbar's native `<select>` for Day/Week with the in-house `Dropdown` atom — styled to match the adjacent "Today" button (border, height, centered text) and MeetingForm's field styling (typography, bordered rows, arrow SVG instead of a Unicode caret). Selected row now shows a persistent light-gray highlight instead of a checkmark. Fixed the dropdown list rendering underneath Day/Week view's sticky headers via z-index.
- **app/components/molecules/MeetingsFilter.tsx**: Zoom Room filter labels truncated (dropped the redundant `" - Zoom"` suffix).

## Testing
- [x] `yarn tsc --noEmit` — clean
- [x] `yarn lint` — 7 warnings, 0 errors (pre-existing baseline plus expected `no-img-element` warnings for the new SVG icons, matching existing codebase conventions)
- [x] `yarn lint:css` — clean
- [x] Manually verified via a local dev server + Playwright screenshots: sidebar resize/hamburger toggle, MiniCalendar sizing, RecurringMeeting button shape, ViewMeeting anchoring near the bottom of the screen, sidebar/Edit/View state interplay, and the CalendarNavbar Day/Week dropdown (centered styling, list z-index, row highlight, padding) in both the navbar context and a normal form-field context (Room dropdown).

## Area(s) Touched
**Product areas**
- [ ] auth — sign-in, sessions, NextAuth, role-based access
- [ ] admin — /admin shell (Diagnostics, Users, Import, Export tabs)
- [ ] billing — lease export, XLSX import, anything affecting invoicing
- [x] ui/ux — frontend layout/styling not tied to a specific integration

**Integrations**
- [ ] google-calendar — Google Calendar sync
- [ ] zoom-api — Zoom meeting/host sync

**Engineering**
- [ ] security — auth hardening, data exposure, dependency/security scanning
- [ ] testing — test suite (Jest/Playwright) changes
- [ ] github-actions — workflows, Dependabot config, other .github/ CI tooling
- [ ] cleanup — refactor or dead-code removal, no behavior change
- [ ] documentation — docs/ or README changes only

## Pre-merge Checklist
- [x] Code follows current formatting conventions and passes lint (`yarn lint`).
- [x] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
- [x] All test suites pass, both run locally and green in GitHub CI. **Do not merge if any test suite is failing.**
- [x] A test suite was added or updated for the feature/fix in this PR.
- [x] Only files relevant to this change are committed — no stray or unrelated files.
- [x] If this branch has a merge conflict with master, master was merged into this branch first (not the other way around).
- [x] The rest of this PR description (Description, Testing) is filled out, not left as template placeholders.
