### PR TITLE
Add overlapping meetings layout to Day/Week views

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -38,7 +38,7 @@ Group related files under one bullet when they're part of the same change, e.g.:
 - [ ] Code follows current formatting conventions and passes lint (`yarn lint`).
 - [ ] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
 - [ ] All test suites pass, both run locally and green in GitHub CI. **Do not merge if any test suite is failing.**
-- [ ] A test suite was added or updated for the feature/fix in this PR. **Double check this if you change a feature and did not update the test suites**.
+- [ ] A test suite was added or updated for the feature/fix in this PR. **Double-check this if you change a feature and did not update the test suites**.
 - [ ] Only files relevant to this change are committed — no stray or unrelated files.
 - [ ] If this branch has a merge conflict with master, master was merged into this branch first (not the other way around).
 - [ ] The rest of this PR description (Description, Testing) is filled out, not left as template placeholders.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -38,7 +38,7 @@ Group related files under one bullet when they're part of the same change, e.g.:
 - [ ] Code follows current formatting conventions and passes lint (`yarn lint`).
 - [ ] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
 - [ ] All test suites pass, both run locally and green in GitHub CI. **Do not merge if any test suite is failing.**
-- [ ] A test suite was added or updated for the feature/fix in this PR.
+- [ ] A test suite was added or updated for the feature/fix in this PR. **Double check this if you change a feature and did not update the test suites**.
 - [ ] Only files relevant to this change are committed — no stray or unrelated files.
 - [ ] If this branch has a merge conflict with master, master was merged into this branch first (not the other way around).
 - [ ] The rest of this PR description (Description, Testing) is filled out, not left as template placeholders.

--- a/frontend/app/(main)/page.tsx
+++ b/frontend/app/(main)/page.tsx
@@ -207,10 +207,11 @@ export default function HomePage() {
     }
   };
 
-  // Day view defaults to all rooms visible; Week defaults to none (opt-in), since
-  // showing every room at once in Week view produces too many overlapping meetings.
+  // Both views default to every room visible -- Week previously defaulted rooms off
+  // (opt-in), but a signed-out user has no sidebar/filter UI to ever check a box, so
+  // Week view rendered permanently empty for them.
   const [dayFilters, setDayFilters] = useState(() => createDefaultFilters(true));
-  const [weekFilters, setWeekFilters] = useState(() => createDefaultFilters(false));
+  const [weekFilters, setWeekFilters] = useState(() => createDefaultFilters(true));
   const filters = selectedView === "Day" ? dayFilters : weekFilters;
   const setFilters = selectedView === "Day" ? setDayFilters : setWeekFilters;
   const convertESTStringToDate = (estDateString: string): Date => {

--- a/frontend/app/components/atoms/BoxText.tsx
+++ b/frontend/app/components/atoms/BoxText.tsx
@@ -1,6 +1,7 @@
 import React, { useLayoutEffect, useRef, useState } from "react";
 import styles from '../../../styles/components/atoms/BoxText.module.scss';
 import { toPastelColor } from '../../../util/color';
+import TagList from './TagList';
 
 interface BoxProps {
   boxType: 'Meeting Block' | 'Room Block';
@@ -94,15 +95,15 @@ const BoxText: React.FC<BoxProps> = ({
 
       {boxType === 'Meeting Block' && <p className={styles.time}>{time}</p>}
       {tags && tags.length > 0 && (
-        <div className={styles.tags}>
-          {tags.map((tag, index) => (
-            <span key={index}
-              style={{ backgroundColor: primaryColor }}
-              className={styles.tag}>
-              {tag}
-            </span>
-          ))}
-        </div>
+        <TagList
+          tags={tags}
+          color={primaryColor}
+          // WeeklyView's tall fillHeight boxes pin tags right under the time line rather
+          // than at the bottom (see BoxText.module.scss's .fillHeight comment) -- but not
+          // when compact, where it's back to DailyView's half-height stacked case.
+          containerStyle={fillHeight && !compact ? { marginTop: 4 } : undefined}
+          tagStyle={compact ? { padding: '1px 6px', lineHeight: 1 } : undefined}
+        />
       )}
     </div>
   );

--- a/frontend/app/components/atoms/BoxText.tsx
+++ b/frontend/app/components/atoms/BoxText.tsx
@@ -16,6 +16,11 @@ interface BoxProps {
   // used by WeeklyView, where the wrapping div's height already encodes the meeting's
   // duration (DailyView instead encodes duration as width, on a fixed-height row).
   fillHeight?: boolean;
+  // Tightens padding/font-size/tag sizing so title + time + tags all still fit when
+  // fillHeight has shrunk the box well below its normal Meeting Block height — used by
+  // DailyView for a meeting sharing its room's row with an overlapping neighbor, where
+  // the box is roughly half-height. Without this, tags get clipped off the bottom.
+  compact?: boolean;
   // Extra badge alongside tags, e.g. flagging a Zoom-room mismatch.
   zoomTag?: string;
   onClick: (meetingId: string, e: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
@@ -31,6 +36,7 @@ const BoxText: React.FC<BoxProps> = ({
   meetingId,
   syncError = false,
   fillHeight = false,
+  compact = false,
   zoomTag,
   selected = false,
   onClick
@@ -67,7 +73,7 @@ const BoxText: React.FC<BoxProps> = ({
   return (
     <div
       data-testid={boxType === 'Meeting Block' ? `meeting-card-${meetingId}` : undefined}
-      className={`${styles.box} ${boxType === 'Meeting Block' ? styles.meeting : styles.room} ${fillHeight ? styles.fillHeight : ''} ${selected ? styles.selected : ''}`}
+      className={`${styles.box} ${boxType === 'Meeting Block' ? styles.meeting : styles.room} ${fillHeight ? styles.fillHeight : ''} ${compact ? styles.compact : ''} ${selected ? styles.selected : ''}`}
       style={{ backgroundColor: bgColor, borderLeft: `6px solid ${primaryColor}`, position: 'relative' }}
       onClick={(e) => onClick(meetingId, e)}
     >

--- a/frontend/app/components/atoms/TagList.tsx
+++ b/frontend/app/components/atoms/TagList.tsx
@@ -20,6 +20,10 @@ const TagList: React.FC<TagListProps> = ({ tags, color, gap = 3, containerStyle,
   const probeRef = useRef<HTMLDivElement>(null);
   const [visibleCount, setVisibleCount] = useState(sorted.length);
   const sortedKey = sorted.join('|');
+  // Stringified rather than the raw object -- tagStyle is an inline object literal at call
+  // sites (e.g. BoxText's `compact ? {...} : undefined`), so a new reference every render
+  // would otherwise re-run this effect constantly instead of only when compact toggles.
+  const tagStyleKey = JSON.stringify(tagStyle ?? {});
 
   // Tags wrap onto as many rows as the surrounding box actually has room for -- e.g. a tall
   // WeeklyView card can fit 2+ rows, while a short stacked DailyView card fits barely one --
@@ -90,7 +94,7 @@ const TagList: React.FC<TagListProps> = ({ tags, color, gap = 3, containerStyle,
     if (container.parentElement) observer.observe(container.parentElement);
     return () => observer.disconnect();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [sortedKey, gap]);
+  }, [sortedKey, gap, tagStyleKey]);
 
   if (sorted.length === 0) return null;
 

--- a/frontend/app/components/atoms/TagList.tsx
+++ b/frontend/app/components/atoms/TagList.tsx
@@ -1,0 +1,118 @@
+import React, { useLayoutEffect, useRef, useState } from "react";
+import styles from '../../../styles/components/atoms/TagList.module.scss';
+import { sortTags } from '../../../util/tagOrder';
+
+interface TagListProps {
+  tags: string[];
+  color: string; // background color for tag pills, including the "+N" overflow pill
+  gap?: number; // px gap between pills -- also fed into the fit calculation below
+  containerStyle?: React.CSSProperties;
+  // Merged onto every pill (visible + overflow), for callers whose tag sizing differs from
+  // the base look. Values must be plain CSS strings (e.g. '12px', not 12) -- these get
+  // assigned straight onto a raw DOM node's style during measurement, which (unlike React)
+  // never auto-appends units to bare numbers.
+  tagStyle?: React.CSSProperties;
+}
+
+const TagList: React.FC<TagListProps> = ({ tags, color, gap = 3, containerStyle, tagStyle }) => {
+  const sorted = sortTags(tags);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const probeRef = useRef<HTMLDivElement>(null);
+  const [visibleCount, setVisibleCount] = useState(sorted.length);
+  const sortedKey = sorted.join('|');
+
+  // Tags wrap onto as many rows as the surrounding box actually has room for -- e.g. a tall
+  // WeeklyView card can fit 2+ rows, while a short stacked DailyView card fits barely one --
+  // and only the remainder collapses into a single "+N" pill. Figuring out how many rows
+  // fit takes two measurements: (1) how much vertical space is actually available, found by
+  // walking up to the nearest ancestor that clips overflow (a fixed-height Meeting Block
+  // card) -- callers with no such ancestor (e.g. ViewMeeting's popup, which just grows and
+  // scrolls) get an unlimited budget, so tags there never get artificially capped; and (2)
+  // how tall N tags actually render once wrapped at the container's real width, tested via
+  // an off-screen probe rebuilt with fewer tags (+ a "+N" pill) until it fits the budget.
+  useLayoutEffect(() => {
+    const container = containerRef.current;
+    const probe = probeRef.current;
+    if (!container || !probe) return;
+
+    const recompute = () => {
+      const containerWidth = container.clientWidth;
+      if (containerWidth === 0) return;
+
+      let node = container.parentElement;
+      let clipAncestor: HTMLElement | null = null;
+      while (node) {
+        const cs = getComputedStyle(node);
+        if (cs.overflow === 'hidden' || cs.overflowY === 'hidden' || cs.overflow === 'clip' || cs.overflowY === 'clip') {
+          clipAncestor = node;
+          break;
+        }
+        node = node.parentElement;
+      }
+      const availableHeight = clipAncestor
+        ? clipAncestor.getBoundingClientRect().bottom - container.getBoundingClientRect().top
+        : Infinity;
+
+      probe.style.width = `${containerWidth}px`;
+      probe.style.gap = `${gap}px`;
+
+      const heightFor = (visibleTagCount: number, overflowCount: number): number => {
+        probe.replaceChildren();
+        const addPill = (text: string, isOverflow: boolean) => {
+          const span = document.createElement('span');
+          span.className = isOverflow ? styles.overflowTag : styles.tag;
+          span.textContent = text;
+          if (tagStyle) Object.assign(span.style, tagStyle as Record<string, string>);
+          probe.appendChild(span);
+        };
+        sorted.slice(0, visibleTagCount).forEach(tag => addPill(tag, false));
+        if (overflowCount > 0) addPill(`+${overflowCount}`, true);
+        return probe.offsetHeight;
+      };
+
+      if (heightFor(sorted.length, 0) <= availableHeight) {
+        setVisibleCount(sorted.length);
+        return;
+      }
+
+      for (let count = sorted.length - 1; count >= 1; count--) {
+        const overflowCount = sorted.length - count;
+        if (heightFor(count, overflowCount) <= availableHeight || count === 1) {
+          setVisibleCount(count);
+          return;
+        }
+      }
+    };
+
+    recompute();
+    const observer = new ResizeObserver(recompute);
+    observer.observe(container);
+    if (container.parentElement) observer.observe(container.parentElement);
+    return () => observer.disconnect();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sortedKey, gap]);
+
+  if (sorted.length === 0) return null;
+
+  const overflowCount = sorted.length - visibleCount;
+
+  return (
+    <>
+      <div ref={containerRef} className={styles.tags} style={{ gap, ...containerStyle }}>
+        {sorted.slice(0, visibleCount).map(tag => (
+          <span key={tag} className={styles.tag} style={{ backgroundColor: color, ...tagStyle }}>
+            {tag}
+          </span>
+        ))}
+        {overflowCount > 0 && (
+          <span className={styles.overflowTag} style={{ backgroundColor: color, ...tagStyle }}>
+            +{overflowCount}
+          </span>
+        )}
+      </div>
+      <div ref={probeRef} className={styles.measurer} aria-hidden="true" />
+    </>
+  );
+};
+
+export default TagList;

--- a/frontend/app/components/atoms/TagList.tsx
+++ b/frontend/app/components/atoms/TagList.tsx
@@ -19,11 +19,16 @@ const TagList: React.FC<TagListProps> = ({ tags, color, gap = 3, containerStyle,
   const containerRef = useRef<HTMLDivElement>(null);
   const probeRef = useRef<HTMLDivElement>(null);
   const [visibleCount, setVisibleCount] = useState(sorted.length);
-  const sortedKey = sorted.join('|');
-  // Stringified rather than the raw object -- tagStyle is an inline object literal at call
-  // sites (e.g. BoxText's `compact ? {...} : undefined`), so a new reference every render
-  // would otherwise re-run this effect constantly instead of only when compact toggles.
+  // JSON-encoded rather than joined -- a plain `sorted.join('|')` would collide for
+  // differently-split tag lists that happen to share the same joined text (e.g.
+  // ["a|b"] vs ["a", "b"]), silently skipping a needed recompute.
+  const sortedKey = JSON.stringify(sorted);
+  // Stringified rather than the raw object -- tagStyle/containerStyle are inline object
+  // literals at call sites (e.g. BoxText's `compact ? {...} : undefined`, or its
+  // `fillHeight`-driven marginTop), so a new reference every render would otherwise
+  // re-run this effect constantly instead of only when the actual style values change.
   const tagStyleKey = JSON.stringify(tagStyle ?? {});
+  const containerStyleKey = JSON.stringify(containerStyle ?? {});
 
   // Tags wrap onto as many rows as the surrounding box actually has room for -- e.g. a tall
   // WeeklyView card can fit 2+ rows, while a short stacked DailyView card fits barely one --
@@ -94,7 +99,7 @@ const TagList: React.FC<TagListProps> = ({ tags, color, gap = 3, containerStyle,
     if (container.parentElement) observer.observe(container.parentElement);
     return () => observer.disconnect();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [sortedKey, gap, tagStyleKey]);
+  }, [sortedKey, gap, tagStyleKey, containerStyleKey]);
 
   if (sorted.length === 0) return null;
 

--- a/frontend/app/components/molecules/DailyViewRow.tsx
+++ b/frontend/app/components/molecules/DailyViewRow.tsx
@@ -64,6 +64,78 @@ const DailyViewRow: React.FC<DailyViewRowProps> = ({
     setAnchorEl(el);
   };
 
+  // Renders a single meeting's card. `forceSelected` is used to promote a folded
+  // "+N" meeting (picked via the overflow modal) onto the stack even though it has
+  // no lane of its own -- same full-row/shadow treatment as selecting one of the two
+  // already-shown stacked meetings.
+  const renderMeetingCard = (meeting: Meeting, key: React.Key, forceSelected = false) => {
+    const startOffset = timeToPixels(meeting.startTime);
+    const endOffset = timeToPixels(meeting.endTime);
+    const width = endOffset - startOffset;
+
+    // Compact ET display (e.g. "9-10AM", "9-9:30AM", "11AM-12:30PM") — uses the true,
+    // unclipped time so a split overnight meeting still labels the same on both halves.
+    const compactTime = formatCompactTimeRange(
+      meeting.displayStartTime ?? meeting.startTime,
+      meeting.displayEndTime ?? meeting.endTime,
+    );
+
+    // Selecting a meeting brings it above any other overlapping meeting in this row --
+    // otherwise stacking just follows DOM/array order, so the clicked one could render
+    // underneath a later-starting neighbor it visually overlaps. Reverts on its own once
+    // deselected, since this is just a render-time override, not stored state.
+    const isSelected = forceSelected || meeting.id === selectedMeetingID;
+
+    // A single meeting fills the room's row exactly; overlapping meetings split it into
+    // top/bottom lanes instead (time already reads along the horizontal axis here, so
+    // overlap splits vertically -- the rotated equivalent of WeeklyView's side-by-side
+    // columns, where time reads vertically and overlap splits horizontally).
+    const isStacked = !!meeting.totalOverlapping && meeting.totalOverlapping > 1;
+    const laneTop = isStacked ? (meeting.positionIndex ?? 0) * (LANE_HEIGHT + LANE_GAP) : undefined;
+
+    return (
+      <div
+        key={key}
+        className={styles.meetingWrapper}
+        style={{
+          left: `${startOffset}px`,
+          width: `${width}px`,
+          top: isSelected ? 0 : laneTop,
+          height: isSelected ? undefined : (isStacked ? `${LANE_HEIGHT}px` : undefined),
+          // Above the "+N" overflow pill's z-index (12, DailyViewRow.module.scss) too,
+          // so a selected meeting is unambiguously the topmost thing in the row.
+          zIndex: isSelected ? 13 : undefined,
+        }}
+        onClick={(e) => e.stopPropagation()} // Prevent row click handler from firing
+      >
+        <BoxText
+          boxType="Meeting Block"
+          title={meeting.title}
+          primaryColor={roomColor}
+          time={compactTime}
+          tags={meeting.tags}
+          meetingId={meeting.id}
+          syncError={meeting.syncError}
+          selected={isSelected}
+          fillHeight={isStacked && !isSelected}
+          compact={isStacked && !isSelected}
+          onClick={(meetingId, e) => {
+            handleBoxClick(meetingId, e.currentTarget);
+            e.stopPropagation();
+          }}
+        />
+      </div>
+    );
+  };
+
+  // If the selected meeting was picked from an overflow "+N" popup rather than one
+  // of the two normally-rendered stacked cards, it has no lane of its own -- find it
+  // in the folded cluster so it can be promoted onto the stack (see renderMeetingCard).
+  const renderedIds = new Set(meetings.filter(m => !m.isOverflowIndicator).map(m => m.id));
+  const promotedMeeting = selectedMeetingID && !renderedIds.has(selectedMeetingID)
+    ? meetings.flatMap(m => m.overflowMeetings ?? []).find(m => m.id === selectedMeetingID)
+    : undefined;
+
   return (
     <div style={{ cursor: "pointer", position: 'relative', width: '100%', height: '100%' }}>
       <div>
@@ -74,12 +146,8 @@ const DailyViewRow: React.FC<DailyViewRowProps> = ({
 
         {/* Render meetings */}
         {meetings.map((meeting, index) => {
-          // Convert times to EDT before calculating pixels
-          const startOffset = timeToPixels(meeting.startTime);
-          const endOffset = timeToPixels(meeting.endTime);
-          const width = endOffset - startOffset;
-
           if (meeting.isOverflowIndicator) {
+            const startOffset = timeToPixels(meeting.startTime);
             return (
               <div
                 key={index}
@@ -99,60 +167,10 @@ const DailyViewRow: React.FC<DailyViewRowProps> = ({
             );
           }
 
-          // Compact ET display (e.g. "9-10AM", "9-9:30AM", "11AM-12:30PM") — uses the true,
-          // unclipped time so a split overnight meeting still labels the same on both halves.
-          const compactTime = formatCompactTimeRange(
-            meeting.displayStartTime ?? meeting.startTime,
-            meeting.displayEndTime ?? meeting.endTime,
-          );
-
-          // Selecting a meeting brings it above any other overlapping meeting in this row --
-          // otherwise stacking just follows DOM/array order, so the clicked one could render
-          // underneath a later-starting neighbor it visually overlaps. Reverts on its own once
-          // deselected, since this is just a render-time override, not stored state.
-          const isSelected = meeting.id === selectedMeetingID;
-
-          // A single meeting fills the room's row exactly; overlapping meetings split it into
-          // top/bottom lanes instead (time already reads along the horizontal axis here, so
-          // overlap splits vertically -- the rotated equivalent of WeeklyView's side-by-side
-          // columns, where time reads vertically and overlap splits horizontally).
-          const isStacked = !!meeting.totalOverlapping && meeting.totalOverlapping > 1;
-          const laneTop = isStacked ? (meeting.positionIndex ?? 0) * (LANE_HEIGHT + LANE_GAP) : undefined;
-
-          return (
-            <div
-              key={index}
-              className={styles.meetingWrapper}
-              style={{
-                left: `${startOffset}px`,
-                width: `${width}px`,
-                top: isSelected ? 0 : laneTop,
-                height: isSelected ? undefined : (isStacked ? `${LANE_HEIGHT}px` : undefined),
-                // Above the "+N" overflow pill's z-index (12, DailyViewRow.module.scss) too,
-                // so a selected meeting is unambiguously the topmost thing in the row.
-                zIndex: isSelected ? 13 : undefined,
-              }}
-              onClick={(e) => e.stopPropagation()} // Prevent row click handler from firing
-            >
-              <BoxText
-                boxType="Meeting Block"
-                title={meeting.title}
-                primaryColor={roomColor}
-                time={compactTime}
-                tags={meeting.tags}
-                meetingId={meeting.id}
-                syncError={meeting.syncError}
-                selected={isSelected}
-                fillHeight={isStacked && !isSelected}
-                compact={isStacked && !isSelected}
-                onClick={(meetingId, e) => {
-                  handleBoxClick(meetingId, e.currentTarget);
-                  e.stopPropagation();
-                }}
-              />
-            </div>
-          );
+          return renderMeetingCard(meeting, index);
         })}
+
+        {promotedMeeting && renderMeetingCard(promotedMeeting, `promoted-${promotedMeeting.id}`, true)}
       </div>
 
       <OverlapMeetingsModal

--- a/frontend/app/components/molecules/DailyViewRow.tsx
+++ b/frontend/app/components/molecules/DailyViewRow.tsx
@@ -164,7 +164,10 @@ const DailyViewRow: React.FC<DailyViewRowProps> = ({
         {/* Render meetings */}
         {meetings.map((meeting, index) => {
           if (meeting.isOverflowIndicator) {
-            const startOffset = timeToPixels(meeting.startTime);
+            // Anchored to the cluster's end time so the pill sits at the top-right of its
+            // time slot instead of top-left, where it would sit directly over the start of
+            // the meeting cards it stands in for (title/time text starts from the left edge).
+            const endOffset = timeToPixels(meeting.endTime);
             return (
               <div
                 key={index}
@@ -172,7 +175,7 @@ const DailyViewRow: React.FC<DailyViewRowProps> = ({
                 tabIndex={0}
                 aria-label={`${meeting.overflowCount} more meetings at this time`}
                 className={styles.overflowIndicator}
-                style={{ left: `${startOffset}px` }}
+                style={{ left: `${endOffset}px`, transform: 'translateX(-100%)' }}
                 title={`${meeting.overflowCount} more meeting${meeting.overflowCount === 1 ? '' : 's'} at this time — click to see all meetings`}
                 onClick={(e) => {
                   e.stopPropagation(); // Prevent row click handler from firing

--- a/frontend/app/components/molecules/DailyViewRow.tsx
+++ b/frontend/app/components/molecules/DailyViewRow.tsx
@@ -1,12 +1,8 @@
-import React from 'react';
+import React, { useState } from 'react';
 import BoxText from '../atoms/BoxText';
+import OverlapMeetingsModal from './OverlapMeetingsModal';
+import styles from '../../../styles/components/molecules/DailyViewRow.module.scss';
 import { formatCompactTimeRange } from '../../../util/timeFormat';
-
-// Extracts ET wall-clock time as 24hr "HH:MM", the format formatCompactTimeRange expects.
-const et24HourFmt = new Intl.DateTimeFormat('en-GB', {
-  timeZone: 'America/New_York',
-  hour: '2-digit', minute: '2-digit', hour12: false,
-});
 
 // Meeting Interface
 interface Meeting {
@@ -18,6 +14,11 @@ interface Meeting {
   tags?: string[];
   id: string;
   syncError?: boolean;
+  positionIndex?: number; // Lane index among overlapping meetings in this room, assigned by layoutOverlappingMeetings
+  totalOverlapping?: number; // Lane count among overlapping meetings in this room
+  isOverflowIndicator?: boolean; // "+N more" pseudo-entry standing in for meetings past the 2 shown lanes
+  overflowCount?: number;
+  overflowMeetings?: Meeting[]; // Full overlapping cluster (shown + folded), for the "+N" popup
 }
 
 // DailyViewRowProps Interface
@@ -30,36 +31,17 @@ interface DailyViewRowProps {
   setAnchorEl: (el: HTMLElement) => void;
 }
 
-const timeToPixels = (datetime: string) => {
-  // Create Date object from raw UTC timestamp
-  const utcDate = new Date(datetime);
-
-  // Convert to EDT using toLocaleString with 'America/New_York' timezone
-  const edtDatetime = utcDate.toLocaleString("en-US", { timeZone: "America/New_York" });
-
-  // Extract date and time components from the converted EDT time string
-  const [, timePart] = edtDatetime.split(', ');
-  const [hour, minute] = timePart.split(':');
-  const edtHours = parseInt(hour);
-  const edtMinutes = parseInt(minute);
-
-  // Extract AM/PM
-  const period = timePart.split(' ')[1];  // 'AM' or 'PM'
-
-  // Convert 12-hour format to 24-hour format
-  let adjustedHours = edtHours;
-  if (period === 'AM' && edtHours === 12) {
-    adjustedHours = 0; // Handle 12 AM as 0 hours
-  } else if (period === 'PM' && edtHours !== 12) {
-    adjustedHours = edtHours + 12; // Convert PM hours (except 12 PM)
-  }
-
-  // Calculate the total minutes since 12:00 AM
-  const totalMinutes = adjustedHours * 60 + edtMinutes;
-
-  // Convert minutes to pixels (1 hour = 155px)
-  return totalMinutes * (155 / 60);  // Pixel scale factor based on minutes per hour
+// 1 hour is 155px in width (155/60 px per minute), matching the 155px-wide hour columns.
+const timeToPixels = (time: string) => {
+  const [hours, minutes] = time.split(':').map(Number);
+  return hours * 155 + minutes * (155 / 60);
 };
+
+// BoxText's fixed Meeting Block height (BoxText.module.scss `.meeting`). When 2 meetings
+// share this room's row at once, each gets half of it, minus a small gap between them.
+const MEETING_SLOT_HEIGHT = 105;
+const LANE_GAP = 5;
+const LANE_HEIGHT = (MEETING_SLOT_HEIGHT - LANE_GAP) / 2;
 
 const DailyViewRow: React.FC<DailyViewRowProps> = ({
   roomColor,
@@ -69,6 +51,11 @@ const DailyViewRow: React.FC<DailyViewRowProps> = ({
   setSelectedNewMeeting,
   setAnchorEl,
 }) => {
+  const [overlapModalMeetings, setOverlapModalMeetings] = useState<Meeting[] | null>(null);
+  // The "+N" pill that opened the modal -- kept as the popup anchor for whichever meeting
+  // gets selected from it, since the modal's own row is unmounted the instant it closes and
+  // getBoundingClientRect() on a detached node would anchor the popup nowhere useful.
+  const [overlapAnchorEl, setOverlapAnchorEl] = useState<HTMLElement | null>(null);
 
   const handleBoxClick = (meetingId: string, el: HTMLElement) => {
     console.log(`Meeting ${meetingId} clicked`);
@@ -92,11 +79,31 @@ const DailyViewRow: React.FC<DailyViewRowProps> = ({
           const endOffset = timeToPixels(meeting.endTime);
           const width = endOffset - startOffset;
 
+          if (meeting.isOverflowIndicator) {
+            return (
+              <div
+                key={index}
+                className={styles.overflowIndicator}
+                style={{ left: `${startOffset}px` }}
+                title={`${meeting.overflowCount} more meeting${meeting.overflowCount === 1 ? '' : 's'} at this time — click to see all meetings`}
+                onClick={(e) => {
+                  e.stopPropagation(); // Prevent row click handler from firing
+                  setOverlapModalMeetings(
+                    (meeting.overflowMeetings ?? []).map(m => ({ ...m, primaryColor: roomColor }))
+                  );
+                  setOverlapAnchorEl(e.currentTarget);
+                }}
+              >
+                +{meeting.overflowCount}
+              </div>
+            );
+          }
+
           // Compact ET display (e.g. "9-10AM", "9-9:30AM", "11AM-12:30PM") — uses the true,
           // unclipped time so a split overnight meeting still labels the same on both halves.
           const compactTime = formatCompactTimeRange(
-            et24HourFmt.format(new Date(meeting.displayStartTime ?? meeting.startTime)),
-            et24HourFmt.format(new Date(meeting.displayEndTime ?? meeting.endTime)),
+            meeting.displayStartTime ?? meeting.startTime,
+            meeting.displayEndTime ?? meeting.endTime,
           );
 
           // Selecting a meeting brings it above any other overlapping meeting in this row --
@@ -105,15 +112,25 @@ const DailyViewRow: React.FC<DailyViewRowProps> = ({
           // deselected, since this is just a render-time override, not stored state.
           const isSelected = meeting.id === selectedMeetingID;
 
+          // A single meeting fills the room's row exactly; overlapping meetings split it into
+          // top/bottom lanes instead (time already reads along the horizontal axis here, so
+          // overlap splits vertically -- the rotated equivalent of WeeklyView's side-by-side
+          // columns, where time reads vertically and overlap splits horizontally).
+          const isStacked = !!meeting.totalOverlapping && meeting.totalOverlapping > 1;
+          const laneTop = isStacked ? (meeting.positionIndex ?? 0) * (LANE_HEIGHT + LANE_GAP) : undefined;
+
           return (
             <div
               key={index}
+              className={styles.meetingWrapper}
               style={{
-                position: 'absolute',
                 left: `${startOffset}px`,
                 width: `${width}px`,
-                borderRadius: '6px',
-                zIndex: isSelected ? 1 : undefined,
+                top: isSelected ? 0 : laneTop,
+                height: isSelected ? undefined : (isStacked ? `${LANE_HEIGHT}px` : undefined),
+                // Above the "+N" overflow pill's z-index (12, DailyViewRow.module.scss) too,
+                // so a selected meeting is unambiguously the topmost thing in the row.
+                zIndex: isSelected ? 13 : undefined,
               }}
               onClick={(e) => e.stopPropagation()} // Prevent row click handler from firing
             >
@@ -126,6 +143,8 @@ const DailyViewRow: React.FC<DailyViewRowProps> = ({
                 meetingId={meeting.id}
                 syncError={meeting.syncError}
                 selected={isSelected}
+                fillHeight={isStacked && !isSelected}
+                compact={isStacked && !isSelected}
                 onClick={(meetingId, e) => {
                   handleBoxClick(meetingId, e.currentTarget);
                   e.stopPropagation();
@@ -135,6 +154,16 @@ const DailyViewRow: React.FC<DailyViewRowProps> = ({
           );
         })}
       </div>
+
+      <OverlapMeetingsModal
+        isOpen={overlapModalMeetings !== null}
+        meetings={overlapModalMeetings ?? []}
+        onClose={() => setOverlapModalMeetings(null)}
+        onSelectMeeting={(meetingId) => {
+          if (overlapAnchorEl) handleBoxClick(meetingId, overlapAnchorEl);
+          setOverlapModalMeetings(null);
+        }}
+      />
     </div>
   );
 };

--- a/frontend/app/components/molecules/DailyViewRow.tsx
+++ b/frontend/app/components/molecules/DailyViewRow.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import BoxText from '../atoms/BoxText';
 import OverlapMeetingsModal from './OverlapMeetingsModal';
 import styles from '../../../styles/components/molecules/DailyViewRow.module.scss';
@@ -52,10 +52,19 @@ const DailyViewRow: React.FC<DailyViewRowProps> = ({
   setAnchorEl,
 }) => {
   const [overlapModalMeetings, setOverlapModalMeetings] = useState<Meeting[] | null>(null);
-  // The "+N" pill that opened the modal -- kept as the popup anchor for whichever meeting
-  // gets selected from it, since the modal's own row is unmounted the instant it closes and
-  // getBoundingClientRect() on a detached node would anchor the popup nowhere useful.
+  // The "+N" pill that opened the modal -- kept as a fallback popup anchor, since the
+  // modal's own row is unmounted the instant it closes and getBoundingClientRect() on a
+  // detached node would anchor the popup nowhere useful. Superseded by the selected
+  // meeting's own card (see selectedCardRef below) once that card renders, since the pill
+  // sits in a fixed corner of the row and can be far from where the card actually is.
   const [overlapAnchorEl, setOverlapAnchorEl] = useState<HTMLElement | null>(null);
+
+  // DOM node of whichever card currently has isSelected===true (normal or promoted).
+  // Selecting a meeting from the overflow modal re-anchors ViewMeeting to this once it
+  // mounts/updates, since the modal-open pill is a poor stand-in for the card's position.
+  const selectedCardRef = useRef<HTMLDivElement | null>(null);
+  // Set right before a modal-driven selection, so the effect below knows to re-anchor.
+  const pendingModalAnchorRef = useRef(false);
 
   const handleBoxClick = (meetingId: string, el: HTMLElement) => {
     console.log(`Meeting ${meetingId} clicked`);
@@ -63,6 +72,13 @@ const DailyViewRow: React.FC<DailyViewRowProps> = ({
     setSelectedNewMeeting(false);
     setAnchorEl(el);
   };
+
+  useEffect(() => {
+    if (pendingModalAnchorRef.current && selectedCardRef.current) {
+      setAnchorEl(selectedCardRef.current);
+      pendingModalAnchorRef.current = false;
+    }
+  }, [selectedMeetingID, setAnchorEl]);
 
   // Renders a single meeting's card. `forceSelected` is used to promote a folded
   // "+N" meeting (picked via the overflow modal) onto the stack even though it has
@@ -96,6 +112,7 @@ const DailyViewRow: React.FC<DailyViewRowProps> = ({
     return (
       <div
         key={key}
+        ref={isSelected ? selectedCardRef : undefined}
         className={styles.meetingWrapper}
         style={{
           left: `${startOffset}px`,
@@ -178,6 +195,7 @@ const DailyViewRow: React.FC<DailyViewRowProps> = ({
         meetings={overlapModalMeetings ?? []}
         onClose={() => setOverlapModalMeetings(null)}
         onSelectMeeting={(meetingId) => {
+          pendingModalAnchorRef.current = true;
           if (overlapAnchorEl) handleBoxClick(meetingId, overlapAnchorEl);
           setOverlapModalMeetings(null);
         }}

--- a/frontend/app/components/molecules/DailyViewRow.tsx
+++ b/frontend/app/components/molecules/DailyViewRow.tsx
@@ -168,6 +168,9 @@ const DailyViewRow: React.FC<DailyViewRowProps> = ({
             return (
               <div
                 key={index}
+                role="button"
+                tabIndex={0}
+                aria-label={`${meeting.overflowCount} more meetings at this time`}
                 className={styles.overflowIndicator}
                 style={{ left: `${startOffset}px` }}
                 title={`${meeting.overflowCount} more meeting${meeting.overflowCount === 1 ? '' : 's'} at this time — click to see all meetings`}
@@ -177,6 +180,16 @@ const DailyViewRow: React.FC<DailyViewRowProps> = ({
                     (meeting.overflowMeetings ?? []).map(m => ({ ...m, primaryColor: roomColor }))
                   );
                   setOverlapAnchorEl(e.currentTarget);
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    setOverlapModalMeetings(
+                      (meeting.overflowMeetings ?? []).map(m => ({ ...m, primaryColor: roomColor }))
+                    );
+                    setOverlapAnchorEl(e.currentTarget);
+                  }
                 }}
               >
                 +{meeting.overflowCount}

--- a/frontend/app/components/molecules/OverlapMeetingsModal.tsx
+++ b/frontend/app/components/molecules/OverlapMeetingsModal.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import styles from '../../../styles/components/molecules/OverlapMeetingsModal.module.scss';
 import { formatCompactTimeRange } from '../../../util/timeFormat';
 import { toPastelColor } from '../../../util/color';
+import TagList from '../atoms/TagList';
 
 interface OverlapMeeting {
     id: string;
@@ -67,17 +68,12 @@ const OverlapMeetingsModal: React.FC<OverlapMeetingsModalProps> = ({
                                     {formatCompactTimeRange(meeting.displayStartTime ?? meeting.startTime, meeting.displayEndTime ?? meeting.endTime)}
                                 </p>
                                 {meeting.tags && meeting.tags.length > 0 && (
-                                    <div className={styles.tags}>
-                                        {meeting.tags.map((tag, index) => (
-                                            <span
-                                                key={index}
-                                                className={styles.tag}
-                                                style={{ backgroundColor: meeting.primaryColor }}
-                                            >
-                                                {tag}
-                                            </span>
-                                        ))}
-                                    </div>
+                                    <TagList
+                                        tags={meeting.tags}
+                                        color={meeting.primaryColor ?? '#999'}
+                                        gap={4}
+                                        tagStyle={{ padding: '2px 12px', color: '#1E1E1E' }}
+                                    />
                                 )}
                             </div>
                         );

--- a/frontend/app/components/molecules/OverlapMeetingsModal.tsx
+++ b/frontend/app/components/molecules/OverlapMeetingsModal.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { createPortal } from 'react-dom';
 import styles from '../../../styles/components/molecules/OverlapMeetingsModal.module.scss';
 import { formatCompactTimeRange } from '../../../util/timeFormat';
 import { toPastelColor } from '../../../util/color';
@@ -32,7 +33,13 @@ const OverlapMeetingsModal: React.FC<OverlapMeetingsModalProps> = ({
 }) => {
     if (!isOpen) return null;
 
-    return (
+    // Portaled to document.body -- both Day and Week view render this from deep inside
+    // absolutely-positioned, z-indexed ancestors (e.g. DailyView's .gridMeetingRow), each
+    // of which forms its own stacking context. Left in place, this modal's z-index would
+    // only be compared *within* that ancestor's context, so a sibling with a higher
+    // z-index at the parent level (e.g. the sticky room-label column) would still paint
+    // over it despite `position: fixed` and z-index: 1000 here.
+    return createPortal(
         <div className={styles.modalOverlay} onClick={(e) => e.stopPropagation()}>
             <div className={styles.modalContent}>
                 <div className={styles.header}>
@@ -80,7 +87,8 @@ const OverlapMeetingsModal: React.FC<OverlapMeetingsModalProps> = ({
                     })}
                 </div>
             </div>
-        </div>
+        </div>,
+        document.body,
     );
 };
 

--- a/frontend/app/components/molecules/WeeklyViewColumn.tsx
+++ b/frontend/app/components/molecules/WeeklyViewColumn.tsx
@@ -62,6 +62,80 @@ const WeeklyViewColumn: React.FC<WeeklyViewColumnProps> = ({
         setAnchorEl(el);
     };
 
+    // Renders a single meeting's card. `forceSelected` is used to promote a folded
+    // "+N" meeting (picked via the overflow modal) onto the stack even though it has
+    // no normal slot of its own -- same full-width/shadow treatment as selecting one
+    // of the two already-shown stacked meetings.
+    const renderMeetingCard = (meeting: Meeting, key: React.Key, forceSelected = false) => {
+        // Remote-only meetings have no physical room, so fall back to the
+        // Zoom room — otherwise the location line would be blank.
+        const locationLabel = meeting.room || meeting.zoomRoom || '';
+        const topOffset = timeToPixels(meeting.startTime);
+        const bottomOffset = timeToPixels(meeting.endTime);
+        const height = bottomOffset - topOffset;
+
+        // A single meeting fills the column exactly; overlapping meetings split it evenly
+        let width = '100%';
+        let left = '0%';
+
+        if (meeting.totalOverlapping && meeting.totalOverlapping > 1) {
+            const singleWidth = 100 / meeting.totalOverlapping;
+            width = `${singleWidth}%`;
+            left = `${(meeting.positionIndex || 0) * singleWidth}%`;
+        }
+
+        // Selecting a meeting that's sharing space in an overlapping cluster brings
+        // it fully into view (and above its siblings) instead of leaving it in its
+        // narrow shared column -- reverts on its own once deselected, since this is
+        // just a render-time override, not stored state.
+        const isSelected = forceSelected || meeting.id === selectedMeetingID;
+
+        return (
+            <div
+                key={key}
+                className={styles.meetingWrapper}
+                style={{
+                    top: `${topOffset}px`,
+                    height: `${height}px`,
+                    width: isSelected ? '100%' : width,
+                    left: isSelected ? '0%' : left,
+                    // Above the "+N" overflow pill's z-index (12, WeeklyViewColumn.module.scss)
+                    // too, so a selected meeting is unambiguously the topmost thing in the column.
+                    zIndex: isSelected ? 13 : undefined,
+                }}
+                onClick={(e) => e.stopPropagation()} // Prevent column click handler from firing
+            >
+                <BoxText
+                    boxType="Meeting Block"
+                    title={meeting.title}
+                    primaryColor={meeting.primaryColor || roomColor}
+                    time={`${locationLabel ? `${locationLabel} · ` : ''}${formatCompactTimeRange(meeting.displayStartTime ?? meeting.startTime, meeting.displayEndTime ?? meeting.endTime)}`}
+                    tags={meeting.tags}
+                    meetingId={meeting.id}
+                    zoomTag={
+                        meeting.room && isZoomRoomMismatched(meeting.room, meeting.zoomRoom)
+                            ? formatZoomRoomLabel(meeting.zoomRoom!)
+                            : undefined
+                    }
+                    fillHeight
+                    selected={isSelected}
+                    onClick={(meetingId, e) => {
+                        handleBoxClick(meetingId, e.currentTarget);
+                        e.stopPropagation(); // Prevent column click handler from firing
+                    }}
+                />
+            </div>
+        );
+    };
+
+    // If the selected meeting was picked from an overflow "+N" popup rather than one
+    // of the two normally-rendered stacked cards, it has no slot of its own -- find it
+    // in the folded cluster so it can be promoted onto the stack (see renderMeetingCard).
+    const renderedIds = new Set(meetings.filter(m => !m.isOverflowIndicator).map(m => m.id));
+    const promotedMeeting = selectedMeetingID && !renderedIds.has(selectedMeetingID)
+        ? meetings.flatMap(m => m.overflowMeetings ?? []).find(m => m.id === selectedMeetingID)
+        : undefined;
+
     return (
         <div className={styles.columnWrapper}>
             <div className={styles.columnBody}>
@@ -75,12 +149,8 @@ const WeeklyViewColumn: React.FC<WeeklyViewColumnProps> = ({
                 ))}
 
                 {meetings.map((meeting, index) => {
-                    // Remote-only meetings have no physical room, so fall back to the
-                    // Zoom room — otherwise the location line would be blank.
-                    const locationLabel = meeting.room || meeting.zoomRoom || '';
-                    const topOffset = timeToPixels(meeting.startTime);
-
                     if (meeting.isOverflowIndicator) {
+                        const topOffset = timeToPixels(meeting.startTime);
                         return (
                             <div
                                 key={index}
@@ -98,62 +168,10 @@ const WeeklyViewColumn: React.FC<WeeklyViewColumnProps> = ({
                         );
                     }
 
-                    const bottomOffset = timeToPixels(meeting.endTime);
-                    const height = bottomOffset - topOffset;
-
-                    // A single meeting fills the column exactly; overlapping meetings split it evenly
-                    let width = '100%';
-                    let left = '0%';
-
-                    if (meeting.totalOverlapping && meeting.totalOverlapping > 1) {
-                        const singleWidth = 100 / meeting.totalOverlapping;
-                        width = `${singleWidth}%`;
-                        left = `${(meeting.positionIndex || 0) * singleWidth}%`;
-                    }
-
-                    // Selecting a meeting that's sharing space in an overlapping cluster brings
-                    // it fully into view (and above its siblings) instead of leaving it in its
-                    // narrow shared column -- reverts on its own once deselected, since this is
-                    // just a render-time override, not stored state.
-                    const isSelected = meeting.id === selectedMeetingID;
-
-                    return (
-                        <div
-                            key={index}
-                            className={styles.meetingWrapper}
-                            style={{
-                                top: `${topOffset}px`,
-                                height: `${height}px`,
-                                width: isSelected ? '100%' : width,
-                                left: isSelected ? '0%' : left,
-                                // Above the "+N" overflow pill's z-index (12, WeeklyViewColumn.module.scss)
-                                // too, so a selected meeting is unambiguously the topmost thing in the column.
-                                zIndex: isSelected ? 13 : undefined,
-                            }}
-                            onClick={(e) => e.stopPropagation()} // Prevent column click handler from firing
-                        >
-                            <BoxText
-                                boxType="Meeting Block"
-                                title={meeting.title}
-                                primaryColor={meeting.primaryColor || roomColor}
-                                time={`${locationLabel ? `${locationLabel} · ` : ''}${formatCompactTimeRange(meeting.displayStartTime ?? meeting.startTime, meeting.displayEndTime ?? meeting.endTime)}`}
-                                tags={meeting.tags}
-                                meetingId={meeting.id}
-                                zoomTag={
-                                    meeting.room && isZoomRoomMismatched(meeting.room, meeting.zoomRoom)
-                                        ? formatZoomRoomLabel(meeting.zoomRoom!)
-                                        : undefined
-                                }
-                                fillHeight
-                                selected={isSelected}
-                                onClick={(meetingId, e) => {
-                                    handleBoxClick(meetingId, e.currentTarget);
-                                    e.stopPropagation(); // Prevent column click handler from firing
-                                }}
-                            />
-                        </div>
-                    );
+                    return renderMeetingCard(meeting, index);
                 })}
+
+                {promotedMeeting && renderMeetingCard(promotedMeeting, `promoted-${promotedMeeting.id}`, true)}
             </div>
 
             <OverlapMeetingsModal

--- a/frontend/app/components/molecules/WeeklyViewColumn.tsx
+++ b/frontend/app/components/molecules/WeeklyViewColumn.tsx
@@ -35,11 +35,16 @@ interface WeeklyViewColumnProps {
     setAnchorEl: (el: HTMLElement) => void;
 }
 
-// 1 hour is 100px in height (100/60 px per minute), matching .timeSlot's 100px row height
+// 1 hour is 120px in height (120/60 px per minute), matching .timeSlot's 120px row height
 const timeToPixels = (time: string) => {
     const [hours, minutes] = time.split(':').map(Number);
-    return hours * 100 + minutes * (100 / 60);
+    return hours * 120 + minutes * (120 / 60);
 };
+
+// Visual breathing room between two back-to-back meetings that would otherwise share
+// a hard edge (one ending exactly when the next starts) -- split evenly off each card's
+// top/bottom so the gap is centered on the boundary between them.
+const VERTICAL_GAP = 6;
 
 const WeeklyViewColumn: React.FC<WeeklyViewColumnProps> = ({
     roomColor,
@@ -86,9 +91,8 @@ const WeeklyViewColumn: React.FC<WeeklyViewColumnProps> = ({
         // Remote-only meetings have no physical room, so fall back to the
         // Zoom room — otherwise the location line would be blank.
         const locationLabel = meeting.room || meeting.zoomRoom || '';
-        const topOffset = timeToPixels(meeting.startTime);
-        const bottomOffset = timeToPixels(meeting.endTime);
-        const height = bottomOffset - topOffset;
+        const topOffset = timeToPixels(meeting.startTime) + VERTICAL_GAP / 2;
+        const height = timeToPixels(meeting.endTime) - timeToPixels(meeting.startTime) - VERTICAL_GAP;
 
         // A single meeting fills the column exactly; overlapping meetings split it evenly
         let width = '100%';
@@ -161,7 +165,7 @@ const WeeklyViewColumn: React.FC<WeeklyViewColumnProps> = ({
                     <div
                         key={hourIndex}
                         className={styles.hourMarker}
-                        style={{ top: `${hourIndex * 100}px` }}
+                        style={{ top: `${hourIndex * 120}px` }}
                     />
                 ))}
 

--- a/frontend/app/components/molecules/WeeklyViewColumn.tsx
+++ b/frontend/app/components/molecules/WeeklyViewColumn.tsx
@@ -178,6 +178,9 @@ const WeeklyViewColumn: React.FC<WeeklyViewColumnProps> = ({
                         return (
                             <div
                                 key={index}
+                                role="button"
+                                tabIndex={0}
+                                aria-label={`${meeting.overflowCount} more meetings at this time`}
                                 className={styles.overflowIndicator}
                                 style={{ top: `${topOffset}px` }}
                                 title={`${meeting.overflowCount} more meeting${meeting.overflowCount === 1 ? '' : 's'} at this time — click to see all meetings`}
@@ -185,6 +188,14 @@ const WeeklyViewColumn: React.FC<WeeklyViewColumnProps> = ({
                                     e.stopPropagation(); // Prevent column click handler from firing
                                     setOverlapModalMeetings(meeting.overflowMeetings ?? []);
                                     setOverlapAnchorEl(e.currentTarget);
+                                }}
+                                onKeyDown={(e) => {
+                                    if (e.key === 'Enter' || e.key === ' ') {
+                                        e.preventDefault();
+                                        e.stopPropagation();
+                                        setOverlapModalMeetings(meeting.overflowMeetings ?? []);
+                                        setOverlapAnchorEl(e.currentTarget);
+                                    }
                                 }}
                             >
                                 +{meeting.overflowCount}

--- a/frontend/app/components/molecules/WeeklyViewColumn.tsx
+++ b/frontend/app/components/molecules/WeeklyViewColumn.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import BoxText from '../atoms/BoxText';
 import OverlapMeetingsModal from './OverlapMeetingsModal';
 import styles from '../../../styles/components/molecules/WeeklyViewColumn.module.scss';
@@ -50,10 +50,19 @@ const WeeklyViewColumn: React.FC<WeeklyViewColumnProps> = ({
     setAnchorEl,
 }) => {
     const [overlapModalMeetings, setOverlapModalMeetings] = useState<Meeting[] | null>(null);
-    // The "+N" pill that opened the modal -- kept as the popup anchor for whichever meeting
-    // gets selected from it, since the modal's own row is unmounted the instant it closes and
-    // getBoundingClientRect() on a detached node would anchor the popup nowhere useful.
+    // The "+N" pill that opened the modal -- kept as a fallback popup anchor, since the
+    // modal's own row is unmounted the instant it closes and getBoundingClientRect() on a
+    // detached node would anchor the popup nowhere useful. Superseded by the selected
+    // meeting's own card (see selectedCardRef below) once that card renders, since the pill
+    // sits in a fixed corner of the column and can be far from where the card actually is.
     const [overlapAnchorEl, setOverlapAnchorEl] = useState<HTMLElement | null>(null);
+
+    // DOM node of whichever card currently has isSelected===true (normal or promoted).
+    // Selecting a meeting from the overflow modal re-anchors ViewMeeting to this once it
+    // mounts/updates, since the modal-open pill is a poor stand-in for the card's position.
+    const selectedCardRef = useRef<HTMLDivElement | null>(null);
+    // Set right before a modal-driven selection, so the effect below knows to re-anchor.
+    const pendingModalAnchorRef = useRef(false);
 
     const handleBoxClick = (meetingId: string, el: HTMLElement) => {
         console.log(`Meeting ${meetingId} clicked`);
@@ -61,6 +70,13 @@ const WeeklyViewColumn: React.FC<WeeklyViewColumnProps> = ({
         setSelectedNewMeeting(false);
         setAnchorEl(el);
     };
+
+    useEffect(() => {
+        if (pendingModalAnchorRef.current && selectedCardRef.current) {
+            setAnchorEl(selectedCardRef.current);
+            pendingModalAnchorRef.current = false;
+        }
+    }, [selectedMeetingID, setAnchorEl]);
 
     // Renders a single meeting's card. `forceSelected` is used to promote a folded
     // "+N" meeting (picked via the overflow modal) onto the stack even though it has
@@ -93,6 +109,7 @@ const WeeklyViewColumn: React.FC<WeeklyViewColumnProps> = ({
         return (
             <div
                 key={key}
+                ref={isSelected ? selectedCardRef : undefined}
                 className={styles.meetingWrapper}
                 style={{
                     top: `${topOffset}px`,
@@ -179,6 +196,7 @@ const WeeklyViewColumn: React.FC<WeeklyViewColumnProps> = ({
                 meetings={overlapModalMeetings ?? []}
                 onClose={() => setOverlapModalMeetings(null)}
                 onSelectMeeting={(meetingId) => {
+                    pendingModalAnchorRef.current = true;
                     if (overlapAnchorEl) handleBoxClick(meetingId, overlapAnchorEl);
                     setOverlapModalMeetings(null);
                 }}

--- a/frontend/app/components/molecules/WeeklyViewColumn.tsx
+++ b/frontend/app/components/molecules/WeeklyViewColumn.tsx
@@ -174,7 +174,10 @@ const WeeklyViewColumn: React.FC<WeeklyViewColumnProps> = ({
 
                 {meetings.map((meeting, index) => {
                     if (meeting.isOverflowIndicator) {
-                        const topOffset = timeToPixels(meeting.startTime);
+                        // Matches renderMeetingCard's topOffset (line 94) so the pill lines up
+                        // with the top of the meeting cards it sits beside, instead of sitting
+                        // VERTICAL_GAP/2 higher than they do.
+                        const topOffset = timeToPixels(meeting.startTime) + VERTICAL_GAP / 2;
                         return (
                             <div
                                 key={index}

--- a/frontend/app/components/molecules/WeeklyViewColumn.tsx
+++ b/frontend/app/components/molecules/WeeklyViewColumn.tsx
@@ -92,7 +92,10 @@ const WeeklyViewColumn: React.FC<WeeklyViewColumnProps> = ({
         // Zoom room — otherwise the location line would be blank.
         const locationLabel = meeting.room || meeting.zoomRoom || '';
         const topOffset = timeToPixels(meeting.startTime) + VERTICAL_GAP / 2;
-        const height = timeToPixels(meeting.endTime) - timeToPixels(meeting.startTime) - VERTICAL_GAP;
+        const height = Math.max(
+            timeToPixels(meeting.endTime) - timeToPixels(meeting.startTime) - VERTICAL_GAP,
+            1,
+        );
 
         // A single meeting fills the column exactly; overlapping meetings split it evenly
         let width = '100%';

--- a/frontend/app/components/organisms/DailyView.tsx
+++ b/frontend/app/components/organisms/DailyView.tsx
@@ -2,22 +2,16 @@ import React, { useCallback, useEffect, useState, useRef } from "react";
 import styles from '../../../styles/components/organisms/DailyView.module.scss';
 import BoxText from '../atoms/BoxText';
 import DailyViewRow from "../molecules/DailyViewRow";
-import { convertUTCToET, formatETDateString, getETDayBounds } from "../../../util/timeUtils";
+import { formatETDateString, getETDayBounds } from "../../../util/timeUtils";
 import { IMeeting } from "../../../util/models";
 import { passesTagFilters, passesRoomFilter, MeetingFilters } from "../../../util/meetingFilters";
 import { createCache } from "../../../util/simpleCache";
 import { defaultRooms } from "../../../util/rooms";
+import { layoutOverlappingMeetings, OverlapMeeting } from "../../../util/meetingOverlapLayout";
 
-type Meeting = {
-  id: string;
-  title: string;
-  startTime: string; // clipped to this day, for positioning
-  endTime: string; // clipped to this day, for positioning
-  displayStartTime: string; // true time, for the label
-  displayEndTime: string; // true time, for the label
-  tags: string[];
+interface Meeting extends OverlapMeeting {
   syncError?: boolean;
-};
+}
 
 type Room = {
   name: string;
@@ -26,6 +20,13 @@ type Room = {
 };
 
 const dayMeetingCache = createCache<Room[]>();
+
+// Extracts ET wall-clock time as "HH:MM" (24hr) -- the format layoutOverlappingMeetings'
+// clustering math (and WeeklyView's equivalent startTime/endTime) expects.
+const etTimeFmt = new Intl.DateTimeFormat('en-GB', {
+  timeZone: 'America/New_York',
+  hour: '2-digit', minute: '2-digit', hour12: false,
+});
 
 export const fetchMeetingsByDay = async (date: Date): Promise<Room[]> => {
   const formattedDate = formatETDateString(date); // ET calendar date, e.g. "2025-04-09"
@@ -84,16 +85,17 @@ export const fetchMeetingsByDay = async (date: Date): Promise<Room[]> => {
         const startUTC = new Date(meeting.startDateTime);
         const endUTC = new Date(meeting.endDateTime);
 
-        const startEDT = convertUTCToET(startUTC.toISOString());
-        const endEDT = convertUTCToET(endUTC.toISOString());
+        const startEDT = etTimeFmt.format(startUTC);
+        const endEDT = etTimeFmt.format(endUTC);
 
-        const meetingEntry: Meeting = {
+        const meetingEntry = {
           id: meeting.mid,
           title: meeting.title,
           startTime: startEDT,
           endTime: endEDT,
-          displayStartTime: convertUTCToET(new Date(meeting.trueStartDateTime).toISOString()),
-          displayEndTime: convertUTCToET(new Date(meeting.trueEndDateTime).toISOString()),
+          displayStartTime: etTimeFmt.format(new Date(meeting.trueStartDateTime)),
+          displayEndTime: etTimeFmt.format(new Date(meeting.trueEndDateTime)),
+          date: formattedDate,
           tags: [...meeting.calType, meeting.modeType],
           syncError: meeting.syncStatus === 'error' || meeting.zoomSyncStatus === 'error',
         };
@@ -107,7 +109,10 @@ export const fetchMeetingsByDay = async (date: Date): Promise<Room[]> => {
           if (!groupedRooms[roomName]) {
             groupedRooms[roomName] = [];
           }
-          groupedRooms[roomName].push(meetingEntry);
+          // Own copy per room bucket -- a Hybrid meeting appears in both its physical
+          // room and Zoom room rows, and each row lays out overlap independently, so
+          // they can't share one `room` field value.
+          groupedRooms[roomName].push({ ...meetingEntry, room: roomName });
         });
       });
 
@@ -233,10 +238,13 @@ const DailyView: React.FC<DailyViewProps> = ({
     }
   }, [refreshTrigger, fetchData]);
 
-  // filter meetings based on meeting type and room filters
+  // filter meetings based on meeting type and room filters, then lay out any that overlap
+  // in time within this room (stacked top/bottom, capped at 2, folded into a "+N" beyond that)
   const filterMeetings = (room: Room): Room => ({
     ...room,
-    meetings: room.meetings.filter(meeting => passesTagFilters(meeting.tags, filters)),
+    meetings: layoutOverlappingMeetings(
+      room.meetings.filter(meeting => passesTagFilters(meeting.tags, filters))
+    ),
   });
 
   // First filter rooms by room name, then filter meetings within each room by meeting type

--- a/frontend/app/components/organisms/ViewMeeting.tsx
+++ b/frontend/app/components/organisms/ViewMeeting.tsx
@@ -3,6 +3,7 @@ import { createPortal } from 'react-dom';
 import styles from '../../../styles/components/organisms/ViewMeeting.module.scss';
 import DeleteRecurringModal from '../molecules/DeleteRecurringModal';
 import DeleteMeetingModal from '../molecules/DeleteMeetingModal';
+import TagList from '../atoms/TagList';
 
 import { IRecurrencePattern } from '../../../util/models';
 import { formatCompactTimeRange, formatMeetingDateLine } from "../../../util/timeFormat";
@@ -462,13 +463,12 @@ const ViewMeetingDetails: React.FC<ViewMeetingDetailsProps> = ({
           <hr className={styles.divider} />
 
           {calType && calType.length > 0 && (
-            <div className={styles.tags}>
-              {calType.map((tag, index) => (
-                <span key={index} style={{ backgroundColor: primaryColor }} className={styles.tag}>
-                  {tag}
-                </span>
-              ))}
-            </div>
+            <TagList
+              tags={calType}
+              color={primaryColor}
+              gap={4}
+              tagStyle={{ padding: '2px 12px', fontSize: '12px', color: '#000' }}
+            />
           )}
         </div>
       </div>

--- a/frontend/app/components/organisms/WeeklyView.tsx
+++ b/frontend/app/components/organisms/WeeklyView.tsx
@@ -162,7 +162,7 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
         const now = new Date();
         const currentHour = now.getHours();
         const currentMinutes = now.getMinutes();
-        const basePosition = currentHour * 100 + currentMinutes * (100 / 60);
+        const basePosition = currentHour * 120 + currentMinutes * (120 / 60);
         const offset = 40; // height of .dayHeader
         setCurrentTimePosition(basePosition + offset);
     }, []);
@@ -174,7 +174,7 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
             const currentHour = now.getHours();
             const currentMinutes = now.getMinutes();
             const dayHeaderOffset = 40; // height of .dayHeader, see updateTimePosition
-            const scrollOffset = dayHeaderOffset + (currentHour * 100 + currentMinutes * (100 / 60)) - 200;
+            const scrollOffset = dayHeaderOffset + (currentHour * 120 + currentMinutes * (120 / 60)) - 240;
             viewContainerRef.current.scrollTop = Math.max(0, scrollOffset);
         }
     }, []);

--- a/frontend/styles/components/atoms/BoxText.module.scss
+++ b/frontend/styles/components/atoms/BoxText.module.scss
@@ -67,17 +67,11 @@
 
   // Stretch to fill the parent's height instead of the fixed Meeting Block height —
   // used by WeeklyView, where the wrapping div's height already encodes the meeting's
-  // duration. Must come after &.meeting so it wins the height tie-break.
+  // duration. Must come after &.meeting so it wins the height tie-break. TagList's
+  // containerStyle override (BoxText.tsx) handles pinning tags under the time line
+  // instead of the bottom for this case.
   &.fillHeight {
     height: 100%;
-
-    // .tags's margin-top:auto anchors it to the bottom of the box, which is invisible
-    // on DailyView's fixed-height cards but drifts badges far below the time line on
-    // WeeklyView's longer (taller) meetings. Keep them right under the time line here,
-    // matching where they'd sit in a 1-hour box, regardless of actual duration.
-    .tags {
-      margin-top: 4px;
-    }
   }
 
   // Tightens spacing so title + time + tags all still fit in a fillHeight box shrunk to
@@ -96,20 +90,11 @@
       line-height: 1.15;
     }
 
-    .tags {
-      // Back to the base (non-fillHeight) rule's auto margin -- not .fillHeight's fixed 4px
-      // (that's for Weekly's tall boxes, keeping tags pinned under the time line regardless
-      // of how much taller the box is than one hour). Here the auto margin instead absorbs
-      // whatever slack is left after title+time and pushes tags down flush against the box's
-      // own padding-bottom -- the same amount of breathing room the title gets from
-      // padding-top at the top, so top and bottom insets end up visually equal.
-      margin-top: auto;
-
-      .tag {
-        padding: 1px 6px;
-        line-height: 1;
-      }
-    }
+    // TagList's tagStyle override (BoxText.tsx) shrinks tag padding/line-height for this
+    // case; its default margin-top:auto (not fillHeight's fixed 4px) still applies, which
+    // pushes tags flush against the box's own padding-bottom -- the same amount of
+    // breathing room the title gets from padding-top at the top, so top and bottom insets
+    // end up visually equal.
   }
 
   // Highlights the box while its View Meeting popup is open.
@@ -149,24 +134,5 @@
   .zoomTagIcon {
     width: 10px;
     height: 10px;
-  }
-
-  .tags {
-    display: flex;
-    flex-wrap: wrap;
-
-    // Anchors to the bottom of the box
-    margin-top: auto;
-    padding: 0;
-    gap: 3px;
-    align-items: center;
-
-    .tag {
-      padding: 2px 7px;
-      border-radius: 10.593px;
-      font-size: 10px;
-      font-weight: 400;
-      white-space: nowrap;
-    }
   }
 }

--- a/frontend/styles/components/atoms/BoxText.module.scss
+++ b/frontend/styles/components/atoms/BoxText.module.scss
@@ -13,11 +13,11 @@
     min-width: 16px;
     height: 105px;
     overflow: hidden;
-    padding: 6px;
+    padding: 5px;
     border-radius: 6px;
 
     .title {
-      font-size: 14px;
+      font-size: 13px;
       margin-top: 0;
       margin-bottom: 0;
       font-weight: 600;
@@ -53,10 +53,10 @@
   }
 
   .time {
-    font-size: 13px;
+    font-size: 12px;
     font-style: normal;
     font-weight: 400;
-    margin-top: 0;
+    margin: 0;
     padding: 0;
     color: #3A3E49;
     overflow-x: hidden;
@@ -77,6 +77,38 @@
     // matching where they'd sit in a 1-hour box, regardless of actual duration.
     .tags {
       margin-top: 4px;
+    }
+  }
+
+  // Tightens spacing so title + time + tags all still fit in a fillHeight box shrunk to
+  // roughly half its normal height (DailyView: two meetings sharing one room row) --
+  // without this, tags get pushed past the box's bottom edge and clipped by overflow: hidden.
+  &.compact {
+    padding: 3px 5px;
+
+    .title {
+      font-size: 12px;
+      line-height: 1.15;
+    }
+
+    .time {
+      font-size: 11px;
+      line-height: 1.15;
+    }
+
+    .tags {
+      // Back to the base (non-fillHeight) rule's auto margin -- not .fillHeight's fixed 4px
+      // (that's for Weekly's tall boxes, keeping tags pinned under the time line regardless
+      // of how much taller the box is than one hour). Here the auto margin instead absorbs
+      // whatever slack is left after title+time and pushes tags down flush against the box's
+      // own padding-bottom -- the same amount of breathing room the title gets from
+      // padding-top at the top, so top and bottom insets end up visually equal.
+      margin-top: auto;
+
+      .tag {
+        padding: 1px 6px;
+        line-height: 1;
+      }
     }
   }
 
@@ -126,11 +158,11 @@
     // Anchors to the bottom of the box
     margin-top: auto;
     padding: 0;
-    gap: 4px;
+    gap: 3px;
     align-items: center;
 
     .tag {
-      padding: 2px 12px;
+      padding: 2px 7px;
       border-radius: 10.593px;
       font-size: 10px;
       font-weight: 400;

--- a/frontend/styles/components/atoms/TagList.module.scss
+++ b/frontend/styles/components/atoms/TagList.module.scss
@@ -1,0 +1,41 @@
+.tags {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  padding: 0;
+  margin-top: auto;
+  min-width: 0;
+}
+
+.tag {
+  padding: 2px 7px;
+  border-radius: 10.593px;
+  font-size: 10px;
+  font-weight: 400;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.overflowTag {
+  padding: 2px 7px;
+  border-radius: 10.593px;
+  font-size: 10px;
+  font-weight: 600;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+// Off-screen probe used to test-wrap candidate tag/overflow-pill combinations at the
+// container's real width and measure the resulting wrapped height -- never visible, and
+// out of normal flow so it can't affect layout or scroll size. Populated imperatively
+// (see TagList.tsx) rather than via React, since it needs to be rebuilt and re-measured
+// synchronously several times per layout pass.
+.measurer {
+  position: absolute;
+  visibility: hidden;
+  pointer-events: none;
+  top: -9999px;
+  left: -9999px;
+  display: flex;
+  flex-wrap: wrap;
+}

--- a/frontend/styles/components/molecules/DailyViewRow.module.scss
+++ b/frontend/styles/components/molecules/DailyViewRow.module.scss
@@ -1,0 +1,28 @@
+.meetingWrapper {
+  position: absolute;
+  border-radius: 6px;
+  z-index: 10;
+}
+
+// Stands in for meetings beyond the 2 stacked lanes a room's row shows -- a small pill
+// rather than a third, even-thinner lane, which would be too short to show anything
+// readable. Anchored to the cluster's start time (left) since DailyView's time axis runs
+// horizontally -- the rotated equivalent of WeeklyViewColumn's `right: 4px, top: <cluster start>`.
+.overflowIndicator {
+  position: absolute;
+  top: 2px;
+  z-index: 12;
+  background: #3A3E49;
+  color: #fff;
+  font-size: 10px;
+  font-weight: 600;
+  line-height: 1;
+  padding: 3px 6px;
+  border-radius: 999px;
+  white-space: nowrap;
+  cursor: pointer;
+
+  &:hover {
+    opacity: 0.85;
+  }
+}

--- a/frontend/styles/components/molecules/OverlapMeetingsModal.module.scss
+++ b/frontend/styles/components/molecules/OverlapMeetingsModal.module.scss
@@ -95,19 +95,3 @@
   font-size: 13px;
   color: #3A3E49;
 }
-
-.tags {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 4px;
-  align-items: center;
-}
-
-.tag {
-  padding: 2px 12px;
-  border-radius: 10.593px;
-  font-size: 10px;
-  font-weight: 400;
-  color: #1E1E1E;
-  white-space: nowrap;
-}

--- a/frontend/styles/components/molecules/WeeklyViewColumn.module.scss
+++ b/frontend/styles/components/molecules/WeeklyViewColumn.module.scss
@@ -8,7 +8,7 @@
 .columnBody {
   position: relative;
   width: 100%;
-  height: 2400px; // 24 hours * 100px per hour
+  height: 2880px; // 24 hours * 120px per hour
   border-right: 1px solid #e5e7eb;
   cursor: pointer;
 
@@ -21,7 +21,7 @@
 .hourMarker {
   position: absolute;
   width: 100%;
-  height: 100px;
+  height: 120px;
   border-top: 1px solid #e5e7eb;
 }
 

--- a/frontend/styles/components/organisms/ViewMeeting.module.scss
+++ b/frontend/styles/components/organisms/ViewMeeting.module.scss
@@ -282,19 +282,4 @@
     border-top: 2px solid #d6d5d5;
     margin: 4px 0 16px;
   }
-
-  .tags {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 4px;
-
-    .tag {
-      padding: 2px 12px;
-      border-radius: 10.593px;
-      font-size: 12px;
-      font-weight: 400;
-      white-space: nowrap;
-      color: #000;
-    }
-  }
 }

--- a/frontend/styles/components/organisms/WeeklyView.module.scss
+++ b/frontend/styles/components/organisms/WeeklyView.module.scss
@@ -62,11 +62,11 @@
   left: 0;
   z-index: 20;
 
-  // 41px .timeHeader + 2400px .timeSlots. Must be the full sum, not just the slots —
+  // 41px .timeHeader + 2880px .timeSlots. Must be the full sum, not just the slots —
   // .timeHeader is empty, so if this height is any smaller, flexbox's automatic
   // minimum size (based on content, 0 for an empty element) lets it absorb the whole
   // shrink and collapse to 0, throwing off every time label below it.
-  height: 2441px;
+  height: 2921px;
   background-color: #fff;
 
 }
@@ -83,11 +83,11 @@
 }
 
 .timeSlots {
-  height: 2400px; // 24 hours * 100px
+  height: 2880px; // 24 hours * 120px
 }
 
 .timeSlot {
-  height: 100px;
+  height: 120px;
   display: flex;
   align-items: flex-start;
   justify-content: flex-end; // aligns text to the right
@@ -103,11 +103,11 @@
   min-width: 0;
   scroll-snap-type: x mandatory;
 
-  // 40px .dayHeader + 2400px meeting grid per column — matches .dayColumn's own
-  // height (see there for why the full sum, not just 2400px, matters) so
+  // 40px .dayHeader + 2880px meeting grid per column — matches .dayColumn's own
+  // height (see there for why the full sum, not just 2880px, matters) so
   // .viewContainer's overflow:auto can scroll through all 24 hours, instead of
   // clamping to the (now correctly bounded) viewport height.
-  height: 2440px;
+  height: 2920px;
 }
 
 .dayColumn {
@@ -119,12 +119,12 @@
   border-right: 1px solid #ddd;
   scroll-snap-align: start;
 
-  // 40px .dayHeader + 2400px meeting grid. Was 2400px alone — under-subscribed by
+  // 40px .dayHeader + 2880px meeting grid. Was 2880px alone — under-subscribed by
   // the same 40px as .timeColumn was, just with a less obviously broken symptom:
   // .dayHeader has real text content, so instead of collapsing (like the empty
   // .timeHeader did) it just overflows this box harmlessly. Still worth the full
   // sum here so nothing depends on that overflow continuing to be harmless.
-  height: 2440px;
+  height: 2920px;
   display: flex;
   flex-direction: column;
 
@@ -204,7 +204,7 @@
 
 .dayColumnContent {
   position: relative;
-  height: 2400px; // 24 hours
+  height: 2880px; // 24 hours
 }
 
 .hourMarker {

--- a/frontend/test/e2e/05-calendar-display.spec.ts
+++ b/frontend/test/e2e/05-calendar-display.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from "./support/fixtures";
 import { seedMeeting } from "../factories/meeting";
 import { convertETToUTC, formatETDateString } from "../../util/timeUtils";
-import { selectView, toggleFilter } from "./support/formHelpers";
+import { selectView } from "./support/formHelpers";
 
 // Manual script §5 (Calendar Display). §5.9 (2+ overlapping meetings sharing space
 // with a "+N more" indicator) is WeeklyViewColumn-specific behavior — DailyView lays
@@ -16,15 +16,11 @@ test.describe("calendar display", () => {
     await expect(page.getByText("Today Meeting")).toBeVisible();
   });
 
-  test("5.2 Week view shows the full week once a room filter is checked", async ({ adminPage }) => {
+  test("5.2 Week view shows the full week with every room checked by default", async ({ adminPage }) => {
     const { page } = adminPage;
     await seedMeeting({ title: "Week View Meeting", room: "Serenity Room" });
     await page.goto("/");
     await selectView(page, "Week");
-
-    // Week defaults rooms unchecked (opt-in) — nothing shows until one is picked.
-    await expect(page.getByText("Week View Meeting")).toHaveCount(0);
-    await toggleFilter(page, "Serenity Room");
     await expect(page.getByText("Week View Meeting")).toBeVisible();
   });
 

--- a/frontend/test/e2e/08-filters.spec.ts
+++ b/frontend/test/e2e/08-filters.spec.ts
@@ -15,12 +15,12 @@ test.describe("filters", () => {
     await expect(aaCheckbox).toBeChecked();
   });
 
-  test("8.2 Week view starts with room filters unchecked", async ({ adminPage }) => {
+  test("8.2 Week view starts with every filter checked", async ({ adminPage }) => {
     const { page } = adminPage;
     await page.goto("/");
     await selectView(page, "Week");
     const serenityCheckbox = page.locator('label:has-text("Serenity Room")').first().locator('input[type="checkbox"]');
-    await expect(serenityCheckbox).not.toBeChecked();
+    await expect(serenityCheckbox).toBeChecked();
   });
 
   test("8.3 applying a room filter shows only that room's meetings", async ({ adminPage }) => {

--- a/frontend/test/e2e/12-weekly-view.spec.ts
+++ b/frontend/test/e2e/12-weekly-view.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from "./support/fixtures";
 import { seedMeeting, seedRecurringMeeting } from "../factories/meeting";
-import { toggleFilter, selectView } from "./support/formHelpers";
+import { selectView } from "./support/formHelpers";
 import { convertETToUTC, formatETDateString } from "../../util/timeUtils";
 
 // Manual script §12 (Weekly View). §12.5 (Zoom-room mismatch indicator) is also
@@ -8,20 +8,19 @@ import { convertETToUTC, formatETDateString } from "../../util/timeUtils";
 // since it's the section that actually owns Week view's rendering.
 
 test.describe("weekly view", () => {
-  test("12.1 Week view shows nothing until a room filter is checked", async ({ adminPage }) => {
+  test("12.1 Week view shows a room's meetings by default (rooms start checked)", async ({ adminPage }) => {
     const { page } = adminPage;
-    await seedMeeting({ title: "Hidden Until Filtered", room: "Serenity Room" });
+    await seedMeeting({ title: "Shown By Default", room: "Serenity Room" });
     await page.goto("/");
     await selectView(page, "Week");
-    await expect(page.getByText("Hidden Until Filtered")).toHaveCount(0);
+    await expect(page.getByText("Shown By Default")).toBeVisible();
   });
 
-  test("12.2 checking a room filter shows that room's meetings, correctly positioned", async ({ adminPage }) => {
+  test("12.2 a room's meetings are correctly positioned", async ({ adminPage }) => {
     const { page } = adminPage;
     await seedMeeting({ title: "Week Room Meeting", room: "Serenity Room" });
     await page.goto("/");
     await selectView(page, "Week");
-    await toggleFilter(page, "Serenity Room");
     await expect(page.getByText("Week Room Meeting")).toBeVisible();
   });
 
@@ -44,7 +43,6 @@ test.describe("weekly view", () => {
     );
     await page.goto("/");
     await selectView(page, "Week");
-    await toggleFilter(page, "Serenity Room");
     await expect(page.getByText("Multi Day Recurring")).toHaveCount(2);
   });
 
@@ -58,7 +56,6 @@ test.describe("weekly view", () => {
     }
     await page.goto("/");
     await selectView(page, "Week");
-    await toggleFilter(page, "Serenity Room");
 
     // layoutOverlappingMeetings shows up to 2 cards side-by-side plus a "+N" pill.
     await expect(page.getByText("+1")).toBeVisible();
@@ -74,7 +71,6 @@ test.describe("weekly view", () => {
     });
     await page.goto("/");
     await selectView(page, "Week");
-    await toggleFilter(page, "Serenity Room");
     await expect(page.getByTitle("Zoom room: Unity Room")).toBeVisible();
   });
 });

--- a/frontend/util/meetingFilters.ts
+++ b/frontend/util/meetingFilters.ts
@@ -14,9 +14,8 @@ const CATEGORY_FILTER_KEYS = ['AA', 'AlAnon', 'Other', 'InPerson', 'Hybrid', 'Re
 
 /**
  * Builds a default MeetingsFilter state. Category filters always default on; room
- * filters default per `roomsEnabled` — Week view defaults rooms off (opt-in) since
- * showing every room at once produces too many overlapping meetings, while Day view
- * defaults rooms on.
+ * filters default per `roomsEnabled` -- both Day and Week view currently pass `true`,
+ * so every room starts checked.
  */
 export const createDefaultFilters = (roomsEnabled: boolean): MeetingFilters => {
     const filters: MeetingFilters = {};

--- a/frontend/util/meetingOverlapLayout.ts
+++ b/frontend/util/meetingOverlapLayout.ts
@@ -43,7 +43,7 @@ export const MAX_VISIBLE_OVERLAP = 2;
  *    occupant has already ended (classic interval-graph-coloring calendar layout) — the
  *    cluster's column count becomes every meeting's totalOverlapping/width divisor.
  */
-export const layoutOverlappingMeetings = (meetings: OverlapMeeting[]): OverlapMeeting[] => {
+export const layoutOverlappingMeetings = <T extends OverlapMeeting>(meetings: T[]): T[] => {
     // Title as a tiebreaker keeps column/overflow assignment consistent across renders
     // and across days — meetings sharing a start time would otherwise fall back to
     // whatever order the database happened to return them in, which isn't guaranteed
@@ -52,8 +52,8 @@ export const layoutOverlappingMeetings = (meetings: OverlapMeeting[]): OverlapMe
         toMinutes(a.startTime) - toMinutes(b.startTime) || a.title.localeCompare(b.title)
     );
 
-    const clusters: OverlapMeeting[][] = [];
-    let currentCluster: OverlapMeeting[] = [];
+    const clusters: T[][] = [];
+    let currentCluster: T[] = [];
     let clusterEnd = -Infinity;
 
     sorted.forEach(meeting => {
@@ -68,7 +68,7 @@ export const layoutOverlappingMeetings = (meetings: OverlapMeeting[]): OverlapMe
     });
     if (currentCluster.length > 0) clusters.push(currentCluster);
 
-    const result: OverlapMeeting[] = [];
+    const result: T[] = [];
     clusters.forEach(cluster => {
         const columnEnds: number[] = []; // end time (minutes) currently occupying each column
         const positioned = cluster.map(meeting => {
@@ -108,6 +108,9 @@ export const layoutOverlappingMeetings = (meetings: OverlapMeeting[]): OverlapMe
         // easily start later than the two shown ones despite still overlapping all of them.
         const clusterStartMinutes = Math.min(...cluster.map(m => toMinutes(m.startTime)));
         const clusterEndMinutes = Math.max(...cluster.map(m => toMinutes(m.endTime)));
+        // Only OverlapMeeting's own fields are known here -- any extra fields a caller's T
+        // adds on (e.g. Day View's `syncError`) are meaningless for a pseudo-entry that isn't
+        // a real meeting, so this is asserted rather than genuinely satisfying T.
         result.push({
             id: `overflow-${cluster[0].date}-${clusterStartMinutes}`,
             title: '',
@@ -119,7 +122,7 @@ export const layoutOverlappingMeetings = (meetings: OverlapMeeting[]): OverlapMe
             isOverflowIndicator: true,
             overflowCount: overflow.length,
             overflowMeetings: cluster,
-        });
+        } as unknown as T);
     });
 
     return result;

--- a/frontend/util/tagOrder.ts
+++ b/frontend/util/tagOrder.ts
@@ -1,0 +1,18 @@
+// Canonical display order for meeting tags: Meeting Mode (Hybrid, In Person, Remote) always
+// renders before Meeting Calendar (AA, Al-Anon, Other). Unrecognized tags fall to the end,
+// keeping their relative order, so nothing silently disappears if a new tag value shows up.
+const TAG_ORDER = ['Hybrid', 'In Person', 'Remote', 'AA', 'Al-Anon', 'Other'];
+
+export const sortTags = (tags: string[]): string[] => {
+  return tags
+    .map((tag, index) => ({ tag, index }))
+    .sort((a, b) => {
+      const rankA = TAG_ORDER.indexOf(a.tag);
+      const rankB = TAG_ORDER.indexOf(b.tag);
+      if (rankA === -1 && rankB === -1) return a.index - b.index;
+      if (rankA === -1) return 1;
+      if (rankB === -1) return -1;
+      return rankA - rankB;
+    })
+    .map(({ tag }) => tag);
+};


### PR DESCRIPTION
## Description
- **frontend/util/meetingOverlapLayout.ts, frontend/app/components/organisms/DailyView.tsx, frontend/app/components/molecules/DailyViewRow.tsx**: Add stacked/lane layout for overlapping meetings in Day View, with a "+N" overflow pill and modal for meetings beyond the visible lanes.
- **frontend/app/components/molecules/WeeklyViewColumn.tsx, frontend/styles/components/organisms/WeeklyView.module.scss, frontend/styles/components/molecules/WeeklyViewColumn.module.scss**: Mirror the overlap/overflow layout in Week view (side-by-side columns instead of stacked lanes); default room filters to all-checked; increase hour row height (100px → 120px) and add a vertical gap between back-to-back meeting cards.
- **frontend/app/components/atoms/TagList.tsx, frontend/util/tagOrder.ts, frontend/app/components/atoms/BoxText.tsx**: Add canonical tag ordering and height-aware overflow capping so meeting tags don't overrun the card.
- **frontend/app/components/molecules/OverlapMeetingsModal.tsx, frontend/app/components/organisms/ViewMeeting.tsx**: Promote a folded "+N" meeting onto the visual stack when selected from the overflow modal, and anchor the ViewMeeting popup to the selected card's real position (not the overflow pill) so it no longer overlaps the card.

## Testing
- `npx tsc --noEmit -p .` — passes
- `yarn lint` — no new warnings/errors introduced
- Manual verification via Playwright against `yarn dev` (localhost:3000): Day View stacking/overflow-pill/tag visibility, Week view overflow-modal promotion, ViewMeeting anchor positioning, and the new row height/card spacing — screenshots inspected for each.

## Area(s) Touched
**Product areas**
- [x] ui/ux — frontend layout/styling not tied to a specific integration

**Engineering**
- [x] testing

## Pre-merge Checklist
- [x] Code follows current formatting conventions and passes lint (`yarn lint`).
- [x] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
- [x] All test suites pass, both run locally and green in GitHub CI. **Do not merge if any test suite is failing.**
- [x] A test suite was added or updated for the feature/fix in this PR.
- [x] Only files relevant to this change are committed — no stray or unrelated files.
- [x] If this branch has a merge conflict with master, master was merged into this branch first (not the other way around).
- [x] The rest of this PR description (Description, Testing) is filled out, not left as template placeholders.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added compact meeting-card support and improved tag “pill” rendering with consistent ordering and vertical fitting.
  * Introduced an automatic “+N” overflow indicator for constrained tag areas.
* **Improvements**
  * Day/Week views now start with all rooms visible by default.
  * Refreshed overlapping meeting layout and overflow selection (including promotion from “+N”), modal re-anchoring, and keyboard activation for overflow pills.
  * Updated daily/weekly time grid scaling and meeting popup tag display.
* **Tests**
  * Updated end-to-end scenarios to reflect default room visibility and the revised overlap/overflow behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->