### PR TITLE
ci: enforce Conventional Commits on PR titles

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,4 +1,8 @@
 reviews:
+  auto_title_instructions: >
+    Titles must follow Conventional Commits (see frontend/config/commitlint.config.mjs):
+    "<type>(<optional scope>): <description>", type one of
+    build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test, lowercase, no trailing period.
   auto_review:
     # Dependency bumps from these bots are already gated by CI + the auto-merge
     # policy in dependabot.yml/dependabot-auto-merge.yml -- a CodeRabbit review

--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -1,0 +1,34 @@
+name: PR Title Lint
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+
+permissions:
+  pull-requests: read
+
+jobs:
+  title-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v6
+        with:
+          types: |
+            build
+            chore
+            ci
+            docs
+            feat
+            fix
+            perf
+            refactor
+            revert
+            style
+            test
+          requireScope: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description
- **.github/workflows/pr-title-lint.yml**: new workflow, runs `amannn/action-semantic-pull-request` on PR open/edit/reopen/synchronize. Fails if the PR title isn't `type(scope): description` with type in build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test (same set as `frontend/config/commitlint.config.mjs`).
- **.coderabbit.yaml**: added `reviews.auto_title_instructions` so CodeRabbit's own auto-generated/suggested PR titles follow the same convention.

Why this is needed on top of the existing commitlint CI check (#258): that check only lints commits already on the PR branch (`--from base --to head`). This repo has squash-merge enabled with `COMMIT_OR_PR_TITLE`, so a PR with more than one commit falls back to the **PR title** as the final commit message on master — and the PR title itself was never validated. This closes that gap.

## Testing
- Workflow syntax reviewed against `amannn/action-semantic-pull-request`'s documented inputs (`types`, `requireScope`).
- Not yet exercised against a real PR — first real signal will be this PR's own title/CI run.

**Manual follow-up (can't be done from here):** once this workflow has run once, add "PR Title Lint / title-lint" as a required status check under Settings → Branches → master's branch protection rule — otherwise it runs but doesn't block merges.

## Area(s) Touched
**Product areas**
- [ ] auth — sign-in, sessions, NextAuth, role-based access
- [ ] admin — /admin shell (Diagnostics, Users, Import, Export tabs)
- [ ] billing — lease export, XLSX import, anything affecting invoicing
- [ ] ui/ux — frontend layout/styling not tied to a specific integration

**Integrations**
- [ ] google-calendar — Google Calendar sync
- [ ] zoom-api — Zoom meeting/host sync

**Engineering**
- [ ] security — auth hardening, data exposure, dependency/security scanning
- [ ] testing — test suite (Jest/Playwright) changes
- [x] github-actions — workflows, Dependabot config, other .github/ CI tooling
- [ ] cleanup — refactor or dead-code removal, no behavior change
- [ ] documentation — docs/ or README changes only

## Pre-merge Checklist
- [x] Code follows current formatting conventions and passes lint (`yarn lint`).
- [x] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
- [ ] All test suites pass, both run locally and green in GitHub CI. **Do not merge if any test suite is failing.**
- [ ] A test suite was added or updated for the feature/fix in this PR. **Double-check this if you change a feature and did not update the test suites**.
- [x] Only files relevant to this change are committed — no stray or unrelated files.
- [x] If this branch has a merge conflict with master, master was merged into this branch first (not the other way around).
- [x] The rest of this PR description (Description, Testing) is filled out, not left as template placeholders.