### PR TITLE
feat(ui/ux): collapsible calendar sidebar with compact icon rail

### DIFF
--- a/frontend/app/(main)/page.module.scss
+++ b/frontend/app/(main)/page.module.scss
@@ -4,6 +4,8 @@
 }
 
 .sidebar {
+  position: relative; // anchors the collapse/expand chevron to the visible viewport,
+                       // not to whatever height the scrollable content grows to
   width: 280px;
   background-color: #ffffff;
   padding: 10px;

--- a/frontend/app/(main)/page.module.scss
+++ b/frontend/app/(main)/page.module.scss
@@ -17,6 +17,10 @@
   // button's tooltip where it pokes past the sidebar's right edge. Scrolling instead lives
   // on .sidebarScroll below, so this box (and the button that's a sibling of that div) stays
   // unclipped.
+
+  // width/padding are also driven from an inline style (CalendarSidebarShell) when compact --
+  // this transition is what makes that swap animate instead of snapping instantly.
+  transition: width 0.25s ease, padding 0.25s ease;
 }
 
 .sidebarScroll {
@@ -24,10 +28,40 @@
   overflow-y: auto;
 }
 
+// Wraps the full <-> compact cross-fade (see CalendarSidebarShell).
+.sidebarSwap {
+  position: relative;
+  height: 100%;
+}
+
+.sidebarLayer {
+  position: absolute;
+  inset: 0;
+  height: 100%;
+}
+
+// Only the full sidebar's layer clips -- its 280px content needs to stay bounded to the
+// animating .sidebar width during a collapse so it doesn't visibly spill past the shrinking
+// edge. The compact rail's layer deliberately has no such clip: its flyouts pop out past the
+// 64px rail on purpose (see CompactCalendarSidebar.module.scss), and clipping .sidebarSwap
+// itself (as an earlier version of this rule did) cut those off entirely.
+.sidebarLayerFull {
+  overflow: hidden;
+}
+
+.sidebarLayerFading {
+  // Only the outgoing layer gets a transition property -- the incoming one snaps to visible
+  // immediately underneath it, so this fade-out (on top, via z-index) is what reads as a
+  // cross-fade without needing a separate fade-in animation for the incoming layer.
+  opacity: 0;
+  transition: opacity 0.2s ease;
+  z-index: 1;
+}
+
 .sidebarToggleWrapper {
   position: absolute;
   top: 50%;
-  right: -10;
+  right: -10px;
   transform: translateY(-50%);
   // `transform` establishes a new stacking context, which traps the tooltip's own z-index
   // inside it -- without an explicit z-index here too, this wrapper paints in plain DOM

--- a/frontend/app/(main)/page.module.scss
+++ b/frontend/app/(main)/page.module.scss
@@ -49,13 +49,29 @@
   overflow: hidden;
 }
 
-.sidebarLayerFading {
-  // Only the outgoing layer gets a transition property -- the incoming one snaps to visible
-  // immediately underneath it, so this fade-out (on top, via z-index) is what reads as a
-  // cross-fade without needing a separate fade-in animation for the incoming layer.
+.sidebarLayerOutgoing {
+  // Fades out immediately on toggle, no delay. The incoming layer (see
+  // .sidebarLayerEntering/.sidebarLayerEntered below) waits out a short delay before fading in,
+  // so the two never visibly cross-fade over each other -- there's a brief gap where neither is
+  // visible instead.
   opacity: 0;
-  transition: opacity 0.2s ease;
+  transition: opacity 0.12s ease;
   z-index: 1;
+}
+
+.sidebarLayerEntering {
+  // Pre-transition mount state for a freshly-swapped-in layer: opacity 0, no transition
+  // property yet. CSS transitions only animate a *change* observed after a paint -- mounting
+  // straight into .sidebarLayerEntered's opacity: 1 would leave nothing to animate from. See
+  // CalendarSidebarShell's double-rAF flip from this class to .sidebarLayerEntered.
+  opacity: 0;
+}
+
+.sidebarLayerEntered {
+  // Fades in only after .sidebarLayerOutgoing's fade-out (120ms) plus a short gap have passed,
+  // so the outgoing and incoming layers never overlap.
+  opacity: 1;
+  transition: opacity 0.12s ease 0.15s;
 }
 
 .sidebarToggleWrapper {

--- a/frontend/app/(main)/page.module.scss
+++ b/frontend/app/(main)/page.module.scss
@@ -1,3 +1,5 @@
+@import '../../styles/Variables.module.scss';
+
 .container {
   display: flex;
   height: 100%;
@@ -9,8 +11,30 @@
   width: 280px;
   background-color: #ffffff;
   padding: 10px;
-  min-height: 0; // lets the flex item shrink so overflow-y actually scrolls
+  min-height: 0; // lets the flex item shrink so .sidebarScroll's height: 100% is bounded
+  // No overflow here on purpose -- overflow-y auto/hidden forces overflow-x to compute as
+  // auto too (CSS can't mix visible with non-visible per-axis), which would clip the toggle
+  // button's tooltip where it pokes past the sidebar's right edge. Scrolling instead lives
+  // on .sidebarScroll below, so this box (and the button that's a sibling of that div) stays
+  // unclipped.
+}
+
+.sidebarScroll {
+  height: 100%;
   overflow-y: auto;
+}
+
+.sidebarToggleWrapper {
+  position: absolute;
+  top: 50%;
+  right: 0;
+  transform: translateY(-50%);
+  // `transform` establishes a new stacking context, which traps the tooltip's own z-index
+  // inside it -- without an explicit z-index here too, this wrapper paints in plain DOM
+  // order at the root stacking context, so .primaryCalendar's content (which comes later
+  // in the DOM) paints over it regardless of the tooltip's z-index. An explicit z-index
+  // promotes the whole wrapper (tooltip included) above that plain in-flow content.
+  z-index: $z-index-dropdown;
 }
 
 .primaryCalendar {

--- a/frontend/app/(main)/page.module.scss
+++ b/frontend/app/(main)/page.module.scss
@@ -10,7 +10,7 @@
                        // not to whatever height the scrollable content grows to
   width: 280px;
   background-color: #ffffff;
-  padding: 10px;
+  padding: 24px;
   min-height: 0; // lets the flex item shrink so .sidebarScroll's height: 100% is bounded
   // No overflow here on purpose -- overflow-y auto/hidden forces overflow-x to compute as
   // auto too (CSS can't mix visible with non-visible per-axis), which would clip the toggle
@@ -27,7 +27,7 @@
 .sidebarToggleWrapper {
   position: absolute;
   top: 50%;
-  right: 0;
+  right: -10;
   transform: translateY(-50%);
   // `transform` establishes a new stacking context, which traps the tooltip's own z-index
   // inside it -- without an explicit z-index here too, this wrapper paints in plain DOM

--- a/frontend/app/(main)/page.tsx
+++ b/frontend/app/(main)/page.tsx
@@ -2,10 +2,8 @@
 import React, { useState, useEffect, useCallback, useRef } from "react";
 import styles from "./page.module.scss";
 import CalendarNavbar from "../components/organisms/CalendarNavbar";
-import CalendarSidebar from "../components/organisms/CalendarSidebar";
-import SignInPrompt from "../components/organisms/SignInPrompt";
+import CalendarSidebarShell from "../components/organisms/CalendarSidebarShell";
 import ViewMeetingDetails from "../components/organisms/ViewMeeting";
-import EditMeetingSidebar from "../components/organisms/EditMeeting";
 import DailyView from "../components/organisms/DailyView";
 import WeeklyView from "../components/organisms/WeeklyView";
 
@@ -242,31 +240,18 @@ export default function HomePage() {
   return (
     <div className={styles.container}>
       {isSidebarOpen && (
-        <div
-          className={styles.sidebar}
-          style={isViewMeetingOpen ? { overflowY: 'hidden' } : undefined}
-        >
-          {isLoggedIn === null ? null : !isLoggedIn ? (
-            <SignInPrompt />
-          ) : showEditMeeting && selectedMeeting ? (
-              <EditMeetingSidebar
-                meeting={selectedMeeting}
-                onClose={handleCloseEdit}
-                onUpdateSuccess={() => {
-                  console.log("Meeting updated!");
-                  triggerCalendarRefresh();
-                }}
-              />) : (
-                <CalendarSidebar
-                  filters={filters}
-                  setFilters={setFilters}
-                  selectedDate={selectedDate}
-                  setSelectedDate={setSelectedDate}
-                  selectedView={selectedView}
-                  triggerCalendarRefresh={triggerCalendarRefresh}
-                />
-              )}
-        </div>
+        <CalendarSidebarShell
+          isLoggedIn={isLoggedIn}
+          filters={filters}
+          setFilters={setFilters}
+          selectedDate={selectedDate}
+          setSelectedDate={setSelectedDate}
+          selectedView={selectedView}
+          triggerCalendarRefresh={triggerCalendarRefresh}
+          selectedMeeting={selectedMeeting}
+          showEditMeeting={showEditMeeting}
+          onCloseEdit={handleCloseEdit}
+        />
       )}
       {selectedMeeting && !showEditMeeting && (
         <ViewMeetingDetails

--- a/frontend/app/(main)/page.tsx
+++ b/frontend/app/(main)/page.tsx
@@ -10,10 +10,8 @@ import WeeklyView from "../components/organisms/WeeklyView";
 import { convertUTCToET } from "../../util/timeUtils";
 import { IMeeting } from "../../util/models";
 import { createDefaultFilters } from "../../util/meetingFilters";
-import { useSidebar } from "../context/SidebarContext";
 
 export default function HomePage() {
-  const { isSidebarOpen, openSidebar } = useSidebar();
   const [isLoggedIn, setIsLoggedIn] = useState<boolean | null>(null);
   const [refreshTrigger, setRefreshTrigger] = useState(0);
 
@@ -125,20 +123,6 @@ export default function HomePage() {
     setAnchorEl(null);
   };
 
-  // NewMeeting's own open/closed state lives inside CalendarSidebar itself, so it already
-  // resets for free when the sidebar unmounts. showEditMeeting lives up here instead, so
-  // hiding the sidebar while Edit is open needs an explicit reset -- and since Edit only
-  // exists as a follow-on from ViewMeeting's popup (see handleOpenEdit below), backing out
-  // of Edit here backs all the way out of ViewMeeting too, same as handleBack elsewhere,
-  // rather than leaving the popup to reappear underneath once the sidebar reopens.
-  useEffect(() => {
-    if (!isSidebarOpen && showEditMeeting) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect
-      handleBack();
-      setShowEditMeeting(false);
-    }
-  }, [isSidebarOpen, showEditMeeting]);
-
   // Switching Day/Week view backs out to neutral (CalendarSidebar, no popup) entirely --
   // not just closing Edit, since the clicked box's anchorEl also goes stale across the
   // switch (Day view's boxes aren't in the DOM once Week view renders, and vice versa),
@@ -157,9 +141,6 @@ export default function HomePage() {
   }, [selectedView]);
 
   const handleOpenEdit = () => {
-    // EditMeetingSidebar renders inside the .sidebar column, so Edit needs it open --
-    // unlike just viewing a meeting, which shows its own popup regardless of sidebar state.
-    openSidebar();
     setShowEditMeeting(true);
   };
 
@@ -239,20 +220,18 @@ export default function HomePage() {
 
   return (
     <div className={styles.container}>
-      {isSidebarOpen && (
-        <CalendarSidebarShell
-          isLoggedIn={isLoggedIn}
-          filters={filters}
-          setFilters={setFilters}
-          selectedDate={selectedDate}
-          setSelectedDate={setSelectedDate}
-          selectedView={selectedView}
-          triggerCalendarRefresh={triggerCalendarRefresh}
-          selectedMeeting={selectedMeeting}
-          showEditMeeting={showEditMeeting}
-          onCloseEdit={handleCloseEdit}
-        />
-      )}
+      <CalendarSidebarShell
+        isLoggedIn={isLoggedIn}
+        filters={filters}
+        setFilters={setFilters}
+        selectedDate={selectedDate}
+        setSelectedDate={setSelectedDate}
+        selectedView={selectedView}
+        triggerCalendarRefresh={triggerCalendarRefresh}
+        selectedMeeting={selectedMeeting}
+        showEditMeeting={showEditMeeting}
+        onCloseEdit={handleCloseEdit}
+      />
       {selectedMeeting && !showEditMeeting && (
         <ViewMeetingDetails
           key={selectedMeeting.mid}

--- a/frontend/app/components/atoms/IconButton.tsx
+++ b/frontend/app/components/atoms/IconButton.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import React from "react";
+import MuiIconButton from "@mui/material/IconButton";
+import styles from "../../../styles/components/atoms/IconButton.module.scss";
+
+interface IconButtonProps {
+    icon: React.ReactNode;
+    ariaLabel: string;
+    onClick?: () => void;
+    variant?: "filled" | "ghost";
+    backgroundColor?: string;
+    size?: "default" | "compact";
+    tooltip?: string;
+    className?: string;
+}
+
+const IconButton: React.FC<IconButtonProps> = ({
+    icon,
+    ariaLabel,
+    onClick,
+    variant = "ghost",
+    backgroundColor,
+    size = "default",
+    tooltip,
+    className,
+}) => {
+    const sizeClass = size === "compact" ? styles.compact : styles.default;
+    const variantClass = variant === "filled" ? styles.filled : styles.ghost;
+
+    const button = (
+        <MuiIconButton
+            className={[styles.iconButton, sizeClass, variantClass, className]
+                .filter(Boolean)
+                .join(" ")}
+            onClick={onClick}
+            aria-label={ariaLabel}
+            style={variant === "filled" && backgroundColor ? { backgroundColor } : undefined}
+        >
+            <span className={styles.iconWrap}>{icon}</span>
+        </MuiIconButton>
+    );
+
+    if (!tooltip) {
+        return button;
+    }
+
+    return (
+        <span className={styles.tooltipWrapper}>
+            {button}
+            <span className={styles.tooltip}>{tooltip}</span>
+        </span>
+    );
+};
+
+export default IconButton;

--- a/frontend/app/components/atoms/IconButton.tsx
+++ b/frontend/app/components/atoms/IconButton.tsx
@@ -2,16 +2,18 @@
 
 import React from "react";
 import MuiIconButton from "@mui/material/IconButton";
+import Tooltip from "./Tooltip";
 import styles from "../../../styles/components/atoms/IconButton.module.scss";
 
 interface IconButtonProps {
     icon: React.ReactNode;
     ariaLabel: string;
     onClick?: () => void;
-    variant?: "filled" | "ghost";
+    variant?: "filled" | "ghost" | "outlined";
     backgroundColor?: string;
     size?: "default" | "compact";
     tooltip?: string;
+    tooltipAlign?: "center" | "left";
     className?: string;
 }
 
@@ -23,10 +25,12 @@ const IconButton: React.FC<IconButtonProps> = ({
     backgroundColor,
     size = "default",
     tooltip,
+    tooltipAlign = "center",
     className,
 }) => {
     const sizeClass = size === "compact" ? styles.compact : styles.default;
-    const variantClass = variant === "filled" ? styles.filled : styles.ghost;
+    const variantClass =
+        variant === "filled" ? styles.filled : variant === "outlined" ? styles.outlined : styles.ghost;
 
     const button = (
         <MuiIconButton
@@ -46,10 +50,9 @@ const IconButton: React.FC<IconButtonProps> = ({
     }
 
     return (
-        <span className={styles.tooltipWrapper}>
+        <Tooltip content={tooltip} align={tooltipAlign}>
             {button}
-            <span className={styles.tooltip}>{tooltip}</span>
-        </span>
+        </Tooltip>
     );
 };
 

--- a/frontend/app/components/atoms/IconButton.tsx
+++ b/frontend/app/components/atoms/IconButton.tsx
@@ -32,12 +32,23 @@ const IconButton: React.FC<IconButtonProps> = ({
     const variantClass =
         variant === "filled" ? styles.filled : variant === "outlined" ? styles.outlined : styles.ghost;
 
+    // A mouse click leaves the button focused, keeping its focus ring showing after the
+    // interaction is done. e.detail is 0 for a "click" synthesized by keyboard activation
+    // (Enter/Space) and >0 for a real pointer click, so this only drops focus for the mouse
+    // case -- tabbing to the button still shows a focus ring until the user tabs away.
+    const handleClick: React.MouseEventHandler<HTMLButtonElement> = (e) => {
+        if (e.detail > 0) {
+            e.currentTarget.blur();
+        }
+        onClick?.();
+    };
+
     const button = (
         <MuiIconButton
             className={[styles.iconButton, sizeClass, variantClass, className]
                 .filter(Boolean)
                 .join(" ")}
-            onClick={onClick}
+            onClick={handleClick}
             aria-label={ariaLabel}
             style={variant === "filled" && backgroundColor ? { backgroundColor } : undefined}
         >

--- a/frontend/app/components/atoms/Tooltip.tsx
+++ b/frontend/app/components/atoms/Tooltip.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import styles from "../../../styles/components/atoms/Tooltip.module.scss";
+
+interface TooltipProps {
+    content: string;
+    children: React.ReactNode;
+    // "center" anchors under the middle of the trigger (default); "left" anchors to the
+    // trigger's left edge instead, for triggers that sit near the left edge of the screen
+    // where a centered tooltip would run off-screen.
+    align?: "center" | "left";
+    className?: string;
+}
+
+const Tooltip: React.FC<TooltipProps> = ({ content, children, align = "center", className }) => {
+    return (
+        <span className={[styles.wrapper, className].filter(Boolean).join(" ")}>
+            {children}
+            <span className={align === "left" ? [styles.tooltip, styles.alignLeft].join(" ") : styles.tooltip}>
+                {content}
+            </span>
+        </span>
+    );
+};
+
+export default Tooltip;

--- a/frontend/app/components/molecules/MeetingsFilter.tsx
+++ b/frontend/app/components/molecules/MeetingsFilter.tsx
@@ -10,7 +10,7 @@ interface MeetingsFilterProps {
     onFilterChange: (name: string, value: boolean) => void;
 }
 
-const LOCATION_ITEMS: FilterGroupItem[] = [
+export const LOCATION_ITEMS: FilterGroupItem[] = [
     { key: 'SerenityRoom', label: 'Serenity Room', color: ROOM_COLORS['Serenity Room'] },
     { key: 'SeedsofHopeRoom', label: 'Seeds of Hope Room', color: ROOM_COLORS['Seeds of Hope Room'] },
     { key: 'UnityRoom', label: 'Unity Room', color: ROOM_COLORS['Unity Room'] },
@@ -19,7 +19,7 @@ const LOCATION_ITEMS: FilterGroupItem[] = [
     { key: 'RoomforGratitude', label: 'Room for Gratitude', color: ROOM_COLORS['Room for Gratitude'] },
 ];
 
-const ZOOM_ITEMS: FilterGroupItem[] = [
+export const ZOOM_ITEMS: FilterGroupItem[] = [
     { key: 'SerenityRoomZoom', label: 'Serenity Room', color: ZOOM_ROOM_COLOR },
     { key: 'SeedsofHopeRoomZoom', label: 'Seeds of Hope Room', color: ZOOM_ROOM_COLOR },
     { key: 'UnityRoomZoom', label: 'Unity Room', color: ZOOM_ROOM_COLOR },
@@ -27,13 +27,13 @@ const ZOOM_ITEMS: FilterGroupItem[] = [
     { key: "Children'sRoom@518Zoom", label: "Children's Room @ 518", color: ZOOM_ROOM_COLOR },
 ];
 
-const CALENDAR_ITEMS: FilterGroupItem[] = [
+export const CALENDAR_ITEMS: FilterGroupItem[] = [
     { key: 'AA', label: 'AA', color: CATEGORY_COLOR },
     { key: 'AlAnon', label: 'Al-Anon', color: CATEGORY_COLOR },
     { key: 'Other', label: 'Other', color: CATEGORY_COLOR },
 ];
 
-const MODE_ITEMS: FilterGroupItem[] = [
+export const MODE_ITEMS: FilterGroupItem[] = [
     { key: 'InPerson', label: 'In Person', color: CATEGORY_COLOR },
     { key: 'Hybrid', label: 'Hybrid', color: CATEGORY_COLOR },
     { key: 'Remote', label: 'Remote', color: CATEGORY_COLOR },

--- a/frontend/app/components/organisms/AppNavbar.tsx
+++ b/frontend/app/components/organisms/AppNavbar.tsx
@@ -6,9 +6,7 @@ import { usePathname } from "next/navigation";
 import Logo from "../atoms/Logo";
 import type { Session } from "next-auth";
 import { signOut } from "next-auth/react";
-import IconButton from "@mui/material/IconButton";
 import Tooltip from "../atoms/Tooltip";
-import { useSidebar } from "../../context/SidebarContext";
 import styles from "../../../styles/components/organisms/AppNavbar.module.scss";
 
 interface AppNavbarProps {
@@ -19,21 +17,11 @@ const AppNavbar: React.FC<AppNavbarProps> = ({ session }) => {
     const isAdmin = session?.user?.role === "ADMIN" || session?.user?.role === "SUPER_ADMIN";
     const pathname = usePathname();
     const navItemClass = (isActive: boolean) => `btn btn-ghost ${isActive ? styles.active : ""}`;
-    const { isSidebarOpen, toggleSidebar } = useSidebar();
 
     return (
         <div className={styles.navbar}>
             <div className={styles.navcontainer}>
                 <div className={styles.navLeft}>
-                    <Tooltip content="Show/Hide calendar sidebar" align="left">
-                        <IconButton
-                            className={styles.sidebarToggleButton}
-                            onClick={toggleSidebar}
-                            aria-label={isSidebarOpen ? "Hide calendar sidebar" : "Show calendar sidebar"}
-                        >
-                            <img src="/svg/menu-icon.svg" alt="" className={styles.menuIcon} />
-                        </IconButton>
-                    </Tooltip>
                     <Logo />
                 </div>
                 <ul className={styles.navigationlist}>

--- a/frontend/app/components/organisms/AppNavbar.tsx
+++ b/frontend/app/components/organisms/AppNavbar.tsx
@@ -7,6 +7,7 @@ import Logo from "../atoms/Logo";
 import type { Session } from "next-auth";
 import { signOut } from "next-auth/react";
 import IconButton from "@mui/material/IconButton";
+import Tooltip from "../atoms/Tooltip";
 import { useSidebar } from "../../context/SidebarContext";
 import styles from "../../../styles/components/organisms/AppNavbar.module.scss";
 
@@ -24,7 +25,7 @@ const AppNavbar: React.FC<AppNavbarProps> = ({ session }) => {
         <div className={styles.navbar}>
             <div className={styles.navcontainer}>
                 <div className={styles.navLeft}>
-                    <span className={styles.sidebarToggleWrapper}>
+                    <Tooltip content="Show/Hide calendar sidebar" align="left">
                         <IconButton
                             className={styles.sidebarToggleButton}
                             onClick={toggleSidebar}
@@ -32,55 +33,45 @@ const AppNavbar: React.FC<AppNavbarProps> = ({ session }) => {
                         >
                             <img src="/svg/menu-icon.svg" alt="" className={styles.menuIcon} />
                         </IconButton>
-                        <span className={styles.tooltip}>
-                            Show/Hide calendar sidebar
-                        </span>
-                    </span>
+                    </Tooltip>
                     <Logo />
                 </div>
                 <ul className={styles.navigationlist}>
-                    <li className={`${navItemClass(pathname === "/")} ${styles.navTooltipWrapper}`}>
-                        <Link href="/">
-                            <p>Main Calendar</p>
-                        </Link>
-                        <span className={styles.tooltip}>
-                            Live calendar — add, edit, or delete meetings
-                        </span>
+                    <li className={navItemClass(pathname === "/")}>
+                        <Tooltip content="Live calendar — add, edit, or delete meetings">
+                            <Link href="/">
+                                <p>Main Calendar</p>
+                            </Link>
+                        </Tooltip>
                     </li>
-                    <li className={`${navItemClass(pathname === "/signage")} ${styles.navTooltipWrapper}`}>
-                        <Link href="/signage">
-                            <p>Signage</p>
-                        </Link>
-                        <span className={styles.tooltip}>
-                            Read-only calendar view for signage
-                        </span>
+                    <li className={navItemClass(pathname === "/signage")}>
+                        <Tooltip content="Read-only calendar view for signage">
+                            <Link href="/signage">
+                                <p>Signage</p>
+                            </Link>
+                        </Tooltip>
                     </li>
-                    <li className={`${navItemClass(pathname?.startsWith("/admin") ?? false)} ${styles.navTooltipWrapper}`}>
+                    <li className={navItemClass(pathname?.startsWith("/admin") ?? false)}>
                         {isAdmin ? (
-                            <>
+                            <Tooltip content="Manage users, imports, exports, and diagnostics">
                                 <Link href="/admin">
                                     <p>Admin</p>
                                 </Link>
-                                <span className={styles.tooltip}>
-                                    Manage users, imports, exports, and diagnostics
-                                </span>
-                            </>
+                            </Tooltip>
                         ) : session ? (
-                            <>
+                            <Tooltip content="Requires admin access">
                                 <button className={styles.navLocked} disabled>
                                     <p>Admin</p>
                                     <img src="/svg/lock-icon.svg" alt="" className={styles.lockIcon} />
                                 </button>
-                                <span className={styles.tooltip}>Requires admin access</span>
-                            </>
+                            </Tooltip>
                         ) : (
-                            <>
+                            <Tooltip content="Sign in to access Admin">
                                 <Link href="/login" className={styles.navLockedLink}>
                                     <p>Admin</p>
                                     <img src="/svg/lock-icon.svg" alt="" className={styles.lockIcon} />
                                 </Link>
-                                <span className={styles.tooltip}>Sign in to access Admin</span>
-                            </>
+                            </Tooltip>
                         )}
                     </li>
                     <li>

--- a/frontend/app/components/organisms/CalendarSidebar.tsx
+++ b/frontend/app/components/organisms/CalendarSidebar.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import TextButton from '../atoms/TextButton';
+import IconButton from '../atoms/IconButton';
 
 import MiniCalendar from '../atoms/MiniCalendar';
 import MeetingsFilter from '../molecules/MeetingsFilter';
 import { MeetingFilters } from '../../../util/meetingFilters';
 import NewMeetingSidebar from './NewMeeting';
+import { useSidebar } from '../../context/SidebarContext';
 import styles from '../../../styles/components/organisms/CalendarSidebar.module.scss';
 import AddIcon from '@mui/icons-material/Add';
 interface CalendarSidebarProps {
@@ -28,12 +30,23 @@ const CalendarSidebar: React.FC<CalendarSidebarProps> = ({
   selectedView,
   triggerCalendarRefresh,
 }) => {
+  const { collapseSidebar } = useSidebar();
+
   const handleOpenNewMeeting = () => {
     setIsNewMeetingOpen(true);
   };
 
   return (
     <div>
+      <div className={styles.collapseButtonWrapper}>
+        <IconButton
+          icon={<img src="/svg/chevron-left-icon.svg" alt="" />}
+          ariaLabel="Collapse sidebar"
+          tooltip="Collapse sidebar"
+          size="compact"
+          onClick={collapseSidebar}
+        />
+      </div>
       {isNewMeetingOpen ? (
         <NewMeetingSidebar
           setIsNewMeetingOpen={setIsNewMeetingOpen}

--- a/frontend/app/components/organisms/CalendarSidebar.tsx
+++ b/frontend/app/components/organisms/CalendarSidebar.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import TextButton from '../atoms/TextButton';
 
 import MiniCalendar from '../atoms/MiniCalendar';
@@ -9,30 +9,25 @@ import styles from '../../../styles/components/organisms/CalendarSidebar.module.
 import AddIcon from '@mui/icons-material/Add';
 interface CalendarSidebarProps {
   filters: MeetingFilters;
-  setFilters: React.Dispatch<React.SetStateAction<MeetingFilters>>;
+  isNewMeetingOpen: boolean;
+  setIsNewMeetingOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  handleFilterChange: (name: string, value: boolean) => void;
+  handleMiniCalendarSelect: (date: Date) => void;
   selectedDate: Date;
-  setSelectedDate: React.Dispatch<React.SetStateAction<Date>>;
   selectedView: string;
   triggerCalendarRefresh: () => void;
 }
 
-const CalendarSidebar: React.FC<CalendarSidebarProps> = ({filters, setFilters, selectedDate, setSelectedDate, selectedView, triggerCalendarRefresh}) => {
-  // State declarations for New Meeting button
-  const [isNewMeetingOpen, setIsNewMeetingOpen] = useState(false);
-
-  // Switching Day/Week view backs out of the New Meeting form, back to the standard sidebar.
-  useEffect(() => {
-    setIsNewMeetingOpen(false);
-  }, [selectedView]);
-
-  const handleMiniCalendarSelect = (date: Date) => {
-    setSelectedDate(date);
-  };
-
-  const handleFilterChange = (name: string, value: boolean) => {
-    setFilters((prev: typeof filters) => ({ ...prev, [name]: value }));
-  };
-
+const CalendarSidebar: React.FC<CalendarSidebarProps> = ({
+  filters,
+  isNewMeetingOpen,
+  setIsNewMeetingOpen,
+  handleFilterChange,
+  handleMiniCalendarSelect,
+  selectedDate,
+  selectedView,
+  triggerCalendarRefresh,
+}) => {
   const handleOpenNewMeeting = () => {
     setIsNewMeetingOpen(true);
   };

--- a/frontend/app/components/organisms/CalendarSidebar.tsx
+++ b/frontend/app/components/organisms/CalendarSidebar.tsx
@@ -1,12 +1,10 @@
 import React from 'react';
 import TextButton from '../atoms/TextButton';
-import IconButton from '../atoms/IconButton';
 
 import MiniCalendar from '../atoms/MiniCalendar';
 import MeetingsFilter from '../molecules/MeetingsFilter';
 import { MeetingFilters } from '../../../util/meetingFilters';
 import NewMeetingSidebar from './NewMeeting';
-import { useSidebar } from '../../context/SidebarContext';
 import styles from '../../../styles/components/organisms/CalendarSidebar.module.scss';
 import AddIcon from '@mui/icons-material/Add';
 interface CalendarSidebarProps {
@@ -30,23 +28,12 @@ const CalendarSidebar: React.FC<CalendarSidebarProps> = ({
   selectedView,
   triggerCalendarRefresh,
 }) => {
-  const { collapseSidebar } = useSidebar();
-
   const handleOpenNewMeeting = () => {
     setIsNewMeetingOpen(true);
   };
 
   return (
     <div>
-      <div className={styles.collapseButtonWrapper}>
-        <IconButton
-          icon={<img src="/svg/chevron-left-icon.svg" alt="" />}
-          ariaLabel="Collapse sidebar"
-          tooltip="Collapse sidebar"
-          size="compact"
-          onClick={collapseSidebar}
-        />
-      </div>
       {isNewMeetingOpen ? (
         <NewMeetingSidebar
           setIsNewMeetingOpen={setIsNewMeetingOpen}

--- a/frontend/app/components/organisms/CalendarSidebarShell.tsx
+++ b/frontend/app/components/organisms/CalendarSidebarShell.tsx
@@ -23,13 +23,30 @@ interface CalendarSidebarShellProps {
   onCloseEdit: () => void;
 }
 
-// Matches the opacity transition duration set on .sidebarLayerFading in page.module.scss --
-// kept in sync manually (CSS durations aren't readable from JS) so the outgoing layer is
-// unmounted right as its fade-out finishes, not before (cutting the animation short) or
-// noticeably after (leaving a dead, already-invisible node around).
-const SIDEBAR_FADE_MS = 200;
+// Matches the staggered fade durations set on .sidebarLayerOutgoing/.sidebarLayerEntered in
+// page.module.scss -- kept in sync manually (CSS durations aren't readable from JS). The
+// outgoing layer fades out immediately (no delay); the incoming layer waits out the delay
+// before fading in, so there's a brief gap where neither is visible instead of the two
+// cross-fading over each other. The outgoing layer is unmounted once the whole sequence
+// (delay + incoming fade-in) has finished.
+const SIDEBAR_INCOMING_DELAY_MS = 150;
+const SIDEBAR_INCOMING_FADE_MS = 120;
+const SIDEBAR_TOTAL_TRANSITION_MS = SIDEBAR_INCOMING_DELAY_MS + SIDEBAR_INCOMING_FADE_MS;
 
 type SidebarMode = "full" | "compact";
+
+// Outgoing layers fade out immediately; the live layer fades in only once it's been flipped
+// past its pre-transition mount state (see the `entered` state in the component below).
+function sidebarLayerTransitionClass(
+  mode: SidebarMode,
+  renderedMode: SidebarMode,
+  outgoingMode: SidebarMode | null,
+  entered: boolean
+): string {
+  if (outgoingMode === mode) return styles.sidebarLayerOutgoing;
+  if (renderedMode === mode) return entered ? styles.sidebarLayerEntered : styles.sidebarLayerEntering;
+  return "";
+}
 
 const CalendarSidebarShell: React.FC<CalendarSidebarShellProps> = ({
   isLoggedIn,
@@ -47,29 +64,56 @@ const CalendarSidebarShell: React.FC<CalendarSidebarShellProps> = ({
   const [isNewMeetingOpen, setIsNewMeetingOpen] = useState(false);
   useBreakpoint(collapseSidebar);
 
-  // Drives the full <-> compact cross-fade. renderedMode is the "live" (interactive) variant;
-  // outgoingMode, when set, is the previous variant still mounted just long enough to fade out
-  // on top of it. Both use a stable `key` per mode (see render below) so React updates the
+  // Drives the full <-> compact staggered cross-fade. renderedMode is the "live" (interactive)
+  // variant; outgoingMode, when set, is the previous variant still mounted long enough to fade
+  // out on top of it. Both use a stable `key` per mode (see render below) so React updates the
   // existing DOM node's class instead of remounting it -- remounting would mean the node never
   // painted at opacity: 1 first, so there'd be nothing for the CSS transition to animate from.
+  //
+  // `entered` tracks whether the current renderedMode's layer has been flipped from its
+  // pre-transition mount state (opacity 0, no transition -- .sidebarLayerEntering) to its
+  // animating-in state (opacity 1, transition delayed by SIDEBAR_INCOMING_DELAY_MS --
+  // .sidebarLayerEntered). CSS transitions only animate a *change* observed after a paint, so a
+  // freshly-mounted layer has to sit at opacity 0 for a frame before switching classes, or there
+  // would be nothing for the browser to interpolate from.
   const [renderedMode, setRenderedMode] = useState<SidebarMode>(isCompact ? "compact" : "full");
   const [outgoingMode, setOutgoingMode] = useState<SidebarMode | null>(null);
-  const fadeTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [entered, setEntered] = useState(true);
+  const outgoingTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const enterRafRef = useRef<number[]>([]);
 
   useEffect(() => {
     const nextMode: SidebarMode = isCompact ? "compact" : "full";
     setRenderedMode((current) => {
       if (current === nextMode) return current;
       setOutgoingMode(current);
-      if (fadeTimeoutRef.current) clearTimeout(fadeTimeoutRef.current);
-      fadeTimeoutRef.current = setTimeout(() => setOutgoingMode(null), SIDEBAR_FADE_MS);
+      setEntered(false);
+      if (outgoingTimeoutRef.current) clearTimeout(outgoingTimeoutRef.current);
+      outgoingTimeoutRef.current = setTimeout(() => setOutgoingMode(null), SIDEBAR_TOTAL_TRANSITION_MS);
       return nextMode;
     });
   }, [isCompact]);
 
+  // Flips the incoming layer from its pre-transition mount state to its animating-in state one
+  // paint later. Double rAF (rather than a single one) reliably lands after React's commit has
+  // actually painted the opacity: 0 state, which a single rAF can sometimes race.
+  useEffect(() => {
+    if (entered) return;
+    const raf1 = requestAnimationFrame(() => {
+      const raf2 = requestAnimationFrame(() => setEntered(true));
+      enterRafRef.current.push(raf2);
+    });
+    enterRafRef.current.push(raf1);
+    return () => {
+      enterRafRef.current.forEach(cancelAnimationFrame);
+      enterRafRef.current = [];
+    };
+  }, [entered, renderedMode]);
+
   useEffect(
     () => () => {
-      if (fadeTimeoutRef.current) clearTimeout(fadeTimeoutRef.current);
+      if (outgoingTimeoutRef.current) clearTimeout(outgoingTimeoutRef.current);
+      enterRafRef.current.forEach(cancelAnimationFrame);
     },
     []
   );
@@ -127,7 +171,7 @@ const CalendarSidebarShell: React.FC<CalendarSidebarShellProps> = ({
               className={[
                 styles.sidebarLayer,
                 styles.sidebarLayerFull,
-                outgoingMode === "full" ? styles.sidebarLayerFading : "",
+                sidebarLayerTransitionClass("full", renderedMode, outgoingMode, entered),
               ]
                 .filter(Boolean)
                 .join(" ")}
@@ -151,11 +195,12 @@ const CalendarSidebarShell: React.FC<CalendarSidebarShellProps> = ({
           {(renderedMode === "compact" || outgoingMode === "compact") && (
             <div
               key="compact"
-              className={
-                outgoingMode === "compact"
-                  ? [styles.sidebarLayer, styles.sidebarLayerFading].join(" ")
-                  : styles.sidebarLayer
-              }
+              className={[
+                styles.sidebarLayer,
+                sidebarLayerTransitionClass("compact", renderedMode, outgoingMode, entered),
+              ]
+                .filter(Boolean)
+                .join(" ")}
               aria-hidden={outgoingMode === "compact" ? true : undefined}
               style={outgoingMode === "compact" ? { pointerEvents: "none" } : undefined}
             >

--- a/frontend/app/components/organisms/CalendarSidebarShell.tsx
+++ b/frontend/app/components/organisms/CalendarSidebarShell.tsx
@@ -67,7 +67,7 @@ const CalendarSidebarShell: React.FC<CalendarSidebarShellProps> = ({
   return (
     <div
       className={styles.sidebar}
-      style={isRailCompact ? { width: 64, padding: "10px 0" } : undefined}
+      style={isRailCompact ? { width: 64, padding: "0 24px 0 0" } : undefined}
     >
       {isLoggedIn === null ? null : !isLoggedIn ? (
         <div className={styles.sidebarScroll}>
@@ -119,10 +119,11 @@ const CalendarSidebarShell: React.FC<CalendarSidebarShellProps> = ({
             icon={<img src={isCompact ? "/svg/chevron-right-icon.svg" : "/svg/chevron-left-icon.svg"} alt="" />}
             ariaLabel={isCompact ? "Show calendar sidebar" : "Collapse sidebar"}
             tooltip={isCompact ? "Show calendar sidebar" : "Collapse sidebar"}
+            tooltipAlign={isCompact ? "left" : "center"}
             variant="outlined"
             size="compact"
             onClick={isCompact ? expandSidebar : collapseSidebar}
-          />
+          /> 
         </div>
       )}
     </div>

--- a/frontend/app/components/organisms/CalendarSidebarShell.tsx
+++ b/frontend/app/components/organisms/CalendarSidebarShell.tsx
@@ -123,6 +123,25 @@ const CalendarSidebarShell: React.FC<CalendarSidebarShellProps> = ({
     setIsNewMeetingOpen(false);
   }, [selectedView]);
 
+  // Opening New Meeting from the compact rail force-expands the sidebar (the form needs the
+  // full 280px width) -- stashedCompactRef remembers that this expand was forced rather than
+  // user-chosen, so closing the form can put the rail back instead of leaving it expanded.
+  // Edit Meeting doesn't need this: it overrides its own width via isRailCompact below without
+  // ever touching isCompact, so there's nothing to restore there.
+  const stashedCompactRef = useRef(false);
+  const wasNewMeetingOpenRef = useRef(isNewMeetingOpen);
+
+  useEffect(() => {
+    const wasOpen = wasNewMeetingOpenRef.current;
+    wasNewMeetingOpenRef.current = isNewMeetingOpen;
+    if (wasOpen && !isNewMeetingOpen && stashedCompactRef.current) {
+      collapseSidebar();
+    }
+    if (!isNewMeetingOpen) {
+      stashedCompactRef.current = false;
+    }
+  }, [isNewMeetingOpen, collapseSidebar]);
+
   const handleMiniCalendarSelect = (date: Date) => {
     setSelectedDate(date);
   };
@@ -215,6 +234,7 @@ const CalendarSidebarShell: React.FC<CalendarSidebarShellProps> = ({
                 selectedDate={selectedDate}
                 handleMiniCalendarSelect={handleMiniCalendarSelect}
                 onOpenNewMeeting={() => {
+                  stashedCompactRef.current = isCompact;
                   expandSidebar();
                   setIsNewMeetingOpen(true);
                 }}

--- a/frontend/app/components/organisms/CalendarSidebarShell.tsx
+++ b/frontend/app/components/organisms/CalendarSidebarShell.tsx
@@ -4,6 +4,7 @@ import SignInPrompt from "./SignInPrompt";
 import EditMeetingSidebar from "./EditMeeting";
 import CalendarSidebar from "./CalendarSidebar";
 import CompactCalendarSidebar from "./CompactCalendarSidebar";
+import IconButton from "../atoms/IconButton";
 import { useSidebar } from "../../context/SidebarContext";
 import { IMeeting } from "../../../util/models";
 import { MeetingFilters } from "../../../util/meetingFilters";
@@ -33,7 +34,7 @@ const CalendarSidebarShell: React.FC<CalendarSidebarShellProps> = ({
   showEditMeeting,
   onCloseEdit,
 }) => {
-  const { isCompact } = useSidebar();
+  const { isCompact, collapseSidebar, expandSidebar } = useSidebar();
   const [isNewMeetingOpen, setIsNewMeetingOpen] = useState(false);
 
   // Switching Day/Week view backs out of the New Meeting form, back to the standard sidebar.
@@ -57,38 +58,56 @@ const CalendarSidebarShell: React.FC<CalendarSidebarShellProps> = ({
   const isEditing = showEditMeeting && !!selectedMeeting;
   const isRailCompact = isLoggedIn === true && !isEditing && isCompact;
 
+  // SignInPrompt/EditMeetingSidebar have nothing to collapse -- the toggle only makes sense
+  // once the full or compact CalendarSidebar is what's actually showing.
+  const showSidebarToggle = isLoggedIn === true && !isEditing;
+
   return (
     <div
       className={styles.sidebar}
-      style={{
-        ...(isViewMeetingOpen ? { overflowY: "hidden" } : {}),
-        ...(isRailCompact ? { width: 64, padding: "10px 0" } : {}),
-      }}
+      style={isRailCompact ? { width: 64, padding: "10px 0" } : undefined}
     >
-      {isLoggedIn === null ? null : !isLoggedIn ? (
-        <SignInPrompt />
-      ) : showEditMeeting && selectedMeeting ? (
-        <EditMeetingSidebar
-          meeting={selectedMeeting}
-          onClose={onCloseEdit}
-          onUpdateSuccess={() => {
-            console.log("Meeting updated!");
-            triggerCalendarRefresh();
-          }}
-        />
-      ) : isCompact ? (
-        <CompactCalendarSidebar />
-      ) : (
-        <CalendarSidebar
-          filters={filters}
-          isNewMeetingOpen={isNewMeetingOpen}
-          setIsNewMeetingOpen={setIsNewMeetingOpen}
-          handleFilterChange={handleFilterChange}
-          handleMiniCalendarSelect={handleMiniCalendarSelect}
-          selectedDate={selectedDate}
-          selectedView={selectedView}
-          triggerCalendarRefresh={triggerCalendarRefresh}
-        />
+      <div
+        className={styles.sidebarScroll}
+        style={isViewMeetingOpen ? { overflowY: "hidden" } : undefined}
+      >
+        {isLoggedIn === null ? null : !isLoggedIn ? (
+          <SignInPrompt />
+        ) : showEditMeeting && selectedMeeting ? (
+          <EditMeetingSidebar
+            meeting={selectedMeeting}
+            onClose={onCloseEdit}
+            onUpdateSuccess={() => {
+              console.log("Meeting updated!");
+              triggerCalendarRefresh();
+            }}
+          />
+        ) : isCompact ? (
+          <CompactCalendarSidebar />
+        ) : (
+          <CalendarSidebar
+            filters={filters}
+            isNewMeetingOpen={isNewMeetingOpen}
+            setIsNewMeetingOpen={setIsNewMeetingOpen}
+            handleFilterChange={handleFilterChange}
+            handleMiniCalendarSelect={handleMiniCalendarSelect}
+            selectedDate={selectedDate}
+            selectedView={selectedView}
+            triggerCalendarRefresh={triggerCalendarRefresh}
+          />
+        )}
+      </div>
+      {showSidebarToggle && (
+        <div className={styles.sidebarToggleWrapper}>
+          <IconButton
+            icon={<img src={isCompact ? "/svg/chevron-right-icon.svg" : "/svg/chevron-left-icon.svg"} alt="" />}
+            ariaLabel={isCompact ? "Show calendar sidebar" : "Collapse sidebar"}
+            tooltip={isCompact ? "Show calendar sidebar" : "Collapse sidebar"}
+            variant="outlined"
+            size="compact"
+            onClick={isCompact ? expandSidebar : collapseSidebar}
+          />
+        </div>
       )}
     </div>
   );

--- a/frontend/app/components/organisms/CalendarSidebarShell.tsx
+++ b/frontend/app/components/organisms/CalendarSidebarShell.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import styles from "../../(main)/page.module.scss";
 import SignInPrompt from "./SignInPrompt";
 import EditMeetingSidebar from "./EditMeeting";
@@ -23,6 +23,14 @@ interface CalendarSidebarShellProps {
   onCloseEdit: () => void;
 }
 
+// Matches the opacity transition duration set on .sidebarLayerFading in page.module.scss --
+// kept in sync manually (CSS durations aren't readable from JS) so the outgoing layer is
+// unmounted right as its fade-out finishes, not before (cutting the animation short) or
+// noticeably after (leaving a dead, already-invisible node around).
+const SIDEBAR_FADE_MS = 200;
+
+type SidebarMode = "full" | "compact";
+
 const CalendarSidebarShell: React.FC<CalendarSidebarShellProps> = ({
   isLoggedIn,
   filters,
@@ -38,6 +46,33 @@ const CalendarSidebarShell: React.FC<CalendarSidebarShellProps> = ({
   const { isCompact, collapseSidebar, expandSidebar } = useSidebar();
   const [isNewMeetingOpen, setIsNewMeetingOpen] = useState(false);
   useBreakpoint(collapseSidebar);
+
+  // Drives the full <-> compact cross-fade. renderedMode is the "live" (interactive) variant;
+  // outgoingMode, when set, is the previous variant still mounted just long enough to fade out
+  // on top of it. Both use a stable `key` per mode (see render below) so React updates the
+  // existing DOM node's class instead of remounting it -- remounting would mean the node never
+  // painted at opacity: 1 first, so there'd be nothing for the CSS transition to animate from.
+  const [renderedMode, setRenderedMode] = useState<SidebarMode>(isCompact ? "compact" : "full");
+  const [outgoingMode, setOutgoingMode] = useState<SidebarMode | null>(null);
+  const fadeTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    const nextMode: SidebarMode = isCompact ? "compact" : "full";
+    setRenderedMode((current) => {
+      if (current === nextMode) return current;
+      setOutgoingMode(current);
+      if (fadeTimeoutRef.current) clearTimeout(fadeTimeoutRef.current);
+      fadeTimeoutRef.current = setTimeout(() => setOutgoingMode(null), SIDEBAR_FADE_MS);
+      return nextMode;
+    });
+  }, [isCompact]);
+
+  useEffect(
+    () => () => {
+      if (fadeTimeoutRef.current) clearTimeout(fadeTimeoutRef.current);
+    },
+    []
+  );
 
   // Switching Day/Week view backs out of the New Meeting form, back to the standard sidebar.
   useEffect(() => {
@@ -84,33 +119,63 @@ const CalendarSidebarShell: React.FC<CalendarSidebarShellProps> = ({
             }}
           />
         </div>
-      ) : isCompact ? (
-        // Not wrapped in .sidebarScroll -- that div's overflow-y: auto forces overflow-x to
-        // compute as auto too (same clipping quirk as the toggle button's tooltip, see
-        // .sidebar's comment in page.module.scss), which would clip the rail's flyouts where
-        // they pop out past the 64px rail's right edge.
-        <CompactCalendarSidebar
-          filters={filters}
-          handleFilterChange={handleFilterChange}
-          selectedDate={selectedDate}
-          handleMiniCalendarSelect={handleMiniCalendarSelect}
-          onOpenNewMeeting={() => {
-            expandSidebar();
-            setIsNewMeetingOpen(true);
-          }}
-        />
       ) : (
-        <div className={styles.sidebarScroll} style={isViewMeetingOpen ? { overflowY: "hidden" } : undefined}>
-          <CalendarSidebar
-            filters={filters}
-            isNewMeetingOpen={isNewMeetingOpen}
-            setIsNewMeetingOpen={setIsNewMeetingOpen}
-            handleFilterChange={handleFilterChange}
-            handleMiniCalendarSelect={handleMiniCalendarSelect}
-            selectedDate={selectedDate}
-            selectedView={selectedView}
-            triggerCalendarRefresh={triggerCalendarRefresh}
-          />
+        <div className={styles.sidebarSwap}>
+          {(renderedMode === "full" || outgoingMode === "full") && (
+            <div
+              key="full"
+              className={[
+                styles.sidebarLayer,
+                styles.sidebarLayerFull,
+                outgoingMode === "full" ? styles.sidebarLayerFading : "",
+              ]
+                .filter(Boolean)
+                .join(" ")}
+              aria-hidden={outgoingMode === "full" ? true : undefined}
+              style={outgoingMode === "full" ? { pointerEvents: "none" } : undefined}
+            >
+              <div className={styles.sidebarScroll} style={isViewMeetingOpen ? { overflowY: "hidden" } : undefined}>
+                <CalendarSidebar
+                  filters={filters}
+                  isNewMeetingOpen={isNewMeetingOpen}
+                  setIsNewMeetingOpen={setIsNewMeetingOpen}
+                  handleFilterChange={handleFilterChange}
+                  handleMiniCalendarSelect={handleMiniCalendarSelect}
+                  selectedDate={selectedDate}
+                  selectedView={selectedView}
+                  triggerCalendarRefresh={triggerCalendarRefresh}
+                />
+              </div>
+            </div>
+          )}
+          {(renderedMode === "compact" || outgoingMode === "compact") && (
+            <div
+              key="compact"
+              className={
+                outgoingMode === "compact"
+                  ? [styles.sidebarLayer, styles.sidebarLayerFading].join(" ")
+                  : styles.sidebarLayer
+              }
+              aria-hidden={outgoingMode === "compact" ? true : undefined}
+              style={outgoingMode === "compact" ? { pointerEvents: "none" } : undefined}
+            >
+              {/* Unlike the full sidebar's layer above, this isn't wrapped in .sidebarScroll --
+                  that div's overflow-y: auto forces overflow-x to compute as auto too (same
+                  clipping quirk as the toggle button's tooltip, see .sidebar's comment in
+                  page.module.scss), which would clip the rail's flyouts where they pop out
+                  past the 64px rail's edge. */}
+              <CompactCalendarSidebar
+                filters={filters}
+                handleFilterChange={handleFilterChange}
+                selectedDate={selectedDate}
+                handleMiniCalendarSelect={handleMiniCalendarSelect}
+                onOpenNewMeeting={() => {
+                  expandSidebar();
+                  setIsNewMeetingOpen(true);
+                }}
+              />
+            </div>
+          )}
         </div>
       )}
       {showSidebarToggle && (

--- a/frontend/app/components/organisms/CalendarSidebarShell.tsx
+++ b/frontend/app/components/organisms/CalendarSidebarShell.tsx
@@ -3,6 +3,8 @@ import styles from "../../(main)/page.module.scss";
 import SignInPrompt from "./SignInPrompt";
 import EditMeetingSidebar from "./EditMeeting";
 import CalendarSidebar from "./CalendarSidebar";
+import CompactCalendarSidebar from "./CompactCalendarSidebar";
+import { useSidebar } from "../../context/SidebarContext";
 import { IMeeting } from "../../../util/models";
 import { MeetingFilters } from "../../../util/meetingFilters";
 
@@ -31,6 +33,7 @@ const CalendarSidebarShell: React.FC<CalendarSidebarShellProps> = ({
   showEditMeeting,
   onCloseEdit,
 }) => {
+  const { isCompact } = useSidebar();
   const [isNewMeetingOpen, setIsNewMeetingOpen] = useState(false);
 
   // Switching Day/Week view backs out of the New Meeting form, back to the standard sidebar.
@@ -50,10 +53,17 @@ const CalendarSidebarShell: React.FC<CalendarSidebarShellProps> = ({
   // sidebar while it's open just fights that anchoring instead of being useful.
   const isViewMeetingOpen = !!(selectedMeeting && !showEditMeeting);
 
+  // Editing always shows the full-width form, regardless of the last compact/expanded choice.
+  const isEditing = showEditMeeting && !!selectedMeeting;
+  const isRailCompact = isLoggedIn === true && !isEditing && isCompact;
+
   return (
     <div
       className={styles.sidebar}
-      style={isViewMeetingOpen ? { overflowY: "hidden" } : undefined}
+      style={{
+        ...(isViewMeetingOpen ? { overflowY: "hidden" } : {}),
+        ...(isRailCompact ? { width: 64, padding: "10px 0" } : {}),
+      }}
     >
       {isLoggedIn === null ? null : !isLoggedIn ? (
         <SignInPrompt />
@@ -66,6 +76,8 @@ const CalendarSidebarShell: React.FC<CalendarSidebarShellProps> = ({
             triggerCalendarRefresh();
           }}
         />
+      ) : isCompact ? (
+        <CompactCalendarSidebar />
       ) : (
         <CalendarSidebar
           filters={filters}

--- a/frontend/app/components/organisms/CalendarSidebarShell.tsx
+++ b/frontend/app/components/organisms/CalendarSidebarShell.tsx
@@ -62,7 +62,7 @@ const CalendarSidebarShell: React.FC<CalendarSidebarShellProps> = ({
 }) => {
   const { isCompact, collapseSidebar, expandSidebar } = useSidebar();
   const [isNewMeetingOpen, setIsNewMeetingOpen] = useState(false);
-  useBreakpoint(collapseSidebar);
+  useBreakpoint(collapseSidebar, expandSidebar);
 
   // Drives the full <-> compact staggered cross-fade. renderedMode is the "live" (interactive)
   // variant; outgoingMode, when set, is the previous variant still mounted long enough to fade
@@ -154,13 +154,13 @@ const CalendarSidebarShell: React.FC<CalendarSidebarShellProps> = ({
   // sidebar while it's open just fights that anchoring instead of being useful.
   const isViewMeetingOpen = !!(selectedMeeting && !showEditMeeting);
 
-  // Editing always shows the full-width form, regardless of the last compact/expanded choice.
+  // New and Editing Meeting always shows the full-width form, regardless of the last compact/expanded choice.
   const isEditing = showEditMeeting && !!selectedMeeting;
-  const isRailCompact = isLoggedIn === true && !isEditing && isCompact;
+  const isRailCompact = isLoggedIn === true && !isEditing && !isNewMeetingOpen && isCompact;
 
   // SignInPrompt/EditMeetingSidebar have nothing to collapse -- the toggle only makes sense
   // once the full or compact CalendarSidebar is what's actually showing.
-  const showSidebarToggle = isLoggedIn === true && !isEditing;
+  const showSidebarToggle = isLoggedIn === true && !isEditing && !isNewMeetingOpen;
 
   return (
     <div

--- a/frontend/app/components/organisms/CalendarSidebarShell.tsx
+++ b/frontend/app/components/organisms/CalendarSidebarShell.tsx
@@ -6,6 +6,7 @@ import CalendarSidebar from "./CalendarSidebar";
 import CompactCalendarSidebar from "./CompactCalendarSidebar";
 import IconButton from "../atoms/IconButton";
 import { useSidebar } from "../../context/SidebarContext";
+import { useBreakpoint } from "../../../hooks/useBreakpoint";
 import { IMeeting } from "../../../util/models";
 import { MeetingFilters } from "../../../util/meetingFilters";
 
@@ -36,6 +37,7 @@ const CalendarSidebarShell: React.FC<CalendarSidebarShellProps> = ({
 }) => {
   const { isCompact, collapseSidebar, expandSidebar } = useSidebar();
   const [isNewMeetingOpen, setIsNewMeetingOpen] = useState(false);
+  useBreakpoint(collapseSidebar);
 
   // Switching Day/Week view backs out of the New Meeting form, back to the standard sidebar.
   useEffect(() => {
@@ -67,13 +69,12 @@ const CalendarSidebarShell: React.FC<CalendarSidebarShellProps> = ({
       className={styles.sidebar}
       style={isRailCompact ? { width: 64, padding: "10px 0" } : undefined}
     >
-      <div
-        className={styles.sidebarScroll}
-        style={isViewMeetingOpen ? { overflowY: "hidden" } : undefined}
-      >
-        {isLoggedIn === null ? null : !isLoggedIn ? (
+      {isLoggedIn === null ? null : !isLoggedIn ? (
+        <div className={styles.sidebarScroll}>
           <SignInPrompt />
-        ) : showEditMeeting && selectedMeeting ? (
+        </div>
+      ) : showEditMeeting && selectedMeeting ? (
+        <div className={styles.sidebarScroll} style={isViewMeetingOpen ? { overflowY: "hidden" } : undefined}>
           <EditMeetingSidebar
             meeting={selectedMeeting}
             onClose={onCloseEdit}
@@ -82,9 +83,24 @@ const CalendarSidebarShell: React.FC<CalendarSidebarShellProps> = ({
               triggerCalendarRefresh();
             }}
           />
-        ) : isCompact ? (
-          <CompactCalendarSidebar />
-        ) : (
+        </div>
+      ) : isCompact ? (
+        // Not wrapped in .sidebarScroll -- that div's overflow-y: auto forces overflow-x to
+        // compute as auto too (same clipping quirk as the toggle button's tooltip, see
+        // .sidebar's comment in page.module.scss), which would clip the rail's flyouts where
+        // they pop out past the 64px rail's right edge.
+        <CompactCalendarSidebar
+          filters={filters}
+          handleFilterChange={handleFilterChange}
+          selectedDate={selectedDate}
+          handleMiniCalendarSelect={handleMiniCalendarSelect}
+          onOpenNewMeeting={() => {
+            expandSidebar();
+            setIsNewMeetingOpen(true);
+          }}
+        />
+      ) : (
+        <div className={styles.sidebarScroll} style={isViewMeetingOpen ? { overflowY: "hidden" } : undefined}>
           <CalendarSidebar
             filters={filters}
             isNewMeetingOpen={isNewMeetingOpen}
@@ -95,8 +111,8 @@ const CalendarSidebarShell: React.FC<CalendarSidebarShellProps> = ({
             selectedView={selectedView}
             triggerCalendarRefresh={triggerCalendarRefresh}
           />
-        )}
-      </div>
+        </div>
+      )}
       {showSidebarToggle && (
         <div className={styles.sidebarToggleWrapper}>
           <IconButton

--- a/frontend/app/components/organisms/CalendarSidebarShell.tsx
+++ b/frontend/app/components/organisms/CalendarSidebarShell.tsx
@@ -1,0 +1,85 @@
+import React, { useEffect, useState } from "react";
+import styles from "../../(main)/page.module.scss";
+import SignInPrompt from "./SignInPrompt";
+import EditMeetingSidebar from "./EditMeeting";
+import CalendarSidebar from "./CalendarSidebar";
+import { IMeeting } from "../../../util/models";
+import { MeetingFilters } from "../../../util/meetingFilters";
+
+interface CalendarSidebarShellProps {
+  isLoggedIn: boolean | null;
+  filters: MeetingFilters;
+  setFilters: React.Dispatch<React.SetStateAction<MeetingFilters>>;
+  selectedDate: Date;
+  setSelectedDate: React.Dispatch<React.SetStateAction<Date>>;
+  selectedView: string;
+  triggerCalendarRefresh: () => void;
+  selectedMeeting: IMeeting | null;
+  showEditMeeting: boolean;
+  onCloseEdit: () => void;
+}
+
+const CalendarSidebarShell: React.FC<CalendarSidebarShellProps> = ({
+  isLoggedIn,
+  filters,
+  setFilters,
+  selectedDate,
+  setSelectedDate,
+  selectedView,
+  triggerCalendarRefresh,
+  selectedMeeting,
+  showEditMeeting,
+  onCloseEdit,
+}) => {
+  const [isNewMeetingOpen, setIsNewMeetingOpen] = useState(false);
+
+  // Switching Day/Week view backs out of the New Meeting form, back to the standard sidebar.
+  useEffect(() => {
+    setIsNewMeetingOpen(false);
+  }, [selectedView]);
+
+  const handleMiniCalendarSelect = (date: Date) => {
+    setSelectedDate(date);
+  };
+
+  const handleFilterChange = (name: string, value: boolean) => {
+    setFilters((prev: typeof filters) => ({ ...prev, [name]: value }));
+  };
+
+  // ViewMeeting's popup is anchored to the clicked box's on-screen position -- scrolling the
+  // sidebar while it's open just fights that anchoring instead of being useful.
+  const isViewMeetingOpen = !!(selectedMeeting && !showEditMeeting);
+
+  return (
+    <div
+      className={styles.sidebar}
+      style={isViewMeetingOpen ? { overflowY: "hidden" } : undefined}
+    >
+      {isLoggedIn === null ? null : !isLoggedIn ? (
+        <SignInPrompt />
+      ) : showEditMeeting && selectedMeeting ? (
+        <EditMeetingSidebar
+          meeting={selectedMeeting}
+          onClose={onCloseEdit}
+          onUpdateSuccess={() => {
+            console.log("Meeting updated!");
+            triggerCalendarRefresh();
+          }}
+        />
+      ) : (
+        <CalendarSidebar
+          filters={filters}
+          isNewMeetingOpen={isNewMeetingOpen}
+          setIsNewMeetingOpen={setIsNewMeetingOpen}
+          handleFilterChange={handleFilterChange}
+          handleMiniCalendarSelect={handleMiniCalendarSelect}
+          selectedDate={selectedDate}
+          selectedView={selectedView}
+          triggerCalendarRefresh={triggerCalendarRefresh}
+        />
+      )}
+    </div>
+  );
+};
+
+export default CalendarSidebarShell;

--- a/frontend/app/components/organisms/CompactCalendarSidebar.tsx
+++ b/frontend/app/components/organisms/CompactCalendarSidebar.tsx
@@ -1,8 +1,127 @@
-import React from 'react';
+import React, { useState } from 'react';
+import IconButton from '../atoms/IconButton';
+import MiniCalendar from '../atoms/MiniCalendar';
+import FilterGroup from '../molecules/FilterGroup';
+import { LOCATION_ITEMS, ZOOM_ITEMS, CALENDAR_ITEMS, MODE_ITEMS } from '../molecules/MeetingsFilter';
+import { MeetingFilters } from '../../../util/meetingFilters';
 import styles from '../../../styles/components/organisms/CompactCalendarSidebar.module.scss';
 
-const CompactCalendarSidebar: React.FC = () => {
-  return <div className={styles.rail} />;
+type FlyoutKey = 'calendar' | 'location' | 'video' | 'group';
+
+interface CompactCalendarSidebarProps {
+  filters: MeetingFilters;
+  handleFilterChange: (name: string, value: boolean) => void;
+  selectedDate: Date;
+  handleMiniCalendarSelect: (date: Date) => void;
+  onOpenNewMeeting: () => void;
+}
+
+const CompactCalendarSidebar: React.FC<CompactCalendarSidebarProps> = ({
+  filters,
+  handleFilterChange,
+  selectedDate,
+  handleMiniCalendarSelect,
+  onOpenNewMeeting,
+}) => {
+  const [openFlyout, setOpenFlyout] = useState<FlyoutKey | null>(null);
+
+  const toggleFlyout = (key: FlyoutKey) => {
+    setOpenFlyout((prev) => (prev === key ? null : key));
+  };
+
+  return (
+    <div className={styles.rail}>
+      <IconButton
+        icon={<img src="/svg/plus-icon-white.svg" alt="" />}
+        ariaLabel="New Meeting"
+        tooltip="New Meeting"
+        variant="filled"
+        backgroundColor="#CC3366"
+        onClick={onOpenNewMeeting}
+      />
+
+      <div className={styles.flyoutAnchor}>
+        <IconButton
+          icon={<img src="/svg/calendar-icon.svg" alt="" />}
+          ariaLabel="Show mini calendar"
+          tooltip="Calendar"
+          onClick={() => toggleFlyout('calendar')}
+        />
+        {openFlyout === 'calendar' && (
+          <div className={styles.flyout}>
+            <MiniCalendar selectedDate={selectedDate} onSelect={handleMiniCalendarSelect} />
+          </div>
+        )}
+      </div>
+
+      <div className={styles.flyoutAnchor}>
+        <IconButton
+          icon={<img src="/svg/location-icon.svg" alt="" />}
+          ariaLabel="Show location filters"
+          tooltip="Location"
+          onClick={() => toggleFlyout('location')}
+        />
+        {openFlyout === 'location' && (
+          <div className={styles.flyout}>
+            <FilterGroup
+              title="Location"
+              items={LOCATION_ITEMS}
+              checked={filters}
+              onToggle={handleFilterChange}
+              headingVariant="title"
+            />
+          </div>
+        )}
+      </div>
+
+      <div className={styles.flyoutAnchor}>
+        <IconButton
+          icon={<img src="/svg/video-call-icon.svg" alt="" />}
+          ariaLabel="Show Zoom Room filters"
+          tooltip="Zoom Rooms"
+          onClick={() => toggleFlyout('video')}
+        />
+        {openFlyout === 'video' && (
+          <div className={styles.flyout}>
+            <FilterGroup
+              title="Zoom Rooms"
+              items={ZOOM_ITEMS}
+              checked={filters}
+              onToggle={handleFilterChange}
+              headingVariant="title"
+            />
+          </div>
+        )}
+      </div>
+
+      <div className={styles.flyoutAnchor}>
+        <IconButton
+          icon={<img src="/svg/group-icon.svg" alt="" />}
+          ariaLabel="Show calendar and mode filters"
+          tooltip="Calendar & Mode"
+          onClick={() => toggleFlyout('group')}
+        />
+        {openFlyout === 'group' && (
+          <div className={styles.flyout}>
+            <FilterGroup
+              title="Calendar"
+              items={CALENDAR_ITEMS}
+              checked={filters}
+              onToggle={handleFilterChange}
+              headingVariant="title"
+            />
+            <FilterGroup
+              title="Mode"
+              items={MODE_ITEMS}
+              checked={filters}
+              onToggle={handleFilterChange}
+              headingVariant="title"
+            />
+          </div>
+        )}
+      </div>
+    </div>
+  );
 };
 
 export default CompactCalendarSidebar;

--- a/frontend/app/components/organisms/CompactCalendarSidebar.tsx
+++ b/frontend/app/components/organisms/CompactCalendarSidebar.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import IconButton from '../atoms/IconButton';
 import MiniCalendar from '../atoms/MiniCalendar';
 import FilterGroup from '../molecules/FilterGroup';
@@ -24,17 +24,36 @@ const CompactCalendarSidebar: React.FC<CompactCalendarSidebarProps> = ({
   onOpenNewMeeting,
 }) => {
   const [openFlyout, setOpenFlyout] = useState<FlyoutKey | null>(null);
+  const railRef = useRef<HTMLDivElement>(null);
 
   const toggleFlyout = (key: FlyoutKey) => {
     setOpenFlyout((prev) => (prev === key ? null : key));
   };
 
+  // Same pattern as DatePicker's outside-click handling: a mousedown anywhere outside the
+  // rail (the icons and their flyouts) closes whichever flyout is open. Clicks on a rail icon
+  // or inside a flyout's own content stay inside railRef, so they're left to their own click
+  // handlers (toggleFlyout, checkbox onChange, etc.) instead of being fought here.
+  useEffect(() => {
+    if (!openFlyout) return;
+
+    const handleClickOutside = (event: MouseEvent) => {
+      if (!railRef.current?.contains(event.target as Node)) {
+        setOpenFlyout(null);
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [openFlyout]);
+
   return (
-    <div className={styles.rail}>
+    <div className={styles.rail} ref={railRef}>
       <IconButton
         icon={<img src="/svg/plus-icon-white.svg" alt="" />}
         ariaLabel="New Meeting"
         tooltip="New Meeting"
+        tooltipAlign="left"
         variant="filled"
         backgroundColor="#CC3366"
         onClick={onOpenNewMeeting}
@@ -45,6 +64,7 @@ const CompactCalendarSidebar: React.FC<CompactCalendarSidebarProps> = ({
           icon={<img src="/svg/calendar-icon.svg" alt="" />}
           ariaLabel="Show mini calendar"
           tooltip="Calendar"
+          tooltipAlign="left"
           onClick={() => toggleFlyout('calendar')}
         />
         {openFlyout === 'calendar' && (
@@ -59,6 +79,7 @@ const CompactCalendarSidebar: React.FC<CompactCalendarSidebarProps> = ({
           icon={<img src="/svg/location-icon.svg" alt="" />}
           ariaLabel="Show location filters"
           tooltip="Location"
+          tooltipAlign="left"
           onClick={() => toggleFlyout('location')}
         />
         {openFlyout === 'location' && (
@@ -79,6 +100,7 @@ const CompactCalendarSidebar: React.FC<CompactCalendarSidebarProps> = ({
           icon={<img src="/svg/video-call-icon.svg" alt="" />}
           ariaLabel="Show Zoom Room filters"
           tooltip="Zoom Rooms"
+          tooltipAlign="left"
           onClick={() => toggleFlyout('video')}
         />
         {openFlyout === 'video' && (
@@ -99,6 +121,7 @@ const CompactCalendarSidebar: React.FC<CompactCalendarSidebarProps> = ({
           icon={<img src="/svg/group-icon.svg" alt="" />}
           ariaLabel="Show calendar and mode filters"
           tooltip="Calendar & Mode"
+          tooltipAlign="left"
           onClick={() => toggleFlyout('group')}
         />
         {openFlyout === 'group' && (

--- a/frontend/app/components/organisms/CompactCalendarSidebar.tsx
+++ b/frontend/app/components/organisms/CompactCalendarSidebar.tsx
@@ -1,24 +1,8 @@
 import React from 'react';
-import IconButton from '../atoms/IconButton';
-import { useSidebar } from '../../context/SidebarContext';
 import styles from '../../../styles/components/organisms/CompactCalendarSidebar.module.scss';
 
 const CompactCalendarSidebar: React.FC = () => {
-  const { expandSidebar } = useSidebar();
-
-  return (
-    <div>
-      <div className={styles.expandButtonWrapper}>
-        <IconButton
-          icon={<img src="/svg/chevron-right-icon.svg" alt="" />}
-          ariaLabel="Show calendar sidebar"
-          tooltip="Show calendar sidebar"
-          size="compact"
-          onClick={expandSidebar}
-        />
-      </div>
-    </div>
-  );
+  return <div className={styles.rail} />;
 };
 
 export default CompactCalendarSidebar;

--- a/frontend/app/components/organisms/CompactCalendarSidebar.tsx
+++ b/frontend/app/components/organisms/CompactCalendarSidebar.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import IconButton from '../atoms/IconButton';
+import { useSidebar } from '../../context/SidebarContext';
+import styles from '../../../styles/components/organisms/CompactCalendarSidebar.module.scss';
+
+const CompactCalendarSidebar: React.FC = () => {
+  const { expandSidebar } = useSidebar();
+
+  return (
+    <div>
+      <div className={styles.expandButtonWrapper}>
+        <IconButton
+          icon={<img src="/svg/chevron-right-icon.svg" alt="" />}
+          ariaLabel="Show calendar sidebar"
+          tooltip="Show calendar sidebar"
+          size="compact"
+          onClick={expandSidebar}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default CompactCalendarSidebar;

--- a/frontend/app/context/SidebarContext.tsx
+++ b/frontend/app/context/SidebarContext.tsx
@@ -3,9 +3,6 @@
 import React, { createContext, useCallback, useContext, useState } from "react";
 
 interface SidebarContextValue {
-    isSidebarOpen: boolean;
-    toggleSidebar: () => void;
-    openSidebar: () => void;
     isCompact: boolean;
     collapseSidebar: () => void;
     expandSidebar: () => void;
@@ -14,20 +11,14 @@ interface SidebarContextValue {
 const SidebarContext = createContext<SidebarContextValue | undefined>(undefined);
 
 export const SidebarProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
-    const [isSidebarOpen, setIsSidebarOpen] = useState(true);
     const [isCompact, setIsCompact] = useState(false);
 
-    const toggleSidebar = useCallback(() => setIsSidebarOpen((prev) => !prev), []);
-    const openSidebar = useCallback(() => setIsSidebarOpen(true), []);
     const collapseSidebar = useCallback(() => setIsCompact(true), []);
     const expandSidebar = useCallback(() => setIsCompact(false), []);
 
     return (
         <SidebarContext.Provider
             value={{
-                isSidebarOpen,
-                toggleSidebar,
-                openSidebar,
                 isCompact,
                 collapseSidebar,
                 expandSidebar,

--- a/frontend/app/context/SidebarContext.tsx
+++ b/frontend/app/context/SidebarContext.tsx
@@ -6,18 +6,33 @@ interface SidebarContextValue {
     isSidebarOpen: boolean;
     toggleSidebar: () => void;
     openSidebar: () => void;
+    isCompact: boolean;
+    collapseSidebar: () => void;
+    expandSidebar: () => void;
 }
 
 const SidebarContext = createContext<SidebarContextValue | undefined>(undefined);
 
 export const SidebarProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
     const [isSidebarOpen, setIsSidebarOpen] = useState(true);
+    const [isCompact, setIsCompact] = useState(false);
 
     const toggleSidebar = useCallback(() => setIsSidebarOpen((prev) => !prev), []);
     const openSidebar = useCallback(() => setIsSidebarOpen(true), []);
+    const collapseSidebar = useCallback(() => setIsCompact(true), []);
+    const expandSidebar = useCallback(() => setIsCompact(false), []);
 
     return (
-        <SidebarContext.Provider value={{ isSidebarOpen, toggleSidebar, openSidebar }}>
+        <SidebarContext.Provider
+            value={{
+                isSidebarOpen,
+                toggleSidebar,
+                openSidebar,
+                isCompact,
+                collapseSidebar,
+                expandSidebar,
+            }}
+        >
             {children}
         </SidebarContext.Provider>
     );

--- a/frontend/hooks/useBreakpoint.ts
+++ b/frontend/hooks/useBreakpoint.ts
@@ -5,14 +5,19 @@ import { TABLET_BREAKPOINT } from "../util/breakpoints";
 // One-way trigger: it only ever calls collapseSidebar() on a downward crossing, never
 // fights a manual expandSidebar() afterward (e.g. widening back past the threshold does
 // not auto re-expand, and narrowing again while already compact is a no-op call).
-export function useBreakpoint(collapseSidebar: () => void): void {
+export function useBreakpoint(collapseSidebar: () => void, expandSidebar: () => void): void {
   useEffect(() => {
     let wasAboveThreshold = window.innerWidth >= TABLET_BREAKPOINT;
+    if (!wasAboveThreshold) {  
+      collapseSidebar();  
+    }  
 
     const handleResize = () => {
       const isAboveThreshold = window.innerWidth >= TABLET_BREAKPOINT;
       if (wasAboveThreshold && !isAboveThreshold) {
         collapseSidebar();
+      } else if (!wasAboveThreshold && isAboveThreshold) {
+        expandSidebar();
       }
       wasAboveThreshold = isAboveThreshold;
     };

--- a/frontend/hooks/useBreakpoint.ts
+++ b/frontend/hooks/useBreakpoint.ts
@@ -1,0 +1,23 @@
+import { useEffect } from "react";
+import { TABLET_BREAKPOINT } from "../util/breakpoints";
+
+// Auto-collapses the sidebar the moment the window narrows past the tablet breakpoint.
+// One-way trigger: it only ever calls collapseSidebar() on a downward crossing, never
+// fights a manual expandSidebar() afterward (e.g. widening back past the threshold does
+// not auto re-expand, and narrowing again while already compact is a no-op call).
+export function useBreakpoint(collapseSidebar: () => void): void {
+  useEffect(() => {
+    let wasAboveThreshold = window.innerWidth >= TABLET_BREAKPOINT;
+
+    const handleResize = () => {
+      const isAboveThreshold = window.innerWidth >= TABLET_BREAKPOINT;
+      if (wasAboveThreshold && !isAboveThreshold) {
+        collapseSidebar();
+      }
+      wasAboveThreshold = isAboveThreshold;
+    };
+
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, [collapseSidebar]);
+}

--- a/frontend/public/svg/chevron-left-icon.svg
+++ b/frontend/public/svg/chevron-left-icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="#848484"><path d="M560-240 320-480l240-240 56 56-184 184 184 184-56 56Z"/></svg>

--- a/frontend/public/svg/chevron-right-icon.svg
+++ b/frontend/public/svg/chevron-right-icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="#848484"><path d="M504-480 320-664l56-56 240 240-240 240-56-56 184-184Z"/></svg>

--- a/frontend/public/svg/menu-icon.svg
+++ b/frontend/public/svg/menu-icon.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="#848484"><path d="M120-240v-80h720v80H120Zm0-200v-80h720v80H120Zm0-200v-80h720v80H120Z"/></svg>

--- a/frontend/public/svg/plus-icon-white.svg
+++ b/frontend/public/svg/plus-icon-white.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="#FFFFFF"><path d="M440-120v-320H120v-80h320v-320h80v320h320v80H520v320h-80Z"/></svg>

--- a/frontend/public/svg/plus-icon.svg
+++ b/frontend/public/svg/plus-icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="#848484"><path d="M440-120v-320H120v-80h320v-320h80v320h320v80H520v320h-80Z"/></svg>

--- a/frontend/styles/Variables.module.scss
+++ b/frontend/styles/Variables.module.scss
@@ -17,4 +17,11 @@ $link-color: #007BFF;
 $warning-bg-color: #FDF3DC;
 $warning-text-color: #B4790A;
 
+// Responsive breakpoints. $breakpoint-tablet (768px) is also the value MeetingForm.module.scss
+// already uses in its own media query — same threshold, not a conflict, just worth knowing
+// they now overlap in purpose. Kept in sync manually with util/breakpoints.ts (Sass vars
+// aren't importable into TS).
+$breakpoint-phone: 480px;
+$breakpoint-tablet: 768px;
+
 @import 'https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400&display=swap';

--- a/frontend/styles/Variables.module.scss
+++ b/frontend/styles/Variables.module.scss
@@ -24,4 +24,14 @@ $warning-text-color: #B4790A;
 $breakpoint-phone: 480px;
 $breakpoint-tablet: 768px;
 
+// Z-index scheme -- ground truth for all NEW z-indexing going forward. Existing z-index
+// values elsewhere in the codebase predate this scheme and are not guaranteed to conform;
+// don't assume a bare number in older CSS maps onto one of these tiers.
+$z-index-background: -1; // Background styling, shadows, or submerged decorative elements.
+$z-index-base: 0; // Normal page content, flowing text, standard grid/flex items.
+$z-index-dropdown: 100; // Floating menus, tooltips, autocomplete boxes just above normal content.
+$z-index-sticky: 200; // Sticky headers, navigation bars, floating action buttons.
+$z-index-modal: 300; // Backdrops and dialog popup windows.
+$z-index-toast: 400; // Alert banners, system toasts, global messages that must always stay on top.
+
 @import 'https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400&display=swap';

--- a/frontend/styles/components/atoms/DatePicker.module.scss
+++ b/frontend/styles/components/atoms/DatePicker.module.scss
@@ -78,4 +78,11 @@
   background-color: white;
   box-shadow: 0 4px 12px rgb(0 0 0 / 15%);
   border-radius: 4px;
+
+  // MiniCalendar's own .container is width: 100% now (needed so it also fits the Main
+  // Calendar sidebar's 196px compact-rail flyout) -- this popup used to get its width for
+  // free from that being a fixed 280px, so without setting it here directly, an
+  // unconstrained position: fixed popup shrinks to fit its content instead of showing the
+  // intended 280px card.
+  width: 280px;
 }

--- a/frontend/styles/components/atoms/IconButton.module.scss
+++ b/frontend/styles/components/atoms/IconButton.module.scss
@@ -1,0 +1,90 @@
+@import '../../Variables.module.scss';
+
+.iconButton {
+    padding: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    box-sizing: border-box;
+}
+
+.default {
+    width: 48px;
+    height: 48px;
+}
+
+.compact {
+    width: 32px;
+    height: 32px;
+}
+
+.ghost {
+    background-color: transparent;
+
+    &:hover,
+    &:focus {
+        background-color: $grey-lightest-color;
+    }
+}
+
+.filled {
+    border-radius: 50%;
+
+    &:hover,
+    &:focus {
+        opacity: 0.85;
+    }
+}
+
+.iconWrap {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 24px;
+
+    img {
+        width: 100%;
+        height: 100%;
+        display: block;
+    }
+}
+
+.compact .iconWrap {
+    width: 18px;
+    height: 18px;
+}
+
+.tooltipWrapper {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+
+    &:hover .tooltip,
+    &:focus-within .tooltip {
+        opacity: 1;
+        visibility: visible;
+    }
+}
+
+.tooltip {
+    position: absolute;
+    top: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    margin-top: 6px;
+    padding: 4px 8px;
+    border-radius: 4px;
+    background-color: $black-color;
+    color: #fff;
+    font-size: 12px;
+    width: max-content;
+    max-width: 220px;
+    text-align: center;
+    line-height: 1.4;
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 0.15s ease;
+    pointer-events: none;
+    z-index: 10;
+}

--- a/frontend/styles/components/atoms/IconButton.module.scss
+++ b/frontend/styles/components/atoms/IconButton.module.scss
@@ -36,6 +36,17 @@
     }
 }
 
+.outlined {
+    background-color: #fff;
+    border: 1px solid $grey-border-color;
+    border-radius: 50%;
+
+    &:hover,
+    &:focus {
+        background-color: $grey-lightest-color;
+    }
+}
+
 .iconWrap {
     display: inline-flex;
     align-items: center;
@@ -53,38 +64,4 @@
 .compact .iconWrap {
     width: 18px;
     height: 18px;
-}
-
-.tooltipWrapper {
-    position: relative;
-    display: inline-flex;
-    align-items: center;
-
-    &:hover .tooltip,
-    &:focus-within .tooltip {
-        opacity: 1;
-        visibility: visible;
-    }
-}
-
-.tooltip {
-    position: absolute;
-    top: 100%;
-    left: 50%;
-    transform: translateX(-50%);
-    margin-top: 6px;
-    padding: 4px 8px;
-    border-radius: 4px;
-    background-color: $black-color;
-    color: #fff;
-    font-size: 12px;
-    width: max-content;
-    max-width: 220px;
-    text-align: center;
-    line-height: 1.4;
-    opacity: 0;
-    visibility: hidden;
-    transition: opacity 0.15s ease;
-    pointer-events: none;
-    z-index: 10;
 }

--- a/frontend/styles/components/atoms/MiniCalendar.module.scss
+++ b/frontend/styles/components/atoms/MiniCalendar.module.scss
@@ -100,8 +100,34 @@
     :global(.rdp-day_button) {
         cursor: pointer;
 
-        &:hover:not(:disabled) {
+        // z-index (not just position: relative) is required here -- without an explicit value
+        // this stays z-index: auto, which does NOT create a stacking context, so the ::before's
+        // z-index: -1 below would escape to the nearest ancestor that does (.container, which
+        // has its own z-index) and paint behind the whole opaque calendar grid instead of just
+        // behind this button's own text. .selectedDay's ::before below works for the same
+        // reason: it sets z-index: 1 on itself, not just position: relative.
+        position: relative;
+        z-index: 0;
+
+        // Fills its cell instead of the fixed --rdp-day_button-width/height above -- those
+        // only match the cell size in the 280px sidebar. In the 196px flyout, .rdp-month_grid's
+        // table-layout: fixed shrinks the actual column below 32px, so a button still pinned to
+        // 32px overflows its cell and renders off-center from .selectedDay's centered ::before
+        // circle (which centers on the cell, not the oversized button).
+        width: 100%;
+        height: 100%;
+
+        &:hover:not(:disabled)::before {
+            content: "";
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            transform: translate(-50%, -50%);
+            width: 100%;
+            aspect-ratio: 1;
+            border-radius: 4px;
             background-color: color.adjust($dark-pink-color, $lightness: 35%);
+            z-index: -1;
         }
     }
 }
@@ -123,9 +149,19 @@
         left: 50%;
         transform: translate(-50%, -50%);
         z-index: -1;
-        width: 25px;
-        height: 25px;
+        width: 100%;
+        aspect-ratio: 1;
     }
+
+}
+
+// The hover rule above actually compiles to .container .rdp-day_button:hover:not(:disabled)::before
+// (four selectors + a pseudo-element, since it's nested inside .container) -- matching that
+// specificity here (.container + .selectedDay + .rdp-day_button + :hover, also with a
+// pseudo-element) and coming later in source order is what makes this win, so hovering an
+// already-selected day doesn't show the lighter hover square behind its solid circle.
+.container .selectedDay :global(.rdp-day_button):hover::before {
+    content: none;
 }
 
 // Outside days (days not in the current month)
@@ -136,7 +172,7 @@
 
 // Today styling
 .today:not(.selectedDay) {
-    color: black;
+    color: $dark-pink-color;
     font-weight: bold;
     text-decoration: underline;
 }

--- a/frontend/styles/components/atoms/MiniCalendar.module.scss
+++ b/frontend/styles/components/atoms/MiniCalendar.module.scss
@@ -11,12 +11,10 @@
 
     // box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
     z-index: 999; // Increased z-index to ensure visibility
-    // .sidebar (page.module.scss) uses the default content-box sizing, so its own
-    // `width: 280px` already *is* its content area -- sibling cards (New Meeting button,
-    // Location/Zoom Rooms filter panel) are plain width:auto blocks that fill exactly that
-    // 280px. Matching it here with a fixed width (rather than width: 100%, which depends on
-    // whatever this happens to be nested inside) is what actually lines this up with them.
-    width: 280px;
+    // Flexible so this also fits the 196px compact-rail flyout, not just the 280px full
+    // sidebar -- the --rdp-day-width vars below still target the 280px case (table-layout:
+    // fixed on .rdp-month_grid shrinks the columns proportionally in the narrower flyout).
+    width: 100%;
     box-sizing: border-box;
 
     span {

--- a/frontend/styles/components/atoms/Tooltip.module.scss
+++ b/frontend/styles/components/atoms/Tooltip.module.scss
@@ -1,0 +1,40 @@
+@import '../../Variables.module.scss';
+
+.wrapper {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+
+    &:hover .tooltip,
+    &:focus-within .tooltip {
+        opacity: 1;
+        visibility: visible;
+    }
+}
+
+.tooltip {
+    position: absolute;
+    top: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    margin-top: 6px;
+    padding: 4px 8px;
+    border-radius: 4px;
+    background-color: $black-color;
+    color: #fff;
+    font-size: 12px;
+    width: max-content;
+    max-width: 220px;
+    text-align: center;
+    line-height: 1.4;
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 0.15s ease;
+    pointer-events: none;
+    z-index: $z-index-dropdown;
+}
+
+.alignLeft {
+    left: 0;
+    transform: none;
+}

--- a/frontend/styles/components/atoms/Tooltip.module.scss
+++ b/frontend/styles/components/atoms/Tooltip.module.scss
@@ -5,8 +5,7 @@
     display: inline-flex;
     align-items: center;
 
-    &:hover .tooltip,
-    &:focus-within .tooltip {
+    &:hover .tooltip {
         opacity: 1;
         visibility: visible;
     }

--- a/frontend/styles/components/atoms/Tooltip.module.scss
+++ b/frontend/styles/components/atoms/Tooltip.module.scss
@@ -5,10 +5,11 @@
     display: inline-flex;
     align-items: center;
 
-    &:hover .tooltip {
-        opacity: 1;
-        visibility: visible;
-    }
+    &:hover .tooltip,  
+    &:focus-within .tooltip {  
+        opacity: 1;  
+        visibility: visible;  
+    }  
 }
 
 .tooltip {

--- a/frontend/styles/components/organisms/AppNavbar.module.scss
+++ b/frontend/styles/components/organisms/AppNavbar.module.scss
@@ -37,20 +37,6 @@
     gap: 8px;
 }
 
-.sidebarToggleButton {
-    color: $black-color;
-
-    &:hover,
-    &:focus {
-        background-color: $grey-lightest-color;
-    }
-}
-
-.menuIcon {
-    width: 24px;
-    height: 24px;
-}
-
 .navigationlist {
     display: contents;
     color: #000;

--- a/frontend/styles/components/organisms/AppNavbar.module.scss
+++ b/frontend/styles/components/organisms/AppNavbar.module.scss
@@ -37,26 +37,6 @@
     gap: 8px;
 }
 
-.sidebarToggleWrapper {
-    position: relative;
-    display: inline-flex;
-    align-items: center;
-
-    &:hover .tooltip,
-    &:focus-within .tooltip {
-        opacity: 1;
-        visibility: visible;
-    }
-
-    // This trigger sits at the far left edge of the screen, so the shared .tooltip rule's
-    // centered left:50%/translateX(-50%) would push it off-screen -- anchor to the left
-    // edge of the button instead of centering under it.
-    .tooltip {
-        left: 0;
-        transform: none;
-    }
-}
-
 .sidebarToggleButton {
     color: $black-color;
 
@@ -107,16 +87,6 @@
             }
         }
 
-        &.navTooltipWrapper {
-            position: relative;
-
-            &:hover .tooltip,
-            &:focus-within .tooltip {
-                opacity: 1;
-                visibility: visible;
-            }
-        }
-
         .navLocked {
             display: inline-flex;
             align-items: center;
@@ -162,28 +132,6 @@
 .lockIcon {
     width: 14px;
     height: 14px;
-}
-
-.tooltip {
-    position: absolute;
-    top: 100%;
-    left: 50%;
-    transform: translateX(-50%);
-    margin-top: 6px;
-    padding: 4px 8px;
-    border-radius: 4px;
-    background-color: $black-color;
-    color: #fff;
-    font-size: 12px;
-    width: max-content;
-    max-width: 220px;
-    text-align: center;
-    line-height: 1.4;
-    opacity: 0;
-    visibility: hidden;
-    transition: opacity 0.15s ease;
-    pointer-events: none;
-    z-index: 10;
 }
 
 .accountGroup {

--- a/frontend/styles/components/organisms/CalendarSidebar.module.scss
+++ b/frontend/styles/components/organisms/CalendarSidebar.module.scss
@@ -7,15 +7,3 @@
   background: #FFF;
   color: rgb(0 0 0);
 }
-
-// No position/height rules here on purpose -- the button's containing block is
-// the outer .sidebar (page.module.scss), which is what actually has the fixed,
-// viewport-matched height. Anchoring to a wrapper in here instead would center
-// the button against the scrollable content's full height rather than the
-// visible sidebar area.
-.collapseButtonWrapper {
-  position: absolute;
-  top: 50%;
-  right: 0;
-  transform: translateY(-50%);
-}

--- a/frontend/styles/components/organisms/CalendarSidebar.module.scss
+++ b/frontend/styles/components/organisms/CalendarSidebar.module.scss
@@ -7,3 +7,15 @@
   background: #FFF;
   color: rgb(0 0 0);
 }
+
+// No position/height rules here on purpose -- the button's containing block is
+// the outer .sidebar (page.module.scss), which is what actually has the fixed,
+// viewport-matched height. Anchoring to a wrapper in here instead would center
+// the button against the scrollable content's full height rather than the
+// visible sidebar area.
+.collapseButtonWrapper {
+  position: absolute;
+  top: 50%;
+  right: 0;
+  transform: translateY(-50%);
+}

--- a/frontend/styles/components/organisms/CompactCalendarSidebar.module.scss
+++ b/frontend/styles/components/organisms/CompactCalendarSidebar.module.scss
@@ -1,8 +1,5 @@
-// No position/height rules on .rail on purpose -- see CalendarSidebar.module.scss's
-// .collapseButtonWrapper comment. The containing block is the outer .sidebar.
-.expandButtonWrapper {
-  position: absolute;
-  top: 50%;
-  right: 0;
-  transform: translateY(-50%);
+.rail {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }

--- a/frontend/styles/components/organisms/CompactCalendarSidebar.module.scss
+++ b/frontend/styles/components/organisms/CompactCalendarSidebar.module.scss
@@ -1,0 +1,8 @@
+// No position/height rules on .rail on purpose -- see CalendarSidebar.module.scss's
+// .collapseButtonWrapper comment. The containing block is the outer .sidebar.
+.expandButtonWrapper {
+  position: absolute;
+  top: 50%;
+  right: 0;
+  transform: translateY(-50%);
+}

--- a/frontend/styles/components/organisms/CompactCalendarSidebar.module.scss
+++ b/frontend/styles/components/organisms/CompactCalendarSidebar.module.scss
@@ -1,5 +1,30 @@
+@import '../../Variables.module.scss';
+
 .rail {
   display: flex;
   flex-direction: column;
   align-items: center;
+  gap: 12px;
+  padding-top: 12px;
+}
+
+// Anchor for each rail icon's flyout -- position: relative (no transform) so it doesn't
+// trap the flyout's z-index in a local stacking context the way .sidebarToggleWrapper's
+// transform does (see page.module.scss's comment on that).
+.flyoutAnchor {
+  position: relative;
+}
+
+.flyout {
+  position: absolute;
+  top: 0;
+  left: 100%;
+  margin-left: 8px;
+  width: 196px;
+  background-color: #fff;
+  border: 1px solid $grey-border-color;
+  border-radius: 6px;
+  box-shadow: 0 4px 8px rgb(0 0 0 / 20%);
+  padding: 12px;
+  z-index: $z-index-dropdown;
 }

--- a/frontend/util/breakpoints.ts
+++ b/frontend/util/breakpoints.ts
@@ -1,0 +1,5 @@
+// JS-side source of truth for responsive breakpoints, mirroring the Sass tokens in
+// Variables.module.scss ($breakpoint-phone / $breakpoint-tablet). Sass vars aren't importable
+// into TS, so these are kept in sync manually — edit both together.
+export const PHONE_BREAKPOINT = 480;
+export const TABLET_BREAKPOINT = 768;


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added layered compact/expanded calendar sidebar with animated cross-fades and a new sidebar shell for sign-in, edit-meeting, and normal modes.
  * Added flyouts for calendars, locations, video rooms, and meeting filters.
  * Introduced reusable IconButton and Tooltip components for consistent navigation hover help.

* **Bug Fixes**
  * Improved mini-calendar sizing and hover/selection stacking.
  * Fixed date-picker popup width in compact sidebar contexts.

* **Chores**
  * Standardized responsive breakpoints and z-index tiers across styles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description
- **`app/components/atoms/IconButton.tsx`**: new in-house icon-button atom (ghost/filled variants, sizes, tooltip) wrapping MUI, replacing ad-hoc raw `IconButton` usage.
- **`app/components/atoms/Tooltip.tsx`**: extracted shared CSS-only hover tooltip, previously duplicated in `AppNavbar`.
- **`util/breakpoints.ts`**: shared phone/tablet breakpoint constants, mirrored in `Variables.module.scss`.
- **`app/components/organisms/CalendarSidebarShell.tsx`** (new): absorbs sidebar state/layout previously split across `page.tsx` and `CalendarSidebar.tsx` — owns full/compact swap, New/Edit Meeting form gating, and the staggered fade transition between layers.
- **`app/components/organisms/CalendarSidebar.tsx`**: shrunk to just the full-width content; adds the collapse chevron.
- **`app/components/organisms/CompactCalendarSidebar.tsx`** (new): 64px icon rail with New Meeting, mini calendar, location/Zoom/calendar+mode filter flyouts, and an expand chevron.
- **`app/context/SidebarContext.tsx`**: replaces the old binary `isSidebarOpen`/`toggleSidebar`/`openSidebar` show/hide model with `isCompact`/`collapseSidebar`/`expandSidebar`; `hooks/useBreakpoint.ts` (new) auto-collapses past the tablet breakpoint on resize (one-way trigger, doesn't fight manual re-expand).
- **`app/(main)/page.tsx`**, **`app/components/organisms/AppNavbar.tsx`**, **`AppNavbar.module.scss`**: removed the old menu-icon toggle button and all `isSidebarOpen`-gated rendering — the sidebar is now always visible (expanded, compact, editing, or sign-in-prompt), so this plumbing and `public/svg/menu-icon.svg` are dead code.
- **`page.module.scss`**: staggered fade transition between the full and compact layers (120ms fade-out, 150ms gap, 120ms fade-in) instead of a simultaneous cross-fade, avoiding ghosting/overlap.
- Opening New Meeting from the compact rail force-expands the sidebar and restores it back to compact on close; Edit Meeting overrides its own width locally without touching shared state.

## Testing
- [x] `yarn tsc --noEmit`
- [x] `yarn lint`
- [x] `yarn lint:css`
- [x] Manual browser verification via dev server: collapse/expand chevrons, auto-collapse below 768px, each rail flyout, New Meeting from the rail (expand + restore), Edit Meeting while compact (expand, no restore needed).
- [x] Scoped/targeted Playwright checks per step (fade timing, mode-restore behavior, navbar/toggle removal) — ad hoc, not committed.
- [x] Full `yarn test:e2e` suite

## Area(s) Touched
**Product areas**
- [x] ui/ux — frontend layout/styling not tied to a specific integration

**Engineering**
- [x] cleanup — refactor or dead-code removal, no behavior change

## Pre-merge Checklist
- [x] Code follows current formatting conventions and passes lint (`yarn lint`).
- [x] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
- [x] All test suites pass, both run locally and green in GitHub CI. **Do not merge if any test suite is failing.**
- [ ] A test suite was added or updated for the feature/fix in this PR. **Double-check this if you change a feature and did not update the test suites**.
- [x] Only files relevant to this change are committed — no stray or unrelated files.
- [x] If this branch has a merge conflict with master, master was merged into this branch first (not the other way around).
- [x] The rest of this PR description (Description, Testing) is filled out, not left as template placeholders.
