### PR TITLE
feat(ui/ux): add profile menu to navbar

### DIFF
--- a/frontend/app/ClientLayout.tsx
+++ b/frontend/app/ClientLayout.tsx
@@ -1,10 +1,11 @@
-"use client"
+"use client";
 
 import { PropsWithChildren } from "react";
 import AppNavbar from "./components/organisms/AppNavbar";
 import { Inter } from "next/font/google";
 import styles from "../styles/MainLayout.module.scss";
 import type { Session } from "next-auth";
+import { SessionProvider } from "next-auth/react";
 import { SidebarProvider } from "./context/SidebarContext";
 
 const inter = Inter({ subsets: ["latin"] });
@@ -19,22 +20,20 @@ export default function ClientLayout({
 }: PropsWithChildren<ClientLayoutProps>) {
     return (
         <html lang="en" suppressHydrationWarning>
-            <head>
-            </head>
-            {/* suppressHydrationWarning: some browser extensions (e.g. security/wallet
-                extensions) inject attributes like bis_register onto <body> or <html> before React
-                hydrates — a real mismatch, but not one our code can control or should warn on. */}
+            <head></head>
             <body className={inter.className} suppressHydrationWarning>
-                <SidebarProvider>
-                    <div className={styles.mainlayout}>
-                        <div className={styles.navigation}>
-                            <AppNavbar session={session} />
+                <SessionProvider session={session}>
+                    <SidebarProvider>
+                        <div className={styles.mainlayout}>
+                            <div className={styles.navigation}>
+                                <AppNavbar />
+                            </div>
+                            <div className={styles.content}>
+                                {children}
+                            </div>
                         </div>
-                        <div className={styles.content}>
-                            {children}
-                        </div>
-                    </div>
-                </SidebarProvider>
+                    </SidebarProvider>
+                </SessionProvider>
             </body>
         </html>
     );

--- a/frontend/app/api/auth/authConfig.ts
+++ b/frontend/app/api/auth/authConfig.ts
@@ -32,11 +32,12 @@ export const authOptions: NextAuthOptions = {
             const admin = await prisma.admin.findUnique({ where: { email: user.email } });
             return !!admin;
         },
-        async jwt({ token, account, profile }) {
+        async jwt({ token, account, user, profile }) {
             if (account) {
                 token.accessToken = account.access_token;
                 token.refreshToken = account.refresh_token;
                 token.expiresAt = account.expires_at;
+                token.picture = user?.image ?? (profile as { picture?: string })?.picture;
 
                 if (token.email) {
                     // signIn already guarantees this row exists (invite or bootstrap) — update, don't create.
@@ -51,7 +52,7 @@ export const authOptions: NextAuthOptions = {
                             name: existing?.name ? undefined : (token.name ?? (profile as { name?: string })?.name ?? undefined),
                             googleId: account.providerAccountId,
                             refreshToken: account.refresh_token ?? undefined,
-                            tokenExpiresAt: account.expires_at ?? undefined,
+                            tokenExpiresAt: account.expires_at ?? undefined
                         },
                         select: { role: true },
                     });
@@ -85,7 +86,10 @@ export const authOptions: NextAuthOptions = {
         },
         async session({ session, token }) {
             session.accessToken = token.accessToken;
-            if (session.user) session.user.role = token.role;
+            if (session.user) {
+                session.user.role = token.role;
+                session.user.image = token.picture as string | undefined;
+            }
             return session;
         },
     },

--- a/frontend/app/components/organisms/AppNavbar.tsx
+++ b/frontend/app/components/organisms/AppNavbar.tsx
@@ -66,6 +66,20 @@ const AppNavbar: React.FC = () => {
         };
     }, [session?.user?.image]);
 
+    const userAvatar = (
+        session?.user.image && !imageError ? (
+            <img
+                src={session.user.image}
+                alt={session.user.name ?? "User avatar"}
+                title={session.user.name ?? "Account"}
+                className={styles.avatar}
+                onError={() => setImageError(true)}
+            />
+        ) : (
+            <div className={styles.avatarFallback}>{session?.user.name?.[0] ?? "U"}</div>
+        )
+    );
+
     return (
         <div className={styles.navbar}>
             <div className={styles.navcontainer}>
@@ -128,19 +142,7 @@ const AppNavbar: React.FC = () => {
                                         className={styles.profileButton}
                                         onClick={() => setOpenFlyout((prev) => !prev)}
                                     >
-                                        {session.user.image && !imageError ? (
-                                            <img
-                                                src={session.user.image}
-                                                alt={session.user.name ?? "User avatar"}
-                                                title={session.user.name ?? "Account"}
-                                                className={styles.avatar}
-                                                onError={() => setImageError(true)}
-                                            />
-                                        ) : (
-                                            <div className={styles.avatarFallback}>
-                                                {session.user.name?.[0] ?? "U"}
-                                            </div>
-                                        )}
+                                        {userAvatar}
                                     </button>
                                 </Tooltip>
                                 {openFlyout && (
@@ -149,19 +151,7 @@ const AppNavbar: React.FC = () => {
                                         className={styles.flyout}
                                     >
                                         <div className={styles.flyoutHeader}>
-                                            {session.user.image && !imageError ? (
-                                                <img
-                                                    src={session.user.image}
-                                                    alt={session.user.name ?? "User avatar"}
-                                                    title={session.user.name ?? "Account"}
-                                                    className={styles.avatar}
-                                                    onError={() => setImageError(true)}
-                                                />
-                                            ) : (
-                                                <div className={styles.avatarFallback}>
-                                                    {session.user.name?.[0] ?? "U"}
-                                                </div>
-                                            )}
+                                            {userAvatar}
                                             <div className={styles.flyoutInfo}>
                                                 <span className={styles.welcome}>Hi, {session.user.name}</span>
                                                 <span className={styles.flyoutEmail}>{session.user.email}</span>

--- a/frontend/app/components/organisms/AppNavbar.tsx
+++ b/frontend/app/components/organisms/AppNavbar.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import React from "react";
+import React, { useState, useEffect, useRef } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import Logo from "../atoms/Logo";
+import IconButton from "../atoms/IconButton";
 import type { Session } from "next-auth";
 import { signOut } from "next-auth/react";
 import Tooltip from "../atoms/Tooltip";
@@ -17,6 +18,28 @@ const AppNavbar: React.FC<AppNavbarProps> = ({ session }) => {
     const isAdmin = session?.user?.role === "ADMIN" || session?.user?.role === "SUPER_ADMIN";
     const pathname = usePathname();
     const navItemClass = (isActive: boolean) => `btn btn-ghost ${isActive ? styles.active : ""}`;
+
+    const [openFlyout, setOpenFlyout] = useState<boolean>(false);
+    const flyoutRef = useRef<HTMLDivElement>(null);
+    useEffect(() => {
+        // Guard clause: Only add the listener if the flyout is open
+        if (!openFlyout) return;
+
+        const handleClickOutside = (event: MouseEvent) => {
+            // Check if the click happened outside the flyout element
+            if (flyoutRef.current && !flyoutRef.current.contains(event.target as Node)) {
+            setOpenFlyout(false); // Close it
+            }
+        };
+
+        // Attach listener to the whole document
+        document.addEventListener('mousedown', handleClickOutside);
+
+        // Clean up the listener when the flyout closes or unmounts
+        return () => {
+            document.removeEventListener('mousedown', handleClickOutside);
+        };
+    }, [openFlyout]);
 
     return (
         <div className={styles.navbar}>
@@ -64,11 +87,57 @@ const AppNavbar: React.FC<AppNavbarProps> = ({ session }) => {
                     </li>
                     <li>
                         {session ? (
-                            <div className={styles.accountGroup}>
-                                <span className={styles.welcome}>Welcome, {session.user?.name}</span>
-                                <button onClick={() => signOut({ callbackUrl: "/" })}>
-                                    <p>Sign Out</p>
-                                </button>
+                            <div className={styles.flyoutAnchor} ref = {flyoutRef}>
+                                <IconButton
+                                    icon={<img 
+                                        src={session.user.image ?? undefined}
+                                        alt={session.user.name ?? "User avatar"} 
+                                        title={session.user.name ?? "Account"}
+                                    />}
+                                    ariaLabel="User avatar"
+                                    onClick={() => setOpenFlyout(true)}
+                                    variant="filled"
+                                    tooltip="Profile"
+                                    tooltipAlign="center"
+                                />
+                                {openFlyout && (
+                                    <div className={styles.flyout}>
+                                        {/* Left Avatar, Right Info */}
+                                        <div className={styles.flyoutHeader}>
+                                            {session?.user?.image ? (
+                                                <img 
+                                                    src={session.user.image}
+                                                    alt={session.user.name ?? "User avatar"} 
+                                                    title={session.user.name ?? "Account"}
+                                                    className={styles.flyoutAvatar}
+                                                />
+                                            ) : (
+                                                <div className={styles.flyoutAvatarFallback}>
+                                                    {session?.user?.name?.[0] ?? "U"}
+                                                </div>
+                                            )}
+                                            <div className={styles.flyoutInfo}>
+                                                <span className={styles.welcome}>Hi, {session?.user?.name}</span>
+                                                <span className={styles.flyoutEmail}>{session?.user?.email}</span>
+                                                <span className={styles.flyoutRole}>
+                                                    {session?.user?.role === "SUPER_ADMIN" ? "Super Admin" :
+                                                    session?.user?.role === "ADMIN" ? "Admin" : "User"}
+                                                </span>
+                                            </div>
+                                        </div>
+
+                                        {/* Separator */}
+                                        <hr className={styles.flyoutSeparator} />
+
+                                        {/* Sign Out button */}
+                                        <button 
+                                            className={styles.signOutButton} 
+                                            onClick={() => signOut({ callbackUrl: "/" })}
+                                        >
+                                            <span>Sign Out</span>
+                                        </button>
+                                    </div>
+                                )}
                             </div>
                         ) : (
                             <Link className={styles.signInButton} href="/login">

--- a/frontend/app/components/organisms/AppNavbar.tsx
+++ b/frontend/app/components/organisms/AppNavbar.tsx
@@ -4,17 +4,13 @@ import React, { useState, useEffect, useRef } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import Logo from "../atoms/Logo";
-import IconButton from "../atoms/IconButton";
-import type { Session } from "next-auth";
-import { signOut } from "next-auth/react";
+import { useSession, signOut } from "next-auth/react";
 import Tooltip from "../atoms/Tooltip";
 import styles from "../../../styles/components/organisms/AppNavbar.module.scss";
 
-interface AppNavbarProps {
-    session: Session | null;
-}
+const AppNavbar: React.FC = () => {
+    const { data: session, status } = useSession();
 
-const AppNavbar: React.FC<AppNavbarProps> = ({ session }) => {
     const isAdmin = session?.user?.role === "ADMIN" || session?.user?.role === "SUPER_ADMIN";
     const pathname = usePathname();
     const navItemClass = (isActive: boolean) => `btn btn-ghost ${isActive ? styles.active : ""}`;
@@ -22,25 +18,46 @@ const AppNavbar: React.FC<AppNavbarProps> = ({ session }) => {
     const [openFlyout, setOpenFlyout] = useState<boolean>(false);
     const [imageError, setImageError] = useState(false);
     const flyoutRef = useRef<HTMLDivElement>(null);
+
+    // Close flyout on outside click or Escape key press
     useEffect(() => {
-        // Guard clause: Only add the listener if the flyout is open
         if (!openFlyout) return;
 
         const handleClickOutside = (event: MouseEvent) => {
-            // Check if the click happened outside the flyout element
             if (flyoutRef.current && !flyoutRef.current.contains(event.target as Node)) {
-            setOpenFlyout(false); // Close it
+                setOpenFlyout(false);
             }
         };
 
-        // Attach listener to the whole document
-        document.addEventListener('mousedown', handleClickOutside);
+        const handleKeyDown = (event: KeyboardEvent) => {
+            if (event.key === "Escape") {
+                setOpenFlyout(false);
+            }
+        };
 
-        // Clean up the listener when the flyout closes or unmounts
+        document.addEventListener("mousedown", handleClickOutside);
+        document.addEventListener("keydown", handleKeyDown);
+
         return () => {
-            document.removeEventListener('mousedown', handleClickOutside);
+            document.removeEventListener("mousedown", handleClickOutside);
+            document.removeEventListener("keydown", handleKeyDown);
         };
     }, [openFlyout]);
+
+    // Pre-verify image URL viability when session updates
+    useEffect(() => {
+        const imageUrl = session?.user?.image;
+        if (!imageUrl) {
+            setImageError(true);
+            return;
+        }
+
+        const img = new Image();
+        img.src = imageUrl;
+
+        img.onload = () => setImageError(false);
+        img.onerror = () => setImageError(true);
+    }, [session?.user?.image]);
 
     return (
         <div className={styles.navbar}>
@@ -87,59 +104,67 @@ const AppNavbar: React.FC<AppNavbarProps> = ({ session }) => {
                         )}
                     </li>
                     <li>
-                        {session ? (
-                            <div className={styles.flyoutAnchor} ref = {flyoutRef}>
-                                {session.user.image && (
-                                <IconButton
-                                    icon={imageError ? (
-                                        <span>{session.user.name?.[0] ?? "U"}</span>
-                                    ) : (
-                                        <img 
-                                            src={session.user.image}
-                                            alt={session.user.name ?? "User avatar"} 
-                                            title={session.user.name ?? "Account"}
-                                            onError={() => setImageError(true)}
-                                        />
-                                    )}
-                                    ariaLabel="User avatar"
-                                    onClick={() => setOpenFlyout(true)}
-                                    variant="filled"
-                                    tooltip="Profile"
-                                    tooltipAlign="center"
-                                />
-                            )}
+                        {status === "loading" ? (
+                            <div className={styles.signInButton} style={{ opacity: 0, pointerEvents: "none" }}>
+                                <p>Loading...</p>
+                            </div>
+                        ) : session && session.user ? (
+                            <div className={styles.flyoutAnchor} ref={flyoutRef}>
+                                <Tooltip content="User menu">
+                                    <button
+                                        type="button"
+                                        aria-label="User menu"
+                                        aria-haspopup="true"
+                                        aria-expanded={openFlyout}
+                                        className={styles.profileButton}
+                                        onClick={() => setOpenFlyout((prev) => !prev)}
+                                    >
+                                        {session.user.image && !imageError ? (
+                                            <img
+                                                src={session.user.image}
+                                                alt={session.user.name ?? "User avatar"}
+                                                title={session.user.name ?? "Account"}
+                                                className={styles.avatar}
+                                                onError={() => setImageError(true)}
+                                            />
+                                        ) : (
+                                            <div className={styles.avatarFallback}>
+                                                {session.user.name?.[0] ?? "U"}
+                                            </div>
+                                        )}
+                                    </button>
+                                </Tooltip>
                                 {openFlyout && (
-                                    <div className={styles.flyout}>
-                                        {/* Left Avatar, Right Info */}
+                                    <div className={styles.flyout} role="menu">
                                         <div className={styles.flyoutHeader}>
-                                            {session?.user?.image ? (
-                                                <img 
+                                            {session.user.image && !imageError ? (
+                                                <img
                                                     src={session.user.image}
-                                                    alt={session.user.name ?? "User avatar"} 
+                                                    alt={session.user.name ?? "User avatar"}
                                                     title={session.user.name ?? "Account"}
-                                                    className={styles.flyoutAvatar}
+                                                    className={styles.avatar}
+                                                    onError={() => setImageError(true)}
                                                 />
                                             ) : (
-                                                <div className={styles.flyoutAvatarFallback}>
-                                                    {session?.user?.name?.[0] ?? "U"}
+                                                <div className={styles.avatarFallback}>
+                                                    {session.user.name?.[0] ?? "U"}
                                                 </div>
                                             )}
                                             <div className={styles.flyoutInfo}>
-                                                <span className={styles.welcome}>Hi, {session?.user?.name}</span>
-                                                <span className={styles.flyoutEmail}>{session?.user?.email}</span>
+                                                <span className={styles.welcome}>Hi, {session.user.name}</span>
+                                                <span className={styles.flyoutEmail}>{session.user.email}</span>
                                                 <span className={styles.flyoutRole}>
-                                                    {session?.user?.role === "SUPER_ADMIN" ? "Super Admin" :
-                                                    session?.user?.role === "ADMIN" ? "Admin" : "User"}
+                                                    {session.user.role === "SUPER_ADMIN"
+                                                        ? "Super Admin"
+                                                        : session.user.role === "ADMIN"
+                                                        ? "Admin"
+                                                        : "User"}
                                                 </span>
                                             </div>
                                         </div>
-
-                                        {/* Separator */}
                                         <hr className={styles.flyoutSeparator} />
-
-                                        {/* Sign Out button */}
-                                        <button 
-                                            className={styles.signOutButton} 
+                                        <button
+                                            className={styles.signOutButton}
                                             onClick={() => signOut({ callbackUrl: "/" })}
                                         >
                                             <span>Sign Out</span>

--- a/frontend/app/components/organisms/AppNavbar.tsx
+++ b/frontend/app/components/organisms/AppNavbar.tsx
@@ -20,6 +20,7 @@ const AppNavbar: React.FC<AppNavbarProps> = ({ session }) => {
     const navItemClass = (isActive: boolean) => `btn btn-ghost ${isActive ? styles.active : ""}`;
 
     const [openFlyout, setOpenFlyout] = useState<boolean>(false);
+    const [imageError, setImageError] = useState(false);
     const flyoutRef = useRef<HTMLDivElement>(null);
     useEffect(() => {
         // Guard clause: Only add the listener if the flyout is open
@@ -88,18 +89,25 @@ const AppNavbar: React.FC<AppNavbarProps> = ({ session }) => {
                     <li>
                         {session ? (
                             <div className={styles.flyoutAnchor} ref = {flyoutRef}>
+                                {session.user.image && (
                                 <IconButton
-                                    icon={<img 
-                                        src={session.user.image ?? undefined}
-                                        alt={session.user.name ?? "User avatar"} 
-                                        title={session.user.name ?? "Account"}
-                                    />}
+                                    icon={imageError ? (
+                                        <span>{session.user.name?.[0] ?? "U"}</span>
+                                    ) : (
+                                        <img 
+                                            src={session.user.image}
+                                            alt={session.user.name ?? "User avatar"} 
+                                            title={session.user.name ?? "Account"}
+                                            onError={() => setImageError(true)}
+                                        />
+                                    )}
                                     ariaLabel="User avatar"
                                     onClick={() => setOpenFlyout(true)}
                                     variant="filled"
                                     tooltip="Profile"
                                     tooltipAlign="center"
                                 />
+                            )}
                                 {openFlyout && (
                                     <div className={styles.flyout}>
                                         {/* Left Avatar, Right Info */}

--- a/frontend/app/components/organisms/AppNavbar.tsx
+++ b/frontend/app/components/organisms/AppNavbar.tsx
@@ -18,6 +18,7 @@ const AppNavbar: React.FC = () => {
     const [openFlyout, setOpenFlyout] = useState<boolean>(false);
     const [imageError, setImageError] = useState(false);
     const flyoutRef = useRef<HTMLDivElement>(null);
+    const buttonRef = useRef<HTMLButtonElement>(null);
 
     // Close flyout on outside click or Escape key press
     useEffect(() => {
@@ -32,6 +33,7 @@ const AppNavbar: React.FC = () => {
         const handleKeyDown = (event: KeyboardEvent) => {
             if (event.key === "Escape") {
                 setOpenFlyout(false);
+                buttonRef.current?.focus(); // Return focus to the trigger button
             }
         };
 
@@ -52,11 +54,16 @@ const AppNavbar: React.FC = () => {
             return;
         }
 
+        let isCurrent = true;
         const img = new Image();
         img.src = imageUrl;
 
-        img.onload = () => setImageError(false);
-        img.onerror = () => setImageError(true);
+        img.onload = () => { if (isCurrent) setImageError(false)};
+        img.onerror = () => { if (isCurrent) setImageError(true)};
+
+        return () => {
+            isCurrent = false;
+        };
     }, [session?.user?.image]);
 
     return (
@@ -112,10 +119,12 @@ const AppNavbar: React.FC = () => {
                             <div className={styles.flyoutAnchor} ref={flyoutRef}>
                                 <Tooltip content="User menu">
                                     <button
+                                        ref={buttonRef}
                                         type="button"
                                         aria-label="User menu"
-                                        aria-haspopup="true"
+                                        aria-haspopup="dialog"
                                         aria-expanded={openFlyout}
+                                        aria-controls="user-profile-flyout"
                                         className={styles.profileButton}
                                         onClick={() => setOpenFlyout((prev) => !prev)}
                                     >
@@ -135,7 +144,10 @@ const AppNavbar: React.FC = () => {
                                     </button>
                                 </Tooltip>
                                 {openFlyout && (
-                                    <div className={styles.flyout} role="menu">
+                                    <div 
+                                        id="user-profile-flyout" 
+                                        className={styles.flyout}
+                                    >
                                         <div className={styles.flyoutHeader}>
                                             {session.user.image && !imageError ? (
                                                 <img
@@ -164,6 +176,7 @@ const AppNavbar: React.FC = () => {
                                         </div>
                                         <hr className={styles.flyoutSeparator} />
                                         <button
+                                            type="button"
                                             className={styles.signOutButton}
                                             onClick={() => signOut({ callbackUrl: "/" })}
                                         >

--- a/frontend/styles/components/organisms/AppNavbar.module.scss
+++ b/frontend/styles/components/organisms/AppNavbar.module.scss
@@ -26,7 +26,7 @@
     align-items: center;
     justify-content: space-between;
     width: 100%;
-    padding-right: 24px;
+    padding-right: 12px;
     box-sizing: border-box;
 }
 
@@ -160,9 +160,23 @@
   gap: 12px;
   padding-bottom: 12px;
 }
+.profileButton {
+  background: none; 
+  border: none; 
+  padding: 0; 
+  cursor: pointer;
+}
 
-.flyoutAvatar,
-.flyoutAvatarFallback {
+.avatar {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  object-fit: cover;
+  flex-shrink: 0;
+}
+
+.cardAvatar,
+.avatarFallback {
   width: 40px;
   height: 40px;
   border-radius: 50%;
@@ -170,9 +184,9 @@
   flex-shrink: 0;
 }
 
-.flyoutAvatarFallback {
-  background-color: #fce7f3; // Soft pink fallback matching your screenshot
-  color: #9d174d;
+.avatarFallback {
+  background-color: color-mix(in srgb, $dark-pink-color 35%, transparent);
+  color: $dark-pink-color;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/frontend/styles/components/organisms/AppNavbar.module.scss
+++ b/frontend/styles/components/organisms/AppNavbar.module.scss
@@ -160,6 +160,7 @@
   gap: 12px;
   padding-bottom: 12px;
 }
+
 .profileButton {
   background: none; 
   border: none; 
@@ -226,7 +227,7 @@
 .flyoutSeparator {
   border: none;
   border-top: 1px solid #e5e7eb;
-  margin: 0 -12px 8px -12px; // Stretches rule edge-to-edge across the flyout box padding
+  margin: 0 -12px 8px; // Stretches rule edge-to-edge across the flyout box padding
 }
 
 // Sign Out Button
@@ -236,7 +237,7 @@
   text-align: left;
   background: transparent;
   border: none;
-  padding: 8px 8px;
+  padding: 8px;
   border-radius: 4px;
   font: inherit;
   font-size: 14px;

--- a/frontend/styles/components/organisms/AppNavbar.module.scss
+++ b/frontend/styles/components/organisms/AppNavbar.module.scss
@@ -120,6 +120,7 @@
     height: 14px;
 }
 
+// Replace accountGroup and welcome with actual styling for 
 .accountGroup {
     display: flex;
     align-items: center;
@@ -129,4 +130,110 @@
 .welcome {
     font-size: 16px;
     white-space: nowrap;
+}
+
+// Anchor for profile icon flyout -- position: relative (no transform) so it doesn't
+// trap the flyout's z-index in a local stacking context the way .sidebarToggleWrapper's
+// transform does (see page.module.scss's comment on that).
+.flyoutAnchor {
+  position: relative;
+}
+
+.flyout {
+  position: absolute;
+  top: 100%;
+  right: 0;
+  margin-left: 8px;
+  width: 240px;
+  background-color: #fff;
+  border: 1px solid $grey-border-color;
+  border-radius: 6px;
+  box-shadow: 0 4px 8px rgb(0 0 0 / 20%);
+  padding: 12px;
+  z-index: $z-index-dropdown;
+}
+
+// First Big Row Layout
+.flyoutHeader {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding-bottom: 12px;
+}
+
+.flyoutAvatar,
+.flyoutAvatarFallback {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  object-fit: cover;
+  flex-shrink: 0;
+}
+
+.flyoutAvatarFallback {
+  background-color: #fce7f3; // Soft pink fallback matching your screenshot
+  color: #9d174d;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+}
+
+.flyoutInfo {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.welcome {
+  font-size: 15px;
+  font-weight: 600;
+  color: #111827;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.flyoutEmail {
+  font-size: 13px;
+  color: #4b5563;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.flyoutRole {
+  font-size: 12px;
+  color: #6b7280;
+  margin-top: 2px;
+}
+
+// Separator
+.flyoutSeparator {
+  border: none;
+  border-top: 1px solid #e5e7eb;
+  margin: 0 -12px 8px -12px; // Stretches rule edge-to-edge across the flyout box padding
+}
+
+// Sign Out Button
+.signOutButton {
+  display: block;
+  width: 100%;
+  text-align: left;
+  background: transparent;
+  border: none;
+  padding: 8px 8px;
+  border-radius: 4px;
+  font: inherit;
+  font-size: 14px;
+  color: #111827;
+  cursor: pointer;
+  transition: background-color 0.2s;
+
+  &:hover,
+  &:focus {
+    background-color: #f3f4f6;
+    color: #111827;
+    outline: none;
+  }
 }

--- a/frontend/styles/components/organisms/AppNavbar.module.scss
+++ b/frontend/styles/components/organisms/AppNavbar.module.scss
@@ -143,7 +143,7 @@
   position: absolute;
   top: 100%;
   right: 0;
-  margin-left: 8px;
+  margin-top: 8px;
   width: 240px;
   background-color: #fff;
   border: 1px solid $grey-border-color;
@@ -168,18 +168,11 @@
   cursor: pointer;
 }
 
-.avatar {
-  width: 32px;
-  height: 32px;
-  border-radius: 50%;
-  object-fit: cover;
-  flex-shrink: 0;
-}
-
 .cardAvatar,
+.avatar,
 .avatarFallback {
-  width: 40px;
-  height: 40px;
+  width: 36px;
+  height: 36px;
   border-radius: 50%;
   object-fit: cover;
   flex-shrink: 0;

--- a/frontend/styles/components/organisms/AppNavbar.module.scss
+++ b/frontend/styles/components/organisms/AppNavbar.module.scss
@@ -120,18 +120,6 @@
     height: 14px;
 }
 
-// Replace accountGroup and welcome with actual styling for 
-.accountGroup {
-    display: flex;
-    align-items: center;
-    gap: 16px;
-}
-
-.welcome {
-    font-size: 16px;
-    white-space: nowrap;
-}
-
 // Anchor for profile icon flyout -- position: relative (no transform) so it doesn't
 // trap the flyout's z-index in a local stacking context the way .sidebarToggleWrapper's
 // transform does (see page.module.scss's comment on that).

--- a/frontend/styles/components/organisms/CompactCalendarSidebar.module.scss
+++ b/frontend/styles/components/organisms/CompactCalendarSidebar.module.scss
@@ -25,6 +25,6 @@
   border: 1px solid $grey-border-color;
   border-radius: 6px;
   box-shadow: 0 4px 8px rgb(0 0 0 / 20%);
-  padding: 0 12px 12px 12px;
+  padding: 0 12px 12px;
   z-index: $z-index-dropdown;
 }

--- a/frontend/styles/components/organisms/CompactCalendarSidebar.module.scss
+++ b/frontend/styles/components/organisms/CompactCalendarSidebar.module.scss
@@ -20,11 +20,11 @@
   top: 0;
   left: 100%;
   margin-left: 8px;
-  width: 196px;
+  width: 240px;
   background-color: #fff;
   border: 1px solid $grey-border-color;
   border-radius: 6px;
   box-shadow: 0 4px 8px rgb(0 0 0 / 20%);
-  padding: 12px;
+  padding: 0 12px 12px 12px;
   z-index: $z-index-dropdown;
 }

--- a/frontend/test/e2e/01-authentication.spec.ts
+++ b/frontend/test/e2e/01-authentication.spec.ts
@@ -28,8 +28,16 @@ test("1.6 session persists across a page reload", async ({ adminPage }) => {
 test("1.7 Sign Out clears the session and reverts to the signed-out view", async ({ adminPage }) => {
   const { page } = adminPage;
   await page.goto("/");
+  
+  // 1. Click the user profile avatar button to open the flyout
+  await expect(page.getByRole("button", { name: "User menu" })).toBeVisible();
+  await page.getByRole("button", { name: "User menu" }).click();
+
+  // 2. Click the "Sign Out" button inside the opened flyout
   await expect(page.getByRole("button", { name: "Sign Out" })).toBeVisible();
   await page.getByRole("button", { name: "Sign Out" }).click();
+
+  // 3. Verify it reverts to the signed-out view
   await expect(page.getByRole("link", { name: "Sign In" })).toBeVisible();
 });
 


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a signed-in user profile menu to the navigation bar, with avatar, email, and role, plus a sign-out action.
  * Navbar now reflects authentication state dynamically (including a loading state) and falls back to a sign-in link when signed out.
* **Bug Fixes**
  * Improved profile menu behavior (closes on outside click and Escape) and added resilient avatar loading to prevent broken images.
  * Ensured user profile images are consistently populated via authentication session updates.
* **Tests**
  * Updated authentication E2E coverage to sign out via the profile menu flyout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description
<!--
Bullet list. Bold the primary file/path first, then what changed and briefly why.
Group related files under one bullet when they're part of the same change, e.g.:
- **path/to/file.ts**: what changed and why
-->
- **frontend/app/api/auth/authConfig.ts**: Add user image url to session token
- **frontend/app/components/organisms/AppNavbar.tsx**: Add profile icon and its associated flyout card that renders if user is signed in, display profile icon, name, email, and sign out button.

## Testing
<!-- Concrete steps a reviewer can actually run — specific commands or repro steps, not "tested thoroughly". -->
- [x] Sign in with an authorized user, observe that there is now the profile icon on the right of the AppNavbar. Click on it should open a profile card, including information and a "Sign Out" button.

## Area(s) Touched
<!-- Select something by placing an x or X inside a bracket.
Automatically applies matching "scope:"/"type:" labels, re-synced on every edit.
A best guess is fine; this gets corrected during triage if wrong. -->
**Product areas**
- [x] ui/ux — frontend layout/styling not tied to a specific integration

## Pre-merge Checklist
<!-- Check every box below before merging to master. -->
- [ ] Code follows current formatting conventions and passes lint (`yarn lint`).
- [ ] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
- [ ] All test suites pass, both run locally and green in GitHub CI. **Do not merge if any test suite is failing.**
- [ ] A test suite was added or updated for the feature/fix in this PR. **Double-check this if you change a feature and did not update the test suites**.
- [ ] Only files relevant to this change are committed — no stray or unrelated files.
- [ ] If this branch has a merge conflict with master, master was merged into this branch first (not the other way around).
- [ ] The rest of this PR description (Description, Testing) is filled out, not left as template placeholders.