### PR TITLE
feat(calendar): render cluster background container beneath overlapping meetings

### DIFF
--- a/frontend/app/components/calendar/DailyViewRow.tsx
+++ b/frontend/app/components/calendar/DailyViewRow.tsx
@@ -19,6 +19,7 @@ interface Meeting {
   isOverflowIndicator?: boolean; // "+N more" pseudo-entry standing in for meetings past the 2 shown lanes
   overflowCount?: number;
   overflowMeetings?: Meeting[]; // Full overlapping cluster (shown + folded), for the "+N" popup
+  clusterRange?: { start: string; end: string; key: string }; // Full cluster time range, shared by every member -- see meetingOverlapLayout.ts
 }
 
 // DailyViewRowProps Interface
@@ -157,6 +158,15 @@ const DailyViewRow: React.FC<DailyViewRowProps> = ({
     ? meetings.flatMap(m => m.overflowMeetings ?? []).find(m => m.id === selectedMeetingID)
     : undefined;
 
+  // One background container per overlapping cluster, deduped by clusterRange.key --
+  // several meetings (and an overflow indicator) can share the same cluster.
+  const clusterRanges = new Map<string, { start: string; end: string }>();
+  meetings.forEach(meeting => {
+    if (meeting.clusterRange && !clusterRanges.has(meeting.clusterRange.key)) {
+      clusterRanges.set(meeting.clusterRange.key, meeting.clusterRange);
+    }
+  });
+
   return (
     <div style={{ cursor: "pointer", position: 'relative', width: '100%', height: '100%' }}>
       <div>
@@ -164,6 +174,24 @@ const DailyViewRow: React.FC<DailyViewRowProps> = ({
         {Array.from({ length: 24 }).map((_, colIndex) => (
           <div key={colIndex}></div>
         ))}
+
+        {/* Cluster containers -- rendered beneath the meeting cards and "+N" pill (see
+            z-index in DailyViewRow.module.scss), spanning each cluster's full time range so
+            it reads as one connected group, like a single meeting spanning the whole cluster. */}
+        {Array.from(clusterRanges.entries()).map(([key, range]) => {
+          const startOffset = timeToPixels(range.start);
+          const endOffset = timeToPixels(range.end);
+          return (
+            <div
+              key={key}
+              className={styles.clusterContainer}
+              // Explicit pixel height, not the CSS class's percentage -- .gridMeetingRow
+              // (an ancestor) is itself position:absolute with no explicit height, which
+              // breaks the percentage-height resolution chain for an empty div.
+              style={{ left: `${startOffset}px`, width: `${endOffset - startOffset}px`, height: `${MEETING_SLOT_HEIGHT}px` }}
+            />
+          );
+        })}
 
         {/* Render meetings */}
         {meetings.map((meeting, index) => {

--- a/frontend/app/components/calendar/OverlapMeetingsModal.tsx
+++ b/frontend/app/components/calendar/OverlapMeetingsModal.tsx
@@ -39,6 +39,18 @@ const OverlapMeetingsModal: React.FC<OverlapMeetingsModalProps> = ({
 }) => {
     if (!isOpen) return null;
 
+    // Full range across every meeting shown (true, unclipped times where available) --
+    // e.g. "9 - 11 AM" for meetings spanning 9-10, 9:30-10:30, and 10-11.
+    const timeRangeLabel = meetings.reduce<{ start: string; end: string } | null>((range, meeting) => {
+        const start = meeting.displayStartTime ?? meeting.startTime;
+        const end = meeting.displayEndTime ?? meeting.endTime;
+        if (!range) return { start, end };
+        return {
+            start: start < range.start ? start : range.start,
+            end: end > range.end ? end : range.end,
+        };
+    }, null);
+
     // Portaled to document.body -- both Day and Week view render this from deep inside
     // absolutely-positioned, z-indexed ancestors (e.g. DailyView's .gridMeetingRow), each
     // of which forms its own stacking context. Left in place, this modal's z-index would
@@ -50,7 +62,8 @@ const OverlapMeetingsModal: React.FC<OverlapMeetingsModalProps> = ({
             <div className={styles.modalContent}>
                 <div className={styles.header}>
                     <h2 className={styles.modalTitle}>
-                        {meetings.length} Meeting{meetings.length === 1 ? '' : 's'} at This Time
+                        {meetings.length} Meeting{meetings.length === 1 ? '' : 's'}
+                        {timeRangeLabel && ` (${formatCompactTimeRange(timeRangeLabel.start, timeRangeLabel.end)})`}
                     </h2>
                     <button className={styles.closeButton} onClick={onClose} aria-label="Close">
                         ✕

--- a/frontend/app/components/calendar/WeeklyViewColumn.tsx
+++ b/frontend/app/components/calendar/WeeklyViewColumn.tsx
@@ -22,6 +22,7 @@ interface Meeting {
     isOverflowIndicator?: boolean; // "+N more" pseudo-entry, rendered as a small pill instead of a meeting card
     overflowCount?: number;
     overflowMeetings?: Meeting[]; // Full overlapping cluster, shown in the "+N" popup
+    clusterRange?: { start: string; end: string; key: string }; // Full cluster time range, shared by every member -- see meetingOverlapLayout.ts
 }
 
 // Drops the " - Zoom" suffix for a more compact badge label
@@ -167,6 +168,15 @@ const WeeklyViewColumn: React.FC<WeeklyViewColumnProps> = ({
         ? meetings.flatMap(m => m.overflowMeetings ?? []).find(m => m.id === selectedMeetingID)
         : undefined;
 
+    // One background container per overlapping cluster, deduped by clusterRange.key --
+    // several meetings (and an overflow indicator) can share the same cluster.
+    const clusterRanges = new Map<string, { start: string; end: string }>();
+    meetings.forEach(meeting => {
+        if (meeting.clusterRange && !clusterRanges.has(meeting.clusterRange.key)) {
+            clusterRanges.set(meeting.clusterRange.key, meeting.clusterRange);
+        }
+    });
+
     return (
         <div className={styles.columnWrapper}>
             <div className={styles.columnBody}>
@@ -178,6 +188,26 @@ const WeeklyViewColumn: React.FC<WeeklyViewColumnProps> = ({
                         style={{ top: `${hourIndex * 120}px` }}
                     />
                 ))}
+
+                {/* Cluster containers -- rendered beneath the meeting cards and "+N" pill (see
+                    z-index in WeeklyViewColumn.module.scss), spanning each cluster's full time
+                    range so it reads as one connected group, like a single meeting spanning the
+                    whole cluster. Same VERTICAL_GAP treatment as renderMeetingCard so it lines up
+                    exactly as if it were a real meeting card for that time range. */}
+                {Array.from(clusterRanges.entries()).map(([key, range]) => {
+                    const topOffset = timeToPixels(range.start) + VERTICAL_GAP / 2;
+                    const height = Math.max(
+                        timeToPixels(range.end) - timeToPixels(range.start) - VERTICAL_GAP,
+                        1,
+                    );
+                    return (
+                        <div
+                            key={key}
+                            className={styles.clusterContainer}
+                            style={{ top: `${topOffset}px`, height: `${height}px` }}
+                        />
+                    );
+                })}
 
                 {meetings.map((meeting, index) => {
                     if (meeting.isOverflowIndicator) {

--- a/frontend/styles/components/calendar/DailyViewRow.module.scss
+++ b/frontend/styles/components/calendar/DailyViewRow.module.scss
@@ -12,6 +12,7 @@
 .clusterContainer {
   position: absolute;
   top: 0;
+
   // Height is set inline (DailyViewRow.tsx) as an explicit pixel value, not here --
   // .gridMeetingRow (an ancestor) is position:absolute with no explicit height, which
   // breaks percentage-height resolution for this empty div.

--- a/frontend/styles/components/calendar/DailyViewRow.module.scss
+++ b/frontend/styles/components/calendar/DailyViewRow.module.scss
@@ -1,7 +1,24 @@
+@import '../../Variables.module.scss';
+
 .meetingWrapper {
   position: absolute;
   border-radius: 6px;
   z-index: 10;
+}
+
+// Background container spanning an overlapping cluster's full time range, rendered beneath
+// the cluster's meeting cards and the "+N" pill (z-index 10/12 below) -- no left-accent
+// border, unlike a real meeting card, since it isn't standing in for any one meeting.
+.clusterContainer {
+  position: absolute;
+  top: 0;
+  // Height is set inline (DailyViewRow.tsx) as an explicit pixel value, not here --
+  // .gridMeetingRow (an ancestor) is position:absolute with no explicit height, which
+  // breaks percentage-height resolution for this empty div.
+  border-radius: 6px;
+  background: $grey-lightest-color;
+  z-index: 5;
+  pointer-events: none;
 }
 
 // Stands in for meetings beyond the 2 stacked lanes a room's row shows -- a small pill

--- a/frontend/styles/components/calendar/WeeklyViewColumn.module.scss
+++ b/frontend/styles/components/calendar/WeeklyViewColumn.module.scss
@@ -1,3 +1,5 @@
+@import '../../Variables.module.scss';
+
 .columnWrapper {
   display: flex;
   flex-direction: column;
@@ -29,6 +31,19 @@
   position: absolute;
   border-radius: 6px;
   z-index: 10;
+}
+
+// Background container spanning an overlapping cluster's full time range, rendered beneath
+// the cluster's meeting cards and the "+N" pill (z-index 10/12 below) -- no left-accent
+// border, unlike a real meeting card, since it isn't standing in for any one meeting.
+.clusterContainer {
+  position: absolute;
+  left: 0;
+  width: 100%;
+  border-radius: 6px;
+  background: $grey-lightest-color;
+  z-index: 5;
+  pointer-events: none;
 }
 
 // Stands in for meetings beyond MAX_VISIBLE_OVERLAP columns — a small pill rather

--- a/frontend/util/meetingOverlapLayout.ts
+++ b/frontend/util/meetingOverlapLayout.ts
@@ -17,6 +17,13 @@ export interface OverlapMeeting {
     isOverflowIndicator?: boolean; // "+N more" pseudo-entry standing in for meetings past MAX_VISIBLE_OVERLAP
     overflowCount?: number;
     overflowMeetings?: OverlapMeeting[]; // Full overlapping cluster (shown + folded), for the "+N" popup
+    // Full cluster time range (min start, max end across every meeting in the cluster, not
+    // just the shown/overflowing subset) -- shared by every meeting and the overflow
+    // indicator belonging to the same cluster. Only set when the cluster has more than one
+    // meeting. Callers use this to render a single background container spanning the whole
+    // cluster, beneath its meeting cards -- ties a "+N" pill visually to the cards it
+    // summarizes instead of leaving it floating with nothing connecting it to them.
+    clusterRange?: { start: string; end: string; key: string };
 }
 
 const toMinutes = (time: string): number => {
@@ -86,9 +93,22 @@ export const layoutOverlappingMeetings = <T extends OverlapMeeting>(meetings: T[
 
         const totalOverlapping = columnEnds.length;
 
+        // Anchored to the whole cluster's time range (every meeting in `cluster`, not just a
+        // shown/overflowing subset) -- a folded meeting can easily start later (or a shown one
+        // end earlier) than the cluster's true bounds despite all still mutually overlapping.
+        const clusterStartMinutes = Math.min(...cluster.map(m => toMinutes(m.startTime)));
+        const clusterEndMinutes = Math.max(...cluster.map(m => toMinutes(m.endTime)));
+        const clusterRange = cluster.length > 1
+            ? {
+                start: minutesToTime(clusterStartMinutes),
+                end: minutesToTime(clusterEndMinutes),
+                key: `cluster-${cluster[0].date}-${clusterStartMinutes}`,
+            }
+            : undefined;
+
         if (totalOverlapping <= MAX_VISIBLE_OVERLAP) {
             positioned.forEach(meeting => {
-                result.push(totalOverlapping > 1 ? { ...meeting, totalOverlapping } : meeting);
+                result.push(totalOverlapping > 1 ? { ...meeting, totalOverlapping, clusterRange } : meeting);
             });
             return;
         }
@@ -99,15 +119,9 @@ export const layoutOverlappingMeetings = <T extends OverlapMeeting>(meetings: T[
         const overflow = positioned.filter(m => (m.positionIndex ?? 0) >= MAX_VISIBLE_OVERLAP);
 
         shown.forEach(meeting => {
-            result.push({ ...meeting, totalOverlapping: MAX_VISIBLE_OVERLAP });
+            result.push({ ...meeting, totalOverlapping: MAX_VISIBLE_OVERLAP, clusterRange });
         });
 
-        // Anchored to the whole cluster's time range (not just the folded subset) so the "+N"
-        // pill always renders at the top of the cluster, regardless of which specific meetings
-        // the greedy column assignment above happened to show vs. fold -- a folded meeting can
-        // easily start later than the two shown ones despite still overlapping all of them.
-        const clusterStartMinutes = Math.min(...cluster.map(m => toMinutes(m.startTime)));
-        const clusterEndMinutes = Math.max(...cluster.map(m => toMinutes(m.endTime)));
         // Only OverlapMeeting's own fields are known here -- any extra fields a caller's T
         // adds on (e.g. Day View's `syncError`) are meaningless for a pseudo-entry that isn't
         // a real meeting, so this is asserted rather than genuinely satisfying T.
@@ -122,6 +136,7 @@ export const layoutOverlappingMeetings = <T extends OverlapMeeting>(meetings: T[
             isOverflowIndicator: true,
             overflowCount: overflow.length,
             overflowMeetings: cluster,
+            clusterRange,
         } as unknown as T);
     });
 


### PR DESCRIPTION
## Summary
- Every overlapping cluster (Day and Week views) now renders a `grey-lightest` background container spanning the cluster's full time range (min start to max end across all members) beneath the meeting cards and "+N" overflow pill — fixes the pill looking orphaned with nothing visually tying it to the cards it summarizes.
- `OverlapMeetingsModal`'s title now reads `"N Meeting(s) (time range)"` (via `formatCompactTimeRange`) instead of the static `"at This Time"`.

## Implementation
- `util/meetingOverlapLayout.ts`: every meeting/overflow-indicator belonging to a multi-meeting cluster now carries a `clusterRange` (`{start, end, key}`).
- `DailyViewRow.tsx`/`.module.scss` and `WeeklyViewColumn.tsx`/`.module.scss`: one container per cluster, `z-index: 5` — below meeting cards (`10`) and the pill (`12`), above the grid skeleton. No accent border.
- Caught and fixed a real bug while verifying live: `DailyViewRow`'s container originally used CSS `height: 100%`, which resolved to `0` because an ancestor (`.gridMeetingRow`) is `position: absolute` with no explicit height, breaking percentage-height resolution for the empty div. Now uses an explicit pixel height matching the row's fixed slot height.

## Test plan
- [x] `tsc --noEmit`, `eslint`, `stylelint` clean
- [x] `yarn build` (real Sass compile) clean
- [x] `test:unit` — 85 passing, no regressions
- [x] Verified live in browser against real dev data: existing same-time cluster (pill now sits attached to a shared container) and a manually-created staggered cluster (9-10 / 9:30-10:30 / 10-11) matching the reported bug, confirmed via DOM inspection (`height: 105`, correct `left`/`width`, `#F1F1F1` background, `z-index: 5`) and visually
- [x] Confirmed modal title renders `"3 Meetings (8:30 - 9:30 AM)"` correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced overlapping-meeting rendering with shaded background blocks that span each full overlap period.
  - Added consistent “cluster” time-range behavior across daily and weekly views, including the “+N” overflow indicator.

- **Bug Fixes**
  - Updated the overlap modal header to show the correct meeting count and an accurate combined time range using displayed start/end values when available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->