### PR TITLE
chore(build): silence Sass @import deprecation warnings

### DIFF
--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -1,4 +1,11 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  sassOptions: {
+    // Our .module.scss files still use the legacy @import syntax -- silences the resulting
+    // Dart Sass deprecation warning (and its noisy "Import traces" dump) without hiding other
+    // Sass warnings. Drop this once the styles/ tree migrates to @use.
+    silenceDeprecations: ["import"],
+  },
+};
 
 export default nextConfig;


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Silenced a Sass deprecation warning during application builds, resulting in cleaner build output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description
- **frontend/next.config.mjs**: adds `sassOptions.silenceDeprecations: ["import"]`. Every `.module.scss` still uses the legacy `@import` syntax, so each Next.js build/test run printed a Dart Sass deprecation warning plus a full "Import traces" dump per file — drowning out real errors in e2e/dev output. This silences just that deprecation category; other Sass warnings still surface.

## Testing
- [x] `yarn playwright test --config config/playwright.config.ts tests/e2e/01-authentication.spec.ts` — 18/18 passing, 0 occurrences of "Import trace"/"SassWarning"/"Deprecation Warning" in output (previously a dozen+ per run)

## Area(s) Touched
**Engineering**
- [x] cleanup — refactor or dead-code removal, no behavior change

## Pre-merge Checklist
- [x] Code follows current formatting conventions and passes lint (`yarn lint`).
- [x] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
- [x] All test suites pass, both run locally and green in GitHub CI. **Do not merge if any test suite is failing.**
- [ ] A test suite was added or updated for the feature/fix in this PR. **Double-check this if you change a feature and did not update the test suites**. 
- [x] Only files relevant to this change are committed — no stray or unrelated files.
- [x] If this branch has a merge conflict with master, master was merged into this branch first (not the other way around).
- [x] The rest of this PR description (Description, Testing) is filled out, not left as template placeholders.