### PR TITLE
refactor(calendar): extract CalendarHeader from CalendarNavbar

### DIFF
--- a/frontend/app/(main)/page.tsx
+++ b/frontend/app/(main)/page.tsx
@@ -14,7 +14,10 @@ import { useConflictMids } from "../../hooks/useConflictMids";
 
 export default function HomePage() {
   const [isLoggedIn, setIsLoggedIn] = useState<boolean | null>(null);
-  const [isAdmin, setIsAdmin] = useState(false);
+  // null until the auth check below resolves -- lets consumers that need to distinguish
+  // "don't know yet" from "confirmed not admin" (e.g. CalendarHeader's View-only pill) avoid
+  // flashing admin-gated UI in its wrong state during that initial fetch.
+  const [isAdmin, setIsAdmin] = useState<boolean | null>(null);
   const [refreshTrigger, setRefreshTrigger] = useState(0);
   // Admin-only -- the endpoint itself rejects non-admins, so gate on role (not just being
   // signed in) to avoid every non-admin viewer firing a denied request on mount and every

--- a/frontend/app/(signage)/signage/page.tsx
+++ b/frontend/app/(signage)/signage/page.tsx
@@ -110,10 +110,6 @@ function SignageContent() {
           selectedDate={selectedDate}
           onDateChange={setSelectedDate}
           onViewChange={(v) => setView(v === "Week" ? "Week" : "Day")}
-          // Signage is a read-only public kiosk display with no sign-in concept at all --
-          // the "View only" admin-hardening pill doesn't apply here, so this is pinned to
-          // true rather than wired to any real auth state.
-          isAdmin={true}
         />
         {view === "Day" ? <DailyView {...viewProps} /> : <WeeklyView {...viewProps} />}
       </div>

--- a/frontend/app/components/calendar/CalendarHeader.tsx
+++ b/frontend/app/components/calendar/CalendarHeader.tsx
@@ -6,7 +6,11 @@ import { formatETDateString } from "../../../util/timeUtils";
 type CalendarHeaderProps = {
   selectedDate: Date;
   selectedView: string;
-  isAdmin: boolean;
+  // null means "not yet known" (the caller's own auth check is still pending, or -- for
+  // signage -- there's no auth check at all): the View-only pill below only appears once
+  // isAdmin has actually resolved to false, not just whenever it's falsy, so it doesn't
+  // flash on into view for a beat before the real (often "is an admin") result comes in.
+  isAdmin: boolean | null;
   // The interactive Day/Week/Today/arrow controls -- CalendarNavbar owns their state and
   // handlers, but they must render as a flex sibling of the <h2> inside .navbarContainer for
   // the container-query-driven scaling below to work, so CalendarHeader takes them as children
@@ -36,7 +40,7 @@ const CalendarHeader: React.FC<CalendarHeaderProps> = ({ selectedDate, selectedV
         <h2 className={styles.navbarHeading}>{getDateRange(selectedDate)}</h2>
         {children}
       </div>
-      {!isAdmin && (
+      {isAdmin === false && (
         <div className={styles.viewOnlyPill}>
           <img src="/svg/lock-icon.svg" alt="" className={styles.viewOnlyIcon} />
           <span>View only - sign in as Admin to manage meetings</span>

--- a/frontend/app/components/calendar/CalendarHeader.tsx
+++ b/frontend/app/components/calendar/CalendarHeader.tsx
@@ -24,7 +24,7 @@ const CalendarHeader: React.FC<CalendarHeaderProps> = ({ selectedDate, selectedV
     return `${monthNameForETDateString(etDateStr)} ${year}`;
   };
 
-  return <h2 className={styles.navbarContainerRight}>{getDateRange(selectedDate)}</h2>;
+  return <h2 className={styles.navbarHeading}>{getDateRange(selectedDate)}</h2>;
 };
 
 export default CalendarHeader;

--- a/frontend/app/components/calendar/CalendarHeader.tsx
+++ b/frontend/app/components/calendar/CalendarHeader.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import styles from "../../../styles/components/calendar/CalendarNavbar.module.scss";
+import { formatMeetingDateLine, monthNameForETDateString, formatMeetingWeekLine } from "../../../util/timeFormat";
+import { formatETDateString } from "../../../util/timeUtils";
+
+type CalendarHeaderProps = {
+  selectedDate: Date;
+  selectedView: string;
+};
+
+const CalendarHeader: React.FC<CalendarHeaderProps> = ({ selectedDate, selectedView }) => {
+  const getDateRange = (date: Date): React.ReactNode => {
+    if (selectedView === 'Day') {
+      return formatMeetingDateLine(date, true);
+    }
+
+    if (selectedView === 'Week') {
+      return formatMeetingWeekLine(date);
+    }
+
+    // Month
+    const etDateStr = formatETDateString(date);
+    const [year] = etDateStr.split('-');
+    return `${monthNameForETDateString(etDateStr)} ${year}`;
+  };
+
+  return <h2 className={styles.navbarContainerRight}>{getDateRange(selectedDate)}</h2>;
+};
+
+export default CalendarHeader;

--- a/frontend/app/components/calendar/CalendarHeader.tsx
+++ b/frontend/app/components/calendar/CalendarHeader.tsx
@@ -6,9 +6,15 @@ import { formatETDateString } from "../../../util/timeUtils";
 type CalendarHeaderProps = {
   selectedDate: Date;
   selectedView: string;
+  isAdmin: boolean;
+  // The interactive Day/Week/Today/arrow controls -- CalendarNavbar owns their state and
+  // handlers, but they must render as a flex sibling of the <h2> inside .navbarContainer for
+  // the container-query-driven scaling below to work, so CalendarHeader takes them as children
+  // instead of rendering just the <h2> in isolation.
+  children: React.ReactNode;
 };
 
-const CalendarHeader: React.FC<CalendarHeaderProps> = ({ selectedDate, selectedView }) => {
+const CalendarHeader: React.FC<CalendarHeaderProps> = ({ selectedDate, selectedView, isAdmin, children }) => {
   const getDateRange = (date: Date): React.ReactNode => {
     if (selectedView === 'Day') {
       return formatMeetingDateLine(date, true);
@@ -24,7 +30,20 @@ const CalendarHeader: React.FC<CalendarHeaderProps> = ({ selectedDate, selectedV
     return `${monthNameForETDateString(etDateStr)} ${year}`;
   };
 
-  return <h2 className={styles.navbarHeading}>{getDateRange(selectedDate)}</h2>;
+  return (
+    <>
+      <div className={styles.navbarContainer}>
+        <h2 className={styles.navbarHeading}>{getDateRange(selectedDate)}</h2>
+        {children}
+      </div>
+      {!isAdmin && (
+        <div className={styles.viewOnlyPill}>
+          <img src="/svg/lock-icon.svg" alt="" className={styles.viewOnlyIcon} />
+          <span>View only - sign in as Admin to manage meetings</span>
+        </div>
+      )}
+    </>
+  );
 };
 
 export default CalendarHeader;

--- a/frontend/app/components/calendar/CalendarNavbar.tsx
+++ b/frontend/app/components/calendar/CalendarNavbar.tsx
@@ -13,10 +13,14 @@ type CalendarNavbarProps = {
     selectedDate: Date;
     onDateChange: (date : Date) => void;
     onViewChange: (view: string) => void;
-    isAdmin: boolean;
+    // Optional: signage (a public kiosk with no sign-in concept at all) renders this without
+    // ever resolving a real admin status, CalendarHeader treats the resulting null the same as 
+    // "not yet known" and skips the View-only pill either way, whereas the main calendar always 
+    // supplies its resolved (or still-loading) boolean | null.
+    isAdmin?: boolean | null;
   };
 
-const CalendarNavbar: React.FC<CalendarNavbarProps> = ({ selectedDate, onDateChange, onViewChange, isAdmin }) => {
+const CalendarNavbar: React.FC<CalendarNavbarProps> = ({ selectedDate, onDateChange, onViewChange, isAdmin = null }) => {
     const [selectedView, setSelectedView] = useState('Day');
 
     const handleViewChange = (value: string) => {

--- a/frontend/app/components/calendar/CalendarNavbar.tsx
+++ b/frontend/app/components/calendar/CalendarNavbar.tsx
@@ -57,36 +57,27 @@ const CalendarNavbar: React.FC<CalendarNavbarProps> = ({ selectedDate, onDateCha
     const handleNext = () => shiftSelectedDate(1);
 
     return (
-      <>
-        <div className={styles.navbarContainer}>
-          <CalendarHeader selectedDate={selectedDate} selectedView={selectedView} />
-          <div className={styles.navbarControls}>
-            <div className={styles.viewDropdown}>
-              <Dropdown
-                label=""
-                value={selectedView}
-                isVisible={true}
-                elements={['Day', 'Week']}
-                name="Select view"
-                onChange={handleViewChange}
-              />
-            </div>
-            <div className={styles.box}>
-              <a href="#" onClick={handleToday}>Today</a>
-            </div>
-            <div className={styles.dateToggle}>
-              <img src="/svg/left-arrow.svg" alt="Left Arrow" width={24} height={24} onClick={handlePrevious} />
-              <img src="/svg/right-arrow.svg" alt="Right Arrow" width={24} height={24} onClick={handleNext} />
-            </div>
+      <CalendarHeader selectedDate={selectedDate} selectedView={selectedView} isAdmin={isAdmin}>
+        <div className={styles.navbarControls}>
+          <div className={styles.viewDropdown}>
+            <Dropdown
+              label=""
+              value={selectedView}
+              isVisible={true}
+              elements={['Day', 'Week']}
+              name="Select view"
+              onChange={handleViewChange}
+            />
+          </div>
+          <div className={styles.box}>
+            <a href="#" onClick={handleToday}>Today</a>
+          </div>
+          <div className={styles.dateToggle}>
+            <img src="/svg/left-arrow.svg" alt="Left Arrow" width={24} height={24} onClick={handlePrevious} />
+            <img src="/svg/right-arrow.svg" alt="Right Arrow" width={24} height={24} onClick={handleNext} />
           </div>
         </div>
-        {!isAdmin && (
-          <div className={styles.viewOnlyPill}>
-            <img src="/svg/lock-icon.svg" alt="" className={styles.viewOnlyIcon} />
-            <span>View only - sign in as Admin to manage meetings</span>
-          </div>
-        )}
-      </>
+      </CalendarHeader>
     );
   };
   

--- a/frontend/app/components/calendar/CalendarNavbar.tsx
+++ b/frontend/app/components/calendar/CalendarNavbar.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import Dropdown from '../atoms/Dropdown';
+import CalendarHeader from './CalendarHeader';
 import styles from "../../../styles/components/calendar/CalendarNavbar.module.scss";
-import { formatMeetingDateLine, monthNameForETDateString, formatMeetingWeekLine } from "../../../util/timeFormat";
 import {
   formatETDateString,
   convertETToUTC,
@@ -19,21 +19,6 @@ type CalendarNavbarProps = {
 const CalendarNavbar: React.FC<CalendarNavbarProps> = ({ selectedDate, onDateChange, onViewChange, isAdmin }) => {
     const [selectedView, setSelectedView] = useState('Day');
 
-    const getDateRange = (date: Date): React.ReactNode => {
-      if (selectedView === 'Day') {
-        return formatMeetingDateLine(date);
-      }
-
-      if (selectedView === 'Week') {
-        return formatMeetingWeekLine(date);
-      }
-
-      // Month
-      const etDateStr = formatETDateString(date);
-      const [year] = etDateStr.split('-');
-      return `${monthNameForETDateString(etDateStr)} ${year}`;
-    };
-  
     const handleViewChange = (value: string) => {
       setSelectedView(value);
       onViewChange(value); // Call the external function
@@ -74,7 +59,7 @@ const CalendarNavbar: React.FC<CalendarNavbarProps> = ({ selectedDate, onDateCha
     return (
       <>
         <div className={styles.navbarContainer}>
-          <h2 className={styles.navbarContainerRight}>{getDateRange(selectedDate)}</h2>
+          <CalendarHeader selectedDate={selectedDate} selectedView={selectedView} />
           <div className={styles.navbarContainerLeft}>
             <div className={styles.viewDropdown}>
               <Dropdown

--- a/frontend/app/components/calendar/CalendarNavbar.tsx
+++ b/frontend/app/components/calendar/CalendarNavbar.tsx
@@ -60,7 +60,7 @@ const CalendarNavbar: React.FC<CalendarNavbarProps> = ({ selectedDate, onDateCha
       <>
         <div className={styles.navbarContainer}>
           <CalendarHeader selectedDate={selectedDate} selectedView={selectedView} />
-          <div className={styles.navbarContainerLeft}>
+          <div className={styles.navbarControls}>
             <div className={styles.viewDropdown}>
               <Dropdown
                 label=""

--- a/frontend/app/components/calendar/CalendarSidebar.tsx
+++ b/frontend/app/components/calendar/CalendarSidebar.tsx
@@ -16,7 +16,7 @@ interface CalendarSidebarProps {
   selectedDate: Date;
   selectedView: string;
   triggerCalendarRefresh: () => void;
-  isAdmin: boolean;
+  isAdmin: boolean | null;
 }
 
 const CalendarSidebar: React.FC<CalendarSidebarProps> = ({

--- a/frontend/app/components/calendar/CalendarSidebarShell.tsx
+++ b/frontend/app/components/calendar/CalendarSidebarShell.tsx
@@ -11,7 +11,7 @@ import { MeetingFilters } from "../../../util/meetingFilters";
 
 interface CalendarSidebarShellProps {
   isLoggedIn: boolean | null;
-  isAdmin: boolean;
+  isAdmin: boolean | null;
   filters: MeetingFilters;
   setFilters: React.Dispatch<React.SetStateAction<MeetingFilters>>;
   selectedDate: Date;

--- a/frontend/app/components/calendar/CompactCalendarSidebar.tsx
+++ b/frontend/app/components/calendar/CompactCalendarSidebar.tsx
@@ -14,7 +14,7 @@ interface CompactCalendarSidebarProps {
   selectedDate: Date;
   handleMiniCalendarSelect: (date: Date) => void;
   onOpenNewMeeting: () => void;
-  isAdmin: boolean;
+  isAdmin: boolean | null;
 }
 
 const CompactCalendarSidebar: React.FC<CompactCalendarSidebarProps> = ({

--- a/frontend/app/components/meeting-form/ViewMeeting.tsx
+++ b/frontend/app/components/meeting-form/ViewMeeting.tsx
@@ -60,8 +60,9 @@ type ViewMeetingDetailsProps = {
   anchorEl: HTMLElement | null;
   // Gates the email row, Zoom host row, and the Edit/Delete kebab menu -- all of them are
   // either PII or actions a non-admin viewer can't act on (the backend already rejects the
-  // writes; this just stops the UI from offering them in the first place).
-  isAdmin: boolean;
+  // writes; this just stops the UI from offering them in the first place). null while the
+  // caller's own auth check is still pending -- treated the same as false (hidden) below.
+  isAdmin: boolean | null;
   onBack: () => void;
   onEdit: () => void;
   onDelete: (mid: string, deleteOption?: 'this' | 'thisAndFollowing' | 'all') => void;

--- a/frontend/hooks/useConflictMids.ts
+++ b/frontend/hooks/useConflictMids.ts
@@ -13,8 +13,9 @@ export type ConflictMids = {
 // 401s and this just resolves to an empty set, no error surfaced, since a public viewer was
 // never meant to see this in the first place. `enabled` (default true) lets a caller that
 // already knows the viewer isn't signed in skip the fetch entirely rather than firing one that's
-// certain to 401.
-export function useConflictMids(refreshTrigger: number, enabled = true): ConflictMids {
+// certain to 401. Also accepts null (the caller's own admin check hasn't resolved yet) and
+// treats it the same as false -- the effect re-runs and fetches once it flips to a real boolean.
+export function useConflictMids(refreshTrigger: number, enabled: boolean | null = true): ConflictMids {
   const [mids, setMids] = useState<Set<string>>(new Set());
   const [counts, setCounts] = useState<Map<string, number>>(new Map());
 

--- a/frontend/styles/components/calendar/CalendarNavbar.module.scss
+++ b/frontend/styles/components/calendar/CalendarNavbar.module.scss
@@ -6,6 +6,13 @@
   gap: 24px;
   font-family: 'Source Sans Pro', sans-serif;
   align-self: stretch;
+  // Lets .navbarHeading/.navbarControls query *this row's* actual available
+  // width below, rather than the viewport's -- the sidebar (CalendarSidebarShell) eats an
+  // arbitrary chunk of viewport width first, so a viewport-based breakpoint doesn't know
+  // how much room this row really has and can fire too late (still 36px when the date text
+  // is already crowding the Day/Today/arrow controls) or too early.
+  container-type: inline-size;
+  container-name: calendar-navbar;
 
   img {
     cursor: pointer;
@@ -18,48 +25,55 @@
   }
 }
 
-.navbarContainerRight {
-  font-size: 36px;
+.navbarHeading {
+  // Scales continuously with the row's own inline size instead of snapping at one fixed
+  // breakpoint -- shrinks exactly as it starts to crowd .navbarControls, and clamps to
+  // the original 36px/18px range so it's a no-op until the row actually gets tight.
+  font-size: clamp(18px, 4cqi, 36px);
   font-weight: 600;
   white-space: nowrap; // Prevent wrapping
   overflow: hidden; // Hide overflow text
-
-  @media (width <= 700px) {
-    font-size: 18px;
-  }
+  text-overflow: ellipsis; // Graceful truncation if it still runs out of room at the 18px floor
+  min-width: 0; // Allow shrinking below the untruncated text's natural width in the flex row
 }
 
-.navbarContainerLeft {
+.navbarControls {
   display: flex;
   justify-content: flex-end;
   align-items: center;
-  gap: 24px;
+  // Same clamp(min, Xcqi, max) approach as .navbarHeading below, so the whole row
+  // shrinks together continuously instead of .navbarHeading fading smoothly into a
+  // gap that's still pinned at 24px. min is exactly half of max throughout this file
+  // (matching the old scale(0.5) floor this replaces), and every clamp here shares the same
+  // container-width transition zone (450px-900px) as .navbarHeading's, so nothing in
+  // the row snaps to a different size than its neighbors.
+  gap: clamp(12px, 2.67cqi, 24px);
   flex: 1;
-
-  @media (width <= 700px) {
-    transform: scale(0.5);
-    transform-origin: top right; // Scale from the top right corner
-    width: 0;
-    height: 0;
-  }
 }
 
 .dateToggle {
   display: flex;
   align-items: flex-start;
-  gap: 48px;
+  gap: clamp(24px, 5.33cqi, 48px);
+
+  img {
+    // Overrides the 24x24 width/height HTML attributes CalendarNavbar sets on the arrow
+    // <img>s -- CSS wins over presentational attributes, so this still shrinks them.
+    width: clamp(12px, 2.67cqi, 24px);
+    height: clamp(12px, 2.67cqi, 24px);
+  }
 }
 
 .box {
   border-radius: 8px;
   border: 1.5px solid $medium-grey-color;
   display: flex;
-  padding: 12px 18px;
+  padding: clamp(6px, 1.33cqi, 12px) clamp(9px, 2cqi, 18px);
   align-items: center;
   cursor: pointer;
 
   a {
-    font-size: 18px;
+    font-size: clamp(9px, 2cqi, 18px);
     color: $black-color;
     text-decoration: none;
   }
@@ -71,18 +85,18 @@
 // and override its default look (fixed 42px height, 6px radius, lighter border, native
 // button font) to mirror .box/.box a's exact styling so the two sit consistently side by side.
 .viewDropdown {
-  width: 110px;
+  width: clamp(55px, 12.22cqi, 110px);
   flex-shrink: 0;
 
   button {
     height: auto;
-    padding: 12px 18px;
+    padding: clamp(6px, 1.33cqi, 12px) clamp(9px, 2cqi, 18px);
     justify-content: center;
     gap: 8px;
     border-radius: 8px;
     border: 1.5px solid $medium-grey-color;
     font-family: 'Source Sans Pro', sans-serif;
-    font-size: 18px;
+    font-size: clamp(9px, 2cqi, 18px);
     font-weight: 400;
   }
 

--- a/frontend/styles/components/calendar/CalendarNavbar.module.scss
+++ b/frontend/styles/components/calendar/CalendarNavbar.module.scss
@@ -6,6 +6,7 @@
   gap: 24px;
   font-family: 'Source Sans Pro', sans-serif;
   align-self: stretch;
+
   // Lets .navbarHeading/.navbarControls query *this row's* actual available
   // width below, rather than the viewport's -- the sidebar (CalendarSidebarShell) eats an
   // arbitrary chunk of viewport width first, so a viewport-based breakpoint doesn't know
@@ -41,6 +42,7 @@
   display: flex;
   justify-content: flex-end;
   align-items: center;
+
   // Same clamp(min, Xcqi, max) approach as .navbarHeading below, so the whole row
   // shrinks together continuously instead of .navbarHeading fading smoothly into a
   // gap that's still pinned at 24px. min is exactly half of max throughout this file

--- a/frontend/util/timeFormat.tsx
+++ b/frontend/util/timeFormat.tsx
@@ -40,18 +40,21 @@ const etYearFmt = new Intl.DateTimeFormat('en-US', {
 });
 
 /**
- * ET calendar date as "Fri, July 24", with the year appended ("Fri, July 24, 2027") only
- * when it differs from the current ET year. Appends a brand-pink " · Today" when `date`
- * falls on the current ET calendar day.
+ * ET calendar date as "Friday, July 24", with the year appended ("Fri, July 24, 2027") only
+ * when it differs from the current ET year. When `isHeader` is true, also appends a
+ * brand-pink " · Today" when `date` falls on the current ET calendar day -- reserved for
+ * the calendar header, since surfacing "Today" on e.g. a meeting popup's date is redundant.
  */
-export const formatMeetingDateLine = (date: Date): ReactNode => {
+export const formatMeetingDateLine = (date: Date, isHeader: boolean = false): ReactNode => {
     const now = new Date();
     const base = etDateLineFmt.format(date);
     const dateYear = etYearFmt.format(date);
     const currentYear = etYearFmt.format(now);
     const label = dateYear === currentYear ? base : `${base}, ${dateYear}`;
-    const isToday = formatETDateString(date) === formatETDateString(now);
 
+    if (!isHeader) return label;
+
+    const isToday = formatETDateString(date) === formatETDateString(now);
     if (!isToday) return label;
 
     return (


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated calendar header component, now used by the calendar navbar to display the correct date heading for Day, Week, and Month views.

* **Bug Fixes**
  * Updated calendar date labeling so the “Today” indicator appears only in header mode and only when the displayed date matches the current ET date.

* **Style**
  * Improved calendar navbar responsiveness with container-query based sizing and smoother layout scaling across controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description
- **frontend/app/components/calendar/CalendarHeader.tsx**: new component that owns `getDateRange` (Day/Week/Month header formatting), extracted out of CalendarNavbar. Takes `selectedDate`/`selectedView` as props and renders the header `<h2>`.
- **frontend/app/components/calendar/CalendarNavbar.tsx**: removed `getDateRange` and now renders `<CalendarHeader />` in its place; dropped the imports that moved with it.
- **frontend/util/timeFormat.tsx**: `formatMeetingDateLine` takes a new `isHeader` param (default `false`). The "· Today" badge now only renders when `isHeader` is `true`, instead of on every caller. Only `CalendarHeader` passes `true`; `ViewMeeting.tsx`'s call site is unchanged, so the meeting-detail popup no longer shows a redundant "Today" badge.

## Testing
- [x] `yarn tsc --noEmit` passes
- [x] `yarn lint` — no new errors/warnings on touched files
- [ ] Manually verify calendar header still renders correctly for Day/Week views, and shows "· Today" only when selectedDate is today

## Area(s) Touched
**Product areas**
- [x] ui/ux — frontend layout/styling not tied to a specific integration

**Engineering**
- [x] cleanup — refactor or dead-code removal, no behavior change

## Pre-merge Checklist
- [x] Code follows current formatting conventions and passes lint (`yarn lint`).
- [x] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
- [ ] All test suites pass, both run locally and green in GitHub CI. **Do not merge if any test suite is failing.**
- [ ] A test suite was added or updated for the feature/fix in this PR. **Double-check this if you change a feature and did not update the test suites**.
- [x] Only files relevant to this change are committed — no stray or unrelated files.
- [x] If this branch has a merge conflict with master, master was merged into this branch first (not the other way around).
- [x] The rest of this PR description (Description, Testing) is filled out, not left as template placeholders.