### PR TITLE
feat(mobile): add CalendarProvider context and mobile AppNavbar

### DIFF
--- a/frontend/app/(main)/page.tsx
+++ b/frontend/app/(main)/page.tsx
@@ -9,8 +9,8 @@ import WeeklyView from "../components/calendar/WeeklyView";
 
 import { convertUTCToET } from "../../util/timeUtils";
 import { IMeeting } from "../../util/models";
-import { createDefaultFilters } from "../../util/meetingFilters";
 import { useConflictMids } from "../../hooks/useConflictMids";
+import { useCalendarContext } from "../context/CalendarProvider";
 
 export default function HomePage() {
   const [isLoggedIn, setIsLoggedIn] = useState<boolean | null>(null);
@@ -57,10 +57,18 @@ export default function HomePage() {
     checkAuthStatus();
   }, []);
 
-  const [selectedDate, setSelectedDate] = useState<Date>(new Date());
+  const {
+    selectedDate,
+    setSelectedDate,
+    selectedView,
+    setSelectedView,
+    dayFilters,
+    setDayFilters,
+    weekFilters,
+    setWeekFilters,
+  } = useCalendarContext();
   const [selectedMeeting, setSelectedMeeting] = useState<IMeeting | null>(null);
   const [selectedMeetingID, setSelectedMeetingID] = useState<string | null>(null);
-  const [selectedView, setSelectedView] = useState<string>("Day");
   const [, setSelectedNewMeeting] = useState<boolean | null>(false);
   const [showEditMeeting, setShowEditMeeting] = useState(false);
   const [lastClickedDate, setLastClickedDate] = useState<Date | null>(null);
@@ -197,11 +205,6 @@ export default function HomePage() {
     }
   };
 
-  // Both views default to every room visible -- Week previously defaulted rooms off
-  // (opt-in), but a signed-out user has no sidebar/filter UI to ever check a box, so
-  // Week view rendered permanently empty for them.
-  const [dayFilters, setDayFilters] = useState(() => createDefaultFilters(true));
-  const [weekFilters, setWeekFilters] = useState(() => createDefaultFilters(true));
   const filters = selectedView === "Day" ? dayFilters : weekFilters;
   const setFilters = selectedView === "Day" ? setDayFilters : setWeekFilters;
   const convertESTStringToDate = (estDateString: string): Date => {

--- a/frontend/app/ClientLayout.tsx
+++ b/frontend/app/ClientLayout.tsx
@@ -7,6 +7,7 @@ import styles from "../styles/MainLayout.module.scss";
 import type { Session } from "next-auth";
 import { SessionProvider } from "next-auth/react";
 import { SidebarProvider } from "./context/SidebarContext";
+import { CalendarProvider } from "./context/CalendarProvider";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -24,14 +25,16 @@ export default function ClientLayout({
             <body className={inter.className} suppressHydrationWarning>
                 <SessionProvider session={session}>
                     <SidebarProvider>
-                        <div className={styles.mainlayout}>
-                            <div className={styles.navigation}>
-                                <AppNavbar />
+                        <CalendarProvider>
+                            <div className={styles.mainlayout}>
+                                <div className={styles.navigation}>
+                                    <AppNavbar />
+                                </div>
+                                <div className={styles.content}>
+                                    {children}
+                                </div>
                             </div>
-                            <div className={styles.content}>
-                                {children}
-                            </div>
-                        </div>
+                        </CalendarProvider>
                     </SidebarProvider>
                 </SessionProvider>
             </body>

--- a/frontend/app/components/navbar/AppNavbar.tsx
+++ b/frontend/app/components/navbar/AppNavbar.tsx
@@ -49,6 +49,14 @@ const AppNavbar: React.FC = () => {
         };
     }, [openFlyout]);
 
+    // null means useIsPhone() hasn't resolved yet (no window on the server, client hasn't
+    // measured) -- render nothing rather than falling through to the desktop nav below,
+    // which is exactly the flash on a real phone useIsPhone's own layout-effect fix already
+    // guards against; a null check here is the other half of that fix.
+    if (isPhone === null) {
+        return null;
+    }
+
     if (isPhone) {
         return <MobileAppNavbar session={session} status={status} userAvatar={userAvatar} />;
     }

--- a/frontend/app/components/navbar/AppNavbar.tsx
+++ b/frontend/app/components/navbar/AppNavbar.tsx
@@ -4,20 +4,22 @@ import React, { useState, useEffect, useRef } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import Logo from "../atoms/Logo";
-import { useSession } from "next-auth/react";
 import Tooltip from "../atoms/Tooltip";
 import ProfileCard from "./ProfileCard";
+import MobileAppNavbar from "./MobileAppNavbar";
+import { useIsPhone } from "../../../hooks/useIsPhone";
+import { useUserAvatar } from "../../../hooks/useUserAvatar";
 import styles from "../../../styles/components/navbar/AppNavbar.module.scss";
 
 const AppNavbar: React.FC = () => {
-    const { data: session, status } = useSession();
+    const isPhone = useIsPhone();
+    const { session, status, userAvatar } = useUserAvatar(styles.avatar, styles.avatarFallback);
 
     const isAdmin = session?.user?.role === "ADMIN" || session?.user?.role === "SUPER_ADMIN";
     const pathname = usePathname();
     const navItemClass = (isActive: boolean) => `btn btn-ghost ${isActive ? styles.active : ""}`;
 
     const [openFlyout, setOpenFlyout] = useState<boolean>(false);
-    const [imageError, setImageError] = useState(false);
     const flyoutRef = useRef<HTMLDivElement>(null);
     const buttonRef = useRef<HTMLButtonElement>(null);
 
@@ -47,39 +49,9 @@ const AppNavbar: React.FC = () => {
         };
     }, [openFlyout]);
 
-    // Pre-verify image URL viability when session updates
-    useEffect(() => {
-        const imageUrl = session?.user?.image;
-        if (!imageUrl) {
-            setImageError(true);
-            return;
-        }
-
-        let isCurrent = true;
-        const img = new Image();
-        img.src = imageUrl;
-
-        img.onload = () => { if (isCurrent) setImageError(false)};
-        img.onerror = () => { if (isCurrent) setImageError(true)};
-
-        return () => {
-            isCurrent = false;
-        };
-    }, [session?.user?.image]);
-
-    const userAvatar = (
-        session?.user.image && !imageError ? (
-            <img
-                src={session.user.image}
-                alt={session.user.name ?? "User avatar"}
-                title={session.user.name ?? "Account"}
-                className={styles.avatar}
-                onError={() => setImageError(true)}
-            />
-        ) : (
-            <div className={styles.avatarFallback}>{session?.user.name?.[0] ?? "U"}</div>
-        )
-    );
+    if (isPhone) {
+        return <MobileAppNavbar session={session} status={status} userAvatar={userAvatar} />;
+    }
 
     return (
         <div className={styles.navbar}>

--- a/frontend/app/components/navbar/MobileAppNavbar.tsx
+++ b/frontend/app/components/navbar/MobileAppNavbar.tsx
@@ -62,6 +62,7 @@ const MobileAppNavbar: React.FC<MobileAppNavbarProps> = ({ session, status, user
               ariaLabel="Navigate to a day"
               variant="outlined"
               size="compact"
+              className={styles.squareIcon}
               onClick={() => setOpenSheet("calendar")}
             />
             <div className={styles.filterButtonWrapper}>
@@ -70,7 +71,7 @@ const MobileAppNavbar: React.FC<MobileAppNavbarProps> = ({ session, status, user
                 ariaLabel="Filter meetings"
                 variant="outlined"
                 size="compact"
-                className={hasActiveFilters ? styles.filterActive : undefined}
+                className={[styles.squareIcon, hasActiveFilters ? styles.filterActive : undefined].filter(Boolean).join(" ")}
                 onClick={() => setOpenSheet("filter")}
               />
               {hasActiveFilters && (

--- a/frontend/app/components/navbar/MobileAppNavbar.tsx
+++ b/frontend/app/components/navbar/MobileAppNavbar.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import React, { useState } from "react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import type { Session } from "next-auth";
+import MenuIcon from "@mui/icons-material/Menu";
+import FilterListIcon from "@mui/icons-material/FilterList";
+import IconButton from "../atoms/IconButton";
+import BottomSheet from "../atoms/BottomSheet";
+import AppSidebar from "./AppSidebar";
+import ProfileCard from "./ProfileCard";
+import MiniCalendar from "../atoms/MiniCalendar";
+import MeetingsFilter from "../calendar/MeetingsFilter";
+import { useCalendarContext } from "../../context/CalendarProvider";
+import styles from "../../../styles/components/navbar/MobileAppNavbar.module.scss";
+
+type OpenSheet = "calendar" | "filter" | "profile" | null;
+
+interface MobileAppNavbarProps {
+  session: Session | null;
+  status: "loading" | "authenticated" | "unauthenticated";
+  userAvatar: React.ReactNode;
+}
+
+// Rendered in place of the desktop AppNavbar at phone widths (see AppNavbar.tsx's
+// useIsPhone() branch). Mounted globally (every route, via ClientLayout.tsx), so the menu
+// toggle and profile button always render; the calendar/filter/Today controls are scoped to
+// the main calendar route only, mirroring how CalendarNavbar today is likewise only ever
+// mounted from app/(main)/page.tsx, never globally.
+const MobileAppNavbar: React.FC<MobileAppNavbarProps> = ({ session, status, userAvatar }) => {
+  const pathname = usePathname();
+  const isCalendarRoute = pathname === "/";
+  const { selectedDate, setSelectedDate, dayFilters, setDayFilters, navHidden } = useCalendarContext();
+
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+  const [openSheet, setOpenSheet] = useState<OpenSheet>(null);
+  const closeSheet = () => setOpenSheet(null);
+
+  const unselectedFilterCount = Object.values(dayFilters).filter((value) => !value).length;
+  const hasActiveFilters = unselectedFilterCount > 0;
+
+  const handleFilterChange = (name: string, value: boolean) => {
+    setDayFilters((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleToday = () => setSelectedDate(new Date());
+
+  return (
+    <div className={`${styles.navbar} ${navHidden ? styles.hidden : ""}`}>
+      <div className={styles.left}>
+        <IconButton
+          icon={<MenuIcon />}
+          ariaLabel="Open menu"
+          variant="ghost"
+          onClick={() => setSidebarOpen(true)}
+        />
+        {isCalendarRoute && (
+          <React.Fragment>
+            <IconButton
+              icon={<img src="/svg/calendar-icon.svg" alt="" />}
+              ariaLabel="Navigate to a day"
+              variant="outlined"
+              size="compact"
+              onClick={() => setOpenSheet("calendar")}
+            />
+            <div className={styles.filterButtonWrapper}>
+              <IconButton
+                icon={<FilterListIcon />}
+                ariaLabel="Filter meetings"
+                variant="outlined"
+                size="compact"
+                className={hasActiveFilters ? styles.filterActive : undefined}
+                onClick={() => setOpenSheet("filter")}
+              />
+              {hasActiveFilters && (
+                <span className={styles.filterBadge}>{unselectedFilterCount}</span>
+              )}
+            </div>
+          </React.Fragment>
+        )}
+      </div>
+
+      <div className={styles.right}>
+        {isCalendarRoute && (
+          <button type="button" className={styles.todayButton} onClick={handleToday}>
+            Today
+          </button>
+        )}
+        {status === "loading" ? (
+          <div className={styles.profileButton} style={{ opacity: 0, pointerEvents: "none" }} />
+        ) : session && session.user ? (
+          <button
+            type="button"
+            className={styles.profileButton}
+            aria-label="Account"
+            onClick={() => setOpenSheet("profile")}
+          >
+            {userAvatar}
+          </button>
+        ) : (
+          <Link href="/login" className={styles.profileButton} aria-label="Sign in">
+            {userAvatar}
+          </Link>
+        )}
+      </div>
+
+      <AppSidebar isOpen={sidebarOpen} onClose={() => setSidebarOpen(false)} />
+
+      <BottomSheet isOpen={openSheet === "calendar"} onClose={closeSheet} title="Navigate to this day">
+        <MiniCalendar
+          selectedDate={selectedDate}
+          onSelect={(date) => {
+            setSelectedDate(date);
+            closeSheet();
+          }}
+        />
+      </BottomSheet>
+
+      <BottomSheet isOpen={openSheet === "filter"} onClose={closeSheet} title="Filter meetings">
+        <MeetingsFilter filters={dayFilters} onFilterChange={handleFilterChange} />
+      </BottomSheet>
+
+      {session && (
+        <BottomSheet isOpen={openSheet === "profile"} onClose={closeSheet} title="Account">
+          <ProfileCard session={session} userAvatar={userAvatar} />
+        </BottomSheet>
+      )}
+    </div>
+  );
+};
+
+export default MobileAppNavbar;

--- a/frontend/app/context/CalendarProvider.tsx
+++ b/frontend/app/context/CalendarProvider.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { createContext, useContext, useState } from "react";
+import React, { createContext, useContext, useMemo, useState } from "react";
 import { createDefaultFilters, MeetingFilters } from "../../util/meetingFilters";
 
 // Bridges calendar state between HomePage's page content and the globally-mounted AppNavbar
@@ -34,21 +34,24 @@ export const CalendarProvider: React.FC<{ children: React.ReactNode }> = ({ chil
   const [weekFilters, setWeekFilters] = useState<MeetingFilters>(() => createDefaultFilters(true));
   const [navHidden, setNavHidden] = useState(false);
 
+  const value = useMemo(
+    () => ({
+      selectedDate,
+      setSelectedDate,
+      selectedView,
+      setSelectedView,
+      dayFilters,
+      setDayFilters,
+      weekFilters,
+      setWeekFilters,
+      navHidden,
+      setNavHidden,
+    }),
+    [selectedDate, selectedView, dayFilters, weekFilters, navHidden]
+  );
+
   return (
-    <CalendarContext.Provider
-      value={{
-        selectedDate,
-        setSelectedDate,
-        selectedView,
-        setSelectedView,
-        dayFilters,
-        setDayFilters,
-        weekFilters,
-        setWeekFilters,
-        navHidden,
-        setNavHidden,
-      }}
-    >
+    <CalendarContext.Provider value={value}>
       {children}
     </CalendarContext.Provider>
   );

--- a/frontend/app/context/CalendarProvider.tsx
+++ b/frontend/app/context/CalendarProvider.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import React, { createContext, useContext, useState } from "react";
+import { createDefaultFilters, MeetingFilters } from "../../util/meetingFilters";
+
+// Bridges calendar state between HomePage's page content and the globally-mounted AppNavbar
+// (ClientLayout.tsx renders them as siblings, not parent/child, so AppNavbar can't just read
+// state HomePage owns locally). Provided once in ClientLayout.tsx, wrapping both; HomePage
+// consumes it instead of owning this state itself. navHidden/setNavHidden is the mobile
+// scroll-hide bridge (written by the mobile day view's scroll listener, read by
+// MobileAppNavbar's hide/show CSS) added ahead of the branch that needs it, same as
+// selectedDate/filters, so the Provider is the single bridge for all of it.
+interface CalendarContextValue {
+  selectedDate: Date;
+  setSelectedDate: React.Dispatch<React.SetStateAction<Date>>;
+  selectedView: string;
+  setSelectedView: React.Dispatch<React.SetStateAction<string>>;
+  dayFilters: MeetingFilters;
+  setDayFilters: React.Dispatch<React.SetStateAction<MeetingFilters>>;
+  weekFilters: MeetingFilters;
+  setWeekFilters: React.Dispatch<React.SetStateAction<MeetingFilters>>;
+  navHidden: boolean;
+  setNavHidden: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+const CalendarContext = createContext<CalendarContextValue | null>(null);
+
+export const CalendarProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [selectedDate, setSelectedDate] = useState<Date>(new Date());
+  const [selectedView, setSelectedView] = useState<string>("Day");
+  // Both views default to every room visible -- see the matching comment on the old
+  // HomePage useState this replaced.
+  const [dayFilters, setDayFilters] = useState<MeetingFilters>(() => createDefaultFilters(true));
+  const [weekFilters, setWeekFilters] = useState<MeetingFilters>(() => createDefaultFilters(true));
+  const [navHidden, setNavHidden] = useState(false);
+
+  return (
+    <CalendarContext.Provider
+      value={{
+        selectedDate,
+        setSelectedDate,
+        selectedView,
+        setSelectedView,
+        dayFilters,
+        setDayFilters,
+        weekFilters,
+        setWeekFilters,
+        navHidden,
+        setNavHidden,
+      }}
+    >
+      {children}
+    </CalendarContext.Provider>
+  );
+};
+
+export function useCalendarContext(): CalendarContextValue {
+  const context = useContext(CalendarContext);
+  if (!context) {
+    throw new Error("useCalendarContext must be used within a CalendarProvider");
+  }
+  return context;
+}

--- a/frontend/config/jest.component.config.ts
+++ b/frontend/config/jest.component.config.ts
@@ -20,6 +20,7 @@ const config: Config = {
   moduleNameMapper: {
     "^server-only$": "<rootDir>/tests/mocks/server-only.js",
     "\\.module\\.scss$": "identity-obj-proxy",
+    "\\.css$": "identity-obj-proxy",
     "\\.(png|jpe?g|gif|svg)$": "<rootDir>/tests/mocks/fileMock.js",
   },
   setupFilesAfterEnv: ["<rootDir>/tests/component/setup.ts"],

--- a/frontend/hooks/useUserAvatar.tsx
+++ b/frontend/hooks/useUserAvatar.tsx
@@ -1,0 +1,55 @@
+import React, { useEffect, useState } from "react";
+import { useSession } from "next-auth/react";
+import type { Session } from "next-auth";
+
+interface UseUserAvatarResult {
+  session: Session | null;
+  status: "loading" | "authenticated" | "unauthenticated";
+  // Real <img> when the session has a loadable avatar URL, otherwise an initial-letter
+  // fallback div -- shared here (rather than recomputed per navbar variant) so the
+  // imageError pre-verification effect below has exactly one copy across desktop AppNavbar
+  // and MobileAppNavbar.
+  userAvatar: React.ReactNode;
+}
+
+// Extracted out of AppNavbar.tsx so the mobile navbar (a separate render path, not nested
+// inside the desktop one) doesn't need its own divergent copy of this logic.
+export function useUserAvatar(avatarClassName: string, fallbackClassName: string): UseUserAvatarResult {
+  const { data: session, status } = useSession();
+  const [imageError, setImageError] = useState(false);
+
+  useEffect(() => {
+    const imageUrl = session?.user?.image;
+    if (!imageUrl) {
+      setImageError(true);
+      return;
+    }
+
+    let isCurrent = true;
+    const img = new Image();
+    img.src = imageUrl;
+
+    img.onload = () => { if (isCurrent) setImageError(false); };
+    img.onerror = () => { if (isCurrent) setImageError(true); };
+
+    return () => {
+      isCurrent = false;
+    };
+  }, [session?.user?.image]);
+
+  const userAvatar = (
+    session?.user.image && !imageError ? (
+      <img
+        src={session.user.image}
+        alt={session.user.name ?? "User avatar"}
+        title={session.user.name ?? "Account"}
+        className={avatarClassName}
+        onError={() => setImageError(true)}
+      />
+    ) : (
+      <div className={fallbackClassName}>{session?.user.name?.[0] ?? "U"}</div>
+    )
+  );
+
+  return { session, status, userAvatar };
+}

--- a/frontend/styles/MainLayout.module.scss
+++ b/frontend/styles/MainLayout.module.scss
@@ -1,4 +1,4 @@
-@import 'Variables.module.scss';
+@import 'Variables.module';
 
 // No global stylesheet exists in this app (SCSS modules only) -- this is the one file
 // guaranteed to load on every page, so it owns zeroing the browser's default 8px body

--- a/frontend/styles/MainLayout.module.scss
+++ b/frontend/styles/MainLayout.module.scss
@@ -1,3 +1,5 @@
+@import 'Variables.module.scss';
+
 // No global stylesheet exists in this app (SCSS modules only) -- this is the one file
 // guaranteed to load on every page, so it owns zeroing the browser's default 8px body
 // margin. Without this, that margin is 16px (top+bottom) of real, page-level scroll room
@@ -17,11 +19,24 @@
 
     .navigation {
         flex: 0 1 auto;
+
+        // MobileAppNavbar (rendered here below $breakpoint-phone -- see AppNavbar.tsx's
+        // useIsPhone() branch) is position: fixed so it can slide off-screen on scroll
+        // without leaving a gap in the flex flow -- this wrapper reserves no layout height
+        // of its own in that case, so .content below gets the matching top padding instead.
+        @media (width <= $breakpoint-phone) {
+            height: 0;
+            overflow: visible;
+        }
     }
 
     .content {
         flex: 1 1 auto;
         min-height: 0; // lets this shrink to the space left under the navbar, so overflow-y actually scrolls instead of growing past the viewport
         overflow-y: auto;
+
+        @media (width <= $breakpoint-phone) {
+            padding-top: 48px; // matches MobileAppNavbar.module.scss's fixed 48px height
+        }
     }
 }

--- a/frontend/styles/components/navbar/MobileAppNavbar.module.scss
+++ b/frontend/styles/components/navbar/MobileAppNavbar.module.scss
@@ -1,0 +1,94 @@
+@import '../../Variables.module.scss';
+
+.navbar {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 48px;
+    z-index: $z-index-sticky;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0 8px;
+    background-color: #fff;
+    border-bottom: 1px solid $grey-border-color;
+    transition: transform 0.25s ease;
+
+    &.hidden {
+        transform: translateY(-100%);
+    }
+}
+
+.left,
+.right {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.filterButtonWrapper {
+    position: relative;
+}
+
+// MUI's SvgIcon fills with currentColor, so setting color here (rather than reaching into
+// the icon itself) is enough to tint it -- matches how IconButton already lets a caller-
+// supplied className override its own styling.
+.filterActive {
+    color: $brand-pink-color !important;
+}
+
+.filterBadge {
+    position: absolute;
+    top: -4px;
+    right: -4px;
+    min-width: 16px;
+    height: 16px;
+    padding: 0 3px;
+    border-radius: 8px;
+    background-color: $brand-pink-color;
+    color: #fff;
+    font-size: 10px;
+    font-weight: 700;
+    line-height: 16px;
+    text-align: center;
+}
+
+.todayButton {
+    height: 32px;
+    padding: 0 12px;
+    border: 1px solid $grey-border-color;
+    border-radius: 16px;
+    background-color: #fff;
+    color: $black-color;
+    font: inherit;
+    font-size: 13px;
+    font-weight: 600;
+    cursor: pointer;
+
+    &:hover,
+    &:focus {
+        background-color: $grey-lightest-color;
+    }
+}
+
+.profileButton {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    border: 1px solid $grey-border-color;
+    background: none;
+    padding: 0;
+    cursor: pointer;
+    overflow: hidden;
+    text-decoration: none;
+
+    img,
+    div {
+        width: 100%;
+        height: 100%;
+    }
+}

--- a/frontend/styles/components/navbar/MobileAppNavbar.module.scss
+++ b/frontend/styles/components/navbar/MobileAppNavbar.module.scss
@@ -1,4 +1,4 @@
-@import '../../Variables.module.scss';
+@import '../../Variables.module';
 
 .navbar {
     position: fixed;

--- a/frontend/styles/components/navbar/MobileAppNavbar.module.scss
+++ b/frontend/styles/components/navbar/MobileAppNavbar.module.scss
@@ -31,6 +31,15 @@
     position: relative;
 }
 
+// IconButton's .outlined variant defaults to a circular border (border-radius: 50%) --
+// overridden here for just the calendar-toggle/filter buttons, which read as a square
+// (8px radius, matching Claude Design's mobile-day-view mockup) box instead. !important
+// to win over .outlined regardless of the two CSS modules' relative bundle order (same
+// idiom as .filterActive below).
+.squareIcon {
+    border-radius: 8px !important;
+}
+
 // MUI's SvgIcon fills with currentColor, so setting color here (rather than reaching into
 // the icon itself) is enough to tint it -- matches how IconButton already lets a caller-
 // supplied className override its own styling.

--- a/frontend/tests/component/MobileAppNavbar.test.tsx
+++ b/frontend/tests/component/MobileAppNavbar.test.tsx
@@ -1,0 +1,126 @@
+import React from "react";
+import { render, screen, fireEvent, within } from "@testing-library/react";
+import { useSession } from "next-auth/react";
+import { usePathname } from "next/navigation";
+import MobileAppNavbar from "../../app/components/navbar/MobileAppNavbar";
+import { CalendarProvider, useCalendarContext } from "../../app/context/CalendarProvider";
+import type { Session } from "next-auth";
+
+jest.mock("next-auth/react", () => ({
+  useSession: jest.fn(),
+  signOut: jest.fn(),
+}));
+
+jest.mock("next/navigation", () => ({
+  usePathname: jest.fn(),
+}));
+
+const mockUseSession = useSession as jest.Mock;
+const mockUsePathname = usePathname as jest.Mock;
+
+const adminSession: Session = {
+  user: { name: "Admin User", email: "admin@example.com", role: "ADMIN" },
+  expires: "2099-01-01T00:00:00.000Z",
+};
+
+// Renders the current context's selectedDate as text so tests can assert the Today button
+// (and, in a later branch, swipe/mini-calendar transitions) actually mutated shared state,
+// without reaching into MobileAppNavbar's own internals.
+const SelectedDateProbe: React.FC = () => {
+  const { selectedDate } = useCalendarContext();
+  return <div data-testid="selected-date">{selectedDate.toDateString()}</div>;
+};
+
+const renderNavbar = () =>
+  render(
+    <CalendarProvider>
+      <SelectedDateProbe />
+      <MobileAppNavbar session={adminSession} status="authenticated" userAvatar={<div data-testid="avatar" />} />
+    </CalendarProvider>
+  );
+
+describe("MobileAppNavbar", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders menu, calendar, filter, today, and profile buttons on the main calendar route", () => {
+    mockUseSession.mockReturnValue({ data: adminSession });
+    mockUsePathname.mockReturnValue("/");
+
+    renderNavbar();
+
+    expect(screen.getByRole("button", { name: "Open menu" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Navigate to a day" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Filter meetings" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Today" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Account" })).toBeInTheDocument();
+  });
+
+  it("only renders menu and profile on a non-calendar route", () => {
+    mockUseSession.mockReturnValue({ data: adminSession });
+    mockUsePathname.mockReturnValue("/admin");
+
+    renderNavbar();
+
+    expect(screen.getByRole("button", { name: "Open menu" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Account" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Navigate to a day" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Filter meetings" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Today" })).not.toBeInTheDocument();
+  });
+
+  it("opens a bottom sheet titled 'Navigate to this day' with a mini calendar", () => {
+    mockUseSession.mockReturnValue({ data: adminSession });
+    mockUsePathname.mockReturnValue("/");
+
+    renderNavbar();
+    fireEvent.click(screen.getByRole("button", { name: "Navigate to a day" }));
+
+    expect(screen.getByRole("dialog", { name: "Navigate to this day" })).toBeInTheDocument();
+  });
+
+  it("sets selectedDate to today when the Today button is clicked", () => {
+    mockUseSession.mockReturnValue({ data: adminSession });
+    mockUsePathname.mockReturnValue("/");
+
+    renderNavbar();
+    fireEvent.click(screen.getByRole("button", { name: "Today" }));
+
+    expect(screen.getByTestId("selected-date")).toHaveTextContent(new Date().toDateString());
+  });
+
+  it("shows no filter badge by default (all filters selected)", () => {
+    mockUseSession.mockReturnValue({ data: adminSession });
+    mockUsePathname.mockReturnValue("/");
+
+    renderNavbar();
+
+    expect(screen.queryByText(/^\d+$/)).not.toBeInTheDocument();
+  });
+
+  it("shows a pink badge with the unselected count after unchecking a filter", () => {
+    mockUseSession.mockReturnValue({ data: adminSession });
+    mockUsePathname.mockReturnValue("/");
+
+    renderNavbar();
+    fireEvent.click(screen.getByRole("button", { name: "Filter meetings" }));
+
+    const sheet = screen.getByRole("dialog", { name: "Filter meetings" });
+    const [firstCheckbox] = within(sheet).getAllByRole("checkbox");
+    fireEvent.click(firstCheckbox);
+
+    expect(screen.getByText("1")).toBeInTheDocument();
+  });
+
+  it("opens the profile bottom sheet with ProfileCard content for a signed-in user", () => {
+    mockUseSession.mockReturnValue({ data: adminSession });
+    mockUsePathname.mockReturnValue("/");
+
+    renderNavbar();
+    fireEvent.click(screen.getByRole("button", { name: "Account" }));
+
+    expect(screen.getByRole("dialog", { name: "Account" })).toBeInTheDocument();
+    expect(screen.getByText("Hi, Admin User")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added responsive mobile navigation with calendar controls, filters, Today navigation, sidebar access, and account actions.
  * Centralized calendar selection and filter state across the main layout and navigation.
  * Added mobile sheets for calendar selection, meeting filters, and account details.
  * Added avatar loading with an initial-letter fallback.

* **Style**
  * Improved mobile layout spacing and fixed navigation positioning.

* **Tests**
  * Added coverage for mobile navigation, calendar interactions, filters, and account actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description
Real mobile top bar, plus the shared `CalendarProvider` context every later branch reads from.
- **app/context/CalendarProvider.tsx**: new Context owning `selectedDate`/filters (previously local `useState` in `page.tsx`) and `navHidden` (bridge between the mobile navbar's scroll-hide CSS and the scroll listener wired in #279).
- **app/components/navbar/MobileAppNavbar.tsx**: 48px bar mounted on every route — menu toggle opens `AppSidebar` (#276), profile icon opens a `BottomSheet` + `ProfileCard`; calendar/filter/Today controls render only on `/`, reading from `CalendarProvider`.
- **hooks/useUserAvatar.tsx**: extracted avatar-resolution logic shared between desktop `AppNavbar` and the new mobile navbar.
- **app/components/navbar/AppNavbar.tsx**: early-returns to `MobileAppNavbar` when `useIsPhone()` is true.
- **app/ClientLayout.tsx** / **app/(main)/page.tsx**: wrapped in `CalendarProvider`; `page.tsx` now consumes `selectedDate`/filters from context instead of local state.

Until #279 lands, a narrow viewport shows both this new mobile navbar's controls and the existing desktop `CalendarNavbar` — expected mid-stack state, not a shipped state.

## Testing
- `yarn test:component` — new `MobileAppNavbar.test.tsx` (route-scoping, bottom sheets open with correct content, filter badge count/color).
- Manual: desktop navbar/profile flyout unaffected at desktop widths.

## Area(s) Touched
**Product areas**
- [x] ui/ux — frontend layout/styling not tied to a specific integration

**Engineering**
- [x] testing — test suite (Jest/Playwright) changes

## Pre-merge Checklist
- [x] Code follows current formatting conventions and passes lint (`yarn lint`).
- [x] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
- [x] All test suites pass, both run locally and green in GitHub CI.
- [x] A test suite was added or updated for the feature/fix in this PR.
- [x] Only files relevant to this change are committed — no stray or unrelated files.
- [x] If this branch has a merge conflict with master, master was merged into this branch first.
- [x] The rest of this PR description is filled out.

---
**Stacked PR — part 3 of 7.** Base: `feat/mobile-app-sidebar` (#276). Next in stack: `feat/mobile-week-strip` (#278).
