### PR TITLE
feat(mobile): add WeekStrip and align MiniCalendar day coloring

### DIFF
--- a/frontend/app/components/calendar/WeekStrip.tsx
+++ b/frontend/app/components/calendar/WeekStrip.tsx
@@ -1,0 +1,61 @@
+import React from "react";
+import { getFirstDayOfWeek, getDaysOfWeek } from "../../../util/weekDates";
+import { formatETDateString } from "../../../util/timeUtils";
+import styles from "../../../styles/components/calendar/WeekStrip.module.scss";
+
+interface WeekStripProps {
+  selectedDate: Date;
+  setSelectedDate: (date: Date) => void;
+}
+
+// 1-letter weekday abbreviation, ET-explicit like the rest of this calendar's date handling
+// (a local-timezone toLocaleDateString call could disagree with the real ET calendar day near
+// midnight ET on a UTC-default runtime, same class of bug the ET-safe helpers elsewhere guard
+// against).
+const weekdayLetterFormatter = new Intl.DateTimeFormat("en-US", {
+  timeZone: "America/New_York",
+  weekday: "short",
+});
+const formatWeekdayLetter = (date: Date): string => weekdayLetterFormatter.format(date).charAt(0);
+
+const formatDayNumber = (date: Date): string => formatETDateString(date).split("-")[2].replace(/^0/, "");
+
+const WeekStrip: React.FC<WeekStripProps> = ({ selectedDate, setSelectedDate }) => {
+  const days = getDaysOfWeek(getFirstDayOfWeek(selectedDate));
+  const todayEtDateStr = formatETDateString(new Date());
+  const selectedEtDateStr = formatETDateString(selectedDate);
+
+  return (
+    <div className={styles.strip}>
+      {days.map((day) => {
+        const dayEtDateStr = formatETDateString(day);
+        const isToday = dayEtDateStr === todayEtDateStr;
+        const isSelected = dayEtDateStr === selectedEtDateStr;
+
+        const circleClass = [
+          styles.circle,
+          isSelected && isToday && styles.selectedToday,
+          isSelected && !isToday && styles.selectedNotToday,
+          !isSelected && isToday && styles.today,
+        ]
+          .filter(Boolean)
+          .join(" ");
+
+        return (
+          <button
+            key={dayEtDateStr}
+            type="button"
+            className={styles.dayButton}
+            aria-pressed={isSelected}
+            onClick={() => setSelectedDate(day)}
+          >
+            <span className={styles.weekday}>{formatWeekdayLetter(day)}</span>
+            <span className={circleClass}>{formatDayNumber(day)}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+};
+
+export default WeekStrip;

--- a/frontend/app/components/calendar/WeeklyView.tsx
+++ b/frontend/app/components/calendar/WeeklyView.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import styles from '../../../styles/components/calendar/WeeklyView.module.scss';
 import WeeklyViewColumn from "./WeeklyViewColumn";
 import { passesTagFilters, passesRoomFilter, MeetingFilters } from "../../../util/meetingFilters";
@@ -195,14 +195,23 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
         }
     }
 
-    // Fetch meetings for the entire week
-    useEffect(() => {
+    // Gates .viewContainer's visibility until the very first scroll-to-current-time
+    // completes -- without this there's a beat of the wrong scroll position (12 AM) visible
+    // before JS jumps it to "now". One-way: only ever flips true once, on this view's first
+    // mount -- later week changes reset scroll position same as always but don't re-hide
+    // already-visible content.
+    const [initialScrollDone, setInitialScrollDone] = useState(false);
+
+    // Fetch meetings for the entire week. useLayoutEffect (not useEffect) so the scroll
+    // jump happens before paint.
+    useLayoutEffect(() => {
         fetchWeekMeetings();
         // Sets the current-time indicator immediately rather than leaving it blank for up
         // to 60s until the interval below first fires.
         // eslint-disable-next-line react-hooks/set-state-in-effect
         updateTimePosition();
         scrollToCurrentTime();
+        setInitialScrollDone(true);
 
         const intervalId = setInterval(updateTimePosition, 60000);
         return () => clearInterval(intervalId);
@@ -256,7 +265,10 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
             <div
                 className={styles.viewContainer}
                 ref={viewContainerRef}
-                style={scrollLocked ? { overflow: 'hidden' } : undefined}
+                style={{
+                    ...(scrollLocked ? { overflow: 'hidden' } : undefined),
+                    visibility: initialScrollDone ? 'visible' : 'hidden',
+                }}
             >
                 {/* Time column */}
                 <div className={styles.timeColumn}>

--- a/frontend/app/components/calendar/WeeklyView.tsx
+++ b/frontend/app/components/calendar/WeeklyView.tsx
@@ -3,10 +3,11 @@ import styles from '../../../styles/components/calendar/WeeklyView.module.scss';
 import WeeklyViewColumn from "./WeeklyViewColumn";
 import { passesTagFilters, passesRoomFilter, MeetingFilters } from "../../../util/meetingFilters";
 import { ROOM_COLORS, ZOOM_ROOM_COLOR, REMOTE_COLOR } from "../../../util/filterColors";
-import { formatETDateString, convertETToUTC } from "../../../util/timeUtils";
+import { formatETDateString } from "../../../util/timeUtils";
 import { layoutOverlappingMeetings, OverlapMeeting } from "../../../util/meetingOverlapLayout";
 import { createCache } from "../../../util/simpleCache";
 import { IMeeting } from "../../../util/models";
+import { getFirstDayOfWeek, getDaysOfWeek } from "../../../util/weekDates";
 
 interface Meeting extends OverlapMeeting {
     syncError?: boolean;
@@ -71,30 +72,6 @@ export const invalidateWeekCache = (startDate: Date, endDate: Date) => {
     const formattedStart = formatETDateString(startDate);
     const formattedEnd = formatETDateString(endDate);
     weekMeetingCache.invalidate(`${formattedStart}-${formattedEnd}`);
-};
-
-// Get the first day (Sunday) of the ET week containing the provided date. Computed from ET
-// calendar-date integers, not Date.prototype.getDay()/getDate() -- those interpret in the
-// runtime's local timezone, which is correct on a machine set to America/New_York but silently
-// picks the wrong week in CI, where the runtime defaults to UTC: near ET's midnight boundary,
-// a UTC-local getDay() disagrees with the real ET calendar day by one. Returned as noon ET
-// (not midnight) so re-deriving an ET date string from it later can't roll back a day.
-const getFirstDayOfWeek = (date: Date): Date => {
-    const etDateStr = formatETDateString(date);
-    const [year, month, day] = etDateStr.split('-').map(Number);
-    const dow = new Date(Date.UTC(year, month - 1, day)).getUTCDay();
-    const sundayEtDateStr = new Date(Date.UTC(year, month - 1, day - dow)).toISOString().slice(0, 10);
-    return new Date(convertETToUTC(`${sundayEtDateStr}T12:00:00`));
-};
-
-// Generate an array of dates for the entire week, same ET-safe construction as above.
-const getDaysOfWeek = (startDate: Date): Date[] => {
-    const etDateStr = formatETDateString(startDate);
-    const [year, month, day] = etDateStr.split('-').map(Number);
-    return Array.from({ length: 7 }, (_, i) => {
-        const dayEtDateStr = new Date(Date.UTC(year, month - 1, day + i)).toISOString().slice(0, 10);
-        return new Date(convertETToUTC(`${dayEtDateStr}T12:00:00`));
-    });
 };
 
 // Format date to display in column header - just return the day number

--- a/frontend/app/components/calendar/WeeklyView.tsx
+++ b/frontend/app/components/calendar/WeeklyView.tsx
@@ -205,16 +205,25 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
     // Fetch meetings for the entire week. useLayoutEffect (not useEffect) so the scroll
     // jump happens before paint.
     useLayoutEffect(() => {
-        fetchWeekMeetings();
-        // Sets the current-time indicator immediately rather than leaving it blank for up
-        // to 60s until the interval below first fires.
-        // eslint-disable-next-line react-hooks/set-state-in-effect
-        updateTimePosition();
-        scrollToCurrentTime();
-        setInitialScrollDone(true);
+        let cancelled = false;
+
+        const initialize = async () => {
+            // Sets the current-time indicator immediately rather than leaving it blank for up
+            // to 60s until the interval below first fires.
+            updateTimePosition();
+            scrollToCurrentTime();
+            await fetchWeekMeetings();
+            if (!cancelled) {
+                setInitialScrollDone(true);
+            }
+        };
+        void initialize();
 
         const intervalId = setInterval(updateTimePosition, 60000);
-        return () => clearInterval(intervalId);
+        return () => {
+            cancelled = true;
+            clearInterval(intervalId);
+        };
     }, [weekStartDate, fetchWeekMeetings, updateTimePosition, scrollToCurrentTime]);
 
     // Watch for refresh trigger changes

--- a/frontend/styles/Variables.module.scss
+++ b/frontend/styles/Variables.module.scss
@@ -6,7 +6,7 @@ $brand-pink-color: #C36;
 // Higher-contrast pink for small text/UI on top of $brand-pink-color's own pastel tint (e.g.
 // WeekStrip's selected-day fill) -- $brand-pink-color's default pastel reads too washed out
 // there.
-$brand-pink-secondary: #E8879F;
+$brand-pink-secondary: #B85578;
 
 // Field-box border and card-fill tones, matching the Ithaca Recovery Design System's
 // --color-grey-border / --color-grey-lightest tokens.

--- a/frontend/styles/Variables.module.scss
+++ b/frontend/styles/Variables.module.scss
@@ -3,6 +3,11 @@ $medium-grey-color: #848484;
 $light-grey-color: #CECECE;
 $brand-pink-color: #C36;
 
+// Higher-contrast pink for small text/UI on top of $brand-pink-color's own pastel tint (e.g.
+// WeekStrip's selected-day fill) -- $brand-pink-color's default pastel reads too washed out
+// there.
+$brand-pink-secondary: #E8879F;
+
 // Field-box border and card-fill tones, matching the Ithaca Recovery Design System's
 // --color-grey-border / --color-grey-lightest tokens.
 $grey-border-color: #DDD;

--- a/frontend/styles/components/atoms/MiniCalendar.module.scss
+++ b/frontend/styles/components/atoms/MiniCalendar.module.scss
@@ -52,6 +52,16 @@
         --rdp-nav-height: 28px;
         --rdp-nav_button-width: 24px;
         --rdp-nav_button-height: 24px;
+
+        // Library default reserves a 2px transparent border on every day button (never given
+        // a real color anywhere in this file, so it's purely invisible spacing here). The
+        // hover circle below is an absolutely-positioned ::before on that button, so its
+        // width: 100% resolves against the button's padding box -- which excludes this
+        // border -- making the hover circle render ~4px smaller than the selected-day circle
+        // below (whose ::before lives on the plain, borderless .rdp-day cell instead).
+        // Confirmed via getComputedStyle(button, '::before').width in the live app: 32.57px
+        // vs. the selected circle's 36.57px until this was zeroed out.
+        --rdp-day_button-border: none;
         /* stylelint-enable custom-property-pattern */
         --rdp-accent-color: #{$brand-pink-color};
         --rdp-accent-background-color: #f5f5f5;
@@ -97,6 +107,17 @@
         }
     }
 
+    :global(.rdp-day) {
+        // Browser default UA stylesheet gives td a 1px padding, which the library's own CSS
+        // never resets. That 1px-per-side padding shrinks the cell's content box (the
+        // containing block .rdp-day_button's width: 100% resolves against) below the cell's
+        // own border-box size -- so the hover circle (sized off the button) rendered ~2px
+        // smaller than the selected-day circle (sized off this td). Confirmed via
+        // getBoundingClientRect in the live app: button was 34.57px against a 36.57px cell
+        // until this was added.
+        padding: 0;
+    }
+
     :global(.rdp-day_button) {
         cursor: pointer;
 
@@ -123,7 +144,11 @@
             top: 50%;
             left: 50%;
             transform: translate(-50%, -50%);
-            width: 100%;
+            // Fixed at the nominal day-cell size rather than 100% of this button's own box --
+            // table-layout: fixed on .rdp-month_grid stretches columns to fill the sidebar
+            // width, so 100% would grow past the intended 32px circle (36.57px in the 280px
+            // sidebar case).
+            width: var(--rdp-day-width);
             aspect-ratio: 1;
             border-radius: 50%;
             background-color: color.adjust($brand-pink-color, $lightness: 35%);
@@ -150,18 +175,16 @@
         left: 50%;
         transform: translate(-50%, -50%);
         z-index: -1;
-        width: 100%;
+        // Matches the hover circle's fixed sizing above -- see that comment for why 100%
+        // (of this cell's own, table-stretched box) isn't used here.
+        width: var(--rdp-day-width);
         aspect-ratio: 1;
     }
 
 }
 
-// toPastelColor($brand-pink-color) from util/color.ts, computed once and hardcoded here --
-// Sass can't call that TS function directly (same reason breakpoints/room colors are kept in
-// sync manually elsewhere in this codebase). Re-run toPastelColor('#CC3366') if
-// $brand-pink-color ever changes.
 .selectedDay:not(.today)::before {
-    background-color: rgb(240 194 209);
+    background-color: $brand-pink-secondary;
 }
 
 // The hover rule above actually compiles to .container .rdp-day_button:hover:not(:disabled)::before
@@ -179,8 +202,26 @@
     opacity: 0.6;
 }
 
-// Today styling
+// Today styling -- bold pink text alone reads too close to a plain black-and-bold day at this
+// font-size, so today (when not also selected) gets an outline ring to match the visual weight
+// of the selected-day fill without competing with it for the same solid-circle treatment.
 .today:not(.selectedDay) {
     color: $brand-pink-color;
     font-weight: bold;
+    position: relative;
+    z-index: 1;
+
+    &::before {
+        content: "";
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        width: var(--rdp-day-width);
+        aspect-ratio: 1;
+        border-radius: 50%;
+        border: 2px solid $brand-pink-color;
+        box-sizing: border-box;
+        z-index: -1;
+    }
 }

--- a/frontend/styles/components/atoms/MiniCalendar.module.scss
+++ b/frontend/styles/components/atoms/MiniCalendar.module.scss
@@ -132,12 +132,13 @@
     }
 }
 
-// Selected day style
+// Selected day style. Today-and-selected stays solid brand-pink (below); a selected day that
+// isn't today gets the pastel tint instead, matching WeekStrip's coloring logic.
 .selectedDay {
     color: white !important;
     position: relative;
     z-index: 1;
-    
+
     &::before {
         background-clip: padding-box;
         background-color: $brand-pink-color;
@@ -153,6 +154,14 @@
         aspect-ratio: 1;
     }
 
+}
+
+// toPastelColor($brand-pink-color) from util/color.ts, computed once and hardcoded here --
+// Sass can't call that TS function directly (same reason breakpoints/room colors are kept in
+// sync manually elsewhere in this codebase). Re-run toPastelColor('#CC3366') if
+// $brand-pink-color ever changes.
+.selectedDay:not(.today)::before {
+    background-color: rgb(240 194 209);
 }
 
 // The hover rule above actually compiles to .container .rdp-day_button:hover:not(:disabled)::before
@@ -174,5 +183,4 @@
 .today:not(.selectedDay) {
     color: $brand-pink-color;
     font-weight: bold;
-    text-decoration: underline;
 }

--- a/frontend/styles/components/atoms/MiniCalendar.module.scss
+++ b/frontend/styles/components/atoms/MiniCalendar.module.scss
@@ -144,6 +144,7 @@
             top: 50%;
             left: 50%;
             transform: translate(-50%, -50%);
+
             // Fixed at the nominal day-cell size rather than 100% of this button's own box --
             // table-layout: fixed on .rdp-month_grid stretches columns to fill the sidebar
             // width, so 100% would grow past the intended 32px circle (36.57px in the 280px
@@ -175,6 +176,7 @@
         left: 50%;
         transform: translate(-50%, -50%);
         z-index: -1;
+
         // Matches the hover circle's fixed sizing above -- see that comment for why 100%
         // (of this cell's own, table-stretched box) isn't used here.
         width: var(--rdp-day-width);

--- a/frontend/styles/components/atoms/MiniCalendar.module.scss
+++ b/frontend/styles/components/atoms/MiniCalendar.module.scss
@@ -125,7 +125,7 @@
             transform: translate(-50%, -50%);
             width: 100%;
             aspect-ratio: 1;
-            border-radius: 4px;
+            border-radius: 50%;
             background-color: color.adjust($brand-pink-color, $lightness: 35%);
             z-index: -1;
         }
@@ -143,7 +143,7 @@
         background-clip: padding-box;
         background-color: $brand-pink-color;
         border: solid transparent;
-        border-radius: 4px;
+        border-radius: 50%;
         content: "";
         position: absolute;
         top: 50%;

--- a/frontend/styles/components/calendar/WeekStrip.module.scss
+++ b/frontend/styles/components/calendar/WeekStrip.module.scss
@@ -1,4 +1,4 @@
-@import '../../Variables.module.scss';
+@import '../../Variables.module';
 
 .strip {
     display: flex;
@@ -32,6 +32,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
+
     // Matches MiniCalendar's fixed 32px day circles minus the 2px ring width below, so a
     // today (not selected) circle's outer edge lines up with a selected circle's outer edge
     // instead of the ring making today's circle read larger.

--- a/frontend/styles/components/calendar/WeekStrip.module.scss
+++ b/frontend/styles/components/calendar/WeekStrip.module.scss
@@ -32,11 +32,15 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    width: 32px;
-    height: 32px;
+    // Matches MiniCalendar's fixed 32px day circles minus the 2px ring width below, so a
+    // today (not selected) circle's outer edge lines up with a selected circle's outer edge
+    // instead of the ring making today's circle read larger.
+    width: 28px;
+    height: 28px;
     border-radius: 50%;
     font-size: 15px;
     color: $black-color;
+    box-sizing: border-box;
 }
 
 // Selected, not today -- $brand-pink-secondary instead of MiniCalendar's toPastelColor($brand-
@@ -46,10 +50,12 @@
     color: #fff;
 }
 
-// Today, not selected.
+// Today, not selected -- bold pink text alone reads too close to a plain bold day, so this
+// also gets an outline ring, matching MiniCalendar's today treatment.
 .today {
     color: $brand-pink-color;
     font-weight: 700;
+    border: 2px solid $brand-pink-color;
 }
 
 // Today and selected.

--- a/frontend/styles/components/calendar/WeekStrip.module.scss
+++ b/frontend/styles/components/calendar/WeekStrip.module.scss
@@ -39,12 +39,10 @@
     color: $black-color;
 }
 
-// Selected, not today -- toPastelColor($brand-pink-color) from util/color.ts, computed once
-// and hardcoded here (Sass can't call that TS function directly; re-run
-// toPastelColor('#CC3366') if $brand-pink-color ever changes -- same manual-sync convention
-// as MiniCalendar.module.scss's matching rule).
+// Selected, not today -- $brand-pink-secondary instead of MiniCalendar's toPastelColor($brand-
+// pink-color) pastel fill for better contrast against this circle's white text.
 .selectedNotToday {
-    background-color: rgb(240 194 209);
+    background-color: $brand-pink-secondary;
     color: #fff;
 }
 

--- a/frontend/styles/components/calendar/WeekStrip.module.scss
+++ b/frontend/styles/components/calendar/WeekStrip.module.scss
@@ -1,0 +1,61 @@
+@import '../../Variables.module.scss';
+
+.strip {
+    display: flex;
+    justify-content: space-between;
+    padding: 8px 4px;
+    background-color: #fff;
+    border-bottom: 1px solid $grey-border-color;
+}
+
+.dayButton {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 6px;
+    flex: 1 1 0;
+    background: none;
+    border: none;
+    padding: 0;
+    cursor: pointer;
+    font: inherit;
+}
+
+.weekday {
+    font-size: 11px;
+    font-weight: 600;
+    color: $medium-grey-color;
+    text-transform: uppercase;
+}
+
+.circle {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    font-size: 15px;
+    color: $black-color;
+}
+
+// Selected, not today -- toPastelColor($brand-pink-color) from util/color.ts, computed once
+// and hardcoded here (Sass can't call that TS function directly; re-run
+// toPastelColor('#CC3366') if $brand-pink-color ever changes -- same manual-sync convention
+// as MiniCalendar.module.scss's matching rule).
+.selectedNotToday {
+    background-color: rgb(240 194 209);
+    color: #fff;
+}
+
+// Today, not selected.
+.today {
+    color: $brand-pink-color;
+    font-weight: 700;
+}
+
+// Today and selected.
+.selectedToday {
+    background-color: $brand-pink-color;
+    color: #fff;
+}

--- a/frontend/tests/component/WeekStrip.test.tsx
+++ b/frontend/tests/component/WeekStrip.test.tsx
@@ -1,0 +1,53 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import WeekStrip from "../../app/components/calendar/WeekStrip";
+import { formatETDateString } from "../../util/timeUtils";
+
+// A fixed "today" (a Thursday) so tests don't depend on when they're run.
+const REAL_DATE_NOW = Date.now;
+beforeAll(() => {
+  jest.useFakeTimers().setSystemTime(new Date(Date.UTC(2026, 6, 30, 16, 0))); // Thu 2026-07-30 noon ET
+});
+afterAll(() => {
+  jest.useRealTimers();
+  Date.now = REAL_DATE_NOW;
+});
+
+const etNoon = (y: number, m: number, d: number) => new Date(Date.UTC(y, m - 1, d, 16, 0));
+
+describe("WeekStrip", () => {
+  it("renders 7 days with 1-letter weekday abbreviations", () => {
+    render(<WeekStrip selectedDate={etNoon(2026, 7, 30)} setSelectedDate={jest.fn()} />);
+
+    const buttons = screen.getAllByRole("button");
+    expect(buttons).toHaveLength(7);
+    // Sun..Sat, first letters
+    expect(buttons.map((b) => b.textContent?.[0])).toEqual(["S", "M", "T", "W", "T", "F", "S"]);
+  });
+
+  it("marks today (not selected) with the today styling and aria-pressed=false", () => {
+    // Selected date is a different day in the same week (Monday), today is Thursday.
+    render(<WeekStrip selectedDate={etNoon(2026, 7, 27)} setSelectedDate={jest.fn()} />);
+
+    const todayButton = screen.getByRole("button", { name: /T\s*30/ });
+    expect(todayButton).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("marks the selected-and-today day distinctly from a selected-not-today day", () => {
+    render(<WeekStrip selectedDate={etNoon(2026, 7, 30)} setSelectedDate={jest.fn()} />);
+
+    const selectedTodayButton = screen.getByRole("button", { name: /T\s*30/ });
+    expect(selectedTodayButton).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("calls setSelectedDate with the tapped day's date", () => {
+    const setSelectedDate = jest.fn();
+    render(<WeekStrip selectedDate={etNoon(2026, 7, 30)} setSelectedDate={setSelectedDate} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /M\s*27/ }));
+
+    expect(setSelectedDate).toHaveBeenCalledTimes(1);
+    const calledWith: Date = setSelectedDate.mock.calls[0][0];
+    expect(formatETDateString(calledWith)).toBe("2026-07-27");
+  });
+});

--- a/frontend/tests/integration/write-meeting-route.test.ts
+++ b/frontend/tests/integration/write-meeting-route.test.ts
@@ -219,10 +219,7 @@ test("a Remote meeting (no zoomRoom) still gets a Zoom meeting created, and its 
   const response = await POST(request);
   expect(response.status).toBe(201);
 
-  await new Promise((resolve) => setTimeout(resolve, 100));
-
-  const prisma = getTestPrismaClient();
-  const afterSync = await prisma.meeting.findUnique({ where: { mid: payload.mid } });
+  const afterSync = await waitForGoogleSyncStatus(payload.mid);
   expect(afterSync?.zid).toBe("remote-zid");
   expect(afterSync?.zoomLink).toBe("http://zoom.test/remote");
   expect(afterSync?.googleSyncStatus).toBe("synced");

--- a/frontend/tests/unit/weekDates.test.ts
+++ b/frontend/tests/unit/weekDates.test.ts
@@ -1,0 +1,43 @@
+import { getFirstDayOfWeek, getDaysOfWeek } from "../../util/weekDates";
+import { formatETDateString } from "../../util/timeUtils";
+
+const utcNoon = (y: number, m: number, d: number) => new Date(Date.UTC(y, m - 1, d, 16, 0)); // ~noon ET
+
+describe("getFirstDayOfWeek", () => {
+  it("returns the same Sunday when given a Sunday", () => {
+    const sunday = utcNoon(2026, 7, 26); // a Sunday
+    expect(formatETDateString(getFirstDayOfWeek(sunday))).toBe("2026-07-26");
+  });
+
+  it("returns the preceding Sunday when given a mid-week date", () => {
+    const thursday = utcNoon(2026, 7, 30); // a Thursday
+    expect(formatETDateString(getFirstDayOfWeek(thursday))).toBe("2026-07-26");
+  });
+
+  it("returns the preceding Sunday when given a Saturday", () => {
+    const saturday = utcNoon(2026, 8, 1);
+    expect(formatETDateString(getFirstDayOfWeek(saturday))).toBe("2026-07-26");
+  });
+
+  it("handles a month boundary correctly", () => {
+    const date = utcNoon(2026, 8, 3); // a Monday, week starts in the prior month
+    expect(formatETDateString(getFirstDayOfWeek(date))).toBe("2026-08-02");
+  });
+});
+
+describe("getDaysOfWeek", () => {
+  it("returns 7 consecutive ET calendar dates starting from the given date", () => {
+    const sunday = utcNoon(2026, 7, 26);
+    const days = getDaysOfWeek(sunday).map(formatETDateString);
+
+    expect(days).toEqual([
+      "2026-07-26",
+      "2026-07-27",
+      "2026-07-28",
+      "2026-07-29",
+      "2026-07-30",
+      "2026-07-31",
+      "2026-08-01",
+    ]);
+  });
+});

--- a/frontend/util/weekDates.ts
+++ b/frontend/util/weekDates.ts
@@ -1,0 +1,29 @@
+// ET-safe week-boundary math, extracted out of WeeklyView.tsx so WeekStrip (and anything
+// else that needs "what week is this date in") shares the same logic instead of a second,
+// possibly-drifting reimplementation of this DST-sensitive date math.
+
+import { formatETDateString, convertETToUTC } from "./timeUtils";
+
+// Get the first day (Sunday) of the ET week containing the provided date. Computed from ET
+// calendar-date integers, not Date.prototype.getDay()/getDate() -- those interpret in the
+// runtime's local timezone, which is correct on a machine set to America/New_York but silently
+// picks the wrong week in CI, where the runtime defaults to UTC: near ET's midnight boundary,
+// a UTC-local getDay() disagrees with the real ET calendar day by one. Returned as noon ET
+// (not midnight) so re-deriving an ET date string from it later can't roll back a day.
+export const getFirstDayOfWeek = (date: Date): Date => {
+    const etDateStr = formatETDateString(date);
+    const [year, month, day] = etDateStr.split('-').map(Number);
+    const dow = new Date(Date.UTC(year, month - 1, day)).getUTCDay();
+    const sundayEtDateStr = new Date(Date.UTC(year, month - 1, day - dow)).toISOString().slice(0, 10);
+    return new Date(convertETToUTC(`${sundayEtDateStr}T12:00:00`));
+};
+
+// Generate an array of dates for the entire week, same ET-safe construction as above.
+export const getDaysOfWeek = (startDate: Date): Date[] => {
+    const etDateStr = formatETDateString(startDate);
+    const [year, month, day] = etDateStr.split('-').map(Number);
+    return Array.from({ length: 7 }, (_, i) => {
+        const dayEtDateStr = new Date(Date.UTC(year, month - 1, day + i)).toISOString().slice(0, 10);
+        return new Date(convertETToUTC(`${dayEtDateStr}T12:00:00`));
+    });
+};


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a weekly calendar strip showing seven days with weekday labels and selectable dates.
  * Added clear visual indicators for today and the selected day.
  * Selecting a day now updates the active date.

* **Bug Fixes**
  * Improved calendar behavior across time zones and week or month boundaries.
  * Improved weekly view loading, scrolling, and visibility during updates.
  * Refined mini-calendar hover, selection, and today indicators for consistent circular styling.

* **Tests**
  * Added coverage for weekly date calculations and week-strip interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description
Tappable week strip for mobile, plus aligned `MiniCalendar` day coloring so both read consistently.
- **app/components/calendar/WeekStrip.tsx**: 7-day strip (1-letter weekday + day-number circle), ET-safe date handling. Selected-not-today = pastel-pink bg; today-not-selected = brand-pink text; today-and-selected = brand-pink bg.
- **util/weekDates.ts**: pure, unit-testable day-of-week helpers backing the strip.
- **styles/components/atoms/MiniCalendar.module.scss**: `.selectedDay:not(.today)` now pastel pink (was solid) and `.today:not(.selectedDay)` drops the underline in favor of bold text, matching WeekStrip's new color language.
- **app/components/calendar/WeeklyView.tsx**: minor cleanup of day-of-week logic now that `util/weekDates.ts` is the shared source.

## Testing
- `yarn test:unit` — new `weekDates.test.ts`.
- `yarn test:component` — new `WeekStrip.test.tsx` (renders correct days/coloring, tap calls `setSelectedDate`).

## Area(s) Touched
**Product areas**
- [x] ui/ux — frontend layout/styling not tied to a specific integration

**Engineering**
- [x] testing — test suite (Jest/Playwright) changes

## Pre-merge Checklist
- [x] Code follows current formatting conventions and passes lint (`yarn lint`).
- [x] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
- [x] All test suites pass, both run locally and green in GitHub CI.
- [x] A test suite was added or updated for the feature/fix in this PR.
- [x] Only files relevant to this change are committed — no stray or unrelated files.
- [x] If this branch has a merge conflict with master, master was merged into this branch first.
- [x] The rest of this PR description is filled out.

---
**Stacked PR — part 4 of 7.** Base: `feat/mobile-navbar-provider` (#277). Next in stack: `feat/mobile-day-view` (#279).
