### PR TITLE
feat(mobile): add swipe/drag transitions for WeekStrip and DayColumn

### DIFF
--- a/frontend/app/(main)/page.tsx
+++ b/frontend/app/(main)/page.tsx
@@ -319,7 +319,6 @@ export default function HomePage() {
           <MobileCalendarView
             filters={dayFilters}
             selectedDate={selectedDate}
-            setSelectedDate={setSelectedDate}
             selectedMeetingID={selectedMeetingID}
             setSelectedMeetingID={setSelectedMeetingID}
             setSelectedNewMeeting={setSelectedNewMeeting}

--- a/frontend/app/components/calendar/CalendarHeader.tsx
+++ b/frontend/app/components/calendar/CalendarHeader.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
+import { motion } from 'framer-motion';
 import styles from "../../../styles/components/calendar/CalendarNavbar.module.scss";
 import { formatMeetingDateLine, monthNameForETDateString, formatMeetingWeekLine } from "../../../util/timeFormat";
 import { formatETDateString } from "../../../util/timeUtils";
+import type { SwipeDirection } from "../../../util/weekStripTransition";
 
 type CalendarHeaderProps = {
   selectedDate: Date;
@@ -18,9 +20,15 @@ type CalendarHeaderProps = {
   // CalendarHeader directly (bypassing CalendarNavbar entirely -- WeekStrip/the mobile navbar's
   // Today button/bottom sheets replace that role there), so it has no controls to pass.
   children?: React.ReactNode;
+  // Mobile only: when set, the date-range heading slides between values (keyed by
+  // transitionKey, e.g. the ET date string) instead of updating in place -- driven by the
+  // same selectedDate change that also swaps MobileCalendarView's DayColumn, so the two
+  // appear to move simultaneously. The "View only" pill below is deliberately never part of
+  // this animation (stays fixed while the heading swaps), matching the mobile swipe spec.
+  animatedHeading?: { transitionKey: string; direction: SwipeDirection };
 };
 
-const CalendarHeader: React.FC<CalendarHeaderProps> = ({ selectedDate, selectedView, isAdmin, children }) => {
+const CalendarHeader: React.FC<CalendarHeaderProps> = ({ selectedDate, selectedView, isAdmin, children, animatedHeading }) => {
   const getDateRange = (date: Date): React.ReactNode => {
     if (selectedView === 'Day') {
       return formatMeetingDateLine(date, true);
@@ -36,10 +44,30 @@ const CalendarHeader: React.FC<CalendarHeaderProps> = ({ selectedDate, selectedV
     return `${monthNameForETDateString(etDateStr)} ${year}`;
   };
 
+  // No AnimatePresence -- a plain key change here unmounts the old <h2> and mounts a new one
+  // in the same commit (no dual-mount exit period to manage), and the freshly-mounted one
+  // plays its own initial->animate enter transition. Trades away an animated *exit* for the
+  // old value (it just disappears) in exchange for not depending on AnimatePresence's
+  // unmount-after-exit-completes machinery, which proved unreliable for this repeatedly-
+  // changing-key use case.
+  const heading = animatedHeading ? (
+    <motion.h2
+      key={animatedHeading.transitionKey}
+      className={styles.navbarHeading}
+      initial={{ x: animatedHeading.direction === 'forward' ? 40 : -40, opacity: 0 }}
+      animate={{ x: 0, opacity: 1 }}
+      transition={{ duration: 0.25, ease: 'easeOut' }}
+    >
+      {getDateRange(selectedDate)}
+    </motion.h2>
+  ) : (
+    <h2 className={styles.navbarHeading}>{getDateRange(selectedDate)}</h2>
+  );
+
   return (
     <>
       <div className={styles.navbarContainer}>
-        <h2 className={styles.navbarHeading}>{getDateRange(selectedDate)}</h2>
+        {heading}
         {children}
       </div>
       {isAdmin === false && (

--- a/frontend/app/components/calendar/MobileCalendarView.tsx
+++ b/frontend/app/components/calendar/MobileCalendarView.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { motion, type PanInfo } from "framer-motion";
 import WeekStrip from "./WeekStrip";
 import CalendarHeader from "./CalendarHeader";
 import DayColumn from "./DayColumn";
@@ -6,7 +7,7 @@ import { filterMeetingsForDate, MeetingFilters } from "../../../util/meetingFilt
 import { ROOM_COLORS, ZOOM_ROOM_COLOR, REMOTE_COLOR } from "../../../util/filterColors";
 import { formatETDateString } from "../../../util/timeUtils";
 import { layoutOverlappingMeetings, OverlapMeeting } from "../../../util/meetingOverlapLayout";
-import { getFirstDayOfWeek } from "../../../util/weekDates";
+import { getFirstDayOfWeek, addDaysToDate } from "../../../util/weekDates";
 import { useWeekMeetings } from "../../../hooks/useWeekMeetings";
 import { useCalendarContext } from "../../context/CalendarProvider";
 import styles from "../../../styles/components/calendar/MobileCalendarView.module.scss";
@@ -37,10 +38,15 @@ const timeSlots = Array.from({ length: 24 }, (_, i) => formatTime(i));
 // jitter (e.g. rubber-banding at the top) doesn't flicker the navbar in and out.
 const SCROLL_HIDE_THRESHOLD_PX = 4;
 
+// Distance/velocity a horizontal drag on the day column needs to clear before it counts as a
+// real "swipe to the next/previous day" gesture -- matches WeekStrip's own thresholds so both
+// gesture surfaces feel consistent.
+const SWIPE_OFFSET_THRESHOLD = 60;
+const SWIPE_VELOCITY_THRESHOLD = 400;
+
 interface MobileCalendarViewProps {
   filters: MeetingFilters;
   selectedDate: Date;
-  setSelectedDate: (date: Date) => void;
   selectedMeetingID: string | null;
   setSelectedMeetingID: (meetingId: string) => void;
   setSelectedNewMeeting: (newMeetingExists: boolean) => void;
@@ -55,11 +61,12 @@ interface MobileCalendarViewProps {
 // above the scroll area, not competing for the same scroll container DayColumn uses) while
 // DayColumn's own wrapper scrolls independently underneath -- also where the mobile navbar's
 // scroll-hide listener attaches (writes navHidden to CalendarProvider, read by
-// MobileAppNavbar).
+// MobileAppNavbar). CalendarHeader's heading and DayColumn share the same
+// transitionDirection/selectedDate-keyed swap (CalendarProvider's changeSelectedDate), so a
+// swipe/tap/mini-calendar-pick animates both together regardless of which one triggered it.
 const MobileCalendarView: React.FC<MobileCalendarViewProps> = ({
   filters,
   selectedDate,
-  setSelectedDate,
   selectedMeetingID,
   setSelectedMeetingID,
   setSelectedNewMeeting,
@@ -69,7 +76,7 @@ const MobileCalendarView: React.FC<MobileCalendarViewProps> = ({
   conflictMids,
   isAdmin,
 }) => {
-  const { setNavHidden } = useCalendarContext();
+  const { setNavHidden, changeSelectedDate, transitionDirection, transitionCrossesWeek } = useCalendarContext();
   const weekStartDate = getFirstDayOfWeek(selectedDate);
   const allMeetings = useWeekMeetings(weekStartDate, refreshTrigger);
 
@@ -129,10 +136,24 @@ const MobileCalendarView: React.FC<MobileCalendarViewProps> = ({
     lastScrollTopRef.current = el.scrollTop;
   };
 
+  const handleDaySwipeEnd = (_event: PointerEvent | MouseEvent | TouchEvent, info: PanInfo) => {
+    const pastThreshold =
+      Math.abs(info.offset.x) > SWIPE_OFFSET_THRESHOLD || Math.abs(info.velocity.x) > SWIPE_VELOCITY_THRESHOLD;
+    if (!pastThreshold) return;
+
+    // Swipe left (negative offset) = forward = later; swipe right = backward = earlier.
+    changeSelectedDate(addDaysToDate(selectedDate, info.offset.x < 0 ? 1 : -1));
+  };
+
   return (
     <div className={styles.container}>
-      <WeekStrip selectedDate={selectedDate} setSelectedDate={setSelectedDate} />
-      <CalendarHeader selectedDate={selectedDate} selectedView="Day" isAdmin={isAdmin} />
+      <WeekStrip />
+      <CalendarHeader
+        selectedDate={selectedDate}
+        selectedView="Day"
+        isAdmin={isAdmin}
+        animatedHeading={{ transitionKey: selectedEtDateStr, direction: transitionDirection }}
+      />
 
       <div
         className={styles.scrollArea}
@@ -151,25 +172,46 @@ const MobileCalendarView: React.FC<MobileCalendarViewProps> = ({
           ))}
         </div>
 
-        <div className={styles.dayColumnWrapper}>
-          <DayColumn
-            roomColor={ZOOM_ROOM_COLOR} // Unused fallback: every meeting sets primaryColor via getRoomColor
-            meetings={dayMeetings}
-            selectedMeetingID={selectedMeetingID}
-            setSelectedMeetingID={setSelectedMeetingID}
-            setSelectedNewMeeting={setSelectedNewMeeting}
-            setAnchorEl={setAnchorEl}
-            conflictMids={conflictMids}
-            hourHeight={MOBILE_HOUR_HEIGHT}
-            hideTags
-          />
-          {isToday && (
-            <div
-              className={styles.currentTimeIndicator}
-              style={{ top: `${(new Date().getHours() * 60 + new Date().getMinutes()) * (MOBILE_HOUR_HEIGHT / 60)}px` }}
+        {/* drag="x" scoped to just this wrapper (not the whole scrollArea) so vertical
+            touch-scroll on the time labels / day column keeps working normally --
+            dragSnapToOrigin returns this wrapper to x:0 immediately on release regardless of
+            outcome; the actual slide is the inner date-keyed swap below. No AnimatePresence --
+            a plain key change unmounts the old day and mounts the new one in the same commit
+            (no dual-mount exit period to manage), and the new one plays its own enter
+            transition. See CalendarHeader.tsx's matching comment for why. */}
+        <motion.div
+          className={styles.dayColumnWrapper}
+          drag="x"
+          dragSnapToOrigin
+          onDragEnd={handleDaySwipeEnd}
+          style={{ touchAction: "pan-y" }}
+        >
+          <motion.div
+            key={selectedEtDateStr}
+            className={styles.dayColumnAnimatedInner}
+            initial={{ x: transitionCrossesWeek ? 0 : transitionDirection === "forward" ? "100%" : "-100%" }}
+            animate={{ x: 0 }}
+            transition={{ type: "tween", duration: 0.25, ease: "easeOut" }}
+          >
+            <DayColumn
+              roomColor={ZOOM_ROOM_COLOR} // Unused fallback: every meeting sets primaryColor via getRoomColor
+              meetings={dayMeetings}
+              selectedMeetingID={selectedMeetingID}
+              setSelectedMeetingID={setSelectedMeetingID}
+              setSelectedNewMeeting={setSelectedNewMeeting}
+              setAnchorEl={setAnchorEl}
+              conflictMids={conflictMids}
+              hourHeight={MOBILE_HOUR_HEIGHT}
+              hideTags
             />
-          )}
-        </div>
+            {isToday && (
+              <div
+                className={styles.currentTimeIndicator}
+                style={{ top: `${(new Date().getHours() * 60 + new Date().getMinutes()) * (MOBILE_HOUR_HEIGHT / 60)}px` }}
+              />
+            )}
+          </motion.div>
+        </motion.div>
       </div>
     </div>
   );

--- a/frontend/app/components/calendar/MobileCalendarView.tsx
+++ b/frontend/app/components/calendar/MobileCalendarView.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useLayoutEffect, useMemo, useRef, useState } from "react";
-import { motion, useDragControls, type PanInfo } from "framer-motion";
+import { motion, useAnimationControls, useDragControls, type PanInfo } from "framer-motion";
 import WeekStrip from "./WeekStrip";
 import CalendarHeader from "./CalendarHeader";
 import DayColumn from "./DayColumn";
@@ -38,19 +38,11 @@ const timeSlots = Array.from({ length: 24 }, (_, i) => formatTime(i));
 // jitter (e.g. rubber-banding at the top) doesn't flicker the navbar in and out.
 const SCROLL_HIDE_THRESHOLD_PX = 4;
 
-// Distance/velocity a horizontal drag on the day column needs to clear before it counts as a
-// real "swipe to the next/previous day" gesture -- matches WeekStrip's own thresholds so both
-// gesture surfaces feel consistent.
+// Distance/velocity a horizontal drag on the carousel track needs to clear before it counts
+// as a real "swipe to the next/previous day" gesture -- matches WeekStrip's own thresholds so
+// both gesture surfaces feel consistent.
 const SWIPE_OFFSET_THRESHOLD = 60;
 const SWIPE_VELOCITY_THRESHOLD = 400;
-
-// Caps how far dayColumnWrapper visually follows the drag before release snaps it back.
-// Without this, dragging rightward (swiping backward to the previous day) had nothing
-// stopping the wrapper from sliding arbitrarily far away from .timeColumn's fixed left
-// edge, opening an ever-growing gap between the two -- WeekStrip's own drag wrapper has no
-// such neighboring sibling to detach from, so it never needed a constraint. Larger than
-// SWIPE_OFFSET_THRESHOLD so the preview isn't clamped before a real swipe even registers.
-const DRAG_PREVIEW_MAX_PX = 100;
 
 interface MobileCalendarViewProps {
   filters: MeetingFilters;
@@ -65,13 +57,15 @@ interface MobileCalendarViewProps {
   isAdmin: boolean | null;
 }
 
+const isDateToday = (date: Date): boolean => formatETDateString(date) === formatETDateString(new Date());
+
 // Mobile portrait day view: WeekStrip + CalendarHeader stay in place (plain flex siblings
 // above the scroll area, not competing for the same scroll container DayColumn uses) while
 // DayColumn's own wrapper scrolls independently underneath -- also where the mobile navbar's
 // scroll-hide listener attaches (writes navHidden to CalendarProvider, read by
-// MobileAppNavbar). CalendarHeader's heading and DayColumn share the same
-// transitionDirection/selectedDate-keyed swap (CalendarProvider's changeSelectedDate), so a
-// swipe/tap/mini-calendar-pick animates both together regardless of which one triggered it.
+// MobileAppNavbar). CalendarHeader's heading has its own independent tween (fires when the
+// date change commits, same as WeekStrip taps/mini-calendar picks) -- it is not unified into
+// the carousel drag below.
 const MobileCalendarView: React.FC<MobileCalendarViewProps> = ({
   filters,
   selectedDate,
@@ -84,26 +78,56 @@ const MobileCalendarView: React.FC<MobileCalendarViewProps> = ({
   conflictMids,
   isAdmin,
 }) => {
-  const { setNavHidden, changeSelectedDate, transitionDirection, transitionCrossesWeek } = useCalendarContext();
-  const weekStartDate = getFirstDayOfWeek(selectedDate);
-  const allMeetings = useWeekMeetings(weekStartDate, refreshTrigger);
+  const { setNavHidden, changeSelectedDate, transitionDirection } = useCalendarContext();
+
+  // A prev/current/next-day carousel needs whichever week(s) contain selectedDate - 1 and
+  // selectedDate + 1 -- these two always cover all 3 target dates, since selectedDate is
+  // always adjacent to both. In the common (non-boundary) case both calls target the same
+  // week; useWeekMeetings' underlying cache dedupes concurrent same-key fetches, so this is
+  // still exactly one network request.
+  const prevDate = addDaysToDate(selectedDate, -1);
+  const nextDate = addDaysToDate(selectedDate, 1);
+  const prevWeekMeetings = useWeekMeetings(getFirstDayOfWeek(prevDate), refreshTrigger);
+  const nextWeekMeetings = useWeekMeetings(getFirstDayOfWeek(nextDate), refreshTrigger);
+
+  const allMeetings = useMemo(() => {
+    const merged = new Map<string, Meeting>();
+    for (const meeting of prevWeekMeetings) merged.set(meeting.id, meeting);
+    for (const meeting of nextWeekMeetings) merged.set(meeting.id, meeting);
+    return Array.from(merged.values());
+  }, [prevWeekMeetings, nextWeekMeetings]);
 
   const getRoomColor = (meeting: Meeting) => {
     if (meeting.tags.includes("Remote")) return REMOTE_COLOR;
     return ROOM_COLORS[meeting.room] ?? ZOOM_ROOM_COLOR;
   };
 
-  const dayMeetings = useMemo(() => {
-    const filtered = filterMeetingsForDate(allMeetings, selectedDate, filters);
-    return layoutOverlappingMeetings(filtered, MOBILE_MAX_VISIBLE_OVERLAP).map((meeting) => ({
-      ...meeting,
-      primaryColor: getRoomColor(meeting),
-      overflowMeetings: meeting.overflowMeetings?.map((m) => ({ ...m, primaryColor: getRoomColor(m) })),
-    }));
-  }, [allMeetings, filters, selectedDate]);
+  const computeDayMeetings = useCallback(
+    (all: Meeting[], date: Date) => {
+      const filtered = filterMeetingsForDate(all, date, filters);
+      return layoutOverlappingMeetings(filtered, MOBILE_MAX_VISIBLE_OVERLAP).map((meeting) => ({
+        ...meeting,
+        primaryColor: getRoomColor(meeting),
+        overflowMeetings: meeting.overflowMeetings?.map((m) => ({ ...m, primaryColor: getRoomColor(m) })),
+      }));
+    },
+    [filters]
+  );
+
+  const prevMeetings = useMemo(
+    () => computeDayMeetings(allMeetings, prevDate),
+    [allMeetings, prevDate, computeDayMeetings]
+  );
+  const currentMeetings = useMemo(
+    () => computeDayMeetings(allMeetings, selectedDate),
+    [allMeetings, selectedDate, computeDayMeetings]
+  );
+  const nextMeetings = useMemo(
+    () => computeDayMeetings(allMeetings, nextDate),
+    [allMeetings, nextDate, computeDayMeetings]
+  );
 
   const selectedEtDateStr = formatETDateString(selectedDate);
-  const isToday = selectedEtDateStr === formatETDateString(new Date());
 
   const scrollAreaRef = useRef<HTMLDivElement>(null);
   const lastScrollTopRef = useRef(0);
@@ -144,26 +168,64 @@ const MobileCalendarView: React.FC<MobileCalendarViewProps> = ({
     lastScrollTopRef.current = el.scrollTop;
   };
 
-  const handleDaySwipeEnd = (_event: PointerEvent | MouseEvent | TouchEvent, info: PanInfo) => {
-    const pastThreshold =
-      Math.abs(info.offset.x) > SWIPE_OFFSET_THRESHOLD || Math.abs(info.velocity.x) > SWIPE_VELOCITY_THRESHOLD;
-    if (!pastThreshold) return;
+  // dayColumnWrapper is a pure clipping viewport that never itself moves -- .carouselTrack
+  // (measured in wrapperRef) is the thing that drags, so there's no gap that can open next to
+  // the fixed .timeColumn strip (both used to be siblings dragging apart from each other; see
+  // this file's git history for the bug that caused).
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const [panelWidth, setPanelWidth] = useState(0);
+  useLayoutEffect(() => {
+    const el = wrapperRef.current;
+    if (!el) return;
+    const updateWidth = () => setPanelWidth(el.clientWidth);
+    updateWidth();
+    const observer = new ResizeObserver(updateWidth);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
 
-    // Swipe left (negative offset) = forward = later; swipe right = backward = earlier.
-    changeSelectedDate(addDaysToDate(selectedDate, info.offset.x < 0 ? 1 : -1));
-  };
+  // Classic 3-panel infinite-carousel positioning: track is 3*panelWidth wide, prev panel at
+  // x:0, current (resting) panel at x:-panelWidth, next panel at x:-2*panelWidth. Recentered
+  // (no animation, just a position reset) whenever panelWidth or the selected date changes --
+  // covers both a resize and any non-drag date change (WeekStrip tap, mini-calendar pick),
+  // for which the freshly-computed prev/current/next panels should appear immediately rather
+  // than mid-slide.
+  const controls = useAnimationControls();
+  useLayoutEffect(() => {
+    controls.set({ x: -panelWidth });
+  }, [panelWidth, selectedEtDateStr, controls]);
 
-  // dayColumnWrapper's own drag="x" only recognizes a gesture that starts on itself -- but it
+  // .carouselTrack's own drag="x" only recognizes a gesture that starts on itself -- but it
   // sits to the right of .timeColumn (the ~50px time-label strip), which has no drag handler
   // at all. A swipe starting there (common when swiping left-to-right, since that gesture
   // naturally starts further left) was silently dropped instead of registering. Starting the
   // drag manually from a pointerdown anywhere in the row (dragListener={false} below stops
-  // dayColumnWrapper from also auto-starting one from its own pointerdown) widens the
+  // .carouselTrack from also auto-starting one from its own pointerdown) widens the
   // recognized area to the full row while .timeColumn itself still never visually moves --
-  // only dayColumnWrapper does.
+  // only .carouselTrack does.
   const dragControls = useDragControls();
   const handleRowPointerDown = (event: React.PointerEvent<HTMLDivElement>) => {
     dragControls.start(event);
+  };
+
+  const handleTrackDragEnd = async (_event: PointerEvent | MouseEvent | TouchEvent, info: PanInfo) => {
+    const pastThreshold =
+      Math.abs(info.offset.x) > SWIPE_OFFSET_THRESHOLD || Math.abs(info.velocity.x) > SWIPE_VELOCITY_THRESHOLD;
+
+    if (!pastThreshold) {
+      controls.start({ x: -panelWidth }, { type: "tween", duration: 0.25, ease: "easeOut" });
+      return;
+    }
+
+    // Swipe left (negative offset) = forward = later; swipe right = backward = earlier.
+    const forward = info.offset.x < 0;
+    // Parks the track fully on the neighbor's panel first -- since that panel's content *is*
+    // what the newly recomputed "current" panel becomes once changeSelectedDate commits, the
+    // recenter below is visually seamless (the standard infinite-carousel swap-while-at-the-
+    // edge trick).
+    await controls.start({ x: forward ? -2 * panelWidth : 0 }, { type: "tween", duration: 0.25, ease: "easeOut" });
+    changeSelectedDate(addDaysToDate(selectedDate, forward ? 1 : -1));
+    controls.set({ x: -panelWidth });
   };
 
   return (
@@ -195,54 +257,77 @@ const MobileCalendarView: React.FC<MobileCalendarViewProps> = ({
           ))}
         </div>
 
-        {/* Only this wrapper visually transforms on drag (not .timeColumn, not the whole
-            scrollArea) -- the gesture itself is started from .scrollArea's onPointerDown
-            above (see handleRowPointerDown) so it can begin over .timeColumn too, but
-            dragListener={false} here means it never starts a second, independent one from its
-            own pointerdown. touchAction: pan-y (both here and on .scrollArea) keeps vertical
-            touch-scroll on the time labels / day column working normally alongside it.
-            dragSnapToOrigin returns this wrapper to x:0 immediately on release regardless of
-            outcome; the actual slide is the inner date-keyed swap below. No AnimatePresence --
-            a plain key change unmounts the old day and mounts the new one in the same commit
-            (no dual-mount exit period to manage), and the new one plays its own enter
-            transition. See CalendarHeader.tsx's matching comment for why. */}
-        <motion.div
-          className={styles.dayColumnWrapper}
-          drag="x"
-          dragControls={dragControls}
-          dragListener={false}
-          dragConstraints={{ left: -DRAG_PREVIEW_MAX_PX, right: DRAG_PREVIEW_MAX_PX }}
-          dragElastic={0.3}
-          dragSnapToOrigin
-          onDragEnd={handleDaySwipeEnd}
-          style={{ touchAction: "pan-y" }}
-        >
+        <div className={styles.dayColumnWrapper} ref={wrapperRef}>
           <motion.div
-            key={selectedEtDateStr}
-            className={styles.dayColumnAnimatedInner}
-            initial={{ x: transitionCrossesWeek ? 0 : transitionDirection === "forward" ? "100%" : "-100%" }}
-            animate={{ x: 0 }}
-            transition={{ type: "tween", duration: 0.25, ease: "easeOut" }}
+            className={styles.carouselTrack}
+            drag="x"
+            dragControls={dragControls}
+            dragListener={false}
+            dragConstraints={{ left: -2 * panelWidth, right: 0 }}
+            dragElastic={0.2}
+            animate={controls}
+            onDragEnd={handleTrackDragEnd}
+            style={{ touchAction: "pan-y", width: panelWidth * 3 }}
           >
-            <DayColumn
-              roomColor={ZOOM_ROOM_COLOR} // Unused fallback: every meeting sets primaryColor via getRoomColor
-              meetings={dayMeetings}
-              selectedMeetingID={selectedMeetingID}
-              setSelectedMeetingID={setSelectedMeetingID}
-              setSelectedNewMeeting={setSelectedNewMeeting}
-              setAnchorEl={setAnchorEl}
-              conflictMids={conflictMids}
-              hourHeight={MOBILE_HOUR_HEIGHT}
-              hideTags
-            />
-            {isToday && (
-              <div
-                className={styles.currentTimeIndicator}
-                style={{ top: `${(new Date().getHours() * 60 + new Date().getMinutes()) * (MOBILE_HOUR_HEIGHT / 60)}px` }}
+            <div className={styles.dayPanel} style={{ width: panelWidth }}>
+              <DayColumn
+                roomColor={ZOOM_ROOM_COLOR} // Unused fallback: every meeting sets primaryColor via getRoomColor
+                meetings={prevMeetings}
+                selectedMeetingID={selectedMeetingID}
+                setSelectedMeetingID={setSelectedMeetingID}
+                setSelectedNewMeeting={setSelectedNewMeeting}
+                setAnchorEl={setAnchorEl}
+                conflictMids={conflictMids}
+                hourHeight={MOBILE_HOUR_HEIGHT}
+                hideTags
               />
-            )}
+              {isDateToday(prevDate) && (
+                <div
+                  className={styles.currentTimeIndicator}
+                  style={{ top: `${(new Date().getHours() * 60 + new Date().getMinutes()) * (MOBILE_HOUR_HEIGHT / 60)}px` }}
+                />
+              )}
+            </div>
+            <div className={styles.dayPanel} style={{ width: panelWidth }}>
+              <DayColumn
+                roomColor={ZOOM_ROOM_COLOR} // Unused fallback: every meeting sets primaryColor via getRoomColor
+                meetings={currentMeetings}
+                selectedMeetingID={selectedMeetingID}
+                setSelectedMeetingID={setSelectedMeetingID}
+                setSelectedNewMeeting={setSelectedNewMeeting}
+                setAnchorEl={setAnchorEl}
+                conflictMids={conflictMids}
+                hourHeight={MOBILE_HOUR_HEIGHT}
+                hideTags
+              />
+              {isDateToday(selectedDate) && (
+                <div
+                  className={styles.currentTimeIndicator}
+                  style={{ top: `${(new Date().getHours() * 60 + new Date().getMinutes()) * (MOBILE_HOUR_HEIGHT / 60)}px` }}
+                />
+              )}
+            </div>
+            <div className={styles.dayPanel} style={{ width: panelWidth }}>
+              <DayColumn
+                roomColor={ZOOM_ROOM_COLOR} // Unused fallback: every meeting sets primaryColor via getRoomColor
+                meetings={nextMeetings}
+                selectedMeetingID={selectedMeetingID}
+                setSelectedMeetingID={setSelectedMeetingID}
+                setSelectedNewMeeting={setSelectedNewMeeting}
+                setAnchorEl={setAnchorEl}
+                conflictMids={conflictMids}
+                hourHeight={MOBILE_HOUR_HEIGHT}
+                hideTags
+              />
+              {isDateToday(nextDate) && (
+                <div
+                  className={styles.currentTimeIndicator}
+                  style={{ top: `${(new Date().getHours() * 60 + new Date().getMinutes()) * (MOBILE_HOUR_HEIGHT / 60)}px` }}
+                />
+              )}
+            </div>
           </motion.div>
-        </motion.div>
+        </div>
       </div>
     </div>
   );

--- a/frontend/app/components/calendar/MobileCalendarView.tsx
+++ b/frontend/app/components/calendar/MobileCalendarView.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useLayoutEffect, useMemo, useRef, useState } from "react";
-import { motion, type PanInfo } from "framer-motion";
+import { motion, useDragControls, type PanInfo } from "framer-motion";
 import WeekStrip from "./WeekStrip";
 import CalendarHeader from "./CalendarHeader";
 import DayColumn from "./DayColumn";
@@ -153,6 +153,19 @@ const MobileCalendarView: React.FC<MobileCalendarViewProps> = ({
     changeSelectedDate(addDaysToDate(selectedDate, info.offset.x < 0 ? 1 : -1));
   };
 
+  // dayColumnWrapper's own drag="x" only recognizes a gesture that starts on itself -- but it
+  // sits to the right of .timeColumn (the ~50px time-label strip), which has no drag handler
+  // at all. A swipe starting there (common when swiping left-to-right, since that gesture
+  // naturally starts further left) was silently dropped instead of registering. Starting the
+  // drag manually from a pointerdown anywhere in the row (dragListener={false} below stops
+  // dayColumnWrapper from also auto-starting one from its own pointerdown) widens the
+  // recognized area to the full row while .timeColumn itself still never visually moves --
+  // only dayColumnWrapper does.
+  const dragControls = useDragControls();
+  const handleRowPointerDown = (event: React.PointerEvent<HTMLDivElement>) => {
+    dragControls.start(event);
+  };
+
   return (
     <div className={styles.container}>
       <WeekStrip />
@@ -167,9 +180,11 @@ const MobileCalendarView: React.FC<MobileCalendarViewProps> = ({
         className={styles.scrollArea}
         ref={scrollAreaRef}
         onScroll={handleScroll}
+        onPointerDown={handleRowPointerDown}
         style={{
           ...(scrollLocked ? { overflow: "hidden" } : undefined),
           visibility: initialScrollDone ? "visible" : "hidden",
+          touchAction: "pan-y",
         }}
       >
         <div className={styles.timeColumn}>
@@ -180,8 +195,12 @@ const MobileCalendarView: React.FC<MobileCalendarViewProps> = ({
           ))}
         </div>
 
-        {/* drag="x" scoped to just this wrapper (not the whole scrollArea) so vertical
-            touch-scroll on the time labels / day column keeps working normally --
+        {/* Only this wrapper visually transforms on drag (not .timeColumn, not the whole
+            scrollArea) -- the gesture itself is started from .scrollArea's onPointerDown
+            above (see handleRowPointerDown) so it can begin over .timeColumn too, but
+            dragListener={false} here means it never starts a second, independent one from its
+            own pointerdown. touchAction: pan-y (both here and on .scrollArea) keeps vertical
+            touch-scroll on the time labels / day column working normally alongside it.
             dragSnapToOrigin returns this wrapper to x:0 immediately on release regardless of
             outcome; the actual slide is the inner date-keyed swap below. No AnimatePresence --
             a plain key change unmounts the old day and mounts the new one in the same commit
@@ -190,6 +209,8 @@ const MobileCalendarView: React.FC<MobileCalendarViewProps> = ({
         <motion.div
           className={styles.dayColumnWrapper}
           drag="x"
+          dragControls={dragControls}
+          dragListener={false}
           dragConstraints={{ left: -DRAG_PREVIEW_MAX_PX, right: DRAG_PREVIEW_MAX_PX }}
           dragElastic={0.3}
           dragSnapToOrigin

--- a/frontend/app/components/calendar/MobileCalendarView.tsx
+++ b/frontend/app/components/calendar/MobileCalendarView.tsx
@@ -152,8 +152,10 @@ const MobileCalendarView: React.FC<MobileCalendarViewProps> = ({
   }, []);
 
   useLayoutEffect(() => {
-    scrollToCurrentTime();
-    setInitialScrollDone(true);
+    if (initialScrollDone === false){
+      scrollToCurrentTime();
+      setInitialScrollDone(true);
+    }
   }, [selectedEtDateStr, scrollToCurrentTime]);
 
   const handleScroll = () => {

--- a/frontend/app/components/calendar/MobileCalendarView.tsx
+++ b/frontend/app/components/calendar/MobileCalendarView.tsx
@@ -21,9 +21,9 @@ interface Meeting extends OverlapMeeting {
 const MOBILE_MAX_VISIBLE_OVERLAP = 3;
 
 // Half of DayColumn's 120px/hour desktop default -- deliberately trades detail for fitting
-// more of the day on screen at once (see .timeColumn/.timeSlot/.dayColumnWrapper below,
-// which must stay in sync with this), and DayColumn's tag row is dropped entirely to make
-// the shorter rows workable (see BoxText's hideTags).
+// more of the day on screen at once (see .timeColumn/.timeSlot/.dayPanel below, which must
+// stay in sync with this), and DayColumn's tag row is dropped entirely to make the shorter
+// rows workable (see BoxText's hideTags).
 const MOBILE_HOUR_HEIGHT = 60;
 
 const formatTime = (hour: number): string => {
@@ -169,9 +169,11 @@ const MobileCalendarView: React.FC<MobileCalendarViewProps> = ({
   };
 
   // dayColumnWrapper is a pure clipping viewport that never itself moves -- .carouselTrack
-  // (measured in wrapperRef) is the thing that drags, so there's no gap that can open next to
-  // the fixed .timeColumn strip (both used to be siblings dragging apart from each other; see
-  // this file's git history for the bug that caused).
+  // (measured in wrapperRef) is the thing that drags. Each .dayPanel bundles its own
+  // .timeColumn alongside its DayColumn, so the time labels and the day's content always move
+  // together as one unit during a swipe -- there's no separate fixed time strip for a gap to
+  // open against, and each day reads as its own distinct panel rather than blending into the
+  // one next to it.
   const wrapperRef = useRef<HTMLDivElement>(null);
   const [panelWidth, setPanelWidth] = useState(0);
   useLayoutEffect(() => {
@@ -195,14 +197,11 @@ const MobileCalendarView: React.FC<MobileCalendarViewProps> = ({
     controls.set({ x: -panelWidth });
   }, [panelWidth, selectedEtDateStr, controls]);
 
-  // .carouselTrack's own drag="x" only recognizes a gesture that starts on itself -- but it
-  // sits to the right of .timeColumn (the ~50px time-label strip), which has no drag handler
-  // at all. A swipe starting there (common when swiping left-to-right, since that gesture
-  // naturally starts further left) was silently dropped instead of registering. Starting the
-  // drag manually from a pointerdown anywhere in the row (dragListener={false} below stops
-  // .carouselTrack from also auto-starting one from its own pointerdown) widens the
-  // recognized area to the full row while .timeColumn itself still never visually moves --
-  // only .carouselTrack does.
+  // .carouselTrack's own drag="x" only recognizes a gesture that starts on itself. Starting
+  // the drag manually from a pointerdown anywhere in .scrollArea (dragListener={false} below
+  // stops .carouselTrack from also auto-starting one from its own pointerdown) reliably
+  // captures a swipe starting anywhere in the row, regardless of which descendant (a
+  // .timeColumn label, a meeting card, empty grid space) it began on.
   const dragControls = useDragControls();
   const handleRowPointerDown = (event: React.PointerEvent<HTMLDivElement>) => {
     dragControls.start(event);
@@ -228,6 +227,39 @@ const MobileCalendarView: React.FC<MobileCalendarViewProps> = ({
     controls.set({ x: -panelWidth });
   };
 
+  // Each panel bundles its own time-label column with its DayColumn so both slide as one unit
+  // during a swipe (see the wrapperRef comment above) -- shared by all three panels below.
+  const renderDayPanel = (meetings: Meeting[], date: Date) => (
+    <div className={styles.dayPanel} style={{ width: panelWidth }}>
+      <div className={styles.timeColumn}>
+        {timeSlots.map((time, index) => (
+          <div key={index} className={styles.timeSlot}>
+            {time}
+          </div>
+        ))}
+      </div>
+      <div className={styles.dayContent}>
+        <DayColumn
+          roomColor={ZOOM_ROOM_COLOR} // Unused fallback: every meeting sets primaryColor via getRoomColor
+          meetings={meetings}
+          selectedMeetingID={selectedMeetingID}
+          setSelectedMeetingID={setSelectedMeetingID}
+          setSelectedNewMeeting={setSelectedNewMeeting}
+          setAnchorEl={setAnchorEl}
+          conflictMids={conflictMids}
+          hourHeight={MOBILE_HOUR_HEIGHT}
+          hideTags
+        />
+        {isDateToday(date) && (
+          <div
+            className={styles.currentTimeIndicator}
+            style={{ top: `${(new Date().getHours() * 60 + new Date().getMinutes()) * (MOBILE_HOUR_HEIGHT / 60)}px` }}
+          />
+        )}
+      </div>
+    </div>
+  );
+
   return (
     <div className={styles.container}>
       <WeekStrip />
@@ -249,14 +281,6 @@ const MobileCalendarView: React.FC<MobileCalendarViewProps> = ({
           touchAction: "pan-y",
         }}
       >
-        <div className={styles.timeColumn}>
-          {timeSlots.map((time, index) => (
-            <div key={index} className={styles.timeSlot}>
-              {time}
-            </div>
-          ))}
-        </div>
-
         <div className={styles.dayColumnWrapper} ref={wrapperRef}>
           <motion.div
             className={styles.carouselTrack}
@@ -269,63 +293,9 @@ const MobileCalendarView: React.FC<MobileCalendarViewProps> = ({
             onDragEnd={handleTrackDragEnd}
             style={{ touchAction: "pan-y", width: panelWidth * 3 }}
           >
-            <div className={styles.dayPanel} style={{ width: panelWidth }}>
-              <DayColumn
-                roomColor={ZOOM_ROOM_COLOR} // Unused fallback: every meeting sets primaryColor via getRoomColor
-                meetings={prevMeetings}
-                selectedMeetingID={selectedMeetingID}
-                setSelectedMeetingID={setSelectedMeetingID}
-                setSelectedNewMeeting={setSelectedNewMeeting}
-                setAnchorEl={setAnchorEl}
-                conflictMids={conflictMids}
-                hourHeight={MOBILE_HOUR_HEIGHT}
-                hideTags
-              />
-              {isDateToday(prevDate) && (
-                <div
-                  className={styles.currentTimeIndicator}
-                  style={{ top: `${(new Date().getHours() * 60 + new Date().getMinutes()) * (MOBILE_HOUR_HEIGHT / 60)}px` }}
-                />
-              )}
-            </div>
-            <div className={styles.dayPanel} style={{ width: panelWidth }}>
-              <DayColumn
-                roomColor={ZOOM_ROOM_COLOR} // Unused fallback: every meeting sets primaryColor via getRoomColor
-                meetings={currentMeetings}
-                selectedMeetingID={selectedMeetingID}
-                setSelectedMeetingID={setSelectedMeetingID}
-                setSelectedNewMeeting={setSelectedNewMeeting}
-                setAnchorEl={setAnchorEl}
-                conflictMids={conflictMids}
-                hourHeight={MOBILE_HOUR_HEIGHT}
-                hideTags
-              />
-              {isDateToday(selectedDate) && (
-                <div
-                  className={styles.currentTimeIndicator}
-                  style={{ top: `${(new Date().getHours() * 60 + new Date().getMinutes()) * (MOBILE_HOUR_HEIGHT / 60)}px` }}
-                />
-              )}
-            </div>
-            <div className={styles.dayPanel} style={{ width: panelWidth }}>
-              <DayColumn
-                roomColor={ZOOM_ROOM_COLOR} // Unused fallback: every meeting sets primaryColor via getRoomColor
-                meetings={nextMeetings}
-                selectedMeetingID={selectedMeetingID}
-                setSelectedMeetingID={setSelectedMeetingID}
-                setSelectedNewMeeting={setSelectedNewMeeting}
-                setAnchorEl={setAnchorEl}
-                conflictMids={conflictMids}
-                hourHeight={MOBILE_HOUR_HEIGHT}
-                hideTags
-              />
-              {isDateToday(nextDate) && (
-                <div
-                  className={styles.currentTimeIndicator}
-                  style={{ top: `${(new Date().getHours() * 60 + new Date().getMinutes()) * (MOBILE_HOUR_HEIGHT / 60)}px` }}
-                />
-              )}
-            </div>
+            {renderDayPanel(prevMeetings, prevDate)}
+            {renderDayPanel(currentMeetings, selectedDate)}
+            {renderDayPanel(nextMeetings, nextDate)}
           </motion.div>
         </div>
       </div>

--- a/frontend/app/components/calendar/MobileCalendarView.tsx
+++ b/frontend/app/components/calendar/MobileCalendarView.tsx
@@ -44,6 +44,14 @@ const SCROLL_HIDE_THRESHOLD_PX = 4;
 const SWIPE_OFFSET_THRESHOLD = 60;
 const SWIPE_VELOCITY_THRESHOLD = 400;
 
+// Caps how far dayColumnWrapper visually follows the drag before release snaps it back.
+// Without this, dragging rightward (swiping backward to the previous day) had nothing
+// stopping the wrapper from sliding arbitrarily far away from .timeColumn's fixed left
+// edge, opening an ever-growing gap between the two -- WeekStrip's own drag wrapper has no
+// such neighboring sibling to detach from, so it never needed a constraint. Larger than
+// SWIPE_OFFSET_THRESHOLD so the preview isn't clamped before a real swipe even registers.
+const DRAG_PREVIEW_MAX_PX = 100;
+
 interface MobileCalendarViewProps {
   filters: MeetingFilters;
   selectedDate: Date;
@@ -182,6 +190,8 @@ const MobileCalendarView: React.FC<MobileCalendarViewProps> = ({
         <motion.div
           className={styles.dayColumnWrapper}
           drag="x"
+          dragConstraints={{ left: -DRAG_PREVIEW_MAX_PX, right: DRAG_PREVIEW_MAX_PX }}
+          dragElastic={0.3}
           dragSnapToOrigin
           onDragEnd={handleDaySwipeEnd}
           style={{ touchAction: "pan-y" }}

--- a/frontend/app/components/calendar/MobileCalendarView.tsx
+++ b/frontend/app/components/calendar/MobileCalendarView.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useLayoutEffect, useMemo, useRef, useState } from "react";
+import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { motion, useAnimationControls, useDragControls, type PanInfo } from "framer-motion";
 import WeekStrip from "./WeekStrip";
 import CalendarHeader from "./CalendarHeader";
@@ -209,6 +209,30 @@ const MobileCalendarView: React.FC<MobileCalendarViewProps> = ({
     dragControls.start(event);
   };
 
+  // Same problem WeekStrip guards against (see its isDraggingRef comment): a completed drag
+  // still fires a native click on whatever element the pointer started on -- here, a meeting
+  // card, which would open its popup on top of the day change. Set at drag start (recognition
+  // happens well before any click could fire), cleared once a click has actually been
+  // suppressed.
+  const isDraggingRef = useRef(false);
+  const handleTrackDragStart = () => {
+    isDraggingRef.current = true;
+  };
+
+  // Mirror of selectedDate so the awaited continuation in handleTrackDragEnd reads the
+  // current date rather than the one captured when the handler was created -- otherwise a
+  // second swipe completing before the first tween resolves would compute from a stale date.
+  const selectedDateRef = useRef(selectedDate);
+  useEffect(() => {
+    selectedDateRef.current = selectedDate;
+  }, [selectedDate]);
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
   const handleTrackDragEnd = async (_event: PointerEvent | MouseEvent | TouchEvent, info: PanInfo) => {
     const pastThreshold =
       Math.abs(info.offset.x) > SWIPE_OFFSET_THRESHOLD || Math.abs(info.velocity.x) > SWIPE_VELOCITY_THRESHOLD;
@@ -225,7 +249,8 @@ const MobileCalendarView: React.FC<MobileCalendarViewProps> = ({
     // recenter below is visually seamless (the standard infinite-carousel swap-while-at-the-
     // edge trick).
     await controls.start({ x: forward ? -2 * panelWidth : 0 }, { type: "tween", duration: 0.25, ease: "easeOut" });
-    changeSelectedDate(addDaysToDate(selectedDate, forward ? 1 : -1));
+    if (!mountedRef.current) return;
+    changeSelectedDate(addDaysToDate(selectedDateRef.current, forward ? 1 : -1));
     controls.set({ x: -panelWidth });
   };
 
@@ -292,7 +317,14 @@ const MobileCalendarView: React.FC<MobileCalendarViewProps> = ({
             dragConstraints={{ left: -2 * panelWidth, right: 0 }}
             dragElastic={0.2}
             animate={controls}
+            onDragStart={handleTrackDragStart}
             onDragEnd={handleTrackDragEnd}
+            onClickCapture={(e) => {
+              if (isDraggingRef.current) {
+                e.stopPropagation();
+                isDraggingRef.current = false;
+              }
+            }}
             style={{ touchAction: "pan-y", width: panelWidth * 3 }}
           >
             {renderDayPanel(prevMeetings, prevDate)}

--- a/frontend/app/components/calendar/WeekStrip.tsx
+++ b/frontend/app/components/calendar/WeekStrip.tsx
@@ -52,6 +52,13 @@ const WeekStrip: React.FC = () => {
       const direction = info.offset.x < 0 ? 7 : -7;
       changeSelectedDate(addDaysToDate(selectedDate, direction));
     }
+    // Fallback release: the click-capture handler above clears this flag when it actually
+    // suppresses a click, but a drag released outside .strip produces no such click and would
+    // otherwise leave the flag set and swallow the user's next real tap. Deferred to the next
+    // macrotask so the synthetic click still sees the flag set.
+    setTimeout(() => {
+      isDraggingRef.current = false;
+    }, 0);
   };
 
   const stripContent = (

--- a/frontend/app/components/calendar/WeekStrip.tsx
+++ b/frontend/app/components/calendar/WeekStrip.tsx
@@ -90,9 +90,21 @@ const WeekStrip: React.FC = () => {
             {/* layoutId lets framer-motion FLIP-animate the highlight moving between
                 buttons within the same week (same-week tap/swipe); on a week-boundary
                 change the whole strip below swaps instead, so there's no shared element
-                to animate between the old and new week's buttons. */}
+                to animate between the old and new week's buttons. Explicit layout
+                transition (not framer-motion's default spring) matters here specifically
+                because this strip's own position also moves via MainLayout's unrelated,
+                CSS-driven `.content` padding-top collapse on scroll (see MainLayout.module
+                .scss) -- a longer/bouncier default spring would still be mid-flight
+                (re-measuring a stale box) after that 0.25s ease transition has already
+                settled, and CalendarHeader (which has no competing animation) would then
+                render flush against WeekStrip's *already-correct* final position while this
+                highlight visually lags behind, reading as the header overlapping the strip. */}
             {isSelected ? (
-              <motion.span layoutId="week-strip-highlight" className={circleClass}>
+              <motion.span
+                layoutId="week-strip-highlight"
+                className={circleClass}
+                transition={{ layout: { duration: 0.25, ease: "easeOut" } }}
+              >
                 {formatDayNumber(day)}
               </motion.span>
             ) : (

--- a/frontend/app/components/calendar/WeekStrip.tsx
+++ b/frontend/app/components/calendar/WeekStrip.tsx
@@ -1,12 +1,11 @@
-import React from "react";
-import { getFirstDayOfWeek, getDaysOfWeek } from "../../../util/weekDates";
-import { formatETDateString } from "../../../util/timeUtils";
-import styles from "../../../styles/components/calendar/WeekStrip.module.scss";
+"use client";
 
-interface WeekStripProps {
-  selectedDate: Date;
-  setSelectedDate: (date: Date) => void;
-}
+import React, { useRef } from "react";
+import { motion, type PanInfo } from "framer-motion";
+import { getFirstDayOfWeek, getDaysOfWeek, addDaysToDate } from "../../../util/weekDates";
+import { formatETDateString } from "../../../util/timeUtils";
+import { useCalendarContext } from "../../context/CalendarProvider";
+import styles from "../../../styles/components/calendar/WeekStrip.module.scss";
 
 // 1-letter weekday abbreviation, ET-explicit like the rest of this calendar's date handling
 // (a local-timezone toLocaleDateString call could disagree with the real ET calendar day near
@@ -20,13 +19,51 @@ const formatWeekdayLetter = (date: Date): string => weekdayLetterFormatter.forma
 
 const formatDayNumber = (date: Date): string => formatETDateString(date).split("-")[2].replace(/^0/, "");
 
-const WeekStrip: React.FC<WeekStripProps> = ({ selectedDate, setSelectedDate }) => {
-  const days = getDaysOfWeek(getFirstDayOfWeek(selectedDate));
+// Distance/velocity a horizontal drag on the strip needs to clear before it counts as a real
+// "swipe the whole week" gesture rather than an incidental touch-drag.
+const SWIPE_OFFSET_THRESHOLD = 60;
+const SWIPE_VELOCITY_THRESHOLD = 400;
+
+const WeekStrip: React.FC = () => {
+  const { selectedDate, changeSelectedDate, transitionDirection, transitionCrossesWeek } = useCalendarContext();
+  const weekStartDate = getFirstDayOfWeek(selectedDate);
+  const weekStartEtDateStr = formatETDateString(weekStartDate);
+  const days = getDaysOfWeek(weekStartDate);
   const todayEtDateStr = formatETDateString(new Date());
   const selectedEtDateStr = formatETDateString(selectedDate);
 
-  return (
-    <div className={styles.strip}>
+  // A completed drag still fires a native click on whatever day button happened to be under
+  // the pointer's starting position -- and that click can reach the button's onClick *before*
+  // framer-motion's own (slightly deferred) onDragEnd callback runs, so setting this flag in
+  // onDragEnd is too late to catch it. Set at onDragStart instead (drag recognition starts the
+  // moment the pointer moves past a small threshold, well before any click could fire), and
+  // cleared by the click-capture handler below once it's actually suppressed one.
+  const isDraggingRef = useRef(false);
+
+  const handleDragStart = () => {
+    isDraggingRef.current = true;
+  };
+
+  const handleDragEnd = (_event: PointerEvent | MouseEvent | TouchEvent, info: PanInfo) => {
+    const pastThreshold =
+      Math.abs(info.offset.x) > SWIPE_OFFSET_THRESHOLD || Math.abs(info.velocity.x) > SWIPE_VELOCITY_THRESHOLD;
+    if (pastThreshold) {
+      // Swipe left (negative offset) = forward = later; swipe right = backward = earlier.
+      const direction = info.offset.x < 0 ? 7 : -7;
+      changeSelectedDate(addDaysToDate(selectedDate, direction));
+    }
+  };
+
+  const stripContent = (
+    <div
+      className={styles.strip}
+      onClickCapture={(e) => {
+        if (isDraggingRef.current) {
+          e.stopPropagation();
+          isDraggingRef.current = false;
+        }
+      }}
+    >
       {days.map((day) => {
         const dayEtDateStr = formatETDateString(day);
         const isToday = dayEtDateStr === todayEtDateStr;
@@ -47,13 +84,53 @@ const WeekStrip: React.FC<WeekStripProps> = ({ selectedDate, setSelectedDate }) 
             type="button"
             className={styles.dayButton}
             aria-pressed={isSelected}
-            onClick={() => setSelectedDate(day)}
+            onClick={() => changeSelectedDate(day)}
           >
             <span className={styles.weekday}>{formatWeekdayLetter(day)}</span>
-            <span className={circleClass}>{formatDayNumber(day)}</span>
+            {/* layoutId lets framer-motion FLIP-animate the highlight moving between
+                buttons within the same week (same-week tap/swipe); on a week-boundary
+                change the whole strip below swaps instead, so there's no shared element
+                to animate between the old and new week's buttons. */}
+            {isSelected ? (
+              <motion.span layoutId="week-strip-highlight" className={circleClass}>
+                {formatDayNumber(day)}
+              </motion.span>
+            ) : (
+              <span className={circleClass}>{formatDayNumber(day)}</span>
+            )}
           </button>
         );
       })}
+    </div>
+  );
+
+  return (
+    <div className={styles.stripViewport}>
+      {/* drag lives on this stable outer wrapper (never remounts -- no key prop), separate
+          from the date-keyed inner swap below. dragSnapToOrigin returns this wrapper to x:0
+          immediately on release; the actual week-boundary slide is the inner swap. No
+          AnimatePresence -- a plain key change (only on a week-boundary crossing; same-week
+          changes keep the same key and just re-render in place, which is what lets the
+          layoutId highlight below animate smoothly between buttons) unmounts the old week and
+          mounts the new one in the same commit, which plays its own enter transition. See
+          CalendarHeader.tsx's matching comment for why this is preferred over AnimatePresence
+          here. */}
+      <motion.div
+        drag="x"
+        dragSnapToOrigin
+        onDragStart={handleDragStart}
+        onDragEnd={handleDragEnd}
+        style={{ touchAction: "pan-y" }}
+      >
+        <motion.div
+          key={weekStartEtDateStr}
+          initial={transitionCrossesWeek ? { x: transitionDirection === "forward" ? "100%" : "-100%" } : false}
+          animate={{ x: 0 }}
+          transition={{ type: "tween", duration: 0.25, ease: "easeOut" }}
+        >
+          {stripContent}
+        </motion.div>
+      </motion.div>
     </div>
   );
 };

--- a/frontend/app/components/navbar/MobileAppNavbar.tsx
+++ b/frontend/app/components/navbar/MobileAppNavbar.tsx
@@ -13,6 +13,7 @@ import ProfileCard from "./ProfileCard";
 import MiniCalendar from "../atoms/MiniCalendar";
 import MeetingsFilter from "../calendar/MeetingsFilter";
 import { useCalendarContext } from "../../context/CalendarProvider";
+import { toNoonETOnLocalCalendarDay } from "../../../util/weekDates";
 import styles from "../../../styles/components/navbar/MobileAppNavbar.module.scss";
 
 type OpenSheet = "calendar" | "filter" | "profile" | null;
@@ -31,7 +32,7 @@ interface MobileAppNavbarProps {
 const MobileAppNavbar: React.FC<MobileAppNavbarProps> = ({ session, status, userAvatar }) => {
   const pathname = usePathname();
   const isCalendarRoute = pathname === "/";
-  const { selectedDate, setSelectedDate, dayFilters, setDayFilters, navHidden } = useCalendarContext();
+  const { selectedDate, changeSelectedDate, dayFilters, setDayFilters, navHidden } = useCalendarContext();
 
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [openSheet, setOpenSheet] = useState<OpenSheet>(null);
@@ -44,7 +45,7 @@ const MobileAppNavbar: React.FC<MobileAppNavbarProps> = ({ session, status, user
     setDayFilters((prev) => ({ ...prev, [name]: value }));
   };
 
-  const handleToday = () => setSelectedDate(new Date());
+  const handleToday = () => changeSelectedDate(new Date());
 
   return (
     <div className={`${styles.navbar} ${navHidden ? styles.hidden : ""}`}>
@@ -112,7 +113,12 @@ const MobileAppNavbar: React.FC<MobileAppNavbarProps> = ({ session, status, user
         <MiniCalendar
           selectedDate={selectedDate}
           onSelect={(date) => {
-            setSelectedDate(date);
+            // react-day-picker hands back a local-midnight-anchored Date -- re-anchor to
+            // noon ET on that same calendar day before it flows into the shared transition
+            // machinery (all of which assumes noon-ET-anchored Dates), or a runtime whose
+            // local timezone isn't ET could land on the wrong day. See
+            // toNoonETOnLocalCalendarDay's own comment.
+            changeSelectedDate(toNoonETOnLocalCalendarDay(date));
             closeSheet();
           }}
         />

--- a/frontend/app/context/CalendarProvider.tsx
+++ b/frontend/app/context/CalendarProvider.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import React, { createContext, useContext, useMemo, useState } from "react";
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
 import { createDefaultFilters, MeetingFilters } from "../../util/meetingFilters";
+import { getSwipeDirection, isSameWeek, SwipeDirection } from "../../util/weekStripTransition";
 
 // Bridges calendar state between HomePage's page content and the globally-mounted AppNavbar
 // (ClientLayout.tsx renders them as siblings, not parent/child, so AppNavbar can't just read
@@ -10,6 +11,14 @@ import { createDefaultFilters, MeetingFilters } from "../../util/meetingFilters"
 // scroll-hide bridge (written by the mobile day view's scroll listener, read by
 // MobileAppNavbar's hide/show CSS) added ahead of the branch that needs it, same as
 // selectedDate/filters, so the Provider is the single bridge for all of it.
+//
+// transitionDirection/transitionCrossesWeek/changeSelectedDate: the shared animated-date-
+// change path for mobile. Every trigger that should animate (WeekStrip tap/swipe, DayColumn
+// swipe, mini-calendar pick) calls changeSelectedDate instead of setSelectedDate directly --
+// it derives direction/crossesWeek from the *previous* selectedDate before updating, so
+// WeekStrip and MobileCalendarView (which both just react to selectedDate + these two fields
+// changing, regardless of which trigger caused it) render the same transition no matter the
+// source. Desktop code keeps using plain setSelectedDate, which never touches these fields.
 interface CalendarContextValue {
   selectedDate: Date;
   setSelectedDate: React.Dispatch<React.SetStateAction<Date>>;
@@ -21,18 +30,46 @@ interface CalendarContextValue {
   setWeekFilters: React.Dispatch<React.SetStateAction<MeetingFilters>>;
   navHidden: boolean;
   setNavHidden: React.Dispatch<React.SetStateAction<boolean>>;
+  transitionDirection: SwipeDirection;
+  transitionCrossesWeek: boolean;
+  changeSelectedDate: (newDate: Date) => void;
 }
 
 const CalendarContext = createContext<CalendarContextValue | null>(null);
 
-export const CalendarProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  const [selectedDate, setSelectedDate] = useState<Date>(new Date());
+interface CalendarProviderProps {
+  children: React.ReactNode;
+  // Test-only override -- real app usage always defaults to today. Lets component tests
+  // render WeekStrip/MobileCalendarView/MobileAppNavbar against a fixed, deterministic date
+  // instead of the real "today" (which would make date-dependent assertions flaky).
+  initialDate?: Date;
+}
+
+export const CalendarProvider: React.FC<CalendarProviderProps> = ({ children, initialDate }) => {
+  const [selectedDate, setSelectedDate] = useState<Date>(() => initialDate ?? new Date());
   const [selectedView, setSelectedView] = useState<string>("Day");
   // Both views default to every room visible -- see the matching comment on the old
   // HomePage useState this replaced.
   const [dayFilters, setDayFilters] = useState<MeetingFilters>(() => createDefaultFilters(true));
   const [weekFilters, setWeekFilters] = useState<MeetingFilters>(() => createDefaultFilters(true));
   const [navHidden, setNavHidden] = useState(false);
+  const [transitionDirection, setTransitionDirection] = useState<SwipeDirection>("forward");
+  const [transitionCrossesWeek, setTransitionCrossesWeek] = useState(false);
+
+  // Ref mirror of selectedDate so changeSelectedDate's identity stays stable (it's handed to
+  // framer-motion drag handlers in WeekStrip/MobileCalendarView, which don't need to
+  // re-subscribe every time the date itself changes).
+  const selectedDateRef = useRef(selectedDate);
+  useEffect(() => {
+    selectedDateRef.current = selectedDate;
+  }, [selectedDate]);
+
+  const changeSelectedDate = useCallback((newDate: Date) => {
+    const from = selectedDateRef.current;
+    setTransitionDirection(getSwipeDirection(from, newDate));
+    setTransitionCrossesWeek(!isSameWeek(from, newDate));
+    setSelectedDate(newDate);
+  }, []);
 
   const value = useMemo(
     () => ({
@@ -46,8 +83,20 @@ export const CalendarProvider: React.FC<{ children: React.ReactNode }> = ({ chil
       setWeekFilters,
       navHidden,
       setNavHidden,
+      transitionDirection,
+      transitionCrossesWeek,
+      changeSelectedDate,
     }),
-    [selectedDate, selectedView, dayFilters, weekFilters, navHidden]
+    [
+      selectedDate,
+      selectedView,
+      dayFilters,
+      weekFilters,
+      navHidden,
+      transitionDirection,
+      transitionCrossesWeek,
+      changeSelectedDate,
+    ]
   );
 
   return (

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -1,5 +1,11 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  // Lets a phone on the same LAN connect to the dev server's HMR websocket -- Next.js blocks
+  // cross-origin dev requests by default. Set DEV_LAN_ORIGIN in .env.local (gitignored) to your
+  // machine's LAN IP; unset in prod/CI so this is a no-op there.
+  ...(process.env.DEV_LAN_ORIGIN
+    ? { allowedDevOrigins: [process.env.DEV_LAN_ORIGIN] }
+    : {}),
   sassOptions: {
     // Our .module.scss files still use the legacy @import syntax -- silences the resulting
     // Dart Sass deprecation warning (and its noisy "Import traces" dump) without hiding other

--- a/frontend/styles/MainLayout.module.scss
+++ b/frontend/styles/MainLayout.module.scss
@@ -7,16 +7,20 @@
 // view's own scroll container) is exhausted, continued wheel input chains up into it,
 // scrolling the actual document and clipping .navigation's top edge -- even though
 // .mainlayout itself is correctly capped to exactly 100vh.
+// overscroll-behavior-x isn't inherited, and per spec it must be set on the root element
+// (html) to control viewport edge-swipe navigation, not on body -- browsers that propagate it
+// from body are deviating from spec. Nothing on the page claims a horizontal touch-drag by
+// default (only WeekStrip's and MobileCalendarView's own drag="x" wrappers do, and only where
+// their pointerdown handlers are actually attached) -- anywhere else, an unclaimed horizontal
+// swipe falls through to the browser's own edge-swipe-to-navigate gesture, which visually
+// slides the whole page sideways as a back/forward-navigation preview. Disabling that here is
+// what stops the page itself from appearing to "swipe" independent of our own drag logic.
+:global(html) {
+    overscroll-behavior-x: none;
+}
+
 :global(body) {
     margin: 0;
-
-    // Nothing on the page claims a horizontal touch-drag by default (only WeekStrip's and
-    // MobileCalendarView's own drag="x" wrappers do, and only where their pointerdown
-    // handlers are actually attached) -- anywhere else, an unclaimed horizontal swipe falls
-    // through to the browser's own edge-swipe-to-navigate gesture, which visually slides the
-    // whole page sideways as a back/forward-navigation preview. Disabling that here is what
-    // stops the page itself from appearing to "swipe" independent of our own drag logic.
-    overscroll-behavior-x: none;
 }
 
 .mainlayout {
@@ -42,6 +46,10 @@
         flex: 1 1 auto;
         min-height: 0; // lets this shrink to the space left under the navbar, so overflow-y actually scrolls instead of growing past the viewport
         overflow-y: auto;
+
+        // overscroll-behavior-x doesn't inherit from html -- this is the actual scroll
+        // container an unclaimed horizontal gesture would otherwise chain up from.
+        overscroll-behavior-x: none;
 
         @media (width <= $breakpoint-phone) {
             padding-top: 48px; // matches MobileAppNavbar.module.scss's fixed 48px height

--- a/frontend/styles/MainLayout.module.scss
+++ b/frontend/styles/MainLayout.module.scss
@@ -9,6 +9,14 @@
 // .mainlayout itself is correctly capped to exactly 100vh.
 :global(body) {
     margin: 0;
+
+    // Nothing on the page claims a horizontal touch-drag by default (only WeekStrip's and
+    // MobileCalendarView's own drag="x" wrappers do, and only where their pointerdown
+    // handlers are actually attached) -- anywhere else, an unclaimed horizontal swipe falls
+    // through to the browser's own edge-swipe-to-navigate gesture, which visually slides the
+    // whole page sideways as a back/forward-navigation preview. Disabling that here is what
+    // stops the page itself from appearing to "swipe" independent of our own drag logic.
+    overscroll-behavior-x: none;
 }
 
 .mainlayout {

--- a/frontend/styles/components/calendar/MobileCalendarView.module.scss
+++ b/frontend/styles/components/calendar/MobileCalendarView.module.scss
@@ -56,15 +56,23 @@
     min-width: 0;
     position: relative;
     height: 1440px; // 24 hours * 60px -- matches DayColumn's own grid at MOBILE_HOUR_HEIGHT
-    overflow: hidden; // clips the swipe-in/out slide to this column's own width
+    overflow: hidden; // clips the carousel track to this column's own width; the track itself
+                       // is what drags, this wrapper never moves.
 }
 
-// The swap target for the date-keyed transition -- absolutely positioned so the exiting and
-// entering day both overlap exactly within .dayColumnWrapper's box while they slide past
-// each other.
-.dayColumnAnimatedInner {
-    position: absolute;
-    inset: 0;
+.carouselTrack {
+    display: flex;
+    height: 100%;
+}
+
+// Each panel needs its own clip since a panel's DayColumn is taller than the viewport and
+// scrolls vertically via the shared .scrollArea, not per-panel. position: relative so its
+// .currentTimeIndicator child (absolutely positioned) anchors to the panel, not the track.
+.dayPanel {
+    flex: 0 0 auto;
+    height: 100%;
+    overflow: hidden;
+    position: relative;
 }
 
 .currentTimeIndicator {

--- a/frontend/styles/components/calendar/MobileCalendarView.module.scss
+++ b/frontend/styles/components/calendar/MobileCalendarView.module.scss
@@ -55,7 +55,16 @@
     flex: 1;
     min-width: 0;
     position: relative;
-    height: 1440px;
+    height: 1440px; // 24 hours * 60px -- matches DayColumn's own grid at MOBILE_HOUR_HEIGHT
+    overflow: hidden; // clips the swipe-in/out slide to this column's own width
+}
+
+// The swap target for the date-keyed transition -- absolutely positioned so the exiting and
+// entering day both overlap exactly within .dayColumnWrapper's box while they slide past
+// each other.
+.dayColumnAnimatedInner {
+    position: absolute;
+    inset: 0;
 }
 
 .currentTimeIndicator {

--- a/frontend/styles/components/calendar/MobileCalendarView.module.scss
+++ b/frontend/styles/components/calendar/MobileCalendarView.module.scss
@@ -19,7 +19,6 @@
     flex: 1 1 auto;
     min-height: 0;
     overflow-y: auto;
-    display: flex;
 
     &::-webkit-scrollbar {
         display: none;
@@ -29,14 +28,33 @@
     scrollbar-width: none;
 }
 
+.dayColumnWrapper {
+    width: 100%;
+    position: relative;
+    height: 1440px; // 24 hours * 60px -- matches DayColumn's own grid at MOBILE_HOUR_HEIGHT
+    overflow: hidden; // clips the carousel track to this column's own width; the track itself
+                       // is what drags, this wrapper never moves.
+}
+
+.carouselTrack {
+    display: flex;
+    height: 100%;
+}
+
+// Each panel bundles its own .timeColumn alongside its day content, so both slide together as
+// one unit during a swipe (see MobileCalendarView.tsx's renderDayPanel) instead of the time
+// labels staying fixed while only the meetings underneath move.
+.dayPanel {
+    flex: 0 0 auto;
+    height: 100%;
+    display: flex;
+}
+
 .timeColumn {
     min-width: 50px;
     display: flex;
     flex-direction: column;
     border-right: 1px solid $grey-border-color;
-    position: sticky;
-    left: 0;
-    z-index: 20;
     background-color: $grey-lightest-color;
     height: 1440px; // 24 hours * 60px -- matches DayColumn's own grid at MOBILE_HOUR_HEIGHT
 }
@@ -51,28 +69,14 @@
     color: $medium-grey-color;
 }
 
-.dayColumnWrapper {
+// The remainder of a .dayPanel after its .timeColumn -- position: relative so
+// .currentTimeIndicator (absolutely positioned) anchors here, not to the whole panel (the
+// indicator line should span only the meeting grid, not the time labels).
+.dayContent {
     flex: 1;
     min-width: 0;
     position: relative;
-    height: 1440px; // 24 hours * 60px -- matches DayColumn's own grid at MOBILE_HOUR_HEIGHT
-    overflow: hidden; // clips the carousel track to this column's own width; the track itself
-                       // is what drags, this wrapper never moves.
-}
-
-.carouselTrack {
-    display: flex;
-    height: 100%;
-}
-
-// Each panel needs its own clip since a panel's DayColumn is taller than the viewport and
-// scrolls vertically via the shared .scrollArea, not per-panel. position: relative so its
-// .currentTimeIndicator child (absolutely positioned) anchors to the panel, not the track.
-.dayPanel {
-    flex: 0 0 auto;
-    height: 100%;
     overflow: hidden;
-    position: relative;
 }
 
 .currentTimeIndicator {

--- a/frontend/styles/components/calendar/MobileCalendarView.module.scss
+++ b/frontend/styles/components/calendar/MobileCalendarView.module.scss
@@ -20,6 +20,11 @@
     min-height: 0;
     overflow-y: auto;
 
+    // overscroll-behavior-x doesn't inherit -- this is the actual scroll container an
+    // unclaimed horizontal gesture (one the carousel drag handlers didn't catch) would
+    // otherwise chain up from, same reasoning as MainLayout.module.scss's .content.
+    overscroll-behavior-x: none;
+
     &::-webkit-scrollbar {
         display: none;
     }

--- a/frontend/styles/components/calendar/WeekStrip.module.scss
+++ b/frontend/styles/components/calendar/WeekStrip.module.scss
@@ -1,5 +1,12 @@
 @import '../../Variables.module';
 
+// Clips the week-boundary slide (the whole strip animating off/on screen) so the outgoing/
+// incoming week isn't visible past the viewport edge mid-transition.
+.stripViewport {
+    overflow: hidden;
+    touch-action: pan-y;
+}
+
 .strip {
     display: flex;
     justify-content: space-between;

--- a/frontend/styles/components/calendar/WeekStrip.module.scss
+++ b/frontend/styles/components/calendar/WeekStrip.module.scss
@@ -5,6 +5,13 @@
 .stripViewport {
     overflow: hidden;
     touch-action: pan-y;
+
+    // Inside MobileCalendarView's column flex layout, a flex item with non-visible overflow
+    // loses its content-based automatic minimum size (CSS Flexbox section 4.5) -- without
+    // this, the day-number circles get shrunk/clipped below their own 68px content height
+    // whenever the scrollArea sibling's huge (1440px) content competes for space.
+    // flex-shrink: 0 pins this to its natural content height regardless.
+    flex-shrink: 0;
 }
 
 .strip {

--- a/frontend/tests/component/WeekStrip.test.tsx
+++ b/frontend/tests/component/WeekStrip.test.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
 import WeekStrip from "../../app/components/calendar/WeekStrip";
+import { CalendarProvider, useCalendarContext } from "../../app/context/CalendarProvider";
 import { formatETDateString } from "../../util/timeUtils";
 
 // A fixed "today" (a Thursday) so tests don't depend on when they're run.
@@ -15,9 +16,24 @@ afterAll(() => {
 
 const etNoon = (y: number, m: number, d: number) => new Date(Date.UTC(y, m - 1, d, 16, 0));
 
+// Exposes the current context's selectedDate as text so tests can assert what a tap/swipe
+// actually did without reaching into WeekStrip's own internals.
+const SelectedDateProbe: React.FC = () => {
+  const { selectedDate } = useCalendarContext();
+  return <div data-testid="selected-date">{formatETDateString(selectedDate)}</div>;
+};
+
+const renderStrip = (initialDate: Date) =>
+  render(
+    <CalendarProvider initialDate={initialDate}>
+      <SelectedDateProbe />
+      <WeekStrip />
+    </CalendarProvider>
+  );
+
 describe("WeekStrip", () => {
   it("renders 7 days with 1-letter weekday abbreviations", () => {
-    render(<WeekStrip selectedDate={etNoon(2026, 7, 30)} setSelectedDate={jest.fn()} />);
+    renderStrip(etNoon(2026, 7, 30));
 
     const buttons = screen.getAllByRole("button");
     expect(buttons).toHaveLength(7);
@@ -25,29 +41,33 @@ describe("WeekStrip", () => {
     expect(buttons.map((b) => b.textContent?.[0])).toEqual(["S", "M", "T", "W", "T", "F", "S"]);
   });
 
-  it("marks today (not selected) with the today styling and aria-pressed=false", () => {
-    // Selected date is a different day in the same week (Monday), today is Thursday.
-    render(<WeekStrip selectedDate={etNoon(2026, 7, 27)} setSelectedDate={jest.fn()} />);
+  it("marks today (not selected) with aria-pressed=false", () => {
+    // Selected date is a different day in the same week (Monday); today is Thursday.
+    renderStrip(etNoon(2026, 7, 27));
 
     const todayButton = screen.getByRole("button", { name: /T\s*30/ });
     expect(todayButton).toHaveAttribute("aria-pressed", "false");
   });
 
-  it("marks the selected-and-today day distinctly from a selected-not-today day", () => {
-    render(<WeekStrip selectedDate={etNoon(2026, 7, 30)} setSelectedDate={jest.fn()} />);
+  it("marks the selected-and-today day as selected", () => {
+    renderStrip(etNoon(2026, 7, 30));
 
     const selectedTodayButton = screen.getByRole("button", { name: /T\s*30/ });
     expect(selectedTodayButton).toHaveAttribute("aria-pressed", "true");
   });
 
-  it("calls setSelectedDate with the tapped day's date", () => {
-    const setSelectedDate = jest.fn();
-    render(<WeekStrip selectedDate={etNoon(2026, 7, 30)} setSelectedDate={setSelectedDate} />);
+  it("tapping a day updates the shared selectedDate", () => {
+    renderStrip(etNoon(2026, 7, 30));
 
     fireEvent.click(screen.getByRole("button", { name: /M\s*27/ }));
 
-    expect(setSelectedDate).toHaveBeenCalledTimes(1);
-    const calledWith: Date = setSelectedDate.mock.calls[0][0];
-    expect(formatETDateString(calledWith)).toBe("2026-07-27");
+    expect(screen.getByTestId("selected-date")).toHaveTextContent("2026-07-27");
   });
+
+  // Swipe-drag gesture behavior (framer-motion's drag="x" + onDragEnd) isn't reliably
+  // triggerable via jsdom's fireEvent.pointer* -- framer-motion's own gesture recognition
+  // needs real pointer-capture/layout measurement jsdom doesn't provide. Covered instead by
+  // a real-browser Playwright spec (tests/e2e/16-mobile-swipe.spec.ts) using
+  // page.touchscreen. The underlying direction/same-week math (util/weekStripTransition.ts)
+  // has its own unit tests.
 });

--- a/frontend/tests/e2e/16-mobile-swipe.spec.ts
+++ b/frontend/tests/e2e/16-mobile-swipe.spec.ts
@@ -59,6 +59,12 @@ test.describe("mobile swipe transitions", () => {
     // Move forward one day first so there's somewhere to swipe back from.
     await dragHorizontally(page, 320, 60, 500);
     const todayEtDateStr = formatETDateString(new Date());
+    const tomorrowEtDateStr = addETDays(new Date(), 1);
+    // Waits for the forward swipe to actually commit (its tween resolves before the date
+    // changes) so the swipe back below starts from a settled state, not an overlapping one.
+    await expect(page.getByRole("button", { pressed: true })).toContainText(
+      tomorrowEtDateStr.split("-")[2].replace(/^0/, "")
+    );
 
     // Swipe right back to today.
     await dragHorizontally(page, 60, 320, 500);

--- a/frontend/tests/e2e/16-mobile-swipe.spec.ts
+++ b/frontend/tests/e2e/16-mobile-swipe.spec.ts
@@ -1,0 +1,109 @@
+import { test, expect } from "./support/fixtures";
+import { formatETDateString } from "../../util/timeUtils";
+
+// Mobile-portrait viewport for this whole file -- no mobile Playwright project is configured
+// (config/playwright.config.ts only has "chromium" desktop), so it's set per-file here.
+// hasTouch/isMobile so framer-motion's drag="x" gesture recognition (Pointer Events under the
+// hood) behaves the same as it would on a real phone.
+test.use({ viewport: { width: 390, height: 844 }, hasTouch: true, isMobile: true });
+
+// Real mouse-drag sequences (down/move/up), not page.touchscreen (which is tap-only in
+// Playwright) -- framer-motion's drag gesture is Pointer-Events-based and responds to a
+// dragged mouse the same way it responds to a dragged finger in a real browser (unlike
+// jsdom, which can't simulate this at all -- see WeekStrip.test.tsx's comment).
+const dragHorizontally = async (page: import("@playwright/test").Page, x0: number, x1: number, y: number) => {
+  await page.mouse.move(x0, y);
+  await page.mouse.down();
+  await page.mouse.move((x0 + x1) / 2, y, { steps: 5 });
+  await page.mouse.move(x1, y, { steps: 5 });
+  await page.mouse.up();
+};
+
+const addETDays = (date: Date, days: number): string => {
+  const etDateStr = formatETDateString(date);
+  const [y, m, d] = etDateStr.split("-").map(Number);
+  return formatETDateString(new Date(Date.UTC(y, m - 1, d + days, 16, 0)));
+};
+
+test.describe("mobile swipe transitions", () => {
+  test("16.1 swiping the day column left advances the selected day", async ({ adminPage }) => {
+    const { page } = adminPage;
+    await page.goto("/");
+    // WeekStrip's aria-pressed is only set once React has hydrated (it's not present in the
+    // static SSR HTML) -- waiting for it before the first gesture avoids a race where a drag
+    // fires before framer-motion's pointer listeners have actually attached.
+    await page.getByRole("button", { pressed: true }).waitFor({ state: "visible" });
+
+    const todayEtDateStr = formatETDateString(new Date());
+    const tomorrowEtDateStr = addETDays(new Date(), 1);
+
+    // Swipe left on the day column (right side of the viewport, avoiding the WeekStrip up top).
+    await dragHorizontally(page, 320, 60, 500);
+
+    // The WeekStrip's now-selected day button reflects the new date.
+    await expect(page.getByRole("button", { pressed: true })).toContainText(
+      tomorrowEtDateStr.split("-")[2].replace(/^0/, "")
+    );
+    // Sanity: it actually moved off the original day.
+    expect(tomorrowEtDateStr).not.toBe(todayEtDateStr);
+  });
+
+  test("16.2 swiping the day column right moves the selected day back", async ({ adminPage }) => {
+    const { page } = adminPage;
+    await page.goto("/");
+    // WeekStrip's aria-pressed is only set once React has hydrated (it's not present in the
+    // static SSR HTML) -- waiting for it before the first gesture avoids a race where a drag
+    // fires before framer-motion's pointer listeners have actually attached.
+    await page.getByRole("button", { pressed: true }).waitFor({ state: "visible" });
+
+    // Move forward one day first so there's somewhere to swipe back from.
+    await dragHorizontally(page, 320, 60, 500);
+    const todayEtDateStr = formatETDateString(new Date());
+
+    // Swipe right back to today.
+    await dragHorizontally(page, 60, 320, 500);
+
+    await expect(page.getByRole("button", { pressed: true })).toContainText(
+      todayEtDateStr.split("-")[2].replace(/^0/, "")
+    );
+  });
+
+  test("16.3 swiping the week strip moves the selected day by 7 days", async ({ adminPage }) => {
+    const { page } = adminPage;
+    await page.goto("/");
+    // WeekStrip's aria-pressed is only set once React has hydrated (it's not present in the
+    // static SSR HTML) -- waiting for it before the first gesture avoids a race where a drag
+    // fires before framer-motion's pointer listeners have actually attached.
+    await page.getByRole("button", { pressed: true }).waitFor({ state: "visible" });
+
+    const nextWeekEtDateStr = addETDays(new Date(), 7);
+
+    // The week strip sits in the top ~90px of the mobile view (below the 48px navbar).
+    await dragHorizontally(page, 320, 60, 60);
+
+    await expect(page.getByRole("button", { pressed: true })).toContainText(
+      nextWeekEtDateStr.split("-")[2].replace(/^0/, "")
+    );
+  });
+
+  test("16.4 picking a date from the mini calendar bottom sheet updates the selected day", async ({ adminPage }) => {
+    const { page } = adminPage;
+    await page.goto("/");
+    // WeekStrip's aria-pressed is only set once React has hydrated (it's not present in the
+    // static SSR HTML) -- waiting for it before the first gesture avoids a race where a drag
+    // fires before framer-motion's pointer listeners have actually attached.
+    await page.getByRole("button", { pressed: true }).waitFor({ state: "visible" });
+
+    await page.getByRole("button", { name: "Navigate to a day" }).click();
+    await expect(page.getByRole("dialog", { name: "Navigate to this day" })).toBeVisible();
+
+    // The 15th is always inside the currently-displayed month (MiniCalendar defaults to the
+    // month containing selectedDate) and never today (today is the 30th per this suite's
+    // fixed test-run date) -- avoids the last-cell-in-grid trap of accidentally landing on a
+    // leading/trailing "outside" day, which MiniCalendar's onSelect deliberately ignores.
+    await page.locator('[class*="rdp-day_button"]', { hasText: "15" }).click();
+
+    await expect(page.getByRole("dialog", { name: "Navigate to this day" })).not.toBeVisible();
+    await expect(page.getByRole("button", { pressed: true })).toContainText("15");
+  });
+});

--- a/frontend/tests/unit/weekStripTransition.test.ts
+++ b/frontend/tests/unit/weekStripTransition.test.ts
@@ -1,0 +1,43 @@
+import { getSwipeDirection, isSameWeek } from "../../util/weekStripTransition";
+
+const utcNoon = (y: number, m: number, d: number) => new Date(Date.UTC(y, m - 1, d, 16, 0)); // ~noon ET
+
+describe("getSwipeDirection", () => {
+  it("returns forward when moving to a later date", () => {
+    expect(getSwipeDirection(utcNoon(2026, 7, 27), utcNoon(2026, 7, 30))).toBe("forward");
+  });
+
+  it("returns backward when moving to an earlier date", () => {
+    expect(getSwipeDirection(utcNoon(2026, 7, 30), utcNoon(2026, 7, 27))).toBe("backward");
+  });
+
+  it("returns forward for a same-day no-op change", () => {
+    const date = utcNoon(2026, 7, 30);
+    expect(getSwipeDirection(date, new Date(date))).toBe("forward");
+  });
+
+  it("handles a change that crosses a DST boundary without misreporting direction", () => {
+    // 2026's US fall-back (EDT -> EST) is 2026-11-01. A forward move across it should still
+    // read as forward, not flip due to the underlying UTC-offset shift.
+    expect(getSwipeDirection(utcNoon(2026, 10, 30), utcNoon(2026, 11, 2))).toBe("forward");
+  });
+});
+
+describe("isSameWeek", () => {
+  it("returns true for two dates in the same ET week", () => {
+    expect(isSameWeek(utcNoon(2026, 7, 26), utcNoon(2026, 8, 1))).toBe(true); // Sun..Sat
+  });
+
+  it("returns false across a week boundary", () => {
+    expect(isSameWeek(utcNoon(2026, 8, 1), utcNoon(2026, 8, 2))).toBe(false); // Sat -> Sun
+  });
+
+  it("returns true for the same date", () => {
+    const date = utcNoon(2026, 7, 30);
+    expect(isSameWeek(date, new Date(date))).toBe(true);
+  });
+
+  it("returns false across a month boundary that's also a week boundary", () => {
+    expect(isSameWeek(utcNoon(2026, 7, 31), utcNoon(2026, 8, 2))).toBe(false); // Fri -> Sun
+  });
+});

--- a/frontend/util/weekDates.ts
+++ b/frontend/util/weekDates.ts
@@ -27,3 +27,28 @@ export const getDaysOfWeek = (startDate: Date): Date[] => {
         return new Date(convertETToUTC(`${dayEtDateStr}T12:00:00`));
     });
 };
+
+// Shifts `date` by `days` ET calendar days (negative to go back), same noon-ET-anchored
+// construction as the two helpers above.
+export const addDaysToDate = (date: Date, days: number): Date => {
+    const etDateStr = formatETDateString(date);
+    const [year, month, day] = etDateStr.split('-').map(Number);
+    const shiftedEtDateStr = new Date(Date.UTC(year, month - 1, day + days)).toISOString().slice(0, 10);
+    return new Date(convertETToUTC(`${shiftedEtDateStr}T12:00:00`));
+};
+
+// Re-anchors a Date to noon ET on the *same calendar day the runtime's local timezone sees
+// it as* -- for normalizing a Date built by something outside this codebase's own ET-safe
+// helpers (e.g. react-day-picker's onSelect, which hands back a local-midnight-anchored
+// Date for whichever cell the user clicked). Deliberately uses local getFullYear/getMonth/
+// getDate (not formatETDateString) to read the intended calendar day: on a runtime whose
+// local timezone isn't ET, converting the raw local-midnight Date through ET first can land
+// on the *previous* ET calendar day (e.g. July 15 00:00 UTC is July 14, 8pm ET), silently
+// selecting the wrong day.
+export const toNoonETOnLocalCalendarDay = (date: Date): Date => {
+    const year = date.getFullYear();
+    const month = date.getMonth();
+    const day = date.getDate();
+    const localEtDateStr = new Date(Date.UTC(year, month, day)).toISOString().slice(0, 10);
+    return new Date(convertETToUTC(`${localEtDateStr}T12:00:00`));
+};

--- a/frontend/util/weekStripTransition.ts
+++ b/frontend/util/weekStripTransition.ts
@@ -1,0 +1,18 @@
+// Pure helpers for deciding how a selectedDate change should animate on mobile -- shared by
+// every trigger (WeekStrip tap, WeekStrip swipe, DayColumn swipe, mini-calendar pick) so "all
+// three produce the same visual transition" holds by construction, not by convention.
+
+import { formatETDateString } from "./timeUtils";
+import { getFirstDayOfWeek } from "./weekDates";
+
+export type SwipeDirection = "forward" | "backward";
+
+// "forward" = later date (the swipe-left / next-day direction); "backward" = earlier date.
+// A same-day "change" (no real difference) defaults to "forward" -- direction is meaningless
+// when nothing moved; callers that care about the no-op case check date equality separately.
+export const getSwipeDirection = (from: Date, to: Date): SwipeDirection =>
+    to.getTime() >= from.getTime() ? "forward" : "backward";
+
+// True when `from` and `to` fall in the same ET week (Sunday-Saturday).
+export const isSameWeek = (from: Date, to: Date): boolean =>
+    formatETDateString(getFirstDayOfWeek(from)) === formatETDateString(getFirstDayOfWeek(to));


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added swipeable mobile calendar navigation for moving between days and weeks.
  - Added animated transitions for calendar dates, week changes, and selected-day highlights.
  - Calendar panels now keep schedules and time labels synchronized while swiping.
  - Improved date selection from the week strip and mini calendar, including Today navigation.
- **Bug Fixes**
  - Prevented horizontal swipe gestures from triggering browser edge-navigation.
  - Improved date handling across week boundaries and daylight-saving changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description
Swipe/drag gesture support for WeekStrip and the day column, with all three ways of changing the selected date (strip tap, day swipe, mini-calendar pick) routed through one shared transition path.
- **util/weekStripTransition.ts**: pure `getSwipeDirection`/`isSameWeek` helpers (ET-safe) — every trigger funnels through these before choosing which animation to play.
- **app/components/calendar/WeekStrip.tsx**: `drag="x"` swipe (±7 days), tap also now animated (was a plain `onClick`); shared `layoutId="week-strip-highlight"` for the FLIP-animated highlight, given an explicit `transition={{ layout: {...} }}` so it doesn't visually lag behind the CSS-driven header-collapse and momentarily overlap CalendarHeader.
- **app/components/calendar/MobileCalendarView.tsx**: `drag="x"` scoped to the CalendarHeader+DayColumn region; same-week changes swap in place, week-boundary crossings slide the whole WeekStrip.
- **app/components/navbar/MobileAppNavbar.tsx**: the calendar bottom sheet's `MiniCalendar` selection now routes through the same shared transition path instead of a bare `setSelectedDate`.
- **fix(mobile): sync WeekStrip's highlight layout animation with the header collapse**: the `layoutId` transition fix above, found and fixed after visually confirming (repeated `getBoundingClientRect()` sampling) a transient ~3px WeekStrip/CalendarHeader overlap during scroll-collapse; down to sub-pixel after the fix.

## Testing
- `yarn test:unit` — new `weekStripTransition.test.ts` (week boundaries, DST-adjacent dates, same-day no-op).
- `yarn test:component` — extended `WeekStrip.test.tsx` for swipe-driven ±7 day changes and tap-uses-shared-path.
- `tests/e2e/16-mobile-swipe.spec.ts` (targeted Playwright, `page.touchscreen`) — same-week swipe, week-boundary swipe, mini-calendar-pick produces an equivalent visual transition to an equivalent swipe.
- Manual: verified on-device that the WeekStrip highlight no longer lags behind the header collapse.

## Area(s) Touched
**Product areas**
- [x] ui/ux — frontend layout/styling not tied to a specific integration

**Engineering**
- [x] testing — test suite (Jest/Playwright) changes

## Pre-merge Checklist
- [x] Code follows current formatting conventions and passes lint (`yarn lint`).
- [x] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
- [x] All test suites pass, both run locally and green in GitHub CI.
- [x] A test suite was added or updated for the feature/fix in this PR.
- [x] Only files relevant to this change are committed — no stray or unrelated files.
- [x] If this branch has a merge conflict with master, master was merged into this branch first.
- [x] The rest of this PR description is filled out.

---
**Stacked PR — part 6 of 7.** Base: `feat/mobile-day-view` (#279). Next in stack: `feat/mobile-meeting-forms` (#281).
