### PR TITLE
feat(mobile): bottom-sheet ViewMeeting, full-screen New/Edit Meeting, FAB

### DIFF
--- a/frontend/app/(auth)/login/page.tsx
+++ b/frontend/app/(auth)/login/page.tsx
@@ -1,9 +1,7 @@
-import Image from "next/image";
 import Link from "next/link";
 import { redirect } from "next/navigation";
 import { getAuth } from "../../../services/auth";
-import GoogleSignInButton from "../../components/atoms/GoogleSignInButton";
-import IcrLogo from "../../assets/icr.png";
+import LoginCard from "../../components/atoms/LoginCard";
 import styles from "./page.module.scss";
 
 export default async function LoginPage() {
@@ -19,24 +17,7 @@ export default async function LoginPage() {
         ← Back to calendar
       </Link>
       <div className={styles.card}>
-        <Image src={IcrLogo} alt="Ithaca Community Recovery" className={styles.logo} width={72} height={72} />
-        <h1 className={styles.heading}>Sign in to manage meetings</h1>
-        <p className={styles.description}>
-          Access is invite-only for Admins and Super Admins. We&apos;ll ask for calendar
-          permission so meetings you create can publish to Google Calendar.
-        </p>
-        <GoogleSignInButton />
-        <p className={styles.footer}>
-          Not an admin? You don&apos;t need an account to view the{" "}
-          <Link href="/" className={styles.footerLink}>
-            Main Calendar
-          </Link>{" "}
-          or{" "}
-          <Link href="/signage" className={styles.footerLink}>
-            Signage
-          </Link>{" "}
-          pages.
-        </p>
+        <LoginCard />
       </div>
     </div>
   );

--- a/frontend/app/(main)/page.tsx
+++ b/frontend/app/(main)/page.tsx
@@ -65,7 +65,7 @@ export default function HomePage() {
 
   const {
     selectedDate,
-    setSelectedDate,
+    changeSelectedDate,
     selectedView,
     setSelectedView,
     dayFilters,
@@ -263,7 +263,7 @@ export default function HomePage() {
           filters={filters}
           setFilters={setFilters}
           selectedDate={selectedDate}
-          setSelectedDate={setSelectedDate}
+          setSelectedDate={changeSelectedDate}
           selectedView={selectedView}
           triggerCalendarRefresh={triggerCalendarRefresh}
           selectedMeeting={selectedMeeting}
@@ -365,7 +365,7 @@ export default function HomePage() {
           <React.Fragment>
             <CalendarNavbar
               selectedDate={selectedDate}
-              onDateChange={setSelectedDate}
+              onDateChange={changeSelectedDate}
               onViewChange={setSelectedView}
               isAdmin={isAdmin}
             />
@@ -373,7 +373,7 @@ export default function HomePage() {
               <DailyView
                 filters={filters}
                 selectedDate={selectedDate}
-                setSelectedDate={setSelectedDate}
+                setSelectedDate={changeSelectedDate}
                 selectedMeetingID={selectedMeetingID}
                 setSelectedMeetingID={setSelectedMeetingID}
                 setSelectedNewMeeting={setSelectedNewMeeting}
@@ -386,7 +386,7 @@ export default function HomePage() {
               <WeeklyView
                 filters={filters}
                 selectedDate={selectedDate}
-                setSelectedDate={setSelectedDate}
+                setSelectedDate={changeSelectedDate}
                 selectedMeetingID={selectedMeetingID}
                 setSelectedMeetingID={setSelectedMeetingID}
                 setSelectedNewMeeting={setSelectedNewMeeting}

--- a/frontend/app/(main)/page.tsx
+++ b/frontend/app/(main)/page.tsx
@@ -7,6 +7,10 @@ import ViewMeetingDetails from "../components/meeting-form/ViewMeeting";
 import DailyView from "../components/calendar/DailyView";
 import WeeklyView from "../components/calendar/WeeklyView";
 import MobileCalendarView from "../components/calendar/MobileCalendarView";
+import MobileFullScreenSheet from "../components/atoms/MobileFullScreenSheet";
+import MobileFab from "../components/calendar/MobileFab";
+import NewMeetingSidebar from "../components/meeting-form/NewMeeting";
+import EditMeetingSidebar from "../components/meeting-form/EditMeeting";
 
 import { convertUTCToET } from "../../util/timeUtils";
 import { IMeeting } from "../../util/models";
@@ -73,6 +77,10 @@ export default function HomePage() {
   const [selectedMeetingID, setSelectedMeetingID] = useState<string | null>(null);
   const [, setSelectedNewMeeting] = useState<boolean | null>(false);
   const [showEditMeeting, setShowEditMeeting] = useState(false);
+  // Lifted here (rather than owned by CalendarSidebarShell, which isn't mounted at all on
+  // phone) so mobile's full-screen New Meeting form and desktop's embedded sidebar form
+  // share one source of truth.
+  const [isNewMeetingOpen, setIsNewMeetingOpen] = useState(false);
   const [lastClickedDate, setLastClickedDate] = useState<Date | null>(null);
   // The clicked meeting box, so the View Meeting popup can anchor itself beside it.
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
@@ -246,8 +254,8 @@ export default function HomePage() {
   return (
     <div className={styles.container}>
       {/* No sidebar on mobile -- filters/mini-calendar move into MobileAppNavbar's bottom
-          sheets instead (see CalendarProvider/MobileAppNavbar). New/Edit Meeting's mobile
-          full-screen equivalent lands in a later branch. */}
+          sheets instead (see CalendarProvider/MobileAppNavbar); New/Edit Meeting instead get
+          the full-screen sheets rendered below. */}
       {!isPhone && (
         <CalendarSidebarShell
           isLoggedIn={isLoggedIn}
@@ -261,7 +269,31 @@ export default function HomePage() {
           selectedMeeting={selectedMeeting}
           showEditMeeting={showEditMeeting}
           onCloseEdit={handleCloseEdit}
+          isNewMeetingOpen={isNewMeetingOpen}
+          setIsNewMeetingOpen={setIsNewMeetingOpen}
         />
+      )}
+      {isPhone && isAdmin && (
+        <React.Fragment>
+          <MobileFullScreenSheet isOpen={isNewMeetingOpen}>
+            <NewMeetingSidebar
+              setIsNewMeetingOpen={setIsNewMeetingOpen}
+              triggerCalendarRefresh={triggerCalendarRefresh}
+              selectedDate={selectedDate}
+              selectedView={selectedView}
+            />
+          </MobileFullScreenSheet>
+          <MobileFullScreenSheet isOpen={showEditMeeting && !!selectedMeeting}>
+            {selectedMeeting && (
+              <EditMeetingSidebar
+                meeting={selectedMeeting}
+                onClose={handleCloseEdit}
+                onUpdateSuccess={triggerCalendarRefresh}
+              />
+            )}
+          </MobileFullScreenSheet>
+          <MobileFab onClick={() => setIsNewMeetingOpen(true)} />
+        </React.Fragment>
       )}
       {selectedMeeting && !showEditMeeting && (
         <ViewMeetingDetails
@@ -307,6 +339,7 @@ export default function HomePage() {
           conflictCount={conflictCounts.get(selectedMeeting.mid) ?? 0}
           currentOccurrenceDate={lastClickedDate || undefined} // Pass the date when the meeting was clicked
           anchorEl={anchorEl}
+          isPhone={isPhone}
           isAdmin={isAdmin}
           onBack={handleBack}
           onEdit={handleOpenEdit}

--- a/frontend/app/components/atoms/BottomSheet.tsx
+++ b/frontend/app/components/atoms/BottomSheet.tsx
@@ -10,6 +10,9 @@ interface BottomSheetProps {
   onClose: () => void;
   title: string;
   children: React.ReactNode;
+  // For content (e.g. ViewMeeting) that already renders its own visible header/title --
+  // title is still required for the dialog's accessible name, just not shown a second time.
+  hideTitleVisually?: boolean;
 }
 
 // Dragging down past this offset (or fast enough downward, regardless of distance) dismisses
@@ -18,7 +21,13 @@ interface BottomSheetProps {
 const DISMISS_OFFSET_PX = 100;
 const DISMISS_VELOCITY = 500;
 
-const BottomSheet: React.FC<BottomSheetProps> = ({ isOpen, onClose, title, children }) => {
+const BottomSheet: React.FC<BottomSheetProps> = ({
+  isOpen,
+  onClose,
+  title,
+  children,
+  hideTitleVisually = false,
+}) => {
   const sheetRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -76,12 +85,16 @@ const BottomSheet: React.FC<BottomSheetProps> = ({ isOpen, onClose, title, child
             exit={{ y: "100%" }}
             transition={{ type: "tween", duration: 0.25, ease: "easeOut" }}
             drag="y"
-            dragConstraints={{ top: 0, bottom: 0 }}
+            // bottom intentionally unbounded (not 0) -- a {top:0, bottom:0} constraint locks
+            // y in place entirely, which also clamps the exit animation's own y:"100%" target
+            // since drag constraints apply to programmatic animation of the same value, not
+            // just user dragging (same bug class WeekStrip's swipe hit, see its own comment).
+            dragConstraints={{ top: 0, bottom: Infinity }}
             dragElastic={{ top: 0, bottom: 0.5 }}
             onDragEnd={handleDragEnd}
           >
             <div className={styles.grabber} />
-            <h2 className={styles.title}>{title}</h2>
+            <h2 className={hideTitleVisually ? styles.titleVisuallyHidden : styles.title}>{title}</h2>
             <div className={styles.content}>{children}</div>
           </motion.div>
         </React.Fragment>

--- a/frontend/app/components/atoms/LoginCard.tsx
+++ b/frontend/app/components/atoms/LoginCard.tsx
@@ -1,0 +1,34 @@
+import Image from "next/image";
+import Link from "next/link";
+import IcrLogo from "../../assets/icr.png";
+import GoogleSignInButton from "./GoogleSignInButton";
+import styles from "../../../styles/components/atoms/LoginCard.module.scss";
+
+// The sign-in card content shared by the /login route (page.tsx, reached by direct
+// navigation/desktop) and MobileLoginSheet (a full-screen slide-in overlay reached from the
+// mobile navbar's signed-out profile button) -- kept as one component so the two surfaces
+// can't drift out of sync.
+const LoginCard: React.FC = () => (
+  <div className={styles.card}>
+    <Image src={IcrLogo} alt="Ithaca Community Recovery" className={styles.logo} width={72} height={72} />
+    <h1 className={styles.heading}>Sign in to manage meetings</h1>
+    <p className={styles.description}>
+      Access is invite-only for Admins and Super Admins. We&apos;ll ask for calendar
+      permission so meetings you create can publish to Google Calendar.
+    </p>
+    <GoogleSignInButton />
+    <p className={styles.footer}>
+      Not an admin? You don&apos;t need an account to view the{" "}
+      <Link href="/" className={styles.footerLink}>
+        Main Calendar
+      </Link>{" "}
+      or{" "}
+      <Link href="/signage" className={styles.footerLink}>
+        Signage
+      </Link>{" "}
+      pages.
+    </p>
+  </div>
+);
+
+export default LoginCard;

--- a/frontend/app/components/atoms/MobileFullScreenSheet.tsx
+++ b/frontend/app/components/atoms/MobileFullScreenSheet.tsx
@@ -8,23 +8,29 @@ import styles from "../../../styles/components/atoms/MobileFullScreenSheet.modul
 interface MobileFullScreenSheetProps {
   isOpen: boolean;
   children: React.ReactNode;
+  // "bottom" (default) for New/Edit Meeting; "right" for the profile-icon -> login slide-in
+  // (MobileLoginSheet), which per spec slides in from the right instead of sliding up.
+  slideFrom?: "bottom" | "right";
 }
 
-// Full-screen slide-up wrapper for New/Edit Meeting on mobile -- a simple, standard
-// conditional-render-inside-AnimatePresence (not a repeatedly-key-swapped child), which is
-// the case AnimatePresence's exit/unmount actually handles reliably (see WeekStrip.tsx's
-// comment for the pattern that doesn't).
-const MobileFullScreenSheet: React.FC<MobileFullScreenSheetProps> = ({ isOpen, children }) => {
+// Full-screen slide wrapper for New/Edit Meeting and the mobile login sheet -- a simple,
+// standard conditional-render-inside-AnimatePresence (not a repeatedly-key-swapped child),
+// which is the case AnimatePresence's exit/unmount actually handles reliably (see
+// WeekStrip.tsx's comment for the pattern that doesn't).
+const MobileFullScreenSheet: React.FC<MobileFullScreenSheetProps> = ({ isOpen, children, slideFrom = "bottom" }) => {
   if (typeof document === "undefined") return null;
+
+  const offscreen = slideFrom === "right" ? { x: "100%" } : { y: "100%" };
+  const onscreen = slideFrom === "right" ? { x: 0 } : { y: 0 };
 
   return createPortal(
     <AnimatePresence>
       {isOpen && (
         <motion.div
           className={styles.fullScreen}
-          initial={{ y: "100%" }}
-          animate={{ y: 0 }}
-          exit={{ y: "100%" }}
+          initial={offscreen}
+          animate={onscreen}
+          exit={offscreen}
           transition={{ type: "tween", duration: 0.25, ease: "easeOut" }}
         >
           {children}

--- a/frontend/app/components/atoms/MobileFullScreenSheet.tsx
+++ b/frontend/app/components/atoms/MobileFullScreenSheet.tsx
@@ -2,8 +2,14 @@
 
 import React from "react";
 import { createPortal } from "react-dom";
-import { AnimatePresence, motion } from "framer-motion";
+import { AnimatePresence, motion, type PanInfo } from "framer-motion";
 import styles from "../../../styles/components/atoms/MobileFullScreenSheet.module.scss";
+
+// Distance/velocity a drag needs to clear before it counts as "swipe to dismiss" -- same
+// thresholds BottomSheet's own drag-to-dismiss uses, for a consistent feel across the app's
+// swipe-to-dismiss surfaces.
+const DISMISS_OFFSET_PX = 100;
+const DISMISS_VELOCITY = 500;
 
 interface MobileFullScreenSheetProps {
   isOpen: boolean;
@@ -11,17 +17,51 @@ interface MobileFullScreenSheetProps {
   // "bottom" (default) for New/Edit Meeting; "right" for the profile-icon -> login slide-in
   // (MobileLoginSheet), which per spec slides in from the right instead of sliding up.
   slideFrom?: "bottom" | "right";
+  // Opt-in drag-to-dismiss, in the same direction this sheet slides back out to (right for
+  // "right", down for "bottom") -- e.g. MobileLoginSheet's swipe-back gesture. Off by default
+  // (undefined) so New/Edit Meeting's scrollable form fields aren't affected by a gesture they
+  // never asked for.
+  onSwipeDismiss?: () => void;
 }
 
 // Full-screen slide wrapper for New/Edit Meeting and the mobile login sheet -- a simple,
 // standard conditional-render-inside-AnimatePresence (not a repeatedly-key-swapped child),
 // which is the case AnimatePresence's exit/unmount actually handles reliably (see
 // WeekStrip.tsx's comment for the pattern that doesn't).
-const MobileFullScreenSheet: React.FC<MobileFullScreenSheetProps> = ({ isOpen, children, slideFrom = "bottom" }) => {
+const MobileFullScreenSheet: React.FC<MobileFullScreenSheetProps> = ({
+  isOpen,
+  children,
+  slideFrom = "bottom",
+  onSwipeDismiss,
+}) => {
   if (typeof document === "undefined") return null;
 
   const offscreen = slideFrom === "right" ? { x: "100%" } : { y: "100%" };
   const onscreen = slideFrom === "right" ? { x: 0 } : { y: 0 };
+
+  const handleDragEnd = (_event: PointerEvent | MouseEvent | TouchEvent, info: PanInfo) => {
+    const past =
+      slideFrom === "right"
+        ? info.offset.x > DISMISS_OFFSET_PX || info.velocity.x > DISMISS_VELOCITY
+        : info.offset.y > DISMISS_OFFSET_PX || info.velocity.y > DISMISS_VELOCITY;
+    if (past) onSwipeDismiss?.();
+  };
+
+  // touchAction: "pan-y" so a vertical scroll inside (e.g. LoginCard content taller than the
+  // viewport) still passes through natively alongside the horizontal drag recognition -- same
+  // reasoning as MobileCalendarView's .scrollArea/.carouselTrack, the other place a horizontal
+  // drag and vertical scroll need to coexist on the same element. Only meaningful when
+  // slideFrom is "right" (an "x" drag); the "bottom" case drags "y", the same axis as the
+  // scroll it's already layered on, so there's no orthogonal gesture to keep separate.
+  const dragProps = onSwipeDismiss
+    ? {
+        drag: (slideFrom === "right" ? "x" : "y") as "x" | "y",
+        dragConstraints: slideFrom === "right" ? { left: 0, right: Infinity } : { top: 0, bottom: Infinity },
+        dragElastic: slideFrom === "right" ? { left: 0, right: 0.5 } : { top: 0, bottom: 0.5 },
+        onDragEnd: handleDragEnd,
+        ...(slideFrom === "right" ? { style: { touchAction: "pan-y" } } : {}),
+      }
+    : {};
 
   return createPortal(
     <AnimatePresence>
@@ -32,6 +72,7 @@ const MobileFullScreenSheet: React.FC<MobileFullScreenSheetProps> = ({ isOpen, c
           animate={onscreen}
           exit={offscreen}
           transition={{ type: "tween", duration: 0.25, ease: "easeOut" }}
+          {...dragProps}
         >
           {children}
         </motion.div>

--- a/frontend/app/components/atoms/MobileFullScreenSheet.tsx
+++ b/frontend/app/components/atoms/MobileFullScreenSheet.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import React from "react";
+import { createPortal } from "react-dom";
+import { AnimatePresence, motion } from "framer-motion";
+import styles from "../../../styles/components/atoms/MobileFullScreenSheet.module.scss";
+
+interface MobileFullScreenSheetProps {
+  isOpen: boolean;
+  children: React.ReactNode;
+}
+
+// Full-screen slide-up wrapper for New/Edit Meeting on mobile -- a simple, standard
+// conditional-render-inside-AnimatePresence (not a repeatedly-key-swapped child), which is
+// the case AnimatePresence's exit/unmount actually handles reliably (see WeekStrip.tsx's
+// comment for the pattern that doesn't).
+const MobileFullScreenSheet: React.FC<MobileFullScreenSheetProps> = ({ isOpen, children }) => {
+  if (typeof document === "undefined") return null;
+
+  return createPortal(
+    <AnimatePresence>
+      {isOpen && (
+        <motion.div
+          className={styles.fullScreen}
+          initial={{ y: "100%" }}
+          animate={{ y: 0 }}
+          exit={{ y: "100%" }}
+          transition={{ type: "tween", duration: 0.25, ease: "easeOut" }}
+        >
+          {children}
+        </motion.div>
+      )}
+    </AnimatePresence>,
+    document.body
+  );
+};
+
+export default MobileFullScreenSheet;

--- a/frontend/app/components/atoms/TagList.tsx
+++ b/frontend/app/components/atoms/TagList.tsx
@@ -50,7 +50,13 @@ const TagList: React.FC<TagListProps> = ({ tags, color, gap = 3, containerStyle,
 
       let node = container.parentElement;
       let clipAncestor: HTMLElement | null = null;
-      while (node) {
+      // Stop before document.body/documentElement -- BottomSheet (mobile ViewMeeting's
+      // wrapper) toggles document.body.style.overflow = 'hidden' as a scroll-lock while open,
+      // which would otherwise get picked up here as a false "clipping ancestor" and cap tags
+      // to whatever tiny sliver of body height happens to sit below this row, even though
+      // there's plenty of horizontal room and ViewMeeting is meant to get an unlimited budget
+      // (see this effect's own comment above).
+      while (node && node !== document.body && node !== document.documentElement) {
         const cs = getComputedStyle(node);
         if (cs.overflow === 'hidden' || cs.overflowY === 'hidden' || cs.overflow === 'clip' || cs.overflowY === 'clip') {
           clipAncestor = node;

--- a/frontend/app/components/calendar/CalendarSidebarShell.tsx
+++ b/frontend/app/components/calendar/CalendarSidebarShell.tsx
@@ -15,7 +15,7 @@ interface CalendarSidebarShellProps {
   filters: MeetingFilters;
   setFilters: React.Dispatch<React.SetStateAction<MeetingFilters>>;
   selectedDate: Date;
-  setSelectedDate: React.Dispatch<React.SetStateAction<Date>>;
+  setSelectedDate: (date: Date) => void;
   selectedView: string;
   triggerCalendarRefresh: () => void;
   selectedMeeting: IMeeting | null;

--- a/frontend/app/components/calendar/CalendarSidebarShell.tsx
+++ b/frontend/app/components/calendar/CalendarSidebarShell.tsx
@@ -21,6 +21,11 @@ interface CalendarSidebarShellProps {
   selectedMeeting: IMeeting | null;
   showEditMeeting: boolean;
   onCloseEdit: () => void;
+  // Lifted to HomePage so mobile's full-screen New Meeting form (a separate render path,
+  // this shell isn't mounted at all on phone) shares the same source of truth instead of a
+  // second, independent boolean.
+  isNewMeetingOpen: boolean;
+  setIsNewMeetingOpen: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 // Matches the staggered fade durations set on .sidebarLayerOutgoing/.sidebarLayerEntered in
@@ -60,9 +65,10 @@ const CalendarSidebarShell: React.FC<CalendarSidebarShellProps> = ({
   selectedMeeting,
   showEditMeeting,
   onCloseEdit,
+  isNewMeetingOpen,
+  setIsNewMeetingOpen,
 }) => {
   const { isCompact, collapseSidebar, expandSidebar } = useSidebar();
-  const [isNewMeetingOpen, setIsNewMeetingOpen] = useState(false);
   useBreakpoint(collapseSidebar, expandSidebar);
 
   // Drives the full <-> compact staggered cross-fade. renderedMode is the "live" (interactive)

--- a/frontend/app/components/calendar/MobileCalendarView.tsx
+++ b/frontend/app/components/calendar/MobileCalendarView.tsx
@@ -135,8 +135,8 @@ const MobileCalendarView: React.FC<MobileCalendarViewProps> = ({
   // same flash DailyView/WeeklyView's own scrollToCurrentTime has always had (a beat of the
   // wrong scroll position at 12 AM before JS jumps it to "now"), which useLayoutEffect alone
   // doesn't fully rule out (e.g. a slow first paint). One-way: only ever flips true once, on
-  // the very first date this view renders -- later date changes don't re-hide already-
-  // visible content.
+  // the very first date this view renders -- later date changes (day swipe/tap/mini-calendar
+  // pick) reset scroll position same as always but don't re-hide already-visible content.
   const [initialScrollDone, setInitialScrollDone] = useState(false);
 
   const scrollToCurrentTime = useCallback(() => {

--- a/frontend/app/components/calendar/MobileCalendarView.tsx
+++ b/frontend/app/components/calendar/MobileCalendarView.tsx
@@ -78,7 +78,8 @@ const MobileCalendarView: React.FC<MobileCalendarViewProps> = ({
   conflictMids,
   isAdmin,
 }) => {
-  const { setNavHidden, changeSelectedDate, transitionDirection } = useCalendarContext();
+  const { setNavHidden, changeSelectedDate, transitionDirection, transitionAlreadyAnimatedByCaller } =
+    useCalendarContext();
 
   // A prev/current/next-day carousel needs whichever week(s) contain selectedDate - 1 and
   // selectedDate + 1 -- these two always cover all 3 target dates, since selectedDate is
@@ -228,6 +229,12 @@ const MobileCalendarView: React.FC<MobileCalendarViewProps> = ({
   }, [selectedDate]);
   const mountedRef = useRef(true);
   useEffect(() => {
+    // Reset (not just declare via useRef(true)) on every effect run, not only cleanup -- React
+    // 18 Strict Mode's dev-only mount/cleanup/remount dance on initial mount runs this cleanup
+    // once before the "real" mount settles, which would otherwise leave this stuck at false
+    // forever despite the component actually being mounted (exactly what was silently no-op'ing
+    // every mobile day-swipe's changeSelectedDate call).
+    mountedRef.current = true;
     return () => {
       mountedRef.current = false;
     };
@@ -250,12 +257,18 @@ const MobileCalendarView: React.FC<MobileCalendarViewProps> = ({
     // edge trick).
     await controls.start({ x: forward ? -2 * panelWidth : 0 }, { type: "tween", duration: 0.25, ease: "easeOut" });
     if (!mountedRef.current) return;
-    changeSelectedDate(addDaysToDate(selectedDateRef.current, forward ? 1 : -1));
+    changeSelectedDate(addDaysToDate(selectedDateRef.current, forward ? 1 : -1), { alreadyAnimatedByCaller: true });
     controls.set({ x: -panelWidth });
   };
 
   // Each panel bundles its own time-label column with its DayColumn so both slide as one unit
   // during a swipe (see the wrapperRef comment above) -- shared by all three panels below.
+  // The inner motion.div plays CalendarHeader's own slide-in (same direction/duration, driven
+  // by the same transitionDirection) so the day grid visibly moves together with the heading
+  // for WeekStrip taps and mini-calendar picks -- previously only the heading animated, since a
+  // drag's own pan is the only thing that ever moved this carousel. initial={false} suppresses
+  // it specifically for drag-committed changes (transitionAlreadyAnimatedByCaller, set by this
+  // view's own handleTrackDragEnd), where the pan gesture itself already was that motion.
   const renderDayPanel = (meetings: Meeting[], date: Date) => (
     <div className={styles.dayPanel} style={{ width: panelWidth }}>
       <div className={styles.timeColumn}>
@@ -266,17 +279,28 @@ const MobileCalendarView: React.FC<MobileCalendarViewProps> = ({
         ))}
       </div>
       <div className={styles.dayContent}>
-        <DayColumn
-          roomColor={ZOOM_ROOM_COLOR} // Unused fallback: every meeting sets primaryColor via getRoomColor
-          meetings={meetings}
-          selectedMeetingID={selectedMeetingID}
-          setSelectedMeetingID={setSelectedMeetingID}
-          setSelectedNewMeeting={setSelectedNewMeeting}
-          setAnchorEl={setAnchorEl}
-          conflictMids={conflictMids}
-          hourHeight={MOBILE_HOUR_HEIGHT}
-          hideTags
-        />
+        <motion.div
+          key={formatETDateString(date)}
+          initial={
+            transitionAlreadyAnimatedByCaller
+              ? false
+              : { x: transitionDirection === "forward" ? 24 : -24, opacity: 0 }
+          }
+          animate={{ x: 0, opacity: 1 }}
+          transition={{ duration: 0.25, ease: "easeOut" }}
+        >
+          <DayColumn
+            roomColor={ZOOM_ROOM_COLOR} // Unused fallback: every meeting sets primaryColor via getRoomColor
+            meetings={meetings}
+            selectedMeetingID={selectedMeetingID}
+            setSelectedMeetingID={setSelectedMeetingID}
+            setSelectedNewMeeting={setSelectedNewMeeting}
+            setAnchorEl={setAnchorEl}
+            conflictMids={conflictMids}
+            hourHeight={MOBILE_HOUR_HEIGHT}
+            hideTags
+          />
+        </motion.div>
         {isDateToday(date) && (
           <div
             className={styles.currentTimeIndicator}

--- a/frontend/app/components/calendar/MobileFab.tsx
+++ b/frontend/app/components/calendar/MobileFab.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import IconButton from "../atoms/IconButton";
+import styles from "../../../styles/components/calendar/MobileFab.module.scss";
+
+interface MobileFabProps {
+  onClick: () => void;
+}
+
+// Pinned bottom-left, rendered as a page-level sibling outside MobileCalendarView's swipe
+// region (see MobileCalendarView.tsx's DayColumn drag wrapper) so the drag gesture never
+// swallows a tap intended for this button.
+const MobileFab: React.FC<MobileFabProps> = ({ onClick }) => {
+  return (
+    <div className={styles.fabWrapper}>
+      <IconButton
+        icon={<img src="/svg/plus-icon-white.svg" alt="" />}
+        ariaLabel="New meeting"
+        variant="filled"
+        backgroundColor="#CC3366" // $brand-pink-color -- IconButton takes a literal color, can't reference the SCSS var directly (same manual-sync convention as CompactCalendarSidebar's matching FAB)
+        onClick={onClick}
+      />
+    </div>
+  );
+};
+
+export default MobileFab;

--- a/frontend/app/components/calendar/MobileFab.tsx
+++ b/frontend/app/components/calendar/MobileFab.tsx
@@ -6,7 +6,7 @@ interface MobileFabProps {
   onClick: () => void;
 }
 
-// Pinned bottom-left, rendered as a page-level sibling outside MobileCalendarView's swipe
+// Pinned bottom-right, rendered as a page-level sibling outside MobileCalendarView's swipe
 // region (see MobileCalendarView.tsx's DayColumn drag wrapper) so the drag gesture never
 // swallows a tap intended for this button.
 const MobileFab: React.FC<MobileFabProps> = ({ onClick }) => {

--- a/frontend/app/components/meeting-form/ViewMeeting.tsx
+++ b/frontend/app/components/meeting-form/ViewMeeting.tsx
@@ -4,6 +4,7 @@ import styles from '../../../styles/components/meeting-form/ViewMeeting.module.s
 import DeleteRecurringModal from './DeleteRecurringModal';
 import DeleteMeetingModal from './DeleteMeetingModal';
 import TagList from '../atoms/TagList';
+import BottomSheet from '../atoms/BottomSheet';
 
 import { IRecurrencePattern } from '../../../util/models';
 import { formatCompactTimeRange, formatMeetingDateLine } from "../../../util/timeFormat";
@@ -58,6 +59,9 @@ type ViewMeetingDetailsProps = {
   conflictCount?: number;
   // The clicked meeting box, so the popup can anchor itself beside it.
   anchorEl: HTMLElement | null;
+  // Renders inside a bottom sheet instead of the desktop anchor-positioned popup -- no
+  // anchorEl/popupPosition math needed there (BottomSheet is always bottom-fixed).
+  isPhone?: boolean;
   // Gates the email row, Zoom host row, and the Edit/Delete kebab menu -- all of them are
   // either PII or actions a non-admin viewer can't act on (the backend already rejects the
   // writes; this just stops the UI from offering them in the first place). null while the
@@ -93,6 +97,7 @@ const ViewMeetingDetails: React.FC<ViewMeetingDetailsProps> = ({
   zoomSyncError: initialZoomSyncError,
   conflictCount = 0,
   anchorEl,
+  isPhone = false,
   isAdmin,
   onBack,
   onEdit,
@@ -177,8 +182,15 @@ const ViewMeetingDetails: React.FC<ViewMeetingDetailsProps> = ({
   }, [!!popupPosition]);
 
   // Closes the whole popup on an outside click -- clicks on the anchor box itself are left
-  // alone since that box's own onClick already handles re-selecting/toggling it.
+  // alone since that box's own onClick already handles re-selecting/toggling it. Desktop
+  // only: popupRef is never attached on phone (that branch renders inside BottomSheet, not
+  // the ref={popupRef} div below), so popupRef.current would always be null there --
+  // treating *every* click, including ones inside the sheet's own kebab menu, as "outside"
+  // and closing it immediately. BottomSheet already has its own correct backdrop-click-to-
+  // close handling for the phone case, so this effect simply doesn't need to run there.
   useEffect(() => {
+    if (isPhone) return;
+
     const handleClickOutside = (event: MouseEvent) => {
       const target = event.target as Node;
       if (popupRef.current?.contains(target)) return;
@@ -188,7 +200,7 @@ const ViewMeetingDetails: React.FC<ViewMeetingDetailsProps> = ({
 
     document.addEventListener('mousedown', handleClickOutside);
     return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, [anchorEl, onBack]);
+  }, [anchorEl, onBack, isPhone]);
 
   // Closes just the kebab dropdown on an outside click, independent of the popup-level one above.
   useEffect(() => {
@@ -339,49 +351,42 @@ const ViewMeetingDetails: React.FC<ViewMeetingDetailsProps> = ({
   const primaryLocation = room || (zoomRoom ? stripZoomSuffix(zoomRoom) : '');
   const showZoomMismatchRow = !!(room && zoomRoom && isZoomRoomMismatched(room, zoomRoom));
 
-  if (!anchorEl || !popupPosition) return null;
+  const content = (
+    <div className={styles.meetingDetails}>
+      <div className={styles.header}>
+        <button className={styles.backButton} onClick={onBack}>
+          <img src="/svg/back-arrow.svg" alt="Back" />
+        </button>
+        <h1>{title}</h1>
+        <span
+          className={styles.settingLabel}
+          style={{ backgroundColor: primaryColor, borderColor: primaryColor }}
+        >
+          {modeType}
+        </span>
+        {isAdmin && (
+          <div className={styles.moreOptions} ref={kebabRef}>
+            <button
+              aria-label="Meeting options"
+              aria-expanded={kebabOpen}
+              onClick={() => setKebabOpen((open) => !open)}
+            >
+              ⋮
+            </button>
+            {kebabOpen && (
+              <div className={styles.optionsMenu}>
+                <button onClick={() => { setKebabOpen(false); onEdit(); }}>Edit</button>
+                <button className={styles.deleteOption} onClick={handleDelete}>Delete</button>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
 
-  return createPortal(
-    <div
-      ref={popupRef}
-      className={styles.popupAnchor}
-      style={{ top: popupPosition.top, left: popupPosition.left, width: POPUP_WIDTH }}
-    >
-      <div className={styles.meetingDetails}>
-        <div className={styles.header}>
-          <button className={styles.backButton} onClick={onBack}>
-            <img src="/svg/back-arrow.svg" alt="Back" />
-          </button>
-          <h1>{title}</h1>
-          <span
-            className={styles.settingLabel}
-            style={{ backgroundColor: primaryColor, borderColor: primaryColor }}
-          >
-            {modeType}
-          </span>
-          {isAdmin && (
-            <div className={styles.moreOptions} ref={kebabRef}>
-              <button
-                aria-label="Meeting options"
-                aria-expanded={kebabOpen}
-                onClick={() => setKebabOpen((open) => !open)}
-              >
-                ⋮
-              </button>
-              {kebabOpen && (
-                <div className={styles.optionsMenu}>
-                  <button onClick={() => { setKebabOpen(false); onEdit(); }}>Edit</button>
-                  <button className={styles.deleteOption} onClick={handleDelete}>Delete</button>
-                </div>
-              )}
-            </div>
-          )}
-        </div>
+      <hr className={styles.divider} />
 
-        <hr className={styles.divider} />
-
-        <div className={styles.details}>
-          {(googleSyncStatus === 'error' || zoomSyncStatus === 'error') && (
+      <div className={styles.details}>
+        {(googleSyncStatus === 'error' || zoomSyncStatus === 'error') && (
             <p className={styles.dangerRow}>
               <img src="/svg/sync-error-icon.svg" alt="" />
               <span>
@@ -517,9 +522,12 @@ const ViewMeetingDetails: React.FC<ViewMeetingDetailsProps> = ({
               tagStyle={{ padding: '2px 12px', fontSize: '12px', color: '#000' }}
             />
           )}
-        </div>
       </div>
+    </div>
+  );
 
+  const modals = (
+    <React.Fragment>
       <DeleteRecurringModal
         isOpen={showDeleteModal}
         onClose={() => setShowDeleteModal(false)}
@@ -532,6 +540,30 @@ const ViewMeetingDetails: React.FC<ViewMeetingDetailsProps> = ({
         onCancel={() => setShowDeleteConfirm(false)}
         onConfirm={handleConfirmDelete}
       />
+    </React.Fragment>
+  );
+
+  if (isPhone) {
+    return (
+      <React.Fragment>
+        <BottomSheet isOpen onClose={onBack} title={title} hideTitleVisually>
+          {content}
+        </BottomSheet>
+        {modals}
+      </React.Fragment>
+    );
+  }
+
+  if (!anchorEl || !popupPosition) return null;
+
+  return createPortal(
+    <div
+      ref={popupRef}
+      className={styles.popupAnchor}
+      style={{ top: popupPosition.top, left: popupPosition.left, width: POPUP_WIDTH }}
+    >
+      {content}
+      {modals}
     </div>,
     document.body
   );

--- a/frontend/app/components/navbar/MobileAppNavbar.tsx
+++ b/frontend/app/components/navbar/MobileAppNavbar.tsx
@@ -5,7 +5,6 @@ import { usePathname } from "next/navigation";
 import type { Session } from "next-auth";
 import MenuIcon from "@mui/icons-material/Menu";
 import FilterListIcon from "@mui/icons-material/FilterList";
-import LockIcon from "@mui/icons-material/Lock";
 import IconButton from "../atoms/IconButton";
 import BottomSheet from "../atoms/BottomSheet";
 import AppSidebar from "./AppSidebar";
@@ -109,7 +108,14 @@ const MobileAppNavbar: React.FC<MobileAppNavbarProps> = ({ session, status, user
             aria-label="Sign in"
             onClick={() => setLoginOpen(true)}
           >
-            <LockIcon className={styles.lockIcon} />
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 -960 960 960"
+              fill="currentColor" // inherits .profileButtonSignedOut's black -- see .signInIcon's comment
+              className={styles.signInIcon}
+            >
+              <path d="M480-120v-80h280v-560H480v-80h280q33 0 56.5 23.5T840-760v560q0 33-23.5 56.5T760-120H480Zm-80-160-55-58 102-102H120v-80h327L345-622l55-58 200 200-200 200Z" />
+            </svg>
           </button>
         )}
       </div>

--- a/frontend/app/components/navbar/MobileAppNavbar.tsx
+++ b/frontend/app/components/navbar/MobileAppNavbar.tsx
@@ -1,15 +1,16 @@
 "use client";
 
 import React, { useState } from "react";
-import Link from "next/link";
 import { usePathname } from "next/navigation";
 import type { Session } from "next-auth";
 import MenuIcon from "@mui/icons-material/Menu";
 import FilterListIcon from "@mui/icons-material/FilterList";
+import LockIcon from "@mui/icons-material/Lock";
 import IconButton from "../atoms/IconButton";
 import BottomSheet from "../atoms/BottomSheet";
 import AppSidebar from "./AppSidebar";
 import ProfileCard from "./ProfileCard";
+import MobileLoginSheet from "./MobileLoginSheet";
 import MiniCalendar from "../atoms/MiniCalendar";
 import MeetingsFilter from "../calendar/MeetingsFilter";
 import { useCalendarContext } from "../../context/CalendarProvider";
@@ -36,6 +37,7 @@ const MobileAppNavbar: React.FC<MobileAppNavbarProps> = ({ session, status, user
 
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [openSheet, setOpenSheet] = useState<OpenSheet>(null);
+  const [loginOpen, setLoginOpen] = useState(false);
   const closeSheet = () => setOpenSheet(null);
 
   const unselectedFilterCount = Object.values(dayFilters).filter((value) => !value).length;
@@ -101,9 +103,14 @@ const MobileAppNavbar: React.FC<MobileAppNavbarProps> = ({ session, status, user
             {userAvatar}
           </button>
         ) : (
-          <Link href="/login" className={styles.profileButton} aria-label="Sign in">
-            {userAvatar}
-          </Link>
+          <button
+            type="button"
+            className={`${styles.profileButton} ${styles.profileButtonSignedOut}`}
+            aria-label="Sign in"
+            onClick={() => setLoginOpen(true)}
+          >
+            <LockIcon className={styles.lockIcon} />
+          </button>
         )}
       </div>
 
@@ -133,6 +140,8 @@ const MobileAppNavbar: React.FC<MobileAppNavbarProps> = ({ session, status, user
           <ProfileCard session={session} userAvatar={userAvatar} />
         </BottomSheet>
       )}
+
+      <MobileLoginSheet isOpen={loginOpen} onBack={() => setLoginOpen(false)} />
     </div>
   );
 };

--- a/frontend/app/components/navbar/MobileLoginSheet.tsx
+++ b/frontend/app/components/navbar/MobileLoginSheet.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import React from "react";
+import ArrowBackIcon from "@mui/icons-material/ArrowBack";
+import MobileFullScreenSheet from "../atoms/MobileFullScreenSheet";
+import LoginCard from "../atoms/LoginCard";
+import IconButton from "../atoms/IconButton";
+import styles from "../../../styles/components/navbar/MobileLoginSheet.module.scss";
+
+interface MobileLoginSheetProps {
+  isOpen: boolean;
+  onBack: () => void;
+}
+
+// Slides in from the right over the calendar when the signed-out profile button is tapped
+// (see MobileAppNavbar.tsx) -- purely a local state toggle, never a real navigation to
+// /login, so "back" just slides this back out and the calendar underneath is exactly as the
+// user left it (nothing unmounted/refetched).
+const MobileLoginSheet: React.FC<MobileLoginSheetProps> = ({ isOpen, onBack }) => (
+  <MobileFullScreenSheet isOpen={isOpen} slideFrom="right">
+    <div className={styles.header}>
+      <IconButton icon={<ArrowBackIcon />} ariaLabel="Back to calendar" variant="ghost" onClick={onBack} />
+    </div>
+    <div className={styles.content}>
+      <LoginCard />
+    </div>
+  </MobileFullScreenSheet>
+);
+
+export default MobileLoginSheet;

--- a/frontend/app/components/navbar/MobileLoginSheet.tsx
+++ b/frontend/app/components/navbar/MobileLoginSheet.tsx
@@ -15,9 +15,10 @@ interface MobileLoginSheetProps {
 // Slides in from the right over the calendar when the signed-out profile button is tapped
 // (see MobileAppNavbar.tsx) -- purely a local state toggle, never a real navigation to
 // /login, so "back" just slides this back out and the calendar underneath is exactly as the
-// user left it (nothing unmounted/refetched).
+// user left it (nothing unmounted/refetched). onSwipeDismiss lets a rightward swipe (the same
+// direction this sheet slides back out to) trigger that same "back" path as the arrow button.
 const MobileLoginSheet: React.FC<MobileLoginSheetProps> = ({ isOpen, onBack }) => (
-  <MobileFullScreenSheet isOpen={isOpen} slideFrom="right">
+  <MobileFullScreenSheet isOpen={isOpen} slideFrom="right" onSwipeDismiss={onBack}>
     <div className={styles.header}>
       <IconButton icon={<ArrowBackIcon />} ariaLabel="Back to calendar" variant="ghost" onClick={onBack} />
     </div>

--- a/frontend/app/context/CalendarProvider.tsx
+++ b/frontend/app/context/CalendarProvider.tsx
@@ -13,12 +13,18 @@ import { getSwipeDirection, isSameWeek, SwipeDirection } from "../../util/weekSt
 // selectedDate/filters, so the Provider is the single bridge for all of it.
 //
 // transitionDirection/transitionCrossesWeek/changeSelectedDate: the shared animated-date-
-// change path for mobile. Every trigger that should animate (WeekStrip tap/swipe, DayColumn
-// swipe, mini-calendar pick) calls changeSelectedDate instead of setSelectedDate directly --
-// it derives direction/crossesWeek from the *previous* selectedDate before updating, so
-// WeekStrip and MobileCalendarView (which both just react to selectedDate + these two fields
-// changing, regardless of which trigger caused it) render the same transition no matter the
-// source. Desktop code keeps using plain setSelectedDate, which never touches these fields.
+// change path for both desktop and mobile -- every date change, from any trigger (desktop
+// nav arrows/mini-calendar/day click, WeekStrip tap/swipe, DayColumn swipe, mobile mini-
+// calendar pick), goes through changeSelectedDate rather than a raw setter. It derives
+// direction/crossesWeek from the *previous* selectedDate before updating, so WeekStrip and
+// MobileCalendarView (which just react to selectedDate + these fields changing, regardless of
+// which trigger caused it) render the same transition no matter the source -- desktop simply
+// never reads transitionDirection/transitionCrossesWeek/transitionAlreadyAnimatedByCaller, so
+// routing its changes through here too is a no-op for it, not a behavior change. There's
+// deliberately no raw setSelectedDate on this context: a desktop call site bypassing
+// changeSelectedDate would leave these three fields stale for whatever mobile view mounts
+// next after a desktop<->mobile resize (MobileCalendarView unmounts/remounts across that
+// boundary, but the context itself does not).
 //
 // transitionAlreadyAnimatedByCaller: set when the caller's own gesture already delivered the
 // motion (only MobileCalendarView's drag -- the pan itself slides the content into place), so
@@ -28,7 +34,6 @@ import { getSwipeDirection, isSameWeek, SwipeDirection } from "../../util/weekSt
 // read during render.
 interface CalendarContextValue {
   selectedDate: Date;
-  setSelectedDate: React.Dispatch<React.SetStateAction<Date>>;
   selectedView: string;
   setSelectedView: React.Dispatch<React.SetStateAction<string>>;
   dayFilters: MeetingFilters;
@@ -84,7 +89,6 @@ export const CalendarProvider: React.FC<CalendarProviderProps> = ({ children, in
   const value = useMemo(
     () => ({
       selectedDate,
-      setSelectedDate,
       selectedView,
       setSelectedView,
       dayFilters,

--- a/frontend/app/context/CalendarProvider.tsx
+++ b/frontend/app/context/CalendarProvider.tsx
@@ -19,6 +19,13 @@ import { getSwipeDirection, isSameWeek, SwipeDirection } from "../../util/weekSt
 // WeekStrip and MobileCalendarView (which both just react to selectedDate + these two fields
 // changing, regardless of which trigger caused it) render the same transition no matter the
 // source. Desktop code keeps using plain setSelectedDate, which never touches these fields.
+//
+// transitionAlreadyAnimatedByCaller: set when the caller's own gesture already delivered the
+// motion (only MobileCalendarView's drag -- the pan itself slides the content into place), so
+// consumers that play their own enter transition on every selectedDate change (MobileCalendarView's
+// per-panel slide-in) know to skip it for that one commit rather than layering a redundant
+// second slide right after the drag's. Plain state (not a ref) specifically so it's safe to
+// read during render.
 interface CalendarContextValue {
   selectedDate: Date;
   setSelectedDate: React.Dispatch<React.SetStateAction<Date>>;
@@ -32,7 +39,8 @@ interface CalendarContextValue {
   setNavHidden: React.Dispatch<React.SetStateAction<boolean>>;
   transitionDirection: SwipeDirection;
   transitionCrossesWeek: boolean;
-  changeSelectedDate: (newDate: Date) => void;
+  transitionAlreadyAnimatedByCaller: boolean;
+  changeSelectedDate: (newDate: Date, opts?: { alreadyAnimatedByCaller?: boolean }) => void;
 }
 
 const CalendarContext = createContext<CalendarContextValue | null>(null);
@@ -55,6 +63,7 @@ export const CalendarProvider: React.FC<CalendarProviderProps> = ({ children, in
   const [navHidden, setNavHidden] = useState(false);
   const [transitionDirection, setTransitionDirection] = useState<SwipeDirection>("forward");
   const [transitionCrossesWeek, setTransitionCrossesWeek] = useState(false);
+  const [transitionAlreadyAnimatedByCaller, setTransitionAlreadyAnimatedByCaller] = useState(false);
 
   // Ref mirror of selectedDate so changeSelectedDate's identity stays stable (it's handed to
   // framer-motion drag handlers in WeekStrip/MobileCalendarView, which don't need to
@@ -64,10 +73,11 @@ export const CalendarProvider: React.FC<CalendarProviderProps> = ({ children, in
     selectedDateRef.current = selectedDate;
   }, [selectedDate]);
 
-  const changeSelectedDate = useCallback((newDate: Date) => {
+  const changeSelectedDate = useCallback((newDate: Date, opts?: { alreadyAnimatedByCaller?: boolean }) => {
     const from = selectedDateRef.current;
     setTransitionDirection(getSwipeDirection(from, newDate));
     setTransitionCrossesWeek(!isSameWeek(from, newDate));
+    setTransitionAlreadyAnimatedByCaller(!!opts?.alreadyAnimatedByCaller);
     setSelectedDate(newDate);
   }, []);
 
@@ -85,6 +95,7 @@ export const CalendarProvider: React.FC<CalendarProviderProps> = ({ children, in
       setNavHidden,
       transitionDirection,
       transitionCrossesWeek,
+      transitionAlreadyAnimatedByCaller,
       changeSelectedDate,
     }),
     [
@@ -95,6 +106,7 @@ export const CalendarProvider: React.FC<CalendarProviderProps> = ({ children, in
       navHidden,
       transitionDirection,
       transitionCrossesWeek,
+      transitionAlreadyAnimatedByCaller,
       changeSelectedDate,
     ]
   );

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -6,19 +6,13 @@ const nextConfig = {
   ...(process.env.DEV_LAN_ORIGIN
     ? { allowedDevOrigins: [process.env.DEV_LAN_ORIGIN] }
     : {}),
-  // Dev-only overlay badge defaults to bottom-left, the same corner the mobile New Meeting
-  // FAB (MobileFab.tsx) is pinned to per spec -- it visually and pointer-event-wise covers
-  // the FAB in dev (confirmed via e2e: "intercepts pointer events"). Doesn't exist in
-  // production, so this is purely a local/dev-server ergonomics fix.
+  // Dev-only overlay badge defaults to bottom-left, which is where it naturally sits -- kept
+  // explicit since the mobile New Meeting FAB (MobileFab.tsx) is pinned bottom-right and the
+  // two would otherwise be one accidental FAB-position change away from overlapping again.
+  // Doesn't exist in production, so this is purely a local/dev-server ergonomics fix.
   devIndicators: {
-    position: "bottom-right",
+    position: "bottom-left",
   },
-  // Lets a phone on the same LAN connect to the dev server's HMR websocket -- Next.js blocks
-  // cross-origin dev requests by default. Set DEV_LAN_ORIGIN in .env.local (gitignored) to your
-  // machine's LAN IP; unset in prod/CI so this is a no-op there.
-  ...(process.env.DEV_LAN_ORIGIN
-    ? { allowedDevOrigins: [process.env.DEV_LAN_ORIGIN] }
-    : {}),
   sassOptions: {
     // Our .module.scss files still use the legacy @import syntax -- silences the resulting
     // Dart Sass deprecation warning (and its noisy "Import traces" dump) without hiding other

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -6,6 +6,13 @@ const nextConfig = {
   ...(process.env.DEV_LAN_ORIGIN
     ? { allowedDevOrigins: [process.env.DEV_LAN_ORIGIN] }
     : {}),
+  // Dev-only overlay badge defaults to bottom-left, the same corner the mobile New Meeting
+  // FAB (MobileFab.tsx) is pinned to per spec -- it visually and pointer-event-wise covers
+  // the FAB in dev (confirmed via e2e: "intercepts pointer events"). Doesn't exist in
+  // production, so this is purely a local/dev-server ergonomics fix.
+  devIndicators: {
+    position: "bottom-right",
+  },
   sassOptions: {
     // Our .module.scss files still use the legacy @import syntax -- silences the resulting
     // Dart Sass deprecation warning (and its noisy "Import traces" dump) without hiding other

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -13,6 +13,12 @@ const nextConfig = {
   devIndicators: {
     position: "bottom-right",
   },
+  // Lets a phone on the same LAN connect to the dev server's HMR websocket -- Next.js blocks
+  // cross-origin dev requests by default. Set DEV_LAN_ORIGIN in .env.local (gitignored) to your
+  // machine's LAN IP; unset in prod/CI so this is a no-op there.
+  ...(process.env.DEV_LAN_ORIGIN
+    ? { allowedDevOrigins: [process.env.DEV_LAN_ORIGIN] }
+    : {}),
   sassOptions: {
     // Our .module.scss files still use the legacy @import syntax -- silences the resulting
     // Dart Sass deprecation warning (and its noisy "Import traces" dump) without hiding other

--- a/frontend/styles/Variables.module.scss
+++ b/frontend/styles/Variables.module.scss
@@ -1,11 +1,13 @@
 $black-color: #1E1E1E;
 $medium-grey-color: #848484;
 $light-grey-color: #CECECE;
-$brand-pink-color: #C36;
+$white-color: #FFF;
+
 
 // Higher-contrast pink for small text/UI on top of $brand-pink-color's own pastel tint (e.g.
 // WeekStrip's selected-day fill) -- $brand-pink-color's default pastel reads too washed out
 // there.
+$brand-pink-color: #C36;
 $brand-pink-secondary: #B85578;
 
 // Field-box border and card-fill tones, matching the Ithaca Recovery Design System's

--- a/frontend/styles/components/atoms/BottomSheet.module.scss
+++ b/frontend/styles/components/atoms/BottomSheet.module.scss
@@ -38,6 +38,19 @@
     color: $black-color;
 }
 
+// Screen-reader-only -- for content that already renders its own visible header/title.
+.titleVisuallyHidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip-path: inset(50%);
+    white-space: nowrap;
+    border: 0;
+}
+
 .content {
     overflow-y: auto;
     touch-action: pan-y;

--- a/frontend/styles/components/atoms/LoginCard.module.scss
+++ b/frontend/styles/components/atoms/LoginCard.module.scss
@@ -1,0 +1,45 @@
+@import '../../Variables.module.scss';
+
+.card {
+    background-color: #fff;
+    border-radius: 8px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+}
+
+.logo {
+    margin-bottom: 16px;
+}
+
+.heading {
+    font-size: 21px;
+    font-weight: 700;
+    color: $black-color;
+    margin: 0 0 12px;
+}
+
+.description {
+    font-size: 14px;
+    color: $medium-grey-color;
+    line-height: 1.5;
+    margin: 0 0 24px;
+}
+
+.footer {
+    font-size: 13px;
+    color: $medium-grey-color;
+    line-height: 1.5;
+    margin: 20px 0 0;
+}
+
+.footerLink {
+    font-weight: 700;
+    color: $black-color;
+    text-decoration: none;
+
+    &:hover {
+        text-decoration: underline;
+    }
+}

--- a/frontend/styles/components/atoms/MobileFullScreenSheet.module.scss
+++ b/frontend/styles/components/atoms/MobileFullScreenSheet.module.scss
@@ -1,0 +1,11 @@
+@import '../../Variables.module.scss';
+
+.fullScreen {
+    position: fixed;
+    inset: 0;
+    z-index: $z-index-modal;
+    background-color: #fff;
+    overflow-y: auto;
+    padding-top: env(safe-area-inset-top);
+    padding-bottom: env(safe-area-inset-bottom);
+}

--- a/frontend/styles/components/calendar/MobileFab.module.scss
+++ b/frontend/styles/components/calendar/MobileFab.module.scss
@@ -1,0 +1,8 @@
+@import '../../Variables.module.scss';
+
+.fabWrapper {
+    position: fixed;
+    left: 16px;
+    bottom: calc(16px + env(safe-area-inset-bottom));
+    z-index: $z-index-sticky;
+}

--- a/frontend/styles/components/calendar/MobileFab.module.scss
+++ b/frontend/styles/components/calendar/MobileFab.module.scss
@@ -2,7 +2,7 @@
 
 .fabWrapper {
     position: fixed;
-    left: 16px;
+    right: 16px;
     bottom: calc(16px + env(safe-area-inset-bottom));
     z-index: $z-index-sticky;
 }

--- a/frontend/styles/components/meeting-form/MeetingForm.module.scss
+++ b/frontend/styles/components/meeting-form/MeetingForm.module.scss
@@ -7,6 +7,11 @@
   height: auto;
   margin: 0 auto; // so the height is responsive to the atoms in it
   border-radius: 0;
+
+  // Needed so the mobile breakpoint's padding below is included in that 100% width instead of
+  // adding to it -- without this the full-screen mobile form (MobileFullScreenSheet) overflows
+  // the viewport by exactly 2x that padding.
+  box-sizing: border-box;
 }
 
 .newMeetingSidebar .dummyComponent {

--- a/frontend/styles/components/navbar/MobileAppNavbar.module.scss
+++ b/frontend/styles/components/navbar/MobileAppNavbar.module.scss
@@ -102,18 +102,18 @@
     }
 }
 
-// Signed-out state: lock icon (black, via currentColor -- light grey read too low-contrast
+// Signed-out state: sign-in icon (black, via currentColor -- light grey read too low-contrast
 // against the pastel-pink tint) on a pastel-pink tint -- rgb(240 194 209) is
 // toPastelColor($brand-pink-color) from util/color.ts, computed once and hardcoded here
 // (same manual-sync convention as WeekStrip.module.scss/MiniCalendar.module.scss's matching
 // rule -- re-run toPastelColor('#CC3366') if $brand-pink-color ever changes).
 .profileButtonSignedOut {
-    background-color: rgb(240 194 209);
+    background-color: $brand-pink-color;
     border-color: transparent;
-    color: $black-color;
+    color: $white-color;
 }
 
-.lockIcon {
+.signInIcon {
     width: 16px;
     height: 16px;
 }

--- a/frontend/styles/components/navbar/MobileAppNavbar.module.scss
+++ b/frontend/styles/components/navbar/MobileAppNavbar.module.scss
@@ -101,3 +101,19 @@
         height: 100%;
     }
 }
+
+// Signed-out state: lock icon (black, via currentColor -- light grey read too low-contrast
+// against the pastel-pink tint) on a pastel-pink tint -- rgb(240 194 209) is
+// toPastelColor($brand-pink-color) from util/color.ts, computed once and hardcoded here
+// (same manual-sync convention as WeekStrip.module.scss/MiniCalendar.module.scss's matching
+// rule -- re-run toPastelColor('#CC3366') if $brand-pink-color ever changes).
+.profileButtonSignedOut {
+    background-color: rgb(240 194 209);
+    border-color: transparent;
+    color: $black-color;
+}
+
+.lockIcon {
+    width: 16px;
+    height: 16px;
+}

--- a/frontend/styles/components/navbar/MobileLoginSheet.module.scss
+++ b/frontend/styles/components/navbar/MobileLoginSheet.module.scss
@@ -1,0 +1,13 @@
+@import '../../Variables.module.scss';
+
+.header {
+    display: flex;
+    align-items: center;
+    padding: 4px 8px;
+}
+
+.content {
+    display: flex;
+    justify-content: center;
+    padding: 24px 24px 40px;
+}

--- a/frontend/tests/component/MobileFab.test.tsx
+++ b/frontend/tests/component/MobileFab.test.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import MobileFab from "../../app/components/calendar/MobileFab";
+
+describe("MobileFab", () => {
+  it("renders a New meeting button and calls onClick when tapped", () => {
+    const onClick = jest.fn();
+    render(<MobileFab onClick={onClick} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "New meeting" }));
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/tests/component/ViewMeeting.test.tsx
+++ b/frontend/tests/component/ViewMeeting.test.tsx
@@ -1,0 +1,66 @@
+import React from "react";
+import { render, screen, within } from "@testing-library/react";
+import ViewMeetingDetails from "../../app/components/meeting-form/ViewMeeting";
+
+beforeEach(() => {
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({ hosts: [] }),
+  }) as jest.Mock;
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+const baseProps = {
+  mid: "m-1",
+  title: "Serenity Group",
+  modeType: "In Person",
+  creator: "Test Suite",
+  group: "Test Group",
+  startDateTime: new Date("2026-07-30T18:00:00Z"),
+  endDateTime: new Date("2026-07-30T19:00:00Z"),
+  email: "seed@test.icr",
+  calType: ["AA"],
+  room: "Serenity Room",
+  isRecurring: false,
+  isAdmin: true,
+  onBack: jest.fn(),
+  onEdit: jest.fn(),
+  onDelete: jest.fn(),
+};
+
+// A real DOM node to anchor the desktop popup to.
+const makeAnchorEl = (): HTMLElement => {
+  const el = document.createElement("div");
+  document.body.appendChild(el);
+  return el;
+};
+
+describe("ViewMeeting", () => {
+  it("desktop: renders nothing without an anchorEl", () => {
+    render(<ViewMeetingDetails {...baseProps} anchorEl={null} isPhone={false} />);
+    expect(screen.queryByText("Serenity Group")).not.toBeInTheDocument();
+  });
+
+  it("desktop: renders the meeting title once an anchorEl is present, outside any dialog role", () => {
+    render(<ViewMeetingDetails {...baseProps} anchorEl={makeAnchorEl()} isPhone={false} />);
+    expect(screen.getByText("Serenity Group")).toBeInTheDocument();
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("mobile: renders inside a bottom sheet even with no anchorEl", () => {
+    render(<ViewMeetingDetails {...baseProps} anchorEl={null} isPhone />);
+    const dialog = screen.getByRole("dialog", { name: "Serenity Group" });
+    expect(dialog).toBeInTheDocument();
+    // ViewMeeting's own <h1> title, distinct from BottomSheet's visually-hidden duplicate
+    // (kept in the DOM for the dialog's accessible name -- see hideTitleVisually).
+    expect(within(dialog).getByRole("heading", { level: 1, name: "Serenity Group" })).toBeInTheDocument();
+  });
+
+  it("mobile: shows the same Edit/Delete kebab menu for an admin", () => {
+    render(<ViewMeetingDetails {...baseProps} anchorEl={null} isPhone isAdmin />);
+    expect(screen.getByRole("button", { name: "Meeting options" })).toBeInTheDocument();
+  });
+});

--- a/frontend/tests/component/setup.ts
+++ b/frontend/tests/component/setup.ts
@@ -1,9 +1,14 @@
 import "@testing-library/jest-dom";
 
-// jsdom doesn't implement ResizeObserver -- TagList (and anything else measuring its own
-// layout, e.g. BoxText's zoomTag width) needs a stub or it throws on mount.
-global.ResizeObserver = class ResizeObserver {
-  observe() {}
-  unobserve() {}
-  disconnect() {}
-};
+// jsdom has no ResizeObserver -- stubbed here (not per-test) since any component tree that
+// happens to mount TagList.tsx (or anything else that measures itself) needs this globally
+// available, not just the specific test that intentionally exercises it.
+if (typeof window !== "undefined" && !("ResizeObserver" in window)) {
+  class ResizeObserverStub {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+  // @ts-expect-error -- test-only stub, not a spec-complete ResizeObserver
+  window.ResizeObserver = ResizeObserverStub;
+}

--- a/frontend/tests/e2e/17-mobile-meeting-forms.spec.ts
+++ b/frontend/tests/e2e/17-mobile-meeting-forms.spec.ts
@@ -1,0 +1,105 @@
+import { test, expect } from "./support/fixtures";
+import type { Page } from "@playwright/test";
+import { fillDatePicker, fillTimeRange, selectFromDropdown, toggleCalType, todayMMDDYYYY } from "./support/formHelpers";
+import { seedMeeting } from "../factories/meeting";
+import { convertETToUTC, formatETDateString } from "../../util/timeUtils";
+
+// Mobile-portrait viewport for this whole file -- no mobile Playwright project is configured
+// (config/playwright.config.ts only has "chromium" desktop), so it's set per-file here.
+test.use({ viewport: { width: 390, height: 844 } });
+
+// Two real races, not one -- both need to settle before interacting:
+// 1. isAdmin starts null (not false) until /api/auth/status resolves, and ViewMeeting's kebab
+//    menu (Meeting options) is gated on isAdmin being truthy -- null && (...) is falsy too, so
+//    a click that races ahead of this fetch finds no kebab at all, not just a hidden one.
+// 2. useIsPhone() starts false to match the server-rendered HTML, then corrects itself in a
+//    layout effect on an actual phone -- but next dev's on-demand compile can still stretch
+//    that window enough for an early interaction to land against the still-mounted desktop
+//    DailyView instead. WeekStrip only exists once the mobile branch has actually rendered,
+//    so waiting for it is a real signal for this, not a proxy.
+async function gotoAndWaitForMobileReady(page: Page): Promise<void> {
+  const authResponse = page.waitForResponse((r) => r.url().includes("/api/auth/status"));
+  await page.goto("/");
+  await authResponse;
+  await page.getByRole("button", { pressed: true }).waitFor({ state: "visible" });
+}
+
+test.describe("mobile meeting interactions", () => {
+  test("17.1 tapping a meeting opens ViewMeeting in a bottom sheet", async ({ adminPage }) => {
+    const { page } = adminPage;
+    await seedMeeting({ title: "Mobile Sheet Meeting", room: "Serenity Room" });
+    await gotoAndWaitForMobileReady(page);
+
+    await page.getByText("Mobile Sheet Meeting", { exact: true }).click();
+
+    const sheet = page.getByRole("dialog", { name: "Mobile Sheet Meeting" });
+    await expect(sheet).toBeVisible();
+    await expect(sheet.getByText("Serenity Room")).toBeVisible();
+  });
+
+  test("17.2 the FAB opens New Meeting full-screen, and submitting it creates the meeting", async ({ adminPage }) => {
+    const { page } = adminPage;
+    await gotoAndWaitForMobileReady(page);
+
+    await page.getByRole("button", { name: "New meeting" }).click();
+    await expect(page.getByRole("heading", { name: "New Meeting" })).toBeVisible();
+
+    await page.getByPlaceholder("Meeting title").fill("Mobile FAB Meeting");
+    await page.getByRole("button", { name: "In Person" }).click();
+    await fillDatePicker(page, todayMMDDYYYY());
+    await fillTimeRange(page, "18:00", "19:00");
+    await selectFromDropdown(page, "Select Room", "Serenity Room");
+    await toggleCalType(page, "AA");
+    await page.getByPlaceholder("Email").fill("mobile-fab@test.icr");
+
+    const dialogPromise = page.waitForEvent("dialog");
+    await page.getByRole("button", { name: "Create Meeting" }).click();
+    const dialog = await dialogPromise;
+    expect(dialog.message()).toContain("Meeting created successfully");
+    await dialog.accept();
+
+    // Full-screen form closes back down, the new meeting is now visible on the calendar.
+    await expect(page.getByRole("heading", { name: "New Meeting" })).not.toBeVisible();
+    await expect(page.getByText("Mobile FAB Meeting", { exact: true })).toBeVisible();
+  });
+
+  test("17.3 editing from within the ViewMeeting sheet opens Edit full-screen", async ({ adminPage }) => {
+    const { page } = adminPage;
+    await seedMeeting({ title: "Mobile Edit Meeting", room: "Serenity Room" });
+    await gotoAndWaitForMobileReady(page);
+
+    await page.getByText("Mobile Edit Meeting", { exact: true }).click();
+    await expect(page.getByRole("dialog", { name: "Mobile Edit Meeting" })).toBeVisible();
+    await page.getByRole("button", { name: "Meeting options" }).click();
+    await page.getByRole("button", { name: "Edit" }).click();
+
+    await expect(page.getByPlaceholder("Meeting title")).toHaveValue("Mobile Edit Meeting");
+    // ViewMeeting's bottom sheet is gone -- Edit fully replaces it, not stacked on top.
+    await expect(page.getByRole("dialog", { name: "Mobile Edit Meeting" })).not.toBeVisible();
+  });
+
+  test("17.4 an overlapping-meetings '+N' popup still renders as a centered modal, not a sheet", async ({ adminPage }) => {
+    const { page } = adminPage;
+    // formatETDateString/convertETToUTC (not new Date().toISOString()) -- the suite runs
+    // with timezoneId: "UTC" (config/playwright.config.ts), so a plain UTC date slice can
+    // land on the wrong calendar day relative to ET near ET's midnight boundary.
+    const etDate = formatETDateString(new Date());
+    const start = new Date(convertETToUTC(`${etDate}T18:00:00`));
+    const end = new Date(convertETToUTC(`${etDate}T19:00:00`));
+    // Mobile shows up to MOBILE_MAX_VISIBLE_OVERLAP (4, see MobileCalendarView.tsx) side by
+    // side before folding -- 5 is the first count that actually triggers a "+N" pill.
+    for (const title of ["Overlap Mobile A", "Overlap Mobile B", "Overlap Mobile C", "Overlap Mobile D", "Overlap Mobile E"]) {
+      await seedMeeting({ title, room: "Serenity Room", startDateTime: start, endDateTime: end });
+    }
+    await gotoAndWaitForMobileReady(page);
+
+    await page.getByRole("button", { name: /more meetings at this time/ }).click();
+
+    // OverlapMeetingsModal has no role="dialog" and no drag grabber (unlike BottomSheet) --
+    // confirms it stayed a plain centered modal rather than getting swept into the bottom-
+    // sheet treatment.
+    const modal = page.locator('[class*="modalContent"]');
+    await expect(modal).toBeVisible();
+    await expect(modal.locator('[class*="grabber"]')).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added mobile meeting creation and editing through full-screen sheets and a “New meeting” button.
  - Added mobile meeting details in bottom sheets, including meeting options and overlapping-meeting views.
  - Added an in-app mobile login sheet for signed-out visitors.
  - Consolidated login content and added links to calendar and signage pages.

- **Bug Fixes**
  - Improved mobile calendar transitions, loading visibility, and tag display calculations.
  - Enhanced sheet accessibility with screen-reader-friendly titles.

- **Tests**
  - Added coverage for mobile meeting creation, editing, details, and responsive interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description
Mobile-izes meeting interactions — the final branch in the mobile portrait stack. `OverlapMeetingsModal`/`DeleteMeetingModal`/`DeleteRecurringModal` are intentionally untouched and still render as centered modals on mobile.
- **app/components/meeting-form/ViewMeeting.tsx**: takes an `isPhone` prop; on phone, renders inside the shared `BottomSheet` instead of the anchor-relative popup positioning desktop uses (no `anchorEl`/position math needed for a bottom sheet).
- **app/components/atoms/MobileFullScreenSheet.tsx** (new): full-screen slide-up wrapper for the New/Edit Meeting forms on mobile.
- **app/components/calendar/MobileFab.tsx** (new): bottom-left "+" FAB, shown only for admins on `/` at phone widths, rendered outside the WeekStrip/DayColumn drag region so it can't be swallowed by the swipe handler.
- **app/(main)/page.tsx**: `isNewMeetingOpen` lifted out of `CalendarSidebarShell.tsx` so mobile's full-screen form and desktop's embedded sidebar form share one source of truth; mobile renders the New/Edit form in `MobileFullScreenSheet` instead of the desktop sidebar slot.
- **app/components/calendar/CalendarSidebarShell.tsx**: `isNewMeetingOpen` now a prop instead of local state; existing rail-collapse coordination logic carried through unchanged.

## Testing
- `yarn test:component` — new `ViewMeeting.test.tsx` (phone renders in `BottomSheet`, desktop unchanged — explicit regression guard), `MobileFab.test.tsx`.
- `tests/e2e/17-mobile-meeting-forms.spec.ts` (targeted Playwright) — tap meeting → bottom sheet; FAB → full-screen New Meeting → submit; Edit from within the sheet → full-screen; asserts `OverlapMeetingsModal`/`DeleteMeetingModal` still render as centered modals on the same mobile viewport.
- Manual: re-verified desktop's New Meeting open/close/rail-collapse-restore flow is unaffected by the `isNewMeetingOpen` lift; full stack tested end-to-end on a real phone over LAN.

## Area(s) Touched
**Product areas**
- [x] ui/ux — frontend layout/styling not tied to a specific integration

**Engineering**
- [x] testing — test suite (Jest/Playwright) changes

## Pre-merge Checklist
- [x] Code follows current formatting conventions and passes lint (`yarn lint`).
- [x] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
- [x] All test suites pass, both run locally and green in GitHub CI.
- [x] A test suite was added or updated for the feature/fix in this PR.
- [x] Only files relevant to this change are committed — no stray or unrelated files.
- [x] If this branch has a merge conflict with master, master was merged into this branch first.
- [x] The rest of this PR description is filled out.

---
**Stacked PR — part 7 of 7 (final).** Base: `feat/mobile-swipe-transitions` (#280).
