### PR TITLE
feat(meetings): suspend/resume backend (schema, routes, GCal sync)

### DIFF
--- a/frontend/app/api/admin/diagnostics/route.ts
+++ b/frontend/app/api/admin/diagnostics/route.ts
@@ -4,6 +4,8 @@ import { requireRole } from "../../../../services/auth";
 import { calendarIdForCategory, checkCalendarReachable } from "../../../../services/googleCalendar";
 import { checkZoomReachable, zoomRoomCalendarId, checkZoomHostPool } from "../../../../services/zoom";
 import { computeConflicts } from "../../../../util/resourceOverlap";
+import { isDateSuspended } from "../../../../util/meetingOccurrences";
+import { formatETDateString } from "../../../../util/timeUtils";
 import { prisma } from "../../../../lib/prisma";
 
 const notDeleted = { OR: [{ deletedAt: null }, { deletedAt: { isSet: false } }] };
@@ -52,10 +54,11 @@ export const GET = async () => {
         mid: true, title: true, group: true, status: true, calType: true, isRecurring: true,
         googleSyncStatus: true, zoomRoom: true, zoomHost: true, zoomSyncStatus: true, zoomSyncError: true,
         room: true, modeType: true, startDateTime: true, endDateTime: true,
-        recurrencePattern: true, updatedAt: true,
+        recurrencePattern: true, updatedAt: true, suspensions: true,
       },
     });
 
+    const todayStr = formatETDateString(new Date());
     const byCategory: Record<string, number> = {};
     categories.forEach((cat) => { byCategory[cat] = 0; });
     let active = 0;
@@ -65,7 +68,7 @@ export const GET = async () => {
     let zoomSyncErrors = 0;
     let pendingZoomSync = 0;
     for (const m of meetings) {
-      if (m.status === "Suspended") suspended++; else active++;
+      if (isDateSuspended(m.suspensions, todayStr)) suspended++; else active++;
       if (m.isRecurring) recurring++;
       for (const cat of m.calType) {
         if (cat in byCategory) byCategory[cat]++;
@@ -102,12 +105,26 @@ export const GET = async () => {
       .sort((a, b) => (b.updatedAt?.getTime() ?? 0) - (a.updatedAt?.getTime() ?? 0))
       .slice(0, 50);
 
-    const suspendedMeetings = await prisma.meeting.findMany({
+    // `status: "Suspended"` is a conservative DB-level pre-filter (a currently-suspended meeting
+    // always has this flag set), narrowed further in-memory by the derived, date-based check so a
+    // meeting whose scheduled resume date already passed correctly drops off this list even if
+    // nothing has explicitly resumed it yet.
+    const suspendedMeetingsRaw = await prisma.meeting.findMany({
       where: { ...notDeleted, status: "Suspended" },
-      select: { mid: true, title: true, group: true, room: true, modeType: true, calType: true, updatedAt: true },
+      select: {
+        mid: true, title: true, group: true, room: true, modeType: true, calType: true,
+        updatedAt: true, suspensions: true,
+      },
       orderBy: { updatedAt: "desc" },
-      take: 20,
+      take: 50,
     });
+    const suspendedMeetings = suspendedMeetingsRaw
+      .filter((m) => isDateSuspended(m.suspensions, todayStr))
+      .slice(0, 20)
+      .map(({ suspensions, ...m }) => {
+        const open = suspensions.find((s) => isDateSuspended([s], todayStr));
+        return { ...m, resumesAt: open?.to ?? null };
+      });
 
     return NextResponse.json({
       database: { ok: true, latencyMs: databaseLatencyMs },

--- a/frontend/app/api/admin/diagnostics/route.ts
+++ b/frontend/app/api/admin/diagnostics/route.ts
@@ -105,25 +105,21 @@ export const GET = async () => {
       .sort((a, b) => (b.updatedAt?.getTime() ?? 0) - (a.updatedAt?.getTime() ?? 0))
       .slice(0, 50);
 
-    // `status: "Suspended"` is a conservative DB-level pre-filter (a currently-suspended meeting
-    // always has this flag set), narrowed further in-memory by the derived, date-based check so a
-    // meeting whose scheduled resume date already passed correctly drops off this list even if
-    // nothing has explicitly resumed it yet.
-    const suspendedMeetingsRaw = await prisma.meeting.findMany({
-      where: { ...notDeleted, status: "Suspended" },
-      select: {
-        mid: true, title: true, group: true, room: true, modeType: true, calType: true,
-        updatedAt: true, suspensions: true,
-      },
-      orderBy: { updatedAt: "desc" },
-      take: 50,
-    });
-    const suspendedMeetings = suspendedMeetingsRaw
+    // Derived from `meetings` (already fetched above with every field needed here) rather than a
+    // separate `status: "Suspended"` query -- that flag can drift from the date-based truth (e.g.
+    // a client-supplied `status` written by the update route), and a status pre-filter combined
+    // with `take` before the date filter could silently undercount/omit currently-suspended rows.
+    const suspendedMeetings = meetings
       .filter((m) => isDateSuspended(m.suspensions, todayStr))
+      .sort((a, b) => (b.updatedAt?.getTime() ?? 0) - (a.updatedAt?.getTime() ?? 0))
       .slice(0, 20)
-      .map(({ suspensions, ...m }) => {
-        const open = suspensions.find((s) => isDateSuspended([s], todayStr));
-        return { ...m, resumesAt: open?.to ?? null };
+      .map((m) => {
+        const open = m.suspensions.find((s) => isDateSuspended([s], todayStr));
+        return {
+          mid: m.mid, title: m.title, group: m.group, room: m.room,
+          modeType: m.modeType, calType: m.calType, updatedAt: m.updatedAt,
+          resumesAt: open?.to ?? null,
+        };
       });
 
     return NextResponse.json({

--- a/frontend/app/api/delete/meeting/route.ts
+++ b/frontend/app/api/delete/meeting/route.ts
@@ -9,6 +9,7 @@ import {
   calendarIdsForMeeting,
 } from '../../../../services/googleCalendar';
 import { deleteZoomMeeting, zoomRoomCalendarId } from '../../../../services/zoom';
+import { reconcilePendingResume } from '../../../../util/suspension';
 import { prisma } from '../../../../lib/prisma';
 
 // Returns "YYYY-MM-DD" in Eastern Time for the given UTC timestamp.
@@ -74,7 +75,7 @@ const deleteMeeting = async (request: Request) => {
 
     const meeting = await prisma.meeting.findUnique({
       where: { mid },
-      include: { recurrencePattern: true }
+      include: { recurrencePattern: true, suspensions: true }
     });
 
     if (!meeting) {
@@ -83,6 +84,10 @@ const deleteMeeting = async (request: Request) => {
         headers: { 'Content-Type': 'application/json' },
       });
     }
+
+    // Lazy self-heal, same as update/meeting/route.ts -- promote a due-but-unpromoted scheduled
+    // resume series before deleting whatever's currently in googleCalendarEventIds.
+    meeting.googleCalendarEventIds = await reconcilePendingResume(meeting);
 
     const isRecurring = !!meeting.recurrencePattern || meeting.isRecurring;
 

--- a/frontend/app/api/update/meeting/resume/route.ts
+++ b/frontend/app/api/update/meeting/resume/route.ts
@@ -85,8 +85,15 @@ const resumeMeeting = async (request: Request) => {
       return NextResponse.json({ error: "Meeting is not currently suspended" }, { status: 400 });
     }
 
-    await prisma.meeting.update({ where: { mid }, data: { status: 'Active' } });
-    await prisma.suspensionPeriod.update({ where: { id: openSuspension.id }, data: { to: new Date() } });
+    await prisma.$transaction([
+      prisma.meeting.update({ where: { mid }, data: { status: 'Active' } }),
+      prisma.suspensionPeriod.update({
+        where: { id: openSuspension.id },
+        // resumeEventIds are deleted by syncResume below, so clear them here too -- otherwise
+        // reconcilePendingResume sees an unpromoted, now-due row and republishes dead IDs.
+        data: { to: new Date(), resumeEventIds: null, promoted: true },
+      }),
+    ]);
 
     after(syncResume(meeting, openSuspension, auth.accessToken));
 

--- a/frontend/app/api/update/meeting/resume/route.ts
+++ b/frontend/app/api/update/meeting/resume/route.ts
@@ -1,0 +1,100 @@
+import { Meeting, RecurrencePattern, Role, SuspensionPeriod } from '@prisma/client';
+import { NextResponse, after } from 'next/server';
+import { requireRole } from '../../../../../services/auth';
+import { deleteCalendarEvent, createCalendarEvent, calendarIdsForMeeting } from '../../../../../services/googleCalendar';
+import { formatETDateString } from '../../../../../util/timeUtils';
+import { getOpenSuspension, reconcilePendingResume } from '../../../../../util/suspension';
+import { IMeeting } from '../../../../../util/models';
+import { prisma } from '../../../../../lib/prisma';
+
+type MeetingWithPattern = Meeting & { recurrencePattern: RecurrencePattern | null };
+
+function toCalendarMeeting(meeting: MeetingWithPattern): IMeeting {
+  return {
+    mid: meeting.mid,
+    title: meeting.title,
+    description: meeting.description,
+    creator: meeting.creator,
+    group: meeting.group,
+    startDateTime: meeting.startDateTime,
+    endDateTime: meeting.endDateTime,
+    email: meeting.email,
+    zoomRoom: meeting.zoomRoom,
+    zoomLink: meeting.zoomLink,
+    calType: meeting.calType,
+    modeType: meeting.modeType,
+    room: meeting.room,
+    isRecurring: meeting.isRecurring,
+    recurrencePattern: meeting.recurrencePattern,
+  };
+}
+
+// Resuming always creates a fresh series/event starting today (or recreates the original
+// one-time event) and writes the result directly to Meeting.googleCalendarEventIds -- an early
+// manual resume (before a scheduled `to` date) was never going to want the pre-created future
+// series' start date, so any pending resumeEventIds on this suspension are discarded, not reused.
+async function syncResume(
+  meeting: MeetingWithPattern,
+  openSuspension: SuspensionPeriod,
+  accessToken: string | undefined,
+): Promise<void> {
+  if (!accessToken) return;
+  const calendarIds = calendarIdsForMeeting(meeting.calType ?? []);
+
+  if (openSuspension.resumeEventIds) {
+    const pending = openSuspension.resumeEventIds as Record<string, string>;
+    for (const [cat, calId] of Object.entries(calendarIds)) {
+      const eventId = pending[cat];
+      if (eventId) await deleteCalendarEvent(accessToken, eventId, calId);
+    }
+  }
+
+  const meetingForSync = toCalendarMeeting(meeting);
+  const eventIds: Record<string, string> = {};
+  for (const [cat, calId] of Object.entries(calendarIds)) {
+    const id = await createCalendarEvent(accessToken, meetingForSync, calId);
+    if (id) eventIds[cat] = id;
+  }
+
+  await prisma.meeting.update({ where: { mid: meeting.mid }, data: { googleCalendarEventIds: eventIds } });
+}
+
+const resumeMeeting = async (request: Request) => {
+  try {
+    const auth = await requireRole(Role.ADMIN);
+    if (auth instanceof Response) return auth;
+
+    const { mid } = await request.json();
+    if (!mid) {
+      return NextResponse.json({ error: "mid is required" }, { status: 400 });
+    }
+
+    const meeting = await prisma.meeting.findUnique({
+      where: { mid },
+      include: { recurrencePattern: true, suspensions: true },
+    });
+    if (!meeting) {
+      return NextResponse.json({ error: "Meeting not found" }, { status: 404 });
+    }
+
+    await reconcilePendingResume(meeting);
+
+    const todayStr = formatETDateString(new Date());
+    const openSuspension = getOpenSuspension(meeting, todayStr);
+    if (!openSuspension) {
+      return NextResponse.json({ error: "Meeting is not currently suspended" }, { status: 400 });
+    }
+
+    await prisma.meeting.update({ where: { mid }, data: { status: 'Active' } });
+    await prisma.suspensionPeriod.update({ where: { id: openSuspension.id }, data: { to: new Date() } });
+
+    after(syncResume(meeting, openSuspension, auth.accessToken));
+
+    return NextResponse.json({ message: "Meeting resumed" });
+  } catch (error) {
+    console.error("Error resuming meeting: ", error);
+    return NextResponse.json({ error: "Failed to resume meeting" }, { status: 500 });
+  }
+};
+
+export { resumeMeeting as POST };

--- a/frontend/app/api/update/meeting/resume/route.ts
+++ b/frontend/app/api/update/meeting/resume/route.ts
@@ -85,15 +85,26 @@ const resumeMeeting = async (request: Request) => {
       return NextResponse.json({ error: "Meeting is not currently suspended" }, { status: 400 });
     }
 
-    await prisma.$transaction([
-      prisma.meeting.update({ where: { mid }, data: { status: 'Active' } }),
-      prisma.suspensionPeriod.update({
-        where: { id: openSuspension.id },
+    // Gated on `promoted: false` -- the only writers that ever set it true are this close and
+    // reconcilePendingResume's own promotion, so it doubles as a single-winner check: if two
+    // resume requests race on the same open suspension, only the first `updateMany` actually
+    // matches a row (count 1); the loser sees count 0 and must not also schedule a duplicate
+    // syncResume, which would otherwise create a second calendar event for the same meeting.
+    const won = await prisma.$transaction(async (tx) => {
+      const closed = await tx.suspensionPeriod.updateMany({
+        where: { id: openSuspension.id, promoted: false },
         // resumeEventIds are deleted by syncResume below, so clear them here too -- otherwise
         // reconcilePendingResume sees an unpromoted, now-due row and republishes dead IDs.
         data: { to: new Date(), resumeEventIds: null, promoted: true },
-      }),
-    ]);
+      });
+      if (closed.count === 0) return false;
+      await tx.meeting.update({ where: { mid }, data: { status: 'Active' } });
+      return true;
+    });
+
+    if (!won) {
+      return NextResponse.json({ error: "Meeting was already resumed" }, { status: 409 });
+    }
 
     after(syncResume(meeting, openSuspension, auth.accessToken));
 

--- a/frontend/app/api/update/meeting/route.ts
+++ b/frontend/app/api/update/meeting/route.ts
@@ -6,6 +6,7 @@ import { createCalendarEvent, updateCalendarEvent, deleteCalendarEvent, reconcil
 import { createZoomMeeting, updateZoomMeeting, deleteZoomMeeting, getZoomMeetingInvitation, resolveZoomHost, zoomRoomCalendarId } from "../../../../services/zoom";
 import { findResourceConflicts } from "../../../../util/resourceOverlap";
 import { meetingSchema } from "../../../../util/meetingValidation";
+import { reconcilePendingResume } from "../../../../util/suspension";
 import { prisma } from "../../../../lib/prisma";
 
 // Runs after the response is sent (see after() call below) — failure updates googleSyncStatus
@@ -189,13 +190,18 @@ const updateMeeting = async (request: Request): Promise<Response> => {
       where: {
         mid: newMeeting.mid,
       },
-      include: { recurrencePattern: true },
+      include: { recurrencePattern: true, suspensions: true },
     });
 
     if (!existingMeeting) {
       console.error('Meeting not found:', newMeeting.mid);
       return NextResponse.json({ error: `Meeting with ID ${newMeeting.mid} not found` }, { status: 404 });
     }
+
+    // Lazy self-heal: promote a scheduled resume's pre-created GCal series into
+    // googleCalendarEventIds if its date has arrived but nothing's promoted it yet, before this
+    // edit reads/writes that field below.
+    existingMeeting.googleCalendarEventIds = await reconcilePendingResume(existingMeeting);
 
     const { mid, recurrencePattern, ...meetingFields } = newMeeting;
 

--- a/frontend/app/api/update/meeting/suspend/route.ts
+++ b/frontend/app/api/update/meeting/suspend/route.ts
@@ -9,7 +9,7 @@ import {
 } from '../../../../../services/googleCalendar';
 import { formatETDateString } from '../../../../../util/timeUtils';
 import { addOneETDay, adjustOccurrenceToDate, firstOccurrenceOnOrAfter } from '../../../../../util/meetingOccurrences';
-import { reconcilePendingResume } from '../../../../../util/suspension';
+import { getOpenSuspension, reconcilePendingResume } from '../../../../../util/suspension';
 import { IMeeting } from '../../../../../util/models';
 import { prisma } from '../../../../../lib/prisma';
 
@@ -81,11 +81,25 @@ async function syncSuspend(
       }
     }
   } else {
-    // One-time meeting: nothing recurring to truncate, just remove the single event -- resuming
-    // recreates it at its original startDateTime.
+    // One-time meeting: nothing recurring to truncate, just remove the single event.
     for (const [cat, calId] of Object.entries(calendarIds)) {
       const eventId = reconciledEventIds[cat];
       if (eventId) await deleteCalendarEvent(accessToken, eventId, calId);
+    }
+
+    // If a resume date was given and the meeting's original occurrence hasn't happened yet,
+    // pre-create it at that same original time so reconcilePendingResume can auto-restore it
+    // once `to` arrives -- otherwise a scheduled (not manually-triggered) resume would leave a
+    // one-time meeting permanently missing from Google Calendar. An early manual resume (via
+    // the resume route) still recreates it fresh regardless of this.
+    if (to && meeting.startDateTime > new Date()) {
+      const resumeMeeting = toCalendarMeeting(meeting, meeting.startDateTime, meeting.endDateTime);
+      const resumeEventIds: Record<string, string> = {};
+      for (const [cat, calId] of Object.entries(calendarIds)) {
+        const id = await createCalendarEvent(accessToken, resumeMeeting, calId);
+        if (id) resumeEventIds[cat] = id;
+      }
+      await prisma.suspensionPeriod.update({ where: { id: suspensionId }, data: { resumeEventIds } });
     }
   }
 }
@@ -110,11 +124,26 @@ const suspendMeeting = async (request: Request) => {
 
     const reconciledEventIds = await reconcilePendingResume(meeting);
 
-    const toDate = to ? new Date(to) : null;
-    await prisma.meeting.update({ where: { mid }, data: { status: 'Suspended' } });
-    const suspension = await prisma.suspensionPeriod.create({
-      data: { mid, from: new Date(), to: toDate },
-    });
+    if (getOpenSuspension(meeting)) {
+      return NextResponse.json({ error: "Meeting is already suspended" }, { status: 400 });
+    }
+
+    const from = new Date();
+    let toDate: Date | null = null;
+    if (to != null) {
+      toDate = new Date(to);
+      if (Number.isNaN(toDate.getTime())) {
+        return NextResponse.json({ error: "to must be a valid date" }, { status: 400 });
+      }
+      if (formatETDateString(toDate) <= formatETDateString(from)) {
+        return NextResponse.json({ error: "to must be after today" }, { status: 400 });
+      }
+    }
+
+    const [, suspension] = await prisma.$transaction([
+      prisma.meeting.update({ where: { mid }, data: { status: 'Suspended' } }),
+      prisma.suspensionPeriod.create({ data: { mid, from, to: toDate } }),
+    ]);
 
     after(syncSuspend(meeting, suspension.id, auth.accessToken, toDate, reconciledEventIds));
 

--- a/frontend/app/api/update/meeting/suspend/route.ts
+++ b/frontend/app/api/update/meeting/suspend/route.ts
@@ -1,0 +1,128 @@
+import { Meeting, RecurrencePattern, Role } from '@prisma/client';
+import { NextResponse, after } from 'next/server';
+import { requireRole } from '../../../../../services/auth';
+import {
+  trimCalendarEventSeries,
+  deleteCalendarEvent,
+  createCalendarEvent,
+  calendarIdsForMeeting,
+} from '../../../../../services/googleCalendar';
+import { formatETDateString } from '../../../../../util/timeUtils';
+import { addOneETDay, adjustOccurrenceToDate, firstOccurrenceOnOrAfter } from '../../../../../util/meetingOccurrences';
+import { reconcilePendingResume } from '../../../../../util/suspension';
+import { IMeeting } from '../../../../../util/models';
+import { prisma } from '../../../../../lib/prisma';
+
+type MeetingWithPattern = Meeting & { recurrencePattern: RecurrencePattern | null };
+
+// Only the fields services/googleCalendar.ts's buildEventBody actually reads -- constructed
+// explicitly rather than spreading the Prisma row, since Prisma's Meeting type doesn't line up
+// field-for-field with IMeeting (e.g. googleCalendarEventIds is a JsonValue here, not a typed
+// Record).
+function toCalendarMeeting(
+  meeting: MeetingWithPattern,
+  startDateTime: Date,
+  endDateTime: Date,
+): IMeeting {
+  return {
+    mid: meeting.mid,
+    title: meeting.title,
+    description: meeting.description,
+    creator: meeting.creator,
+    group: meeting.group,
+    startDateTime,
+    endDateTime,
+    email: meeting.email,
+    zoomRoom: meeting.zoomRoom,
+    zoomLink: meeting.zoomLink,
+    calType: meeting.calType,
+    modeType: meeting.modeType,
+    room: meeting.room,
+    isRecurring: meeting.isRecurring,
+    recurrencePattern: meeting.recurrencePattern
+      ? { ...meeting.recurrencePattern, startDate: startDateTime }
+      : null,
+  };
+}
+
+async function syncSuspend(
+  meeting: MeetingWithPattern,
+  suspensionId: string,
+  accessToken: string | undefined,
+  to: Date | null,
+  reconciledEventIds: Record<string, string>,
+): Promise<void> {
+  if (!accessToken) return;
+  const calendarIds = calendarIdsForMeeting(meeting.calType ?? []);
+
+  if (meeting.isRecurring && meeting.recurrencePattern) {
+    // Truncate starting tomorrow, not today -- a suspension taking effect this instant
+    // shouldn't retroactively remove today's already-scheduled occurrence.
+    const tomorrowStr = addOneETDay(formatETDateString(new Date()));
+    for (const [cat, calId] of Object.entries(calendarIds)) {
+      const eventId = reconciledEventIds[cat];
+      if (eventId) await trimCalendarEventSeries(accessToken, eventId, tomorrowStr, calId);
+    }
+
+    if (to) {
+      const resumeDateStr = firstOccurrenceOnOrAfter(
+        { ...meeting.recurrencePattern, daysOfWeek: meeting.recurrencePattern.daysOfWeek ?? [] },
+        formatETDateString(to),
+      );
+      if (resumeDateStr) {
+        const { start, end } = adjustOccurrenceToDate(meeting, resumeDateStr);
+        const resumeMeeting = toCalendarMeeting(meeting, start, end);
+        const resumeEventIds: Record<string, string> = {};
+        for (const [cat, calId] of Object.entries(calendarIds)) {
+          const id = await createCalendarEvent(accessToken, resumeMeeting, calId);
+          if (id) resumeEventIds[cat] = id;
+        }
+        await prisma.suspensionPeriod.update({ where: { id: suspensionId }, data: { resumeEventIds } });
+      }
+    }
+  } else {
+    // One-time meeting: nothing recurring to truncate, just remove the single event -- resuming
+    // recreates it at its original startDateTime.
+    for (const [cat, calId] of Object.entries(calendarIds)) {
+      const eventId = reconciledEventIds[cat];
+      if (eventId) await deleteCalendarEvent(accessToken, eventId, calId);
+    }
+  }
+}
+
+const suspendMeeting = async (request: Request) => {
+  try {
+    const auth = await requireRole(Role.ADMIN);
+    if (auth instanceof Response) return auth;
+
+    const { mid, to } = await request.json();
+    if (!mid) {
+      return NextResponse.json({ error: "mid is required" }, { status: 400 });
+    }
+
+    const meeting = await prisma.meeting.findUnique({
+      where: { mid },
+      include: { recurrencePattern: true, suspensions: true },
+    });
+    if (!meeting) {
+      return NextResponse.json({ error: "Meeting not found" }, { status: 404 });
+    }
+
+    const reconciledEventIds = await reconcilePendingResume(meeting);
+
+    const toDate = to ? new Date(to) : null;
+    await prisma.meeting.update({ where: { mid }, data: { status: 'Suspended' } });
+    const suspension = await prisma.suspensionPeriod.create({
+      data: { mid, from: new Date(), to: toDate },
+    });
+
+    after(syncSuspend(meeting, suspension.id, auth.accessToken, toDate, reconciledEventIds));
+
+    return NextResponse.json({ message: "Meeting suspended", suspensionId: suspension.id });
+  } catch (error) {
+    console.error("Error suspending meeting: ", error);
+    return NextResponse.json({ error: "Failed to suspend meeting" }, { status: 500 });
+  }
+};
+
+export { suspendMeeting as POST };

--- a/frontend/prisma/schema.prisma
+++ b/frontend/prisma/schema.prisma
@@ -44,6 +44,7 @@ model Meeting {
   status                 String               @default("Active")
   isRecurring            Boolean              @default(false)
   recurrencePattern      RecurrencePattern?   @relation("MeetingToRecurrencePattern")
+  suspensions            SuspensionPeriod[]   @relation("MeetingToSuspensionPeriod")
   googleCalendarEventId  String?
   googleCalendarEventIds Json?
   googleSyncStatus       String?
@@ -78,6 +79,27 @@ model RecurrencePattern {
   excludedDates      DateTime[] @default([])
 }
 
+
+// One row per suspend→resume cycle for a meeting (never mutated once superseded by a new
+// suspension) — real date-range history, not a flag, so past-date calendar views can correctly
+// answer "was this meeting suspended on that specific date."
+model SuspensionPeriod {
+  id             String    @id @default(auto()) @map("_id") @db.ObjectId
+  mid            String
+  meeting        Meeting   @relation("MeetingToSuspensionPeriod", fields: [mid], references: [mid])
+  from           DateTime
+  to             DateTime?
+  // GCal event IDs (keyed by calendarId) pre-created for the post-resume series when `to` was set
+  // at suspend time. Held here until reconciled into Meeting.googleCalendarEventIds once `to`
+  // actually arrives — never promoted early, so the live-series pointer never references a series
+  // that hasn't started yet.
+  resumeEventIds Json?
+  // Whether resumeEventIds has already been copied into Meeting.googleCalendarEventIds by the
+  // reconciliation step. Tracked explicitly rather than inferred by comparing JSON blobs.
+  promoted       Boolean   @default(false)
+
+  @@index([mid])
+}
 
 model User {
   id   String @id @default(auto()) @map("_id") @db.ObjectId

--- a/frontend/tests/e2e/provisional.spec.ts
+++ b/frontend/tests/e2e/provisional.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "./support/fixtures";
-import { seedMeeting } from "../factories/meeting";
+import { seedSuspendedMeeting } from "../factories/meeting";
 
 // Provisional tests: lock in the *current* stub/absent behavior of features that
 // aren't fully implemented yet, so whoever ships the real feature finds these
@@ -34,28 +34,26 @@ test.describe("provisional — unimplemented features", () => {
 
   test("[PROVISIONAL:suspend-workflow] a Suspended meeting is only reachable via direct DB write, never through the UI", async ({ superAdminPage }) => {
     const { page } = superAdminPage;
-    // No component anywhere calls PUT /api/update/meeting with status: 'Suspended'
-    // — seedMeeting({ status: 'Suspended' }) (test/factories/meeting.ts) is a
-    // direct Prisma write standing in for a UI action that doesn't exist. This
-    // test both documents the gap and confirms Diagnostics' read side (which does
-    // exist) still surfaces a meeting suspended that way.
-    await seedMeeting({ title: "Suspended Stub Meeting", status: "Suspended" });
+    // The backend half of this ticket has landed: app/api/update/meeting/{suspend,resume}/
+    // route.ts are real routes, Diagnostics derives its suspended panel/count from real
+    // SuspensionPeriod date ranges (app/api/admin/diagnostics/route.ts), and
+    // util/meetingOccurrences.ts's getMeetingsForDate now genuinely hides a currently-suspended
+    // meeting from the live calendar. What's still missing, and what this test now documents,
+    // is the UI half: no component anywhere calls those routes — seedSuspendedMeeting()
+    // (tests/factories/meeting.ts) is a direct Prisma write standing in for a UI action
+    // (ViewMeeting's kebab menu, per the ticket) that doesn't exist yet.
+    await seedSuspendedMeeting({ title: "Suspended Stub Meeting" });
     await page.goto("/admin");
 
     await expect(
       page.getByTestId("diagnostics-suspended-panel").getByText("Suspended Stub Meeting"),
     ).toBeVisible();
 
-    // No suspend/unsuspend control exists on the meeting detail panel. And
-    // suspension isn't a visibility toggle within the app itself — status is never
-    // filtered on in util/meetingOccurrences.ts's getMeetingsForDate(), so the
-    // meeting still renders on the live calendar identically to an Active one; the
-    // Diagnostics subhead's "hidden from Google Calendar" is specifically about the
-    // one-way external sync (write/meeting/route.ts skips both GCal/Zoom sync when
-    // status === 'Suspended'), not about the calendar view.
+    // Real behavior now, not a stub: a currently-suspended meeting is hidden from the live
+    // Day view.
     const dayResponse = page.waitForResponse((r) => r.url().includes("/api/retrieve/meeting/day"));
     await page.goto("/");
     await dayResponse;
-    await expect(page.getByText("Suspended Stub Meeting")).toBeVisible();
+    await expect(page.getByText("Suspended Stub Meeting")).not.toBeVisible();
   });
 });

--- a/frontend/tests/factories/meeting.ts
+++ b/frontend/tests/factories/meeting.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "crypto";
-import { Meeting, RecurrencePattern } from "@prisma/client";
+import { Meeting, RecurrencePattern, SuspensionPeriod } from "@prisma/client";
 import { getTestPrismaClient } from "./db";
 import { convertETToUTC, formatETDateString } from "../../util/timeUtils";
 
@@ -49,9 +49,25 @@ export async function seedRecurringMeeting(
   return { meeting, recurrencePattern };
 }
 
+export async function seedSuspensionPeriod(
+  mid: string,
+  overrides: Partial<SuspensionPeriod> = {},
+): Promise<SuspensionPeriod> {
+  const prisma = getTestPrismaClient();
+  return prisma.suspensionPeriod.create({
+    data: {
+      mid,
+      from: new Date(Date.now() - 24 * 60 * 60 * 1000), // yesterday, so "today" is covered
+      to: null,
+      ...overrides,
+    },
+  });
+}
+
 export async function seedSuspendedMeeting(overrides: Partial<Meeting> = {}): Promise<Meeting> {
-  // No UI path sets this today (confirmed gap) — only reachable via direct seed.
-  return seedMeeting({ status: "Suspended", ...overrides });
+  const meeting = await seedMeeting({ status: "Suspended", ...overrides });
+  await seedSuspensionPeriod(meeting.mid);
+  return meeting;
 }
 
 // Plain-data counterpart to seedMeeting, for route tests that build the data

--- a/frontend/tests/integration/resume-meeting-route.test.ts
+++ b/frontend/tests/integration/resume-meeting-route.test.ts
@@ -1,0 +1,109 @@
+import { getTestPrismaClient, disconnectTestPrismaClient } from "../factories/db";
+import { seedMeeting, seedRecurringMeeting, seedSuspensionPeriod } from "../factories/meeting";
+
+jest.mock("next/server", () => ({
+  ...jest.requireActual("next/server"),
+  after: () => {},
+}));
+
+jest.mock("../../services/auth", () => ({
+  requireRole: jest.fn().mockResolvedValue({
+    user: { role: "ADMIN" },
+    accessToken: "fake-token",
+  }),
+}));
+
+jest.mock("../../services/googleCalendar", () => ({
+  calendarIdsForMeeting: jest.fn().mockReturnValue({ AA: "fake-calendar-id" }),
+  createCalendarEvent: jest.fn().mockResolvedValue("fresh-event-id"),
+  deleteCalendarEvent: jest.fn().mockResolvedValue(true),
+}));
+
+import { createCalendarEvent, deleteCalendarEvent } from "../../services/googleCalendar";
+import { POST } from "../../app/api/update/meeting/resume/route";
+
+const mockedCreate = createCalendarEvent as jest.Mock;
+const mockedDelete = deleteCalendarEvent as jest.Mock;
+
+afterAll(async () => {
+  await disconnectTestPrismaClient();
+});
+
+beforeEach(() => {
+  mockedCreate.mockClear();
+  mockedDelete.mockClear();
+});
+
+async function waitFor<T>(fn: () => Promise<T | null | undefined>, timeoutMs = 2000): Promise<T | null> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    const result = await fn();
+    if (result != null) return result;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  return null;
+}
+
+test("resuming an indefinitely-suspended meeting creates a fresh series and closes the open suspension", async () => {
+  const { meeting } = await seedRecurringMeeting({ status: "Suspended" });
+  await seedSuspensionPeriod(meeting.mid); // from: yesterday, to: null
+
+  const request = new Request("http://localhost/api/update/meeting/resume", {
+    method: "POST",
+    body: JSON.stringify({ mid: meeting.mid }),
+  });
+  const response = await POST(request);
+  expect(response.status).toBe(200);
+
+  const prisma = getTestPrismaClient();
+  const updated = await prisma.meeting.findUnique({ where: { mid: meeting.mid } });
+  expect(updated?.status).toBe("Active");
+
+  const suspensions = await prisma.suspensionPeriod.findMany({ where: { mid: meeting.mid } });
+  expect(suspensions).toHaveLength(1);
+  expect(suspensions[0].to).not.toBeNull();
+
+  const withEventIds = await waitFor(async () => {
+    const m = await prisma.meeting.findUnique({ where: { mid: meeting.mid } });
+    return m?.googleCalendarEventIds ? m : null;
+  });
+  expect(withEventIds?.googleCalendarEventIds).toEqual({ AA: "fresh-event-id" });
+  expect(mockedDelete).not.toHaveBeenCalled();
+});
+
+test("resuming early discards the pre-created future series instead of promoting it", async () => {
+  const { meeting } = await seedRecurringMeeting({ status: "Suspended" });
+  const farFuture = new Date(Date.now() + 60 * 24 * 60 * 60 * 1000); // 60 days out -- not due yet
+  await seedSuspensionPeriod(meeting.mid, { to: farFuture, resumeEventIds: { AA: "pending-future-event-id" } });
+
+  const request = new Request("http://localhost/api/update/meeting/resume", {
+    method: "POST",
+    body: JSON.stringify({ mid: meeting.mid }),
+  });
+  const response = await POST(request);
+  expect(response.status).toBe(200);
+
+  await waitFor(async () => (mockedDelete.mock.calls.length > 0 ? true : null));
+  expect(mockedDelete).toHaveBeenCalledWith("fake-token", "pending-future-event-id", "fake-calendar-id");
+  expect(mockedCreate).toHaveBeenCalled();
+});
+
+test("resuming a meeting that isn't currently suspended returns 400", async () => {
+  const meeting = await seedMeeting({ status: "Active" });
+
+  const request = new Request("http://localhost/api/update/meeting/resume", {
+    method: "POST",
+    body: JSON.stringify({ mid: meeting.mid }),
+  });
+  const response = await POST(request);
+  expect(response.status).toBe(400);
+});
+
+test("a request for a nonexistent meeting returns 404", async () => {
+  const request = new Request("http://localhost/api/update/meeting/resume", {
+    method: "POST",
+    body: JSON.stringify({ mid: "does-not-exist" }),
+  });
+  const response = await POST(request);
+  expect(response.status).toBe(404);
+});

--- a/frontend/tests/integration/suspend-meeting-route.test.ts
+++ b/frontend/tests/integration/suspend-meeting-route.test.ts
@@ -1,0 +1,128 @@
+import { getTestPrismaClient, disconnectTestPrismaClient } from "../factories/db";
+import { seedMeeting, seedRecurringMeeting } from "../factories/meeting";
+import { formatETDateString, convertETToUTC } from "../../util/timeUtils";
+
+jest.mock("next/server", () => ({
+  ...jest.requireActual("next/server"),
+  after: () => {},
+}));
+
+jest.mock("../../services/auth", () => ({
+  requireRole: jest.fn().mockResolvedValue({
+    user: { role: "ADMIN" },
+    accessToken: "fake-token",
+  }),
+}));
+
+jest.mock("../../services/googleCalendar", () => ({
+  calendarIdsForMeeting: jest.fn().mockReturnValue({ AA: "fake-calendar-id" }),
+  trimCalendarEventSeries: jest.fn().mockResolvedValue(true),
+  createCalendarEvent: jest.fn().mockResolvedValue("resume-event-id"),
+  deleteCalendarEvent: jest.fn().mockResolvedValue(true),
+}));
+
+import { trimCalendarEventSeries, createCalendarEvent, deleteCalendarEvent } from "../../services/googleCalendar";
+import { POST } from "../../app/api/update/meeting/suspend/route";
+
+const mockedTrim = trimCalendarEventSeries as jest.Mock;
+const mockedCreate = createCalendarEvent as jest.Mock;
+const mockedDelete = deleteCalendarEvent as jest.Mock;
+
+afterAll(async () => {
+  await disconnectTestPrismaClient();
+});
+
+beforeEach(() => {
+  mockedTrim.mockClear();
+  mockedCreate.mockClear();
+  mockedDelete.mockClear();
+});
+
+async function waitFor<T>(fn: () => Promise<T | null | undefined>, timeoutMs = 2000): Promise<T | null> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    const result = await fn();
+    if (result != null) return result;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  return null;
+}
+
+test("suspending a recurring meeting indefinitely truncates its GCal series and records an open-ended suspension", async () => {
+  const { meeting } = await seedRecurringMeeting({ googleCalendarEventIds: { AA: "existing-event-id" } });
+
+  const request = new Request("http://localhost/api/update/meeting/suspend", {
+    method: "POST",
+    body: JSON.stringify({ mid: meeting.mid }),
+  });
+  const response = await POST(request);
+  expect(response.status).toBe(200);
+
+  const prisma = getTestPrismaClient();
+  const updated = await prisma.meeting.findUnique({ where: { mid: meeting.mid } });
+  expect(updated?.status).toBe("Suspended");
+
+  const suspensions = await prisma.suspensionPeriod.findMany({ where: { mid: meeting.mid } });
+  expect(suspensions).toHaveLength(1);
+  expect(suspensions[0].to).toBeNull();
+
+  await waitFor(async () => (mockedTrim.mock.calls.length > 0 ? true : null));
+  expect(mockedTrim).toHaveBeenCalledWith("fake-token", "existing-event-id", expect.any(String), "fake-calendar-id");
+  expect(mockedCreate).not.toHaveBeenCalled();
+});
+
+test("suspending with an 'until' date pre-creates the resume series on the SuspensionPeriod row, not on Meeting.googleCalendarEventIds", async () => {
+  const { meeting } = await seedRecurringMeeting(
+    { googleCalendarEventIds: { AA: "existing-event-id" } },
+    { daysOfWeek: ["Monday", "Wednesday", "Friday"], interval: 1 },
+  );
+
+  const etDate = formatETDateString(new Date());
+  const to = new Date(new Date(convertETToUTC(`${etDate}T00:00:00`)).getTime() + 30 * 24 * 60 * 60 * 1000).toISOString();
+
+  const request = new Request("http://localhost/api/update/meeting/suspend", {
+    method: "POST",
+    body: JSON.stringify({ mid: meeting.mid, to }),
+  });
+  const response = await POST(request);
+  expect(response.status).toBe(200);
+
+  const prisma = getTestPrismaClient();
+
+  const suspension = await waitFor(async () => {
+    const rows = await prisma.suspensionPeriod.findMany({ where: { mid: meeting.mid } });
+    return rows[0]?.resumeEventIds ? rows[0] : null;
+  });
+
+  expect(suspension).not.toBeNull();
+  expect(suspension?.resumeEventIds).toEqual({ AA: "resume-event-id" });
+  expect(suspension?.promoted).toBe(false);
+
+  // Not promoted into the live pointer yet -- the resume date hasn't arrived.
+  const updatedMeeting = await prisma.meeting.findUnique({ where: { mid: meeting.mid } });
+  expect(updatedMeeting?.googleCalendarEventIds).toEqual({ AA: "existing-event-id" });
+});
+
+test("suspending a one-time (non-recurring) meeting deletes its single GCal event instead of trimming a series", async () => {
+  const meeting = await seedMeeting({ googleCalendarEventIds: { AA: "one-time-event-id" } });
+
+  const request = new Request("http://localhost/api/update/meeting/suspend", {
+    method: "POST",
+    body: JSON.stringify({ mid: meeting.mid }),
+  });
+  const response = await POST(request);
+  expect(response.status).toBe(200);
+
+  await waitFor(async () => (mockedDelete.mock.calls.length > 0 ? true : null));
+  expect(mockedDelete).toHaveBeenCalledWith("fake-token", "one-time-event-id", "fake-calendar-id");
+  expect(mockedTrim).not.toHaveBeenCalled();
+});
+
+test("a request for a nonexistent meeting returns 404", async () => {
+  const request = new Request("http://localhost/api/update/meeting/suspend", {
+    method: "POST",
+    body: JSON.stringify({ mid: "does-not-exist" }),
+  });
+  const response = await POST(request);
+  expect(response.status).toBe(404);
+});

--- a/frontend/tests/integration/update-meeting-route.test.ts
+++ b/frontend/tests/integration/update-meeting-route.test.ts
@@ -34,6 +34,7 @@ jest.mock("../../services/zoom", () => ({
 }));
 
 import { getTestPrismaClient, disconnectTestPrismaClient } from "../factories/db";
+import { seedSuspensionPeriod } from "../factories/meeting";
 import { PUT } from "../../app/api/update/meeting/route";
 import { updateZoomMeeting, createZoomMeeting, deleteZoomMeeting, resolveZoomHost } from "../../services/zoom";
 import { reconcileMeetingCalendars, createCalendarEvent } from "../../services/googleCalendar";
@@ -282,4 +283,43 @@ test("an explicit host reassignment tears down the old Zoom meeting and creates 
   expect(afterSync?.zid).toBe("zid-reassigned");
   expect(afterSync?.zoomHost).toBe("new-host@icr.test");
   expect(afterSync?.zoomSyncStatus).toBe("synced");
+});
+
+test("editing a meeting whose scheduled resume date has already passed promotes the pre-created resume series first", async () => {
+  mockedReconcileMeetingCalendars.mockResolvedValue({ updatedEventIds: { AA: "still-stale-id" }, allSynced: true });
+
+  const prisma = getTestPrismaClient();
+  const mid = `m-${randomUUID()}`;
+  const { recurrencePattern: _rp, ...existingMeetingData } = buildMeetingPayload({
+    mid,
+    googleCalendarEventIds: { AA: "stale-pre-suspend-event-id" },
+  });
+  await prisma.meeting.create({ data: existingMeetingData });
+  const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000);
+  await seedSuspensionPeriod(mid, {
+    from: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000),
+    to: yesterday,
+    resumeEventIds: { AA: "resume-event-id" },
+    promoted: false,
+  });
+
+  const payload = buildMeetingPayload({ mid, title: "Edited Title" });
+  const request = new Request("http://localhost/api/update/meeting", {
+    method: "PUT",
+    body: JSON.stringify(payload),
+  });
+
+  const response = await PUT(request);
+  expect(response.status).toBe(200);
+
+  // reconcileMeetingCalendars must have been called against the promoted pointer
+  // (resume-event-id), not the stale pre-suspend one still sitting in the DB row.
+  expect(mockedReconcileMeetingCalendars).toHaveBeenCalledWith(
+    "fake-token",
+    expect.anything(),
+    { AA: "resume-event-id" },
+  );
+
+  const suspension = await prisma.suspensionPeriod.findFirst({ where: { mid } });
+  expect(suspension?.promoted).toBe(true);
 });

--- a/frontend/tests/unit/resourceOverlap.test.ts
+++ b/frontend/tests/unit/resourceOverlap.test.ts
@@ -9,6 +9,10 @@ import {
 const utcDate = (y: number, m: number, d: number, h = 0, min = 0) =>
   new Date(Date.UTC(y, m - 1, d, h, min));
 
+// computeConflicts derives "suspended" from suspensions[], not the status field -- this fixture
+// stands in for "suspended indefinitely, started well in the past."
+const suspendedIndefinitely = [{ from: utcDate(2020, 1, 1), to: null }];
+
 const weeklyMondayPattern = {
   type: "weekly",
   startDate: utcDate(2026, 7, 6), // a Monday
@@ -174,7 +178,7 @@ describe("computeConflicts", () => {
       ...baseMeeting,
       mid: "m2",
       title: "Meeting Two",
-      status: "Suspended",
+      suspensions: suspendedIndefinitely,
       startDateTime: utcDate(2026, 7, 6, 19, 30),
       endDateTime: utcDate(2026, 7, 6, 20, 30),
     };
@@ -219,7 +223,7 @@ describe("computeConflicts", () => {
   it("flags a zoomHost conflict even when one of the two meetings is suspended", () => {
     // Unlike room/zoomRoom, a suspended meeting's Zoom host is still genuinely reserved
     // (its Zoom sync is skipped, not torn down) -- see resolveZoomHost's includeSuspended: true.
-    const withHost: ConflictCandidateMeeting = { ...baseMeeting, zoomHost: "host1@icr.test", status: "Suspended" };
+    const withHost: ConflictCandidateMeeting = { ...baseMeeting, zoomHost: "host1@icr.test", suspensions: suspendedIndefinitely };
     const meetingTwo: ConflictCandidateMeeting = {
       ...baseMeeting,
       mid: "m2",
@@ -235,12 +239,12 @@ describe("computeConflicts", () => {
   });
 
   it("does not flag two suspended meetings sharing a room (room conflicts still exclude suspended)", () => {
-    const meetingOne: ConflictCandidateMeeting = { ...baseMeeting, status: "Suspended" };
+    const meetingOne: ConflictCandidateMeeting = { ...baseMeeting, suspensions: suspendedIndefinitely };
     const meetingTwo: ConflictCandidateMeeting = {
       ...baseMeeting,
       mid: "m2",
       title: "Meeting Two",
-      status: "Suspended",
+      suspensions: suspendedIndefinitely,
       startDateTime: utcDate(2026, 7, 6, 19, 30),
       endDateTime: utcDate(2026, 7, 6, 20, 30),
     };

--- a/frontend/util/meetingOccurrences.ts
+++ b/frontend/util/meetingOccurrences.ts
@@ -15,6 +15,20 @@ const etTimeFmt = new Intl.DateTimeFormat('en-GB', {
 const isDateExcluded = (excludedDates: Date[], dateStr: string): boolean =>
     excludedDates.some(excl => etFmt.format(new Date(excl)) === dateStr);
 
+// Returns true if the given ET date string falls inside one of a meeting's suspension windows.
+// `dateStr` must be the date actually being evaluated (the calendar date being rendered, or
+// today's ET date for "is this meeting suspended right now" contexts) -- never implicitly "now",
+// so a past-date calendar view correctly reflects what was true on that date, not live status.
+export const isDateSuspended = (
+    suspensions: { from: Date; to: Date | null }[],
+    dateStr: string,
+): boolean =>
+    suspensions.some(s => {
+        const fromStr = etFmt.format(new Date(s.from));
+        const toStr = s.to ? etFmt.format(new Date(s.to)) : null;
+        return dateStr >= fromStr && (toStr === null || dateStr < toStr);
+    });
+
 // Returns true if the given ET date string is past the series end date.
 // Compares ET date strings to avoid UTC-midnight vs ET-midnight mismatches.
 const isAfterSeriesEnd = (endDate: Date | null, dateStr: string): boolean => {
@@ -103,7 +117,7 @@ export const matchesRecurrencePattern = (
 
 // Adds one calendar day to an ET date string ("YYYY-MM-DD"), via UTC-anchored date-component
 // arithmetic (not a real elapsed-time addition), so this can't be thrown off by DST.
-const addOneETDay = (etDateStr: string): string => {
+export const addOneETDay = (etDateStr: string): string => {
     const [year, month, day] = etDateStr.split('-').map(Number);
     const next = new Date(Date.UTC(year, month - 1, day + 1));
     return `${next.getUTCFullYear()}-${String(next.getUTCMonth() + 1).padStart(2, '0')}-${String(next.getUTCDate()).padStart(2, '0')}`;
@@ -134,6 +148,26 @@ export const adjustOccurrenceToDate = (
     return { start, end };
 };
 
+// Walks forward day-by-day from `fromEtDateStr` (inclusive) and returns the first ET date
+// string on/after it that the recurrence pattern actually produces an occurrence on. Bounded to
+// ~370 days so a pattern that (mis)matches nothing near `fromEtDateStr` can't loop forever.
+export const firstOccurrenceOnOrAfter = (
+    recurrence: { type: string; startDate: Date; endDate: Date | null; interval: number; daysOfWeek: string[]; weekOfMonth: number | null; dayOfMonth: number | null; excludedDates: Date[] },
+    fromEtDateStr: string,
+): string | null => {
+    const [year, month, day] = fromEtDateStr.split('-').map(Number);
+    let cursor = Date.UTC(year, month - 1, day);
+    const msPerDay = 24 * 60 * 60 * 1000;
+    for (let i = 0; i < 370; i++) {
+        const localDate = new Date(cursor);
+        const etDateStr = `${localDate.getUTCFullYear()}-${String(localDate.getUTCMonth() + 1).padStart(2, '0')}-${String(localDate.getUTCDate()).padStart(2, '0')}`;
+        if (isAfterSeriesEnd(recurrence.endDate, etDateStr)) return null;
+        if (matchesRecurrencePattern(recurrence, etDateStr, localDate)) return etDateStr;
+        cursor += msPerDay;
+    }
+    return null;
+};
+
 /**
  * Returns every meeting occurrence (one-time + recurring, expanded) that falls on the given
  * ET calendar date, with recurring occurrences' start/end times adjusted onto that date.
@@ -152,13 +186,16 @@ export const getMeetingsForDate = async (etDateStr: string): Promise<PublicMeeti
             AND: [notDeleted, { startDateTime: { lte: endOfDay }, endDateTime: { gte: startOfDay } }]
         },
         include: {
-            recurrencePattern: true
+            recurrencePattern: true,
+            suspensions: true
         }
     });
 
-    const regularMeetings = directlyScheduledMeetings.filter(meeting => !meeting.isRecurring);
+    const regularMeetings = directlyScheduledMeetings.filter(meeting =>
+        !meeting.isRecurring && !isDateSuspended(meeting.suspensions, etDateStr));
     const originalDayRecurringMeetings = directlyScheduledMeetings.filter(meeting => {
         if (!meeting.isRecurring) return false;
+        if (isDateSuspended(meeting.suspensions, etDateStr)) return false;
         const recurrence = meeting.recurrencePattern;
         if (isAfterSeriesEnd(recurrence?.endDate ?? null, etDateStr)) return false;
         if (recurrence?.excludedDates?.length && isDateExcluded(recurrence.excludedDates, etDateStr)) return false;
@@ -178,10 +215,11 @@ export const getMeetingsForDate = async (etDateStr: string): Promise<PublicMeeti
                 { NOT: { AND: [{ startDateTime: { lte: endOfDay } }, { endDateTime: { gte: startOfDay } }] } }
             ]
         },
-        include: { recurrencePattern: true }
+        include: { recurrencePattern: true, suspensions: true }
     });
 
     const patternDayMeetings = otherRecurringMeetings.filter(meeting => {
+        if (isDateSuspended(meeting.suspensions, etDateStr)) return false;
         const recurrence = meeting.recurrencePattern;
         if (!recurrence) return false;
         return matchesRecurrencePattern(recurrence, etDateStr, localDate);

--- a/frontend/util/resourceOverlap.ts
+++ b/frontend/util/resourceOverlap.ts
@@ -1,7 +1,9 @@
 import { Prisma } from "@prisma/client";
 import { prisma } from "../lib/prisma";
 import { formatETDateString } from "./timeUtils";
-import { matchesRecurrencePattern, adjustOccurrenceToDate } from "./meetingOccurrences";
+import { matchesRecurrencePattern, adjustOccurrenceToDate, isDateSuspended } from "./meetingOccurrences";
+
+type SuspensionWindow = { from: Date; to: Date | null };
 
 const notDeleted = { OR: [{ deletedAt: null }, { deletedAt: { isSet: false } }] };
 
@@ -51,6 +53,7 @@ export type ConflictCandidateMeeting = OccurrenceInput & {
   zoomHost?: string | null;
   status?: string | null;
   calType?: string[];
+  suspensions?: SuspensionWindow[];
 };
 
 // Every occurrence of `meeting` that falls within [rangeStart, rangeEnd), sorted by start time.
@@ -177,11 +180,11 @@ export async function findResourceConflicts(
       notDeleted,
       fieldWhere(field, value),
       ...(opts.excludeMid ? [{ mid: { not: opts.excludeMid } }] : []),
-      ...(opts.includeSuspended ? [] : [{ status: { not: "Suspended" } }]),
     ],
   };
 
-  const meetings = await prisma.meeting.findMany({
+  const todayStr = formatETDateString(new Date());
+  const meetingsRaw = await prisma.meeting.findMany({
     where,
     select: {
       mid: true,
@@ -190,8 +193,12 @@ export async function findResourceConflicts(
       endDateTime: true,
       isRecurring: true,
       recurrencePattern: true,
+      suspensions: true,
     },
   });
+  const meetings = opts.includeSuspended
+    ? meetingsRaw
+    : meetingsRaw.filter((m) => !isDateSuspended(m.suspensions, todayStr));
 
   const conflicts: { mid: string; title: string }[] = [];
   for (const meeting of meetings) {
@@ -288,7 +295,8 @@ export function computeConflicts(
   horizonYears: number = OVERLAP_HORIZON_YEARS,
 ): ConflictRow[] {
   const [rangeStart, rangeEnd] = horizonRange(horizonYears);
-  const activeMeetings = meetings.filter((m) => m.status !== "Suspended");
+  const todayStr = formatETDateString(new Date());
+  const activeMeetings = meetings.filter((m) => !isDateSuspended(m.suspensions ?? [], todayStr));
   const conflicts: ConflictRow[] = [];
 
   const fieldMeetings: Record<"room" | "zoomRoom" | "zoomHost", ConflictCandidateMeeting[]> = {

--- a/frontend/util/suspension.ts
+++ b/frontend/util/suspension.ts
@@ -1,0 +1,39 @@
+import "server-only";
+import { Meeting, RecurrencePattern, SuspensionPeriod } from "@prisma/client";
+import { formatETDateString } from "./timeUtils";
+import { isDateSuspended } from "./meetingOccurrences";
+import { prisma } from "../lib/prisma";
+
+type MeetingWithSuspensions = Meeting & {
+  recurrencePattern: RecurrencePattern | null;
+  suspensions: SuspensionPeriod[];
+};
+
+// The suspension row covering today, if any -- "currently suspended" is always this, never a
+// stored flag. `null` if the meeting isn't suspended today (whether it never was, or a past
+// suspension's `to` date has already passed).
+export const getOpenSuspension = (meeting: MeetingWithSuspensions, todayStr = formatETDateString(new Date())): SuspensionPeriod | null =>
+  meeting.suspensions.find((s) => isDateSuspended([s], todayStr)) ?? null;
+
+// Lazy self-heal: if the meeting's most recent suspension pre-created a post-resume GCal series
+// (resumeEventIds) and that series' start date has actually arrived, but nothing has promoted it
+// into Meeting.googleCalendarEventIds yet, do that now. Cron-free by design -- this only needs to
+// run the next time anything touches the meeting (update/delete/suspend/resume routes all call it
+// right after fetching), and GCal's own recurrence engine already shows the pre-created series to
+// the public regardless of whether our DB pointer has caught up.
+export const reconcilePendingResume = async (meeting: MeetingWithSuspensions): Promise<Record<string, string>> => {
+  const eventIds = (meeting.googleCalendarEventIds ?? {}) as Record<string, string>;
+  const todayStr = formatETDateString(new Date());
+
+  const pending = meeting.suspensions.find(
+    (s) => !s.promoted && s.resumeEventIds && s.to && formatETDateString(new Date(s.to)) <= todayStr,
+  );
+  if (!pending) return eventIds;
+
+  const resumeEventIds = pending.resumeEventIds as Record<string, string>;
+  await prisma.$transaction([
+    prisma.meeting.update({ where: { mid: meeting.mid }, data: { googleCalendarEventIds: resumeEventIds } }),
+    prisma.suspensionPeriod.update({ where: { id: pending.id }, data: { promoted: true } }),
+  ]);
+  return resumeEventIds;
+};

--- a/frontend/util/suspension.ts
+++ b/frontend/util/suspension.ts
@@ -25,9 +25,11 @@ export const reconcilePendingResume = async (meeting: MeetingWithSuspensions): P
   const eventIds = (meeting.googleCalendarEventIds ?? {}) as Record<string, string>;
   const todayStr = formatETDateString(new Date());
 
-  const pending = meeting.suspensions.find(
-    (s) => !s.promoted && s.resumeEventIds && s.to && formatETDateString(new Date(s.to)) <= todayStr,
-  );
+  // Sorted by `from` descending -- if more than one period is somehow due and unpromoted at
+  // once, the most recent one's event IDs are the ones actually live on Google Calendar.
+  const pending = meeting.suspensions
+    .filter((s) => !s.promoted && s.resumeEventIds && s.to && formatETDateString(new Date(s.to)) <= todayStr)
+    .sort((a, b) => b.from.getTime() - a.from.getTime())[0];
   if (!pending) return eventIds;
 
   const resumeEventIds = pending.resumeEventIds as Record<string, string>;


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Administrators can suspend and resume meetings.
  * Supports indefinite and date-based suspensions with automatic calendar updates.
  * Diagnostics displays active suspensions and scheduled resume dates.
* **Bug Fixes**
  * Availability, conflicts, updates, and deletions now reflect suspension dates accurately.
  * Pending calendar resumes are reconciled before meeting changes.
* **Tests**
  * Added coverage for suspension, resumption, calendar synchronization, diagnostics, and conflict handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description
- **frontend/prisma/schema.prisma**: adds a `SuspensionPeriod` relation on `Meeting` (`from`, `to`, `resumeEventIds`, `promoted`) — one row per suspend→resume cycle, real date-range history instead of the dead-end `status: "Suspended"` flag, which was only ever reachable via a direct DB write.
- **frontend/app/api/update/meeting/suspend/route.ts**, **frontend/app/api/update/meeting/resume/route.ts**: new suspend/resume action routes, following the existing role-guard → fetch → mutate → deferred-`after()`-sync template used by the other meeting routes. Suspend truncates the live GCal series (reuses `trimCalendarEventSeries`) starting the next day, and — if an "until" date is given — pre-creates the resume series ahead of time at the first valid recurrence date on/after it.
- **frontend/util/suspension.ts**: `reconcilePendingResume`, a lazy self-heal step (called from `update/meeting`, `delete/meeting`, and both new routes) that promotes a due resume series into `Meeting.googleCalendarEventIds` only once its date has actually arrived — never eagerly, so that pointer never briefly references a series that hasn't started. Cron-free, matching this app's existing no-scheduler constraint.
- **frontend/util/meetingOccurrences.ts**: `isDateSuspended`, always given the date being evaluated explicitly (never implicitly "now"), so Daily/Weekly calendar navigation to a *past* date correctly reflects what was true on that date, not live status. Wired into both `getMeetingsForDate` call sites, including the previously-unhandled non-recurring case.
- **frontend/util/resourceOverlap.ts**, **frontend/app/api/admin/diagnostics/route.ts**: `findResourceConflicts`, `computeConflicts`, and Diagnostics' suspended count/panel all switch from the `status` flag to the derived date-range check.
- Zoom is intentionally untouched by suspend/resume — its existing skip-but-don't-tear-down guards were already correct and consistent (no recurrence concept in `services/zoom.ts`, and `includeSuspended: true` already keeps a suspended meeting's host reserved).

No UI in this PR — the new routes aren't wired to any component yet. That's the follow-up PR, stacked on top of this branch.

## Testing
- [x] `yarn tsc --noEmit` clean
- [x] `yarn lint` — 0 errors (pre-existing warnings only, none in touched files)
- [x] `yarn test:unit` — 108/108 passing (3 existing `resourceOverlap` tests updated for the new suspension model)
- [x] `yarn test:integration` — 32/32 passing, including 8 new tests covering suspend/resume/early-resume/one-time-meeting/404s/reconciliation (`tests/integration/suspend-meeting-route.test.ts`, `tests/integration/resume-meeting-route.test.ts`, plus a reconciliation case added to `tests/integration/update-meeting-route.test.ts`)
- [x] `yarn build` succeeds, new routes registered

## Area(s) Touched

**Integrations**
- [x] google-calendar — Google Calendar sync

**Engineering**
- [x] testing — test suite (Jest/Playwright) changes

## Pre-merge Checklist
- [x] Code follows current formatting conventions and passes lint (`yarn lint`).
- [x] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
- [x] All test suites pass, both run locally and green in GitHub CI. **Do not merge if any test suite is failing.**
- [x] A test suite was added or updated for the feature/fix in this PR. **Double-check this if you change a feature and did not update the test suites**.
- [x] Only files relevant to this change are committed — no stray or unrelated files.
- [x] If this branch has a merge conflict with master, master was merged into this branch first (not the other way around).
- [x] The rest of this PR description (Description, Testing) is filled out, not left as template placeholders.