### PR TITLE
fix(calendar): ignore navbar hide/show while overscrolled in MobileCalendarView

### DIFF
--- a/frontend/app/components/calendar/MobileCalendarView.tsx
+++ b/frontend/app/components/calendar/MobileCalendarView.tsx
@@ -170,9 +170,9 @@ const MobileCalendarView: React.FC<MobileCalendarViewProps> = ({
     // Rubber-band overscroll (elastic bounce past the top/bottom edge) reports scrollTop
     // outside [0, maxScroll] and snaps back next frame, producing a delta spike in the
     // opposite direction of the actual scroll -- ignore nav show/hide while overscrolled.
-    const maxScroll = el.scrollHeight - el.clientHeight;
+    const maxScroll = Math.max(0, el.scrollHeight - el.clientHeight);
     if (el.scrollTop < 0 || el.scrollTop > maxScroll) {
-      lastScrollTopRef.current = el.scrollTop;
+      lastScrollTopRef.current = Math.min(Math.max(el.scrollTop, 0), maxScroll);
       return;
     }
 

--- a/frontend/app/components/calendar/MobileCalendarView.tsx
+++ b/frontend/app/components/calendar/MobileCalendarView.tsx
@@ -166,6 +166,16 @@ const MobileCalendarView: React.FC<MobileCalendarViewProps> = ({
   const handleScroll = () => {
     const el = scrollAreaRef.current;
     if (!el) return;
+
+    // Rubber-band overscroll (elastic bounce past the top/bottom edge) reports scrollTop
+    // outside [0, maxScroll] and snaps back next frame, producing a delta spike in the
+    // opposite direction of the actual scroll -- ignore nav show/hide while overscrolled.
+    const maxScroll = el.scrollHeight - el.clientHeight;
+    if (el.scrollTop < 0 || el.scrollTop > maxScroll) {
+      lastScrollTopRef.current = el.scrollTop;
+      return;
+    }
+
     const delta = el.scrollTop - lastScrollTopRef.current;
     if (delta > SCROLL_HIDE_THRESHOLD_PX) {
       setNavHidden(true);


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mobile calendar scrolling by preventing unintended navbar visibility changes during rubber-band overscroll.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Summary
- Fixes MobileCalendarView's mobile navbar unintentionally showing/hiding during fast scrolls near the top/bottom edge of the calendar.
- Root cause: rubber-band overscroll reports `scrollTop` outside `[0, maxScroll]` and snaps back next frame, producing a delta spike in the opposite direction of the actual scroll (e.g. scrolling to the bottom fast, the elastic bounce briefly reads as an upward scroll, incorrectly re-showing the navbar).
- Fix: `handleScroll` now ignores nav show/hide logic while `el.scrollTop` is outside `[0, el.scrollHeight - el.clientHeight]`, updating `lastScrollTopRef` and returning early instead.

## Test plan
- [x] `yarn lint` — 0 errors, 41 pre-existing warnings
- [x] `yarn test:unit` — 114 passed
- [x] `yarn test:component` — 46 passed
- [x] `yarn test:integration` — 47 passed
- [x] `yarn test:e2e` — 93 passed
- [x] Manual: fast-scroll to top/bottom boundary on mobile viewport, confirm navbar no longer flickers/shows during the bounce