### PR TITLE
fix(tests): flush useZoomHostPool fetch effect in ViewMeeting component tests

### DIFF
--- a/frontend/tests/component/ViewMeeting.test.tsx
+++ b/frontend/tests/component/ViewMeeting.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen, within } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import ViewMeetingDetails from "../../app/components/meeting-form/ViewMeeting";
 
 beforeEach(() => {
@@ -39,34 +39,36 @@ const makeAnchorEl = (): HTMLElement => {
 };
 
 describe("ViewMeeting", () => {
-  it("desktop: renders nothing without an anchorEl", () => {
+  it("desktop: renders nothing without an anchorEl", async () => {
     render(<ViewMeetingDetails {...baseProps} anchorEl={null} isPhone={false} />);
-    expect(screen.queryByText("Serenity Group")).not.toBeInTheDocument();
+    // useZoomHostPool's fetch effect still resolves post-render; wait for it to settle
+    // (inside act) rather than asserting synchronously and leaving it unflushed.
+    await waitFor(() => expect(screen.queryByText("Serenity Group")).not.toBeInTheDocument());
   });
 
-  it("desktop: renders the meeting title once an anchorEl is present, outside any dialog role", () => {
+  it("desktop: renders the meeting title once an anchorEl is present, outside any dialog role", async () => {
     render(<ViewMeetingDetails {...baseProps} anchorEl={makeAnchorEl()} isPhone={false} />);
-    expect(screen.getByText("Serenity Group")).toBeInTheDocument();
+    expect(await screen.findByText("Serenity Group")).toBeInTheDocument();
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
   });
 
-  it("mobile: renders inside a bottom sheet even with no anchorEl", () => {
+  it("mobile: renders inside a bottom sheet even with no anchorEl", async () => {
     render(<ViewMeetingDetails {...baseProps} anchorEl={null} isPhone />);
-    const dialog = screen.getByRole("dialog", { name: "Serenity Group" });
+    const dialog = await screen.findByRole("dialog", { name: "Serenity Group" });
     expect(dialog).toBeInTheDocument();
     // ViewMeeting's own <h1> title, distinct from BottomSheet's visually-hidden duplicate
     // (kept in the DOM for the dialog's accessible name -- see hideTitleVisually).
     expect(within(dialog).getByRole("heading", { level: 1, name: "Serenity Group" })).toBeInTheDocument();
   });
 
-  it("mobile: shows the same Edit/Delete kebab menu for an admin", () => {
+  it("mobile: shows the same Edit/Delete kebab menu for an admin", async () => {
     render(<ViewMeetingDetails {...baseProps} anchorEl={null} isPhone isAdmin />);
-    expect(screen.getByRole("button", { name: "Meeting options" })).toBeInTheDocument();
+    expect(await screen.findByRole("button", { name: "Meeting options" })).toBeInTheDocument();
   });
 
-  it("prefixes the mode label with its mode icon", () => {
+  it("prefixes the mode label with its mode icon", async () => {
     render(<ViewMeetingDetails {...baseProps} anchorEl={makeAnchorEl()} isPhone={false} />);
-    const label = screen.getByText("In Person");
+    const label = await screen.findByText("In Person");
     expect(label.querySelector("img")).toHaveAttribute("src", "/svg/location-icon.svg");
   });
 });


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved component tests to reliably wait for asynchronous content and controls before making assertions.
  * Increased test stability across desktop and mobile meeting views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description
- **frontend/tests/component/ViewMeeting.test.tsx**: Each test rendered `ViewMeetingDetails` and asserted synchronously without awaiting the async Zoom host-pool fetch that `useZoomHostPool`'s `useEffect` kicks off (`frontend/hooks/useZoomHostPool.ts:26-30`). `setHosts` then fired after the test body had already returned, outside any `act()` boundary, producing a React `act(...)` warning on every run (tests still passed — this was a warning, not a bug). Swapped the relevant `getBy*`/`queryBy*` assertions for `findBy*`/`waitFor` so the effect resolves inside `act()` before each test completes.
- Audited the other `frontend/tests/component/*.test.tsx` files for the same pattern (mount-time fetch/async hook + synchronous `render()` + no `await`/`waitFor`/`findBy*`); none of the other component-under-test files use an async-on-mount hook, so no other files needed changes. `MobileCalendarView.test.tsx` already awaits correctly (fixed in #293).

## Testing
- [x] `yarn test:component` — 46 tests / 10 suites passed, no `act()` warnings
- [x] `yarn lint` — 0 errors
- [x] `yarn test:unit` — 114 tests / 12 suites passed
- [x] `yarn test:integration` — 47 tests / 10 suites passed

## Area(s) Touched
**Engineering**
- [x] testing — test suite (Jest/Playwright) changes

## Pre-merge Checklist
- [x] Code follows current formatting conventions and passes lint (`yarn lint`).
- [x] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
- [x] All test suites pass, both run locally and green in GitHub CI. **Do not merge if any test suite is failing.**
- [x] A test suite was added or updated for the feature/fix in this PR.
- [x] Only files relevant to this change are committed — no stray or unrelated files.
- [ ] If this branch has a merge conflict with master, master was merged into this branch first (not the other way around).
- [x] The rest of this PR description (Description, Testing) is filled out, not left as template placeholders.