### PR TITLE
fix(calendar): position DailyView's current-time line in ET, not browser-local time

### DIFF
--- a/frontend/app/components/calendar/DailyView.tsx
+++ b/frontend/app/components/calendar/DailyView.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useEffect, useLayoutEffect, useState, useRef } from
 import styles from '../../../styles/components/calendar/DailyView.module.scss';
 import BoxText from '../atoms/BoxText';
 import DailyViewRow from "./DailyViewRow";
-import { formatETDateString, getETDayBounds } from "../../../util/timeUtils";
+import { formatETDateString, getCurrentETMinutesSinceMidnight, getETDayBounds } from "../../../util/timeUtils";
 import { IMeeting } from "../../../util/models";
 import { passesTagFilters, passesRoomFilter, MeetingFilters } from "../../../util/meetingFilters";
 import { createCache } from "../../../util/simpleCache";
@@ -201,18 +201,19 @@ const DailyView: React.FC<DailyViewProps> = ({
   // here would sync the ref *after* that layout effect's fetchData() already read it.
   const selectedDateRef = useRef(selectedDate);
 
+  // ET wall-clock, not the browser's local timezone -- meeting boxes are positioned via
+  // timeToPixels() against their ET-clipped startTime (see DailyViewRow.tsx), so a viewer
+  // whose local zone isn't ET (any CI runner, or any real user outside America/New_York)
+  // would otherwise draw this line at the wrong x-position relative to the boxes it's
+  // supposed to line up with.
   const updateTimePosition = useCallback(() => {
-    const now = new Date();
-    const currentHour = now.getHours();
-    const currentMinutes = now.getMinutes();
-    const position = (currentHour * 60 + currentMinutes) * (155 / 60);
+    const position = getCurrentETMinutesSinceMidnight() * (155 / 60);
     setCurrentTimePosition(position);
   }, []);
 
   const scrollToCurrentTime = useCallback(() => {
     if (scrollContainerRef.current) {
-      const now = new Date();
-      const currentHour = now.getHours();
+      const currentHour = Math.floor(getCurrentETMinutesSinceMidnight() / 60);
       const scrollOffset = (currentHour * 155) - 300;
       const scrollPosition = Math.max(0, scrollOffset);
       scrollContainerRef.current.scrollLeft = scrollPosition;

--- a/frontend/styles/components/calendar/DailyView.module.scss
+++ b/frontend/styles/components/calendar/DailyView.module.scss
@@ -67,19 +67,11 @@
   height: 100%;
   width: 4px;
   background-color: $brand-pink-color;
-  z-index: 10; 
+  z-index: 10;
+  // Purely a "now" marker, not interactive -- without this it sits on top of whatever
+  // meeting box its x-position happens to cross and swallows the click instead.
+  pointer-events: none;
 }
-
-// .currentTimeLine::before {
-//   content: "";
-//   position: absolute;
-//   top: -6px; 
-//   left: -4px; 
-//   width: 12px; 
-//   height: 12px; 
-//   border-radius: 50%;
-//   background-color: #cc3366; 
-// }
 
 .scrollContainer {
   display: grid;

--- a/frontend/styles/components/calendar/DailyView.module.scss
+++ b/frontend/styles/components/calendar/DailyView.module.scss
@@ -68,6 +68,7 @@
   width: 4px;
   background-color: $brand-pink-color;
   z-index: 10;
+  
   // Purely a "now" marker, not interactive -- without this it sits on top of whatever
   // meeting box its x-position happens to cross and swallows the click instead.
   pointer-events: none;


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the calendar’s current-time indicator and automatic scrolling to use Eastern Time consistently.
  * Prevented the current-time marker from blocking clicks on meeting boxes.
  * Removed an unused decorative marker element.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description
- **frontend/app/components/calendar/DailyView.tsx**: `updateTimePosition`/`scrollToCurrentTime` positioned the "now" line using raw `Date.getHours()`/`getMinutes()`, which follow the *browser's local* timezone. Meeting boxes, however, are positioned via `timeToPixels()` (`DailyViewRow.tsx`) against their **ET**-clipped `startTime`. Any viewer whose local zone isn't ET — including every CI run, since Playwright's config forces `timezoneId: "UTC"` — draws the line up to 4 hours off from the boxes it's meant to align with. Switched both functions to the project's existing `getCurrentETMinutesSinceMidnight()` helper (already used elsewhere for the same ET wall-clock math) so the line is always positioned correctly regardless of the viewer's local timezone.
- **frontend/styles/components/calendar/DailyView.module.scss**: added `pointer-events: none` to `.currentTimeLine` as defense-in-depth — it's a decorative marker, not an interactive element, so it shouldn't be able to intercept clicks on whatever it happens to visually cross. Also deleted a stale commented-out `::before` block on the same lines (dead code, no longer needed).

## Root cause of master's failing `Test` / `e2e` CI run
During the ~1-hour-a-day window where the browser-local (UTC-in-CI) hour digit happens to numerically match a meeting's real ET hour digit, the old mispositioned line's 4px-wide hitbox lands inside that meeting's box and swallows Playwright's click. That's exactly what broke `tests/e2e/03-meeting-editing.spec.ts` tests 3.3 and 3.4 on master's last CI run (job ran 18:27–18:34 UTC, meeting fixture scheduled at 18:00 ET) — a real, always-present timezone bug that only becomes click-blocking during that narrow daily window, not ordinary flakiness.

## Testing
- [x] `yarn lint` — 0 errors, 41 pre-existing warnings (unchanged)
- [x] `yarn test:e2e` — 93/93 passed, including the two that failed on master (`03-meeting-editing.spec.ts` 3.3, 3.4)
- [x] `yarn test:unit` — 114 tests / 12 suites passed
- [x] `yarn test:component` — 46 tests / 10 suites passed
- [x] `yarn test:integration` — 47 tests / 10 suites passed
- [x] Merged latest `origin/master` into this branch (brought in #294 cleanly, no conflicts)

## Area(s) Touched
**Product areas**
- [x] ui/ux — frontend layout/styling not tied to a specific integration

**Engineering**
- [x] testing — test suite (Jest/Playwright) changes

## Pre-merge Checklist
- [x] Code follows current formatting conventions and passes lint (`yarn lint`).
- [x] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
- [x] All test suites pass, both run locally and green in GitHub CI. **Do not merge if any test suite is failing.**
- [x] A test suite was added or updated for the feature/fix in this PR. — N/A: existing e2e tests already cover this path (03-meeting-editing.spec.ts 3.3/3.4); this is a bugfix, not new behavior.
- [x] Only files relevant to this change are committed — no stray or unrelated files.
- [x] If this branch has a merge conflict with master, master was merged into this branch first (not the other way around).
- [x] The rest of this PR description (Description, Testing) is filled out, not left as template placeholders.