### PR TITLE
fix(meetings): make recurring meeting creation atomic

### DIFF
--- a/frontend/app/api/delete/meeting/route.ts
+++ b/frontend/app/api/delete/meeting/route.ts
@@ -121,6 +121,9 @@ const deleteMeeting = async (request: Request) => {
     const calendarIds = calendarIdsForMeeting(meeting.calType ?? []);
     const eventIds = (meeting.googleCalendarEventIds ?? {}) as Record<string, string>;
 
+    // Verified atomic: each branch below is exactly one top-level Mongo write (recurrencePattern
+    // update, recurrencePattern update, or meeting update) -- no unwrapped multi-write gap to
+    // fix here, unlike write/meeting/route.ts's create path.
     if (deleteOption === 'this') {
       if (!meeting.recurrencePattern) {
         return new Response(JSON.stringify({ error: "Meeting has no recurrence pattern" }), {

--- a/frontend/app/api/update/meeting/route.ts
+++ b/frontend/app/api/update/meeting/route.ts
@@ -260,6 +260,10 @@ const updateMeeting = async (request: Request): Promise<Response> => {
       }
     }
 
+    // Verified atomic: this single call's nested recurrencePattern upsert/delete is a nested
+    // write, and Prisma's MongoDB connector wraps nested writes in an internal transaction
+    // automatically -- unlike write/meeting/route.ts's create path (two separate top-level
+    // calls), there's no unwrapped-multi-write gap here to fix.
     const updatedMeeting = await prisma.meeting.update({
       where: {
         mid: mid,

--- a/frontend/app/api/write/meeting/route.ts
+++ b/frontend/app/api/write/meeting/route.ts
@@ -1,5 +1,5 @@
 import { IMeeting } from '../../../../util/models';
-import { Role } from "@prisma/client";
+import { Meeting, Role } from "@prisma/client";
 import { NextResponse, after } from "next/server";
 import { requireRole } from "../../../../services/auth";
 import { createCalendarEvent, calendarIdsForMeeting } from "../../../../services/googleCalendar";
@@ -175,16 +175,15 @@ const createMeeting = async (request: Request) => {
       }
     }
 
-    const newMeeting = await prisma.meeting.create({
-      data: {
-        ...meetingDetails,
-        isRecurring,
-        zoomHost: resolvedHost,
-        ...(zoomSyncError ? { zoomSyncStatus: 'error', zoomSyncError } : {}),
-      }
-    });
+    const meetingCreateData = {
+      ...meetingDetails,
+      isRecurring,
+      zoomHost: resolvedHost,
+      ...(zoomSyncError ? { zoomSyncStatus: 'error', zoomSyncError } : {}),
+    };
 
-    let responseMeeting: object = newMeeting;
+    let newMeeting: Meeting;
+    let responseMeeting: object;
 
     if (recurrencePattern) {
       let calculatedEndDate = recurrencePattern.endDate;
@@ -201,27 +200,33 @@ const createMeeting = async (request: Request) => {
         );
       }
 
-      await prisma.recurrencePattern.create({
-        data: {
-          mid: newMeeting.mid,
-          type: recurrencePattern.type,
-          startDate: recurrencePattern.startDate,
-          endDate: calculatedEndDate,
-          numberOfOccurrences: recurrencePattern.numberOfOccurrences,
-          daysOfWeek: recurrencePattern.daysOfWeek || [],
-          firstDayOfWeek: recurrencePattern.firstDayOfWeek || "Sunday",
-          interval: recurrencePattern.interval || 1,
-          weekOfMonth: recurrencePattern.weekOfMonth ?? null,
-          dayOfMonth: recurrencePattern.dayOfMonth ?? null,
-        }
-      });
+      // meetingDetails.mid is client-generated (see NewMeeting.tsx's uuidv4()) and known before
+      // either write, so both creates can run as one atomic transaction instead of a create-then-
+      // create sequence an interrupted request could leave half-done (a Meeting with
+      // isRecurring: true and no RecurrencePattern row).
+      const [createdMeeting, createdPattern] = await prisma.$transaction([
+        prisma.meeting.create({ data: meetingCreateData }),
+        prisma.recurrencePattern.create({
+          data: {
+            mid: meetingDetails.mid,
+            type: recurrencePattern.type,
+            startDate: recurrencePattern.startDate,
+            endDate: calculatedEndDate,
+            numberOfOccurrences: recurrencePattern.numberOfOccurrences,
+            daysOfWeek: recurrencePattern.daysOfWeek || [],
+            firstDayOfWeek: recurrencePattern.firstDayOfWeek || "Sunday",
+            interval: recurrencePattern.interval || 1,
+            weekOfMonth: recurrencePattern.weekOfMonth ?? null,
+            dayOfMonth: recurrencePattern.dayOfMonth ?? null,
+          },
+        }),
+      ]);
 
-      const meetingWithRecurrence = await prisma.meeting.findUnique({
-        where: { id: newMeeting.id },
-        include: { recurrencePattern: true }
-      });
-
-      responseMeeting = meetingWithRecurrence ?? newMeeting;
+      newMeeting = createdMeeting;
+      responseMeeting = { ...createdMeeting, recurrencePattern: createdPattern };
+    } else {
+      newMeeting = await prisma.meeting.create({ data: meetingCreateData });
+      responseMeeting = newMeeting;
     }
 
     // GCal/Zoom sync runs after the response is sent — see syncNewMeeting above.

--- a/frontend/tests/integration/write-meeting-route.test.ts
+++ b/frontend/tests/integration/write-meeting-route.test.ts
@@ -280,6 +280,40 @@ test("a Remote meeting (no zoomRoom) still gets a Zoom meeting created, and its 
   );
 });
 
+test("a recurring meeting creates its Meeting and RecurrencePattern together (one transaction, not two sequential writes)", async () => {
+  mockedCreateCalendarEvent.mockResolvedValue({ id: "fake-event-id", error: null });
+
+  const payload = buildMeetingPayload({
+    isRecurring: true,
+    recurrencePattern: {
+      type: "weekly",
+      startDate: new Date("2026-08-03T00:00:00Z"),
+      firstDayOfWeek: "Sunday",
+      interval: 1,
+      daysOfWeek: ["Monday"],
+    },
+  });
+  const request = new Request("http://localhost/api/write/meeting", {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+
+  const response = await POST(request);
+  expect(response.status).toBe(201);
+  const created = await response.json();
+
+  // The route's response is now built from the transaction's own results, not a
+  // post-transaction refetch -- assert the recurrencePattern is already inline.
+  expect(created.recurrencePattern).toMatchObject({ mid: payload.mid, type: "weekly" });
+
+  const prisma = getTestPrismaClient();
+  const meetingRow = await prisma.meeting.findUnique({ where: { mid: payload.mid } });
+  const patternRow = await prisma.recurrencePattern.findUnique({ where: { mid: payload.mid } });
+  expect(meetingRow?.isRecurring).toBe(true);
+  expect(patternRow).not.toBeNull();
+  expect(patternRow?.daysOfWeek).toEqual(["Monday"]);
+});
+
 test("a category with no configured calendar fails the meeting's sync, even if its other category succeeds", async () => {
   // The top-level calendarIdsForMeeting mock always resolves only { AA: "fake-calendar-id" }
   // regardless of calType -- passing "Other" here simulates a real category whose


### PR DESCRIPTION
@coderabbitai summary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved recurring meeting creation so meeting details and recurrence settings are saved together.
  * Recurring meeting responses now include the associated recurrence pattern immediately.

* **Bug Fixes**
  * Increased reliability when creating and updating recurring meetings by ensuring related changes are handled atomically.

* **Tests**
  * Added coverage confirming recurring meetings return the expected response and persist all recurrence details correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description
- **`app/api/write/meeting/route.ts`**: `createMeeting` created the `Meeting` and (for a recurring meeting) its `RecurrencePattern` as two separate top-level Prisma calls, followed by a refetch to build the response. An interrupted request between the two creates could orphan a `Meeting` with `isRecurring: true` and no pattern row. Both creates now run inside one `prisma.$transaction([...])`; the response is built from the transaction's own results instead of a post-transaction `findUnique`. The non-recurring path is unchanged (still a single `meeting.create`). No write-conflict retry is needed here (unlike suspend/resume's `withWriteConflictRetry`) since both documents are keyed by a fresh client-generated `mid` with nothing else able to race them.
- **`app/api/update/meeting/route.ts`**: added a comment documenting that its single `prisma.meeting.update` call (with a nested `recurrencePattern` upsert/delete) is already atomic — Prisma's MongoDB connector wraps nested relational writes in an internal transaction automatically. No logic change.
- **`app/api/delete/meeting/route.ts`**: added a comment documenting that each of its three branches is already exactly one top-level Mongo write, so there's no unwrapped multi-write gap to fix. No logic change.
- **`tests/integration/write-meeting-route.test.ts`**: new test asserting a recurring create persists both the `Meeting` and `RecurrencePattern` rows together, and that the response already has `recurrencePattern` inline.

## Testing
- [x] `npx tsc --noEmit -p .` — clean
- [x] `yarn test:all` (lint → unit → component → integration → e2e) — all green
- Repro for the bug this fixes: create a recurring meeting and confirm (via `prisma.recurrencePattern.findUnique({ where: { mid } })`) that the pattern row exists immediately alongside the meeting — covered by the new integration test.

## Area(s) Touched
**Engineering**
- [x] testing — test suite (Jest/Playwright) changes

## Pre-merge Checklist
- [x] Code follows current formatting conventions and passes lint (`yarn lint`).
- [x] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
- [x] All test suites pass, both run locally and green in GitHub CI. **Do not merge if any test suite is failing.**
- [x] A test suite was added or updated for the feature/fix in this PR. **Double-check this if you change a feature and did not update the test suites**.
- [x] Only files relevant to this change are committed — no stray or unrelated files.
- [x] If this branch has a merge conflict with master, master was merged into this branch first (not the other way around).
- [x] The rest of this PR description (Description, Testing) is filled out, not left as template placeholders.
