### PR TITLE
feat(meetings): block saving into a booked room/Zoom room, add confirm-to-override

### DIFF
--- a/frontend/app/api/update/meeting/route.ts
+++ b/frontend/app/api/update/meeting/route.ts
@@ -4,7 +4,7 @@ import { requireRole } from "../../../../services/auth";
 import { IMeeting } from "../../../../util/models";
 import { createCalendarEvent, updateCalendarEvent, deleteCalendarEvent, reconcileMeetingCalendars } from "../../../../services/googleCalendar";
 import { createZoomMeeting, updateZoomMeeting, deleteZoomMeeting, getZoomMeetingInvitation, resolveZoomHost, zoomRoomCalendarId } from "../../../../services/zoom";
-import { findResourceConflicts } from "../../../../util/resourceOverlap";
+import { findResourceConflicts, findResourceConflictRows, ConflictRow } from "../../../../util/resourceOverlap";
 import { meetingSchema } from "../../../../util/meetingValidation";
 import { reconcilePendingResume } from "../../../../util/suspension";
 import { prisma } from "../../../../lib/prisma";
@@ -211,7 +211,26 @@ const updateMeeting = async (request: Request): Promise<Response> => {
     // edit reads/writes that field below.
     existingMeeting.googleCalendarEventIds = await reconcilePendingResume(existingMeeting);
 
-    const { mid, recurrencePattern, ...meetingFields } = newMeeting;
+    const { mid, recurrencePattern, confirmOverride, ...meetingFields } = newMeeting;
+
+    // Blocks the save outright on a room/zoomRoom collision -- distinct from the zoomHost check
+    // below, which defers the calendar publish and stores the error on the meeting instead of
+    // rejecting the request. confirmOverride only bypasses this block, not zoomHost's handling.
+    if (!confirmOverride) {
+      const conflictRows: ConflictRow[] = [];
+      if (newMeeting.room) {
+        conflictRows.push(...await findResourceConflictRows("room", newMeeting.room, newMeeting, { excludeMid: mid }));
+      }
+      if (newMeeting.zoomRoom) {
+        conflictRows.push(...await findResourceConflictRows("zoomRoom", newMeeting.zoomRoom, newMeeting, { excludeMid: mid }));
+      }
+      if (conflictRows.length > 0) {
+        return NextResponse.json(
+          { error: "This meeting conflicts with an existing meeting's room or Zoom room.", conflicts: conflictRows },
+          { status: 409 },
+        );
+      }
+    }
 
     // A new Zoom host is only needed when this meeting has no Zoom meeting to keep using —
     // either it never had one, or its room changed (a Zoom meeting can't move rooms, so the

--- a/frontend/app/api/update/meeting/route.ts
+++ b/frontend/app/api/update/meeting/route.ts
@@ -7,6 +7,7 @@ import { createZoomMeeting, updateZoomMeeting, deleteZoomMeeting, getZoomMeeting
 import { findResourceConflicts, findResourceConflictRows, ConflictRow } from "../../../../util/resourceOverlap";
 import { meetingSchema } from "../../../../util/meetingValidation";
 import { reconcilePendingResume } from "../../../../util/suspension";
+import { calculateEndDateFromOccurrences } from "../../../../util/meetingOccurrences";
 import { prisma } from "../../../../lib/prisma";
 
 // Runs after the response is sent (see after() call below) — failure updates googleSyncStatus
@@ -217,12 +218,34 @@ const updateMeeting = async (request: Request): Promise<Response> => {
     // below, which defers the calendar publish and stores the error on the meeting instead of
     // rejecting the request. confirmOverride only bypasses this block, not zoomHost's handling.
     if (!confirmOverride) {
+      // A count-bounded series (numberOfOccurrences set, no explicit endDate) has a real last
+      // occurrence -- checking conflicts against the raw (still-null) endDate would expand it
+      // out to the full OVERLAP_HORIZON_YEARS window instead, risking a false 409 against an
+      // unrelated booking that falls after the series actually ends. Only affects the conflict
+      // candidate below, not what's persisted (unchanged from the existing upsert further down).
+      let calculatedEndDate = recurrencePattern?.endDate ?? null;
+      if (recurrencePattern?.numberOfOccurrences && !recurrencePattern.endDate) {
+        calculatedEndDate = calculateEndDateFromOccurrences(
+          recurrencePattern.startDate,
+          recurrencePattern.daysOfWeek || [],
+          recurrencePattern.numberOfOccurrences,
+          recurrencePattern.interval || 1,
+          recurrencePattern.type,
+          recurrencePattern.weekOfMonth ?? null,
+          recurrencePattern.dayOfMonth ?? null,
+        );
+      }
+      const conflictCandidate = {
+        ...newMeeting,
+        recurrencePattern: recurrencePattern ? { ...recurrencePattern, endDate: calculatedEndDate } : null,
+      };
+
       const conflictRows: ConflictRow[] = [];
       if (newMeeting.room) {
-        conflictRows.push(...await findResourceConflictRows("room", newMeeting.room, newMeeting, { excludeMid: mid }));
+        conflictRows.push(...await findResourceConflictRows("room", newMeeting.room, conflictCandidate, { excludeMid: mid }));
       }
       if (newMeeting.zoomRoom) {
-        conflictRows.push(...await findResourceConflictRows("zoomRoom", newMeeting.zoomRoom, newMeeting, { excludeMid: mid }));
+        conflictRows.push(...await findResourceConflictRows("zoomRoom", newMeeting.zoomRoom, conflictCandidate, { excludeMid: mid }));
       }
       if (conflictRows.length > 0) {
         return NextResponse.json(

--- a/frontend/app/api/write/meeting/route.ts
+++ b/frontend/app/api/write/meeting/route.ts
@@ -4,7 +4,7 @@ import { NextResponse, after } from "next/server";
 import { requireRole } from "../../../../services/auth";
 import { createCalendarEvent, calendarIdsForMeeting } from "../../../../services/googleCalendar";
 import { createZoomMeeting, getZoomMeetingInvitation, resolveZoomHost, zoomRoomCalendarId } from "../../../../services/zoom";
-import { findResourceConflicts } from "../../../../util/resourceOverlap";
+import { findResourceConflicts, findResourceConflictRows, ConflictRow } from "../../../../util/resourceOverlap";
 import { convertETToUTC } from "../../../../util/timeUtils";
 import { meetingSchema } from "../../../../util/meetingValidation";
 import { prisma } from "../../../../lib/prisma";
@@ -143,8 +143,28 @@ const createMeeting = async (request: Request) => {
     }
     const meetingData = parsed.data as IMeeting;
 
-    const { recurrencePattern, ...meetingDetails } = meetingData;
+    const { recurrencePattern, confirmOverride, ...meetingDetails } = meetingData;
     const isRecurring = !!recurrencePattern;
+
+    // Blocks the save outright on a room/zoomRoom collision -- distinct from the zoomHost check
+    // below, which defers the calendar publish and stores the error on the meeting instead of
+    // rejecting the request. confirmOverride only bypasses this block, not zoomHost's handling.
+    if (!confirmOverride) {
+      const candidate = { ...meetingData, isRecurring };
+      const conflictRows: ConflictRow[] = [];
+      if (meetingData.room) {
+        conflictRows.push(...await findResourceConflictRows("room", meetingData.room, candidate, { excludeMid: meetingData.mid }));
+      }
+      if (meetingData.zoomRoom) {
+        conflictRows.push(...await findResourceConflictRows("zoomRoom", meetingData.zoomRoom, candidate, { excludeMid: meetingData.mid }));
+      }
+      if (conflictRows.length > 0) {
+        return NextResponse.json(
+          { error: "This meeting conflicts with an existing meeting's room or Zoom room.", conflicts: conflictRows },
+          { status: 409 },
+        );
+      }
+    }
 
     const zoomEnabled = (meetingData.modeType === 'Hybrid' || meetingData.modeType === 'Remote')
       && meetingData.status !== 'Suspended';

--- a/frontend/app/api/write/meeting/route.ts
+++ b/frontend/app/api/write/meeting/route.ts
@@ -5,8 +5,8 @@ import { requireRole } from "../../../../services/auth";
 import { createCalendarEvent, calendarIdsForMeeting } from "../../../../services/googleCalendar";
 import { createZoomMeeting, getZoomMeetingInvitation, resolveZoomHost, zoomRoomCalendarId } from "../../../../services/zoom";
 import { findResourceConflicts, findResourceConflictRows, ConflictRow } from "../../../../util/resourceOverlap";
-import { convertETToUTC } from "../../../../util/timeUtils";
 import { meetingSchema } from "../../../../util/meetingValidation";
+import { calculateEndDateFromOccurrences } from "../../../../util/meetingOccurrences";
 import { prisma } from "../../../../lib/prisma";
 
 // Runs after the response is sent (see after() call below) — failure sets googleSyncStatus but
@@ -146,11 +146,33 @@ const createMeeting = async (request: Request) => {
     const { recurrencePattern, confirmOverride, ...meetingDetails } = meetingData;
     const isRecurring = !!recurrencePattern;
 
+    // Resolved once, up front, so the conflict check below and the eventual RecurrencePattern
+    // write use the same finite endpoint -- a count-bounded series (numberOfOccurrences set, no
+    // explicit endDate) has a real last occurrence, and checking conflicts against the raw
+    // (still-null) endDate would expand it out to the full OVERLAP_HORIZON_YEARS window instead,
+    // risking a false 409 against an unrelated booking that falls after the series actually ends.
+    let calculatedEndDate = recurrencePattern?.endDate ?? null;
+    if (recurrencePattern?.numberOfOccurrences && !recurrencePattern.endDate) {
+      calculatedEndDate = calculateEndDateFromOccurrences(
+        recurrencePattern.startDate,
+        recurrencePattern.daysOfWeek || [],
+        recurrencePattern.numberOfOccurrences,
+        recurrencePattern.interval || 1,
+        recurrencePattern.type,
+        recurrencePattern.weekOfMonth ?? null,
+        recurrencePattern.dayOfMonth ?? null,
+      );
+    }
+
     // Blocks the save outright on a room/zoomRoom collision -- distinct from the zoomHost check
     // below, which defers the calendar publish and stores the error on the meeting instead of
     // rejecting the request. confirmOverride only bypasses this block, not zoomHost's handling.
     if (!confirmOverride) {
-      const candidate = { ...meetingData, isRecurring };
+      const candidate = {
+        ...meetingData,
+        isRecurring,
+        recurrencePattern: recurrencePattern ? { ...recurrencePattern, endDate: calculatedEndDate } : null,
+      };
       const conflictRows: ConflictRow[] = [];
       if (meetingData.room) {
         conflictRows.push(...await findResourceConflictRows("room", meetingData.room, candidate, { excludeMid: meetingData.mid }));
@@ -206,20 +228,6 @@ const createMeeting = async (request: Request) => {
     let responseMeeting: object;
 
     if (recurrencePattern) {
-      let calculatedEndDate = recurrencePattern.endDate;
-
-      if (recurrencePattern.numberOfOccurrences && !recurrencePattern.endDate) {
-        calculatedEndDate = calculateEndDateFromOccurrences(
-          recurrencePattern.startDate,
-          recurrencePattern.daysOfWeek || [],
-          recurrencePattern.numberOfOccurrences,
-          recurrencePattern.interval || 1,
-          recurrencePattern.type,
-          recurrencePattern.weekOfMonth ?? null,
-          recurrencePattern.dayOfMonth ?? null,
-        );
-      }
-
       // meetingDetails.mid is client-generated (see NewMeeting.tsx's uuidv4()) and known before
       // either write, so both creates can run as one atomic transaction instead of a create-then-
       // create sequence an interrupted request could leave half-done (a Meeting with
@@ -261,109 +269,5 @@ const createMeeting = async (request: Request) => {
     return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
   }
 };
-
-/**
- * Calculate the end date based on a specific number of occurrences
- */
-function calculateEndDateFromOccurrences(
-  startDate: Date,
-  daysOfWeek: string[],
-  numberOfOccurrences: number,
-  interval: number,
-  type: string,
-  weekOfMonth: number | null = null,
-  dayOfMonth: number | null = null,
-): Date {
-  const patternStartDate = new Date(startDate);
-
-  if (numberOfOccurrences <= 0) return patternStartDate;
-
-  const dayNameToIndex: Record<string, number> = {
-    "Sunday": 0, "Monday": 1, "Tuesday": 2, "Wednesday": 3,
-    "Thursday": 4, "Friday": 5, "Saturday": 6,
-  };
-
-  if (type === "monthly") {
-    // The Nth occurrence is (N-1) intervals after the start month
-    const rawMonth = patternStartDate.getUTCMonth() + (numberOfOccurrences - 1) * interval;
-    const targetYear = patternStartDate.getUTCFullYear() + Math.floor(rawMonth / 12);
-    const targetMonth = rawMonth % 12;
-
-    // 23:59:59 ET so the end date is inclusive of its full day
-    // even against a naive instant comparison (e.g. `meetingStart <= endDate`).
-    const toETDate = (day: number) => new Date(convertETToUTC(
-      `${targetYear}-${String(targetMonth + 1).padStart(2, '0')}-${String(day).padStart(2, '0')}T23:59:59`
-    ));
-
-    if (dayOfMonth != null) {
-      return toETDate(dayOfMonth);
-    }
-
-    if (weekOfMonth != null && daysOfWeek.length > 0) {
-      const targetDay = dayNameToIndex[daysOfWeek[0]];
-      const daysInMonth = new Date(Date.UTC(targetYear, targetMonth + 1, 0)).getUTCDate();
-
-      if (weekOfMonth === -1) {
-        for (let d = daysInMonth; d >= 1; d--) {
-          if (new Date(Date.UTC(targetYear, targetMonth, d)).getUTCDay() === targetDay) {
-            return toETDate(d);
-          }
-        }
-      } else {
-        let count = 0;
-        for (let d = 1; d <= daysInMonth; d++) {
-          if (new Date(Date.UTC(targetYear, targetMonth, d)).getUTCDay() === targetDay) {
-            if (++count === weekOfMonth) {
-              return toETDate(d);
-            }
-          }
-        }
-      }
-    }
-
-    return toETDate(patternStartDate.getUTCDate());
-  }
-
-  // Weekly
-  if (daysOfWeek.length === 0) return patternStartDate;
-
-  const recurrenceDays = daysOfWeek
-    .map(day => dayNameToIndex[day])
-    .filter(index => index !== undefined)
-    .sort((a, b) => a - b);
-
-  if (recurrenceDays.length === 0) return patternStartDate;
-
-  const endDate = new Date(patternStartDate);
-  let occurrenceCount = 0;
-  let currentWeek = 0;
-  const startDayOfWeek = patternStartDate.getUTCDay();
-
-  // The start date only counts as an occurrence if its weekday is in daysOfWeek.
-  if (recurrenceDays.includes(startDayOfWeek)) {
-    occurrenceCount++;
-    if (occurrenceCount >= numberOfOccurrences) return patternStartDate;
-  }
-
-  let nextDayIndex = recurrenceDays.findIndex(day => day > startDayOfWeek);
-  if (nextDayIndex === -1) { nextDayIndex = 0; currentWeek++; }
-
-  while (occurrenceCount < numberOfOccurrences) {
-    if (currentWeek % interval === 0) {
-      while (nextDayIndex < recurrenceDays.length) {
-        const daysToAdd = (currentWeek * 7) +
-          (recurrenceDays[nextDayIndex] - startDayOfWeek + 7) % 7;
-        endDate.setUTCDate(patternStartDate.getUTCDate() + daysToAdd);
-        occurrenceCount++;
-        nextDayIndex++;
-        if (occurrenceCount >= numberOfOccurrences) return endDate;
-      }
-    }
-    currentWeek++;
-    nextDayIndex = 0;
-  }
-
-  return endDate;
-}
 
 export { createMeeting as POST };

--- a/frontend/app/components/admin/ConflictList.tsx
+++ b/frontend/app/components/admin/ConflictList.tsx
@@ -43,7 +43,7 @@ interface ConflictListProps {
   onMeetingUpdated?: () => void;
 }
 
-const fieldLabel = (field: "room" | "zoomRoom" | "zoomHost"): string => {
+export const fieldLabel = (field: "room" | "zoomRoom" | "zoomHost"): string => {
   if (field === "room") return "Room";
   if (field === "zoomRoom") return "Zoom Room";
   return "Zoom Host";
@@ -66,7 +66,7 @@ const compactTimeRange = (start: Date, end: Date): string =>
 
 // "Overlap: Tue 7-8PM · next occurs Jul 14, 2026" for a recurring pair, or
 // "Overlap: Fri 6-7PM (single occurrence) · Sep 12, 2026" when both are one-time.
-const formatOverlapSummary = (overlap: ConflictListRow["overlap"], meetings: ConflictListRow["meetings"]): string => {
+export const formatOverlapSummary = (overlap: ConflictListRow["overlap"], meetings: ConflictListRow["meetings"]): string => {
   const start = new Date(overlap.start);
   const end = new Date(overlap.end);
   const bothOneTime = meetings.every((m) => !m.isRecurring);
@@ -81,7 +81,7 @@ const formatOverlapSummary = (overlap: ConflictListRow["overlap"], meetings: Con
 // ViewMeeting.tsx's getRecurrenceText, reusing the same Day-column formatter as the XLSX/lease
 // exports. The time shown is this meeting's own occurrence, not the overlap window above, since
 // the two can differ (e.g. 6-8PM vs. 7-9PM overlapping 7-8PM).
-const formatMeetingSchedule = (meeting: ConflictMeetingSummary): string => {
+export const formatMeetingSchedule = (meeting: ConflictMeetingSummary): string => {
   const { recurrencePattern, occurrence } = meeting;
   const time = compactTimeRange(new Date(occurrence.start), new Date(occurrence.end));
   if (!recurrencePattern) return `One-time meeting · ${time}`;

--- a/frontend/app/components/admin/ConflictList.tsx
+++ b/frontend/app/components/admin/ConflictList.tsx
@@ -1,39 +1,20 @@
 "use client";
 
 import React, { useState } from "react";
-import { formatDayColumn } from "../../../util/recurrenceDisplay";
-import { formatCompactTimeRange } from "../../../util/timeFormat";
 import EditMeetingSidebar from "../meeting-form/EditMeeting";
 import { IMeeting } from "../../../util/models";
 import { useZoomHostPool } from "../../../hooks/useZoomHostPool";
 import { zoomHostLabel } from "../../../util/zoomHosts";
+import {
+  ConflictListRow,
+  fieldLabel,
+  formatOverlapSummary,
+  formatMeetingSchedule,
+} from "../../../util/conflictDisplay";
 import styles from "../../../styles/components/admin/ConflictList.module.scss";
 
-export interface ConflictRecurrenceSummary {
-  type: string;
-  interval: number;
-  daysOfWeek: string[];
-  weekOfMonth: number | null;
-  dayOfMonth: number | null;
-}
-
-export interface ConflictMeetingSummary {
-  mid: string;
-  title: string;
-  calType: string[];
-  isRecurring: boolean;
-  recurrencePattern: ConflictRecurrenceSummary | null;
-  // ISO strings -- this meeting's own occurrence, not the overlap intersection.
-  occurrence: { start: string; end: string };
-}
-
-export interface ConflictListRow {
-  field: "room" | "zoomRoom" | "zoomHost";
-  value: string;
-  // ISO strings -- Dates don't survive JSON as-is.
-  overlap: { start: string; end: string };
-  meetings: [ConflictMeetingSummary, ConflictMeetingSummary];
-}
+export type { ConflictRecurrenceSummary, ConflictMeetingSummary, ConflictListRow } from "../../../util/conflictDisplay";
+export { fieldLabel, formatOverlapSummary, formatMeetingSchedule } from "../../../util/conflictDisplay";
 
 interface ConflictListProps {
   conflicts: ConflictListRow[];
@@ -42,61 +23,6 @@ interface ConflictListProps {
   // conflict (e.g. moved to a different room/time) -- lets the parent refetch.
   onMeetingUpdated?: () => void;
 }
-
-export const fieldLabel = (field: "room" | "zoomRoom" | "zoomHost"): string => {
-  if (field === "room") return "Room";
-  if (field === "zoomRoom") return "Zoom Room";
-  return "Zoom Host";
-};
-
-// Extracts ET wall-clock time as "HH:MM" (24hr), which is what formatCompactTimeRange expects
-// -- mirrors ViewMeeting.tsx's etTimeFmt.
-const etTimeFmt = new Intl.DateTimeFormat("en-GB", {
-  timeZone: "America/New_York", hour: "2-digit", minute: "2-digit", hour12: false,
-});
-
-const etWeekday = (date: Date): string =>
-  new Intl.DateTimeFormat("en-US", { timeZone: "America/New_York", weekday: "short" }).format(date);
-
-const etDate = (date: Date): string =>
-  new Intl.DateTimeFormat("en-US", { timeZone: "America/New_York", month: "short", day: "numeric", year: "numeric" }).format(date);
-
-const compactTimeRange = (start: Date, end: Date): string =>
-  formatCompactTimeRange(etTimeFmt.format(start), etTimeFmt.format(end));
-
-// "Overlap: Tue 7-8PM · next occurs Jul 14, 2026" for a recurring pair, or
-// "Overlap: Fri 6-7PM (single occurrence) · Sep 12, 2026" when both are one-time.
-export const formatOverlapSummary = (overlap: ConflictListRow["overlap"], meetings: ConflictListRow["meetings"]): string => {
-  const start = new Date(overlap.start);
-  const end = new Date(overlap.end);
-  const bothOneTime = meetings.every((m) => !m.isRecurring);
-  const timeRange = `${etWeekday(start)} ${compactTimeRange(start, end)}`;
-  const dateLabel = etDate(start);
-  return bothOneTime
-    ? `Overlap: ${timeRange} (single occurrence) · ${dateLabel}`
-    : `Overlap: ${timeRange} · next occurs ${dateLabel}`;
-};
-
-// "Weekly · Tue · 7-8PM", "Monthly · 2nd Fri · 7-8PM", or "One-time meeting · 7-8PM" -- mirrors
-// ViewMeeting.tsx's getRecurrenceText, reusing the same Day-column formatter as the XLSX/lease
-// exports. The time shown is this meeting's own occurrence, not the overlap window above, since
-// the two can differ (e.g. 6-8PM vs. 7-9PM overlapping 7-8PM).
-export const formatMeetingSchedule = (meeting: ConflictMeetingSummary): string => {
-  const { recurrencePattern, occurrence } = meeting;
-  const time = compactTimeRange(new Date(occurrence.start), new Date(occurrence.end));
-  if (!recurrencePattern) return `One-time meeting · ${time}`;
-
-  const day = formatDayColumn(recurrencePattern);
-  if (recurrencePattern.type === "monthly") {
-    return `${day ? `Monthly · ${day}` : "Monthly"} · ${time}`;
-  }
-
-  let intervalText = "Weekly";
-  if (recurrencePattern.interval === 2) intervalText = "Biweekly";
-  else if (recurrencePattern.interval === 3) intervalText = "Triweekly";
-  else if (recurrencePattern.interval > 1) intervalText = `Every ${recurrencePattern.interval} weeks`;
-  return `${day ? `${intervalText} · ${day}` : intervalText} · ${time}`;
-};
 
 // Shared by DiagnosticsTab's Conflicts panel and ImportTab's post-import results — same
 // resource-conflict shape (see util/resourceOverlap.ts's ConflictRow), rendered the same way

--- a/frontend/app/components/meeting-form/ConflictOverrideModal.tsx
+++ b/frontend/app/components/meeting-form/ConflictOverrideModal.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import styles from '../../../styles/components/meeting-form/ConflictOverrideModal.module.scss';
+import { fieldLabel, formatOverlapSummary, formatMeetingSchedule, ConflictListRow } from '../admin/ConflictList';
+
+interface ConflictOverrideModalProps {
+  isOpen: boolean;
+  conflicts: ConflictListRow[];
+  onCancel: () => void;
+  onConfirm: () => void;
+  isConfirming?: boolean;
+}
+
+// Shown when a create/edit save collides on room or zoomRoom -- write/meeting and update/meeting
+// both reject the save with a 409 + these rows (see findResourceConflictRows) unless the payload
+// is resubmitted with confirmOverride: true. excludeMid already keeps the meeting being saved out
+// of its own conflict rows, so every meeting listed here is a genuine other meeting -- no
+// filtering needed before rendering.
+const ConflictOverrideModal: React.FC<ConflictOverrideModalProps> = ({
+  isOpen,
+  conflicts,
+  onCancel,
+  onConfirm,
+  isConfirming = false,
+}) => {
+  if (!isOpen) return null;
+
+  return (
+    <div className={styles.modalOverlay}>
+      <div className={styles.modalContent}>
+        <div className={styles.header}>
+          <span className={styles.iconCircle}>
+            <img src="/svg/warning-circle-icon.svg" alt="" width="20" height="20" />
+          </span>
+          <h2 className={styles.title}>Scheduling conflict</h2>
+        </div>
+
+        <p className={styles.message}>
+          This meeting&apos;s room or Zoom room is already booked at this time. You can save anyway,
+          or go back and change the room, Zoom room, or schedule.
+        </p>
+
+        <div className={styles.conflictList}>
+          {conflicts.map((conflict, i) => (
+            <div key={`${conflict.field}-${conflict.value}-${i}`} className={styles.conflictGroup}>
+              <div className={styles.conflictMeta}>
+                {fieldLabel(conflict.field)}: <span className={styles.conflictValue}>{conflict.value}</span>
+              </div>
+              <div className={styles.overlapSummary}>{formatOverlapSummary(conflict.overlap, conflict.meetings)}</div>
+              {conflict.meetings.map((meeting) => (
+                <div key={meeting.mid} className={styles.conflictEntry}>
+                  <span className={styles.meetingTitle}>{meeting.title}</span>
+                  <div className={styles.meetingSchedule}>{formatMeetingSchedule(meeting)}</div>
+                </div>
+              ))}
+            </div>
+          ))}
+        </div>
+
+        <div className={styles.buttonContainer}>
+          <button className={styles.cancelButton} onClick={onCancel} disabled={isConfirming}>Go back</button>
+          <button className={styles.overrideButton} onClick={onConfirm} disabled={isConfirming}>
+            {isConfirming ? "Saving…" : "Save anyway"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ConflictOverrideModal;

--- a/frontend/app/components/meeting-form/ConflictOverrideModal.tsx
+++ b/frontend/app/components/meeting-form/ConflictOverrideModal.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import styles from '../../../styles/components/meeting-form/ConflictOverrideModal.module.scss';
-import { fieldLabel, formatOverlapSummary, formatMeetingSchedule, ConflictListRow } from '../admin/ConflictList';
+import { fieldLabel, formatOverlapSummary, formatMeetingSchedule, ConflictListRow } from '../../../util/conflictDisplay';
 
 interface ConflictOverrideModalProps {
   isOpen: boolean;
@@ -22,16 +22,38 @@ const ConflictOverrideModal: React.FC<ConflictOverrideModalProps> = ({
   onConfirm,
   isConfirming = false,
 }) => {
+  // "Go back" (the non-destructive default) gets initial focus, mirroring BottomSheet.tsx's own
+  // focus-on-open/restore-on-close pattern -- without this, focus stays on the form's now-
+  // re-enabled submit button underneath, and Enter/Space could resubmit it while this is up.
+  const cancelButtonRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const previouslyFocused = document.activeElement as HTMLElement | null;
+    cancelButtonRef.current?.focus();
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onCancel();
+    };
+    document.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      previouslyFocused?.focus();
+    };
+  }, [isOpen, onCancel]);
+
   if (!isOpen) return null;
 
   return (
     <div className={styles.modalOverlay}>
-      <div className={styles.modalContent}>
+      <div className={styles.modalContent} role="dialog" aria-modal="true" aria-labelledby="conflict-override-title">
         <div className={styles.header}>
           <span className={styles.iconCircle}>
             <img src="/svg/warning-circle-icon.svg" alt="" width="20" height="20" />
           </span>
-          <h2 className={styles.title}>Scheduling conflict</h2>
+          <h2 id="conflict-override-title" className={styles.title}>Scheduling conflict</h2>
         </div>
 
         <p className={styles.message}>
@@ -57,7 +79,9 @@ const ConflictOverrideModal: React.FC<ConflictOverrideModalProps> = ({
         </div>
 
         <div className={styles.buttonContainer}>
-          <button className={styles.cancelButton} onClick={onCancel} disabled={isConfirming}>Go back</button>
+          <button ref={cancelButtonRef} className={styles.cancelButton} onClick={onCancel} disabled={isConfirming}>
+            Go back
+          </button>
           <button className={styles.overrideButton} onClick={onConfirm} disabled={isConfirming}>
             {isConfirming ? "Saving…" : "Save anyway"}
           </button>

--- a/frontend/app/components/meeting-form/EditMeeting.tsx
+++ b/frontend/app/components/meeting-form/EditMeeting.tsx
@@ -9,12 +9,14 @@ import Dropdown from '../atoms/Dropdown';
 import LabeledCheckbox from '../atoms/CheckBox';
 import RecurringMeetingForm from './RecurringMeeting';
 import ZoomHostField from './ZoomHostField';
+import ConflictOverrideModal from './ConflictOverrideModal';
 import CloseIcon from '@mui/icons-material/Close';
 import IconButton from '@mui/material/IconButton';
 
 import { IMeeting } from '../../../util/models'
 import { physicalRoomOptions, zoomRoomOptions } from "../../../util/rooms";
 import { useMeetingForm, CAL_TYPE_OPTIONS, CAL_TYPE_COLOR, DESCRIPTION_MAX_LENGTH } from '../../../hooks/useMeetingForm';
+import { ConflictListRow } from '../admin/ConflictList';
 
 import styles from '../../../styles/components/meeting-form/MeetingForm.module.scss';
 
@@ -49,9 +51,46 @@ const EditMeetingSidebar: React.FC<EditMeetingSidebarProps> =
     } = useMeetingForm(meeting);
 
     const [isSubmitting, setIsSubmitting] = useState(false);
+    // Holds the payload + conflict rows across the confirm round-trip -- a 409 doesn't discard
+    // the edit, it just pauses submission until the modal's Cancel or "Save anyway".
+    const [conflictState, setConflictState] = useState<{ payload: IMeeting; conflicts: ConflictListRow[] } | null>(null);
     // Narrow Main Calendar sidebar gets ~80%-scaled field fonts; the "wide" embed (e.g.
     // Diagnostics Conflicts panel) has room to spare and keeps full size.
     const compact = layout === "sidebar";
+
+    const submitMeeting = async (payload: IMeeting, confirmOverride: boolean) => {
+      setIsSubmitting(true);
+      try {
+        const response = await fetch('/api/update/meeting', {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ ...payload, confirmOverride }),
+        });
+
+        if (response.status === 409) {
+          const body = await response.json();
+          if (body.conflicts) {
+            setConflictState({ payload, conflicts: body.conflicts });
+            return;
+          }
+        }
+
+        if (!response.ok) {
+          throw new Error(`HTTP error! status: ${response.status}`);
+        }
+
+        const meetingResponse = await response.json();
+        console.log(meetingResponse);
+        setConflictState(null);
+        alert("Meeting updated successfully! Please check the Meeting collection on MongoDB.");
+        onUpdateSuccess();
+        onClose();
+      } catch (error) {
+        console.error('There was an error fetching the data:', error);
+      } finally {
+        setIsSubmitting(false);
+      }
+    };
 
     const updateMeeting = async () => {
       // Guards against duplicate/racing updates from rapid/double clicks — the
@@ -68,28 +107,7 @@ const EditMeetingSidebar: React.FC<EditMeetingSidebarProps> =
       const updatedMeeting = buildMeetingPayload(meeting.mid, meeting.status ?? 'Active');
       if (!updatedMeeting) return;
 
-      setIsSubmitting(true);
-      try {
-        const response = await fetch('/api/update/meeting', {
-          method: 'PUT',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(updatedMeeting),
-        });
-
-        if (!response.ok) {
-          throw new Error(`HTTP error! status: ${response.status}`);
-        }
-
-        const meetingResponse = await response.json();
-        console.log(meetingResponse);
-        alert("Meeting updated successfully! Please check the Meeting collection on MongoDB.");
-        onUpdateSuccess();
-        onClose();
-      } catch (error) {
-        console.error('There was an error fetching the data:', error);
-      } finally {
-        setIsSubmitting(false);
-      }
+      await submitMeeting(updatedMeeting, false);
     };
 
     return (
@@ -212,6 +230,19 @@ const EditMeetingSidebar: React.FC<EditMeetingSidebarProps> =
           buttonText={isSubmitting ? "Updating…" : "Update Meeting"}
           isSubmitting={isSubmitting}
           layout={layout}
+        />
+        <ConflictOverrideModal
+          isOpen={!!conflictState}
+          conflicts={conflictState?.conflicts ?? []}
+          onCancel={() => setConflictState(null)}
+          onConfirm={() => {
+            // confirmOverride: true always skips the server-side check, so this can never
+            // hit the 409 branch again -- safe to close the modal immediately rather than
+            // keep it open through a resubmit that can't reject.
+            const payload = conflictState?.payload;
+            setConflictState(null);
+            if (payload) submitMeeting(payload, true);
+          }}
         />
       </div>
     );

--- a/frontend/app/components/meeting-form/EditMeeting.tsx
+++ b/frontend/app/components/meeting-form/EditMeeting.tsx
@@ -16,7 +16,7 @@ import IconButton from '@mui/material/IconButton';
 import { IMeeting } from '../../../util/models'
 import { physicalRoomOptions, zoomRoomOptions } from "../../../util/rooms";
 import { useMeetingForm, CAL_TYPE_OPTIONS, CAL_TYPE_COLOR, DESCRIPTION_MAX_LENGTH } from '../../../hooks/useMeetingForm';
-import { ConflictListRow } from '../admin/ConflictList';
+import { ConflictListRow } from '../../../util/conflictDisplay';
 
 import styles from '../../../styles/components/meeting-form/MeetingForm.module.scss';
 

--- a/frontend/app/components/meeting-form/NewMeeting.tsx
+++ b/frontend/app/components/meeting-form/NewMeeting.tsx
@@ -17,7 +17,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { physicalRoomOptions, zoomRoomOptions } from "../../../util/rooms";
 import { useMeetingForm, CAL_TYPE_OPTIONS, CAL_TYPE_COLOR, DESCRIPTION_MAX_LENGTH } from '../../../hooks/useMeetingForm';
 import { IMeeting } from '../../../util/models';
-import { ConflictListRow } from '../admin/ConflictList';
+import { ConflictListRow } from '../../../util/conflictDisplay';
 
 import styles from '../../../styles/components/meeting-form/MeetingForm.module.scss';
 

--- a/frontend/app/components/meeting-form/NewMeeting.tsx
+++ b/frontend/app/components/meeting-form/NewMeeting.tsx
@@ -9,12 +9,15 @@ import Dropdown from '../atoms/Dropdown';
 import LabeledCheckbox from '../atoms/CheckBox';
 import RecurringMeetingForm from './RecurringMeeting';
 import ZoomHostField from './ZoomHostField';
+import ConflictOverrideModal from './ConflictOverrideModal';
 import CloseIcon from '@mui/icons-material/Close';
 import IconButton from '@mui/material/IconButton';
 
 import { v4 as uuidv4 } from 'uuid';
 import { physicalRoomOptions, zoomRoomOptions } from "../../../util/rooms";
 import { useMeetingForm, CAL_TYPE_OPTIONS, CAL_TYPE_COLOR, DESCRIPTION_MAX_LENGTH } from '../../../hooks/useMeetingForm';
+import { IMeeting } from '../../../util/models';
+import { ConflictListRow } from '../admin/ConflictList';
 
 import styles from '../../../styles/components/meeting-form/MeetingForm.module.scss';
 
@@ -53,10 +56,48 @@ const NewMeetingSidebar: React.FC<NewMeetingSidebarProps> = ({
     } = useMeetingForm(undefined, { selectedDate, selectedView });
 
     const [isSubmitting, setIsSubmitting] = useState(false);
+    // Holds the payload + conflict rows across the confirm round-trip -- a 409 doesn't clear
+    // the form, it just pauses submission until the modal's Cancel or "Save anyway".
+    const [conflictState, setConflictState] = useState<{ payload: IMeeting; conflicts: ConflictListRow[] } | null>(null);
 
     const handleCloseNewMeeting = () => {
       resetForm();
       setIsNewMeetingOpen(false);
+    };
+
+    const submitMeeting = async (payload: IMeeting, confirmOverride: boolean) => {
+      setIsSubmitting(true);
+      try {
+        const response = await fetch('/api/write/meeting', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ ...payload, confirmOverride }),
+        });
+
+        if (response.status === 409) {
+          const body = await response.json();
+          if (body.conflicts) {
+            setConflictState({ payload, conflicts: body.conflicts });
+            return;
+          }
+        }
+
+        if (!response.ok) {
+          throw new Error(`HTTP error! status: ${response.status}`);
+        }
+
+        const meetingResponse = await response.json();
+        console.log(meetingResponse);
+
+        setConflictState(null);
+        triggerCalendarRefresh();
+        alert("Meeting created successfully! Please check the Meeting collection on MongoDB.");
+        handleCloseNewMeeting();
+      } catch (error) {
+        console.error('There was an error fetching the data:', error);
+      } finally {
+        setIsSubmitting(false);
+      }
     };
 
     const createMeeting = async () => {
@@ -74,29 +115,7 @@ const NewMeetingSidebar: React.FC<NewMeetingSidebarProps> = ({
       const newMeeting = buildMeetingPayload(uuidv4(), 'Active');
       if (!newMeeting) return;
 
-      setIsSubmitting(true);
-      try {
-        const response = await fetch('/api/write/meeting', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(newMeeting),
-        });
-
-        if (!response.ok) {
-          throw new Error(`HTTP error! status: ${response.status}`);
-        }
-
-        const meetingResponse = await response.json();
-        console.log(meetingResponse);
-
-        triggerCalendarRefresh();
-        alert("Meeting created successfully! Please check the Meeting collection on MongoDB.");
-        handleCloseNewMeeting();
-      } catch (error) {
-        console.error('There was an error fetching the data:', error);
-      } finally {
-        setIsSubmitting(false);
-      }
+      await submitMeeting(newMeeting, false);
     };
 
     return (
@@ -214,6 +233,19 @@ const NewMeetingSidebar: React.FC<NewMeetingSidebarProps> = ({
           handleMeetingSubmit={createMeeting}
           buttonText={isSubmitting ? "Creating…" : "Create Meeting"}
           isSubmitting={isSubmitting}
+        />
+        <ConflictOverrideModal
+          isOpen={!!conflictState}
+          conflicts={conflictState?.conflicts ?? []}
+          onCancel={() => setConflictState(null)}
+          onConfirm={() => {
+            // confirmOverride: true always skips the server-side check, so this can never
+            // hit the 409 branch again -- safe to close the modal immediately rather than
+            // keep it open through a resubmit that can't reject.
+            const payload = conflictState?.payload;
+            setConflictState(null);
+            if (payload) submitMeeting(payload, true);
+          }}
         />
       </div>
     );

--- a/frontend/styles/components/meeting-form/ConflictOverrideModal.module.scss
+++ b/frontend/styles/components/meeting-form/ConflictOverrideModal.module.scss
@@ -15,6 +15,7 @@
 
 .modalContent {
   box-sizing: border-box;
+
   // A short viewport or high text zoom can otherwise push the action buttons off-screen with
   // no way to reach them -- the overlay itself has no scroll, so the modal needs its own.
   max-height: calc(100vh - 32px);

--- a/frontend/styles/components/meeting-form/ConflictOverrideModal.module.scss
+++ b/frontend/styles/components/meeting-form/ConflictOverrideModal.module.scss
@@ -1,0 +1,159 @@
+@import '../../Variables.module.scss';
+
+.modalOverlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgb(0 0 0 / 50%);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+}
+
+.modalContent {
+  background-color: white;
+  border-radius: 8px;
+  width: 440px;
+  max-width: 90%;
+  padding: 24px;
+  font-family: "Source Sans Pro", sans-serif;
+  color: $black-color;
+  box-shadow: 0 4px 12px rgb(0 0 0 / 15%);
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 8px;
+}
+
+.iconCircle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background-color: $warning-bg-color;
+  flex-shrink: 0;
+}
+
+.title {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 600;
+}
+
+// Left-indented to align under the title text (36px icon circle + 12px header gap), matching
+// SuspendMeetingModal's own .message convention.
+.message {
+  margin: 0 0 16px;
+  padding-left: 48px;
+  font-size: 15px;
+  line-height: 1.5;
+  color: #444;
+}
+
+// Scrolls internally instead of growing the modal unbounded -- a save can collide with more
+// than one existing meeting across both room and zoomRoom.
+.conflictList {
+  max-height: 260px;
+  overflow-y: auto;
+  margin-bottom: 20px;
+  padding: 12px;
+  background-color: $warning-bg-color;
+  border-radius: 8px;
+}
+
+.conflictGroup {
+  padding: 8px 0;
+
+  &:not(:first-of-type) {
+    border-top: 1px solid rgb(0 0 0 / 8%);
+  }
+}
+
+.conflictMeta {
+  font-size: 13px;
+  color: #555;
+}
+
+.conflictValue {
+  font-weight: 600;
+  color: $black-color;
+}
+
+.overlapSummary {
+  font-size: 13px;
+  color: $warning-text-color;
+  margin-top: 2px;
+  margin-bottom: 6px;
+}
+
+.conflictEntry {
+  padding: 4px 0 4px 12px;
+}
+
+.meetingTitle {
+  font-weight: 600;
+  font-size: 14px;
+  color: $black-color;
+}
+
+.meetingSchedule {
+  font-size: 13px;
+  color: $medium-grey-color;
+  margin-top: 1px;
+}
+
+.buttonContainer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.cancelButton {
+  padding: 8px 16px;
+  border-radius: 6px;
+  border: 1.5px solid $light-grey-color;
+  background-color: white;
+  color: $black-color;
+  font-size: 14px;
+  font-weight: 600;
+  text-align: center;
+  cursor: pointer;
+
+  &:hover {
+    background-color: #F5F5F5;
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.6;
+  }
+}
+
+.overrideButton {
+  padding: 8px 16px;
+  border-radius: 6px;
+  border: none;
+  background-color: $warning-text-color;
+  color: $white-color;
+  font-size: 14px;
+  font-weight: 600;
+  text-align: center;
+  cursor: pointer;
+
+  &:hover {
+    background-color: #96620A;
+  }
+
+  &:disabled {
+    background-color: $light-grey-color;
+    cursor: not-allowed;
+  }
+}

--- a/frontend/styles/components/meeting-form/ConflictOverrideModal.module.scss
+++ b/frontend/styles/components/meeting-form/ConflictOverrideModal.module.scss
@@ -14,6 +14,11 @@
 }
 
 .modalContent {
+  box-sizing: border-box;
+  // A short viewport or high text zoom can otherwise push the action buttons off-screen with
+  // no way to reach them -- the overlay itself has no scroll, so the modal needs its own.
+  max-height: calc(100vh - 32px);
+  overflow-y: auto;
   background-color: white;
   border-radius: 8px;
   width: 440px;

--- a/frontend/tests/component/ConflictOverrideModal.test.tsx
+++ b/frontend/tests/component/ConflictOverrideModal.test.tsx
@@ -1,0 +1,70 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import ConflictOverrideModal from "../../app/components/meeting-form/ConflictOverrideModal";
+import { ConflictListRow } from "../../app/components/admin/ConflictList";
+
+const conflicts: ConflictListRow[] = [
+  {
+    field: "room",
+    value: "Fellowship Room",
+    overlap: { start: "2026-09-01T18:00:00.000Z", end: "2026-09-01T19:00:00.000Z" },
+    meetings: [
+      {
+        mid: "m-candidate",
+        title: "New Meeting",
+        calType: ["AA"],
+        isRecurring: false,
+        recurrencePattern: null,
+        occurrence: { start: "2026-09-01T18:00:00.000Z", end: "2026-09-01T19:00:00.000Z" },
+      },
+      {
+        mid: "m-busy",
+        title: "Busy Meeting",
+        calType: ["AA"],
+        isRecurring: false,
+        recurrencePattern: null,
+        occurrence: { start: "2026-09-01T18:00:00.000Z", end: "2026-09-01T19:00:00.000Z" },
+      },
+    ],
+  },
+];
+
+describe("ConflictOverrideModal", () => {
+  it("renders nothing when closed", () => {
+    render(<ConflictOverrideModal isOpen={false} conflicts={conflicts} onCancel={jest.fn()} onConfirm={jest.fn()} />);
+    expect(screen.queryByText("Scheduling conflict")).not.toBeInTheDocument();
+  });
+
+  it("lists the conflicting meetings by field and title when open", () => {
+    const { container } = render(
+      <ConflictOverrideModal isOpen conflicts={conflicts} onCancel={jest.fn()} onConfirm={jest.fn()} />,
+    );
+    expect(screen.getByText("Scheduling conflict")).toBeInTheDocument();
+    // "Room:" and its value render as separate text/element siblings within .conflictMeta, so
+    // check the container's full text rather than an exact single-node match.
+    expect(container.textContent).toContain("Room:");
+    expect(screen.getByText("Fellowship Room")).toBeInTheDocument();
+    expect(screen.getByText("New Meeting")).toBeInTheDocument();
+    expect(screen.getByText("Busy Meeting")).toBeInTheDocument();
+  });
+
+  it("calls onCancel when Go back is clicked", () => {
+    const onCancel = jest.fn();
+    render(<ConflictOverrideModal isOpen conflicts={conflicts} onCancel={onCancel} onConfirm={jest.fn()} />);
+    fireEvent.click(screen.getByRole("button", { name: "Go back" }));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onConfirm when Save anyway is clicked", () => {
+    const onConfirm = jest.fn();
+    render(<ConflictOverrideModal isOpen conflicts={conflicts} onCancel={jest.fn()} onConfirm={onConfirm} />);
+    fireEvent.click(screen.getByRole("button", { name: "Save anyway" }));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables both buttons while confirming", () => {
+    render(<ConflictOverrideModal isOpen conflicts={conflicts} onCancel={jest.fn()} onConfirm={jest.fn()} isConfirming />);
+    expect(screen.getByRole("button", { name: "Go back" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Saving…" })).toBeDisabled();
+  });
+});

--- a/frontend/tests/component/ConflictOverrideModal.test.tsx
+++ b/frontend/tests/component/ConflictOverrideModal.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
 import ConflictOverrideModal from "../../app/components/meeting-form/ConflictOverrideModal";
-import { ConflictListRow } from "../../app/components/admin/ConflictList";
+import { ConflictListRow } from "../../util/conflictDisplay";
 
 const conflicts: ConflictListRow[] = [
   {

--- a/frontend/tests/integration/update-meeting-route.test.ts
+++ b/frontend/tests/integration/update-meeting-route.test.ts
@@ -254,11 +254,14 @@ test("confirmOverride: true bypasses the room conflict check and saves the edit 
   const response = await PUT(request);
   expect(response.status).toBe(200);
 
-  // Let the deferred sync job (which the mock above resolves) finish before the test exits,
-  // so it can't leak an in-flight reconcileMeetingCalendars call into a later test.
-  await new Promise((resolve) => setTimeout(resolve, 400));
+  // Waits for (and asserts) the deferred sync job's terminal status, rather than a fixed delay
+  // that could pass without proving the background reconcileMeetingCalendars call completed.
+  const updated = await waitFor(async () => {
+    const row = await prisma.meeting.findUnique({ where: { mid: editedMid } });
+    return row?.googleSyncStatus != null ? row : null;
+  });
 
-  const updated = await prisma.meeting.findUnique({ where: { mid: editedMid } });
+  expect(updated?.googleSyncStatus).toBe("synced");
   expect(updated?.room).toBe("Fellowship Room");
 });
 

--- a/frontend/tests/integration/update-meeting-route.test.ts
+++ b/frontend/tests/integration/update-meeting-route.test.ts
@@ -186,6 +186,82 @@ test("a same-room time edit that now conflicts with another meeting on the same 
   expect(afterSync?.zoomSyncError).toMatch(/conflicts with another meeting/i);
 });
 
+test("editing a meeting into a room that's already booked is rejected with 409 + conflicts, and never reaches the Prisma update", async () => {
+  const prisma = getTestPrismaClient();
+  const start = new Date("2026-09-02T18:00:00Z");
+  const end = new Date("2026-09-02T19:00:00Z");
+
+  const busyMid = `m-${randomUUID()}`;
+  const { recurrencePattern: _rp1, ...busyMeetingData } = buildMeetingPayload({
+    mid: busyMid, room: "Fellowship Room", startDateTime: start, endDateTime: end,
+  });
+  await prisma.meeting.create({ data: busyMeetingData });
+
+  const editedMid = `m-${randomUUID()}`;
+  const { recurrencePattern: _rp2, ...editedMeetingData } = buildMeetingPayload({
+    mid: editedMid, room: "Serenity Room", startDateTime: start, endDateTime: end,
+  });
+  const original = await prisma.meeting.create({ data: editedMeetingData });
+
+  const payload = buildMeetingPayload({
+    mid: editedMid, room: "Fellowship Room", startDateTime: start, endDateTime: end,
+  });
+  const request = new Request("http://localhost/api/update/meeting", {
+    method: "PUT",
+    body: JSON.stringify(payload),
+  });
+
+  const response = await PUT(request);
+  expect(response.status).toBe(409);
+  const body = await response.json();
+  expect(body.conflicts).toHaveLength(1);
+  expect(body.conflicts[0]).toMatchObject({ field: "room", value: "Fellowship Room" });
+  expect(body.conflicts[0].meetings.map((m: { mid: string }) => m.mid)).toContain(busyMid);
+
+  // The room edit never landed -- still the pre-update value.
+  const unchanged = await prisma.meeting.findUnique({ where: { mid: editedMid } });
+  expect(unchanged?.room).toBe(original.room);
+});
+
+test("confirmOverride: true bypasses the room conflict check and saves the edit anyway", async () => {
+  mockedReconcileMeetingCalendars.mockResolvedValue({ updatedEventIds: {}, allSynced: true });
+
+  const prisma = getTestPrismaClient();
+  const start = new Date("2026-09-03T18:00:00Z");
+  const end = new Date("2026-09-03T19:00:00Z");
+
+  const busyMid = `m-${randomUUID()}`;
+  const { recurrencePattern: _rp1, ...busyMeetingData } = buildMeetingPayload({
+    mid: busyMid, room: "Fellowship Room", startDateTime: start, endDateTime: end,
+  });
+  await prisma.meeting.create({ data: busyMeetingData });
+
+  const editedMid = `m-${randomUUID()}`;
+  const { recurrencePattern: _rp2, ...editedMeetingData } = buildMeetingPayload({
+    mid: editedMid, room: "Serenity Room", startDateTime: start, endDateTime: end,
+  });
+  await prisma.meeting.create({ data: editedMeetingData });
+
+  const payload = {
+    ...buildMeetingPayload({ mid: editedMid, room: "Fellowship Room", startDateTime: start, endDateTime: end }),
+    confirmOverride: true,
+  };
+  const request = new Request("http://localhost/api/update/meeting", {
+    method: "PUT",
+    body: JSON.stringify(payload),
+  });
+
+  const response = await PUT(request);
+  expect(response.status).toBe(200);
+
+  // Let the deferred sync job (which the mock above resolves) finish before the test exits,
+  // so it can't leak an in-flight reconcileMeetingCalendars call into a later test.
+  await new Promise((resolve) => setTimeout(resolve, 400));
+
+  const updated = await prisma.meeting.findUnique({ where: { mid: editedMid } });
+  expect(updated?.room).toBe("Fellowship Room");
+});
+
 test("a newly resolved Zoom host is persisted synchronously when a meeting first gets a Zoom room", async () => {
   mockedResolveZoomHost.mockResolvedValue("new-host@icr.test");
   const SYNC_DELAY_MS = 300;

--- a/frontend/tests/integration/write-meeting-route.test.ts
+++ b/frontend/tests/integration/write-meeting-route.test.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "crypto";
 import { getTestPrismaClient, disconnectTestPrismaClient } from "../factories/db";
+import { seedSuspensionPeriod } from "../factories/meeting";
 import type { IMeeting } from "../../util/models";
 
 // Next's after() throws when called outside a real request scope, which route handlers
@@ -339,15 +340,92 @@ test("confirmOverride: true bypasses the room conflict check and creates the mee
   const created = await prisma.meeting.findUnique({ where: { mid: payload.mid } });
   expect(created).not.toBeNull();
 
-  // Let the deferred sync job (which the mock above resolves) finish before the test exits,
-  // so it can't leak an in-flight createCalendarEvent call into a later test.
+  // Waits for (and asserts) the deferred sync job's terminal status, rather than a fixed delay
+  // that could pass without proving the background work actually completed.
+  const afterSync = await waitForGoogleSyncStatus(payload.mid);
+  expect(afterSync?.googleSyncStatus).toBe("synced");
+});
+
+// The daysOfWeek below covers all 7 days so the pattern produces an occurrence every day --
+// avoids day-of-week alignment fragility for these date-math-sensitive suspension cases.
+const ALL_DAYS = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
+const daysFromNow = (n: number, time: string) => {
+  const d = new Date();
+  d.setUTCDate(d.getUTCDate() + n);
+  return new Date(`${d.toISOString().slice(0, 10)}T${time}Z`);
+};
+
+test("a recurring meeting that's suspended today but resumes before the candidate's occurrence still conflicts", async () => {
+  const prisma = getTestPrismaClient();
+  const busyMid = `m-${randomUUID()}`;
+  await prisma.meeting.create({
+    data: {
+      mid: busyMid, title: "Suspended-Then-Resumed Meeting", modeType: "In Person", description: "", creator: "Creator", group: "Group",
+      startDateTime: daysFromNow(0, "18:00:00"), endDateTime: daysFromNow(0, "19:00:00"), email: "busy@test.icr",
+      calType: ["AA"], status: "Active", room: "Fellowship Room", isRecurring: true,
+    },
+  });
+  await prisma.recurrencePattern.create({
+    data: { mid: busyMid, type: "weekly", startDate: daysFromNow(0, "18:00:00"), daysOfWeek: ALL_DAYS, firstDayOfWeek: "Sunday", interval: 1 },
+  });
+  // Suspended from yesterday, resumes in 5 days -- well before the candidate's occurrence 10
+  // days out, so that specific future occurrence is not actually suspended.
+  await seedSuspensionPeriod(busyMid, { from: daysFromNow(-1, "00:00:00"), to: daysFromNow(5, "00:00:00") });
+
+  const payload = buildMeetingPayload({ room: "Fellowship Room", startDateTime: daysFromNow(10, "18:00:00"), endDateTime: daysFromNow(10, "19:00:00") });
+  const request = new Request("http://localhost/api/write/meeting", {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+
+  const response = await POST(request);
+  expect(response.status).toBe(409);
+  const body = await response.json();
+  expect(body.conflicts[0].meetings.map((m: { mid: string }) => m.mid)).toContain(busyMid);
+});
+
+test("a recurring meeting with a future suspension window doesn't conflict with a booking inside it", async () => {
+  mockedCreateCalendarEvent.mockResolvedValue({ id: "fake-event-id", error: null });
+
+  const prisma = getTestPrismaClient();
+  const busyMid = `m-${randomUUID()}`;
+  await prisma.meeting.create({
+    data: {
+      mid: busyMid, title: "Soon-To-Be-Suspended Meeting", modeType: "In Person", description: "", creator: "Creator", group: "Group",
+      startDateTime: daysFromNow(0, "18:00:00"), endDateTime: daysFromNow(0, "19:00:00"), email: "busy@test.icr",
+      calType: ["AA"], status: "Active", room: "Fellowship Room 2", isRecurring: true,
+    },
+  });
+  await prisma.recurrencePattern.create({
+    data: { mid: busyMid, type: "weekly", startDate: daysFromNow(0, "18:00:00"), daysOfWeek: ALL_DAYS, firstDayOfWeek: "Sunday", interval: 1 },
+  });
+  // Not suspended today, but will be starting in 5 days, indefinitely -- covers the candidate's
+  // occurrence 10 days out.
+  await seedSuspensionPeriod(busyMid, { from: daysFromNow(5, "00:00:00"), to: null });
+
+  const payload = buildMeetingPayload({ room: "Fellowship Room 2", startDateTime: daysFromNow(10, "18:00:00"), endDateTime: daysFromNow(10, "19:00:00") });
+  const request = new Request("http://localhost/api/write/meeting", {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+
+  const response = await POST(request);
+  expect(response.status).toBe(201);
+
+  // Let the deferred sync job (which the mock above resolves) finish before the test exits, so
+  // it can't leak an in-flight createCalendarEvent call into a later test.
   await waitForGoogleSyncStatus(payload.mid);
 });
 
 test("a recurring meeting creates its Meeting and RecurrencePattern together (one transaction, not two sequential writes)", async () => {
   mockedCreateCalendarEvent.mockResolvedValue({ id: "fake-event-id", error: null });
 
+  // Distinct room -- buildMeetingPayload's default ("Serenity Room") is shared by other tests
+  // in this suite, and the room/zoomRoom conflict check added alongside this transaction fix
+  // would otherwise make this order-dependent on unrelated leftover data (same reasoning as the
+  // manually-selected-host test above).
   const payload = buildMeetingPayload({
+    room: "Fellowship Room 3",
     isRecurring: true,
     recurrencePattern: {
       type: "weekly",

--- a/frontend/tests/integration/write-meeting-route.test.ts
+++ b/frontend/tests/integration/write-meeting-route.test.ts
@@ -280,6 +280,70 @@ test("a Remote meeting (no zoomRoom) still gets a Zoom meeting created, and its 
   );
 });
 
+test("a room conflict is rejected with 409 + conflicts, and never reaches the Prisma create", async () => {
+  const prisma = getTestPrismaClient();
+  const start = new Date("2026-11-02T18:00:00Z");
+  const end = new Date("2026-11-02T19:00:00Z");
+
+  const busyMid = `m-${randomUUID()}`;
+  await prisma.meeting.create({
+    data: {
+      mid: busyMid, title: "Room Conflict Meeting", modeType: "In Person", description: "", creator: "Creator", group: "Group",
+      startDateTime: start, endDateTime: end, email: "busy@test.icr",
+      calType: ["AA"], status: "Active", room: "Fellowship Room", isRecurring: false,
+    },
+  });
+
+  const payload = buildMeetingPayload({ room: "Fellowship Room", startDateTime: start, endDateTime: end });
+  const request = new Request("http://localhost/api/write/meeting", {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+
+  const response = await POST(request);
+  expect(response.status).toBe(409);
+  const body = await response.json();
+  expect(body.conflicts).toHaveLength(1);
+  expect(body.conflicts[0]).toMatchObject({ field: "room", value: "Fellowship Room" });
+  expect(body.conflicts[0].meetings.map((m: { mid: string }) => m.mid)).toContain(busyMid);
+
+  const created = await prisma.meeting.findUnique({ where: { mid: payload.mid } });
+  expect(created).toBeNull();
+});
+
+test("confirmOverride: true bypasses the room conflict check and creates the meeting anyway", async () => {
+  mockedCreateCalendarEvent.mockResolvedValue({ id: "fake-event-id", error: null });
+
+  const prisma = getTestPrismaClient();
+  const start = new Date("2026-11-03T18:00:00Z");
+  const end = new Date("2026-11-03T19:00:00Z");
+
+  const busyMid = `m-${randomUUID()}`;
+  await prisma.meeting.create({
+    data: {
+      mid: busyMid, title: "Room Conflict Meeting", modeType: "In Person", description: "", creator: "Creator", group: "Group",
+      startDateTime: start, endDateTime: end, email: "busy@test.icr",
+      calType: ["AA"], status: "Active", room: "Fellowship Room", isRecurring: false,
+    },
+  });
+
+  const payload = { ...buildMeetingPayload({ room: "Fellowship Room", startDateTime: start, endDateTime: end }), confirmOverride: true };
+  const request = new Request("http://localhost/api/write/meeting", {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+
+  const response = await POST(request);
+  expect(response.status).toBe(201);
+
+  const created = await prisma.meeting.findUnique({ where: { mid: payload.mid } });
+  expect(created).not.toBeNull();
+
+  // Let the deferred sync job (which the mock above resolves) finish before the test exits,
+  // so it can't leak an in-flight createCalendarEvent call into a later test.
+  await waitForGoogleSyncStatus(payload.mid);
+});
+
 test("a recurring meeting creates its Meeting and RecurrencePattern together (one transaction, not two sequential writes)", async () => {
   mockedCreateCalendarEvent.mockResolvedValue({ id: "fake-event-id", error: null });
 

--- a/frontend/util/conflictDisplay.ts
+++ b/frontend/util/conflictDisplay.ts
@@ -1,0 +1,88 @@
+// Shared by ConflictList.tsx (Diagnostics conflicts panel) and ConflictOverrideModal.tsx
+// (save-time room/zoomRoom conflict modal) -- pulled out to a neutral module rather than
+// exported from ConflictList.tsx directly, since ConflictList also imports EditMeetingSidebar
+// (for its inline edit panel) and EditMeetingSidebar itself needs these types, which would
+// otherwise create a circular import between admin/ConflictList.tsx and meeting-form/EditMeeting.tsx.
+import { formatDayColumn } from "./recurrenceDisplay";
+import { formatCompactTimeRange } from "./timeFormat";
+
+export interface ConflictRecurrenceSummary {
+  type: string;
+  interval: number;
+  daysOfWeek: string[];
+  weekOfMonth: number | null;
+  dayOfMonth: number | null;
+}
+
+export interface ConflictMeetingSummary {
+  mid: string;
+  title: string;
+  calType: string[];
+  isRecurring: boolean;
+  recurrencePattern: ConflictRecurrenceSummary | null;
+  // ISO strings -- this meeting's own occurrence, not the overlap intersection.
+  occurrence: { start: string; end: string };
+}
+
+export interface ConflictListRow {
+  field: "room" | "zoomRoom" | "zoomHost";
+  value: string;
+  // ISO strings -- Dates don't survive JSON as-is.
+  overlap: { start: string; end: string };
+  meetings: [ConflictMeetingSummary, ConflictMeetingSummary];
+}
+
+export const fieldLabel = (field: "room" | "zoomRoom" | "zoomHost"): string => {
+  if (field === "room") return "Room";
+  if (field === "zoomRoom") return "Zoom Room";
+  return "Zoom Host";
+};
+
+// Extracts ET wall-clock time as "HH:MM" (24hr), which is what formatCompactTimeRange expects
+// -- mirrors ViewMeeting.tsx's etTimeFmt.
+const etTimeFmt = new Intl.DateTimeFormat("en-GB", {
+  timeZone: "America/New_York", hour: "2-digit", minute: "2-digit", hour12: false,
+});
+
+const etWeekday = (date: Date): string =>
+  new Intl.DateTimeFormat("en-US", { timeZone: "America/New_York", weekday: "short" }).format(date);
+
+const etDate = (date: Date): string =>
+  new Intl.DateTimeFormat("en-US", { timeZone: "America/New_York", month: "short", day: "numeric", year: "numeric" }).format(date);
+
+const compactTimeRange = (start: Date, end: Date): string =>
+  formatCompactTimeRange(etTimeFmt.format(start), etTimeFmt.format(end));
+
+// "Overlap: Tue 7-8PM · next occurs Jul 14, 2026" for a recurring pair, or
+// "Overlap: Fri 6-7PM (single occurrence) · Sep 12, 2026" when both are one-time.
+export const formatOverlapSummary = (overlap: ConflictListRow["overlap"], meetings: ConflictListRow["meetings"]): string => {
+  const start = new Date(overlap.start);
+  const end = new Date(overlap.end);
+  const bothOneTime = meetings.every((m) => !m.isRecurring);
+  const timeRange = `${etWeekday(start)} ${compactTimeRange(start, end)}`;
+  const dateLabel = etDate(start);
+  return bothOneTime
+    ? `Overlap: ${timeRange} (single occurrence) · ${dateLabel}`
+    : `Overlap: ${timeRange} · next occurs ${dateLabel}`;
+};
+
+// "Weekly · Tue · 7-8PM", "Monthly · 2nd Fri · 7-8PM", or "One-time meeting · 7-8PM" -- mirrors
+// ViewMeeting.tsx's getRecurrenceText, reusing the same Day-column formatter as the XLSX/lease
+// exports. The time shown is this meeting's own occurrence, not the overlap window above, since
+// the two can differ (e.g. 6-8PM vs. 7-9PM overlapping 7-8PM).
+export const formatMeetingSchedule = (meeting: ConflictMeetingSummary): string => {
+  const { recurrencePattern, occurrence } = meeting;
+  const time = compactTimeRange(new Date(occurrence.start), new Date(occurrence.end));
+  if (!recurrencePattern) return `One-time meeting · ${time}`;
+
+  const day = formatDayColumn(recurrencePattern);
+  if (recurrencePattern.type === "monthly") {
+    return `${day ? `Monthly · ${day}` : "Monthly"} · ${time}`;
+  }
+
+  let intervalText = "Weekly";
+  if (recurrencePattern.interval === 2) intervalText = "Biweekly";
+  else if (recurrencePattern.interval === 3) intervalText = "Triweekly";
+  else if (recurrencePattern.interval > 1) intervalText = `Every ${recurrencePattern.interval} weeks`;
+  return `${day ? `${intervalText} · ${day}` : intervalText} · ${time}`;
+};

--- a/frontend/util/meetingOccurrences.ts
+++ b/frontend/util/meetingOccurrences.ts
@@ -246,3 +246,110 @@ export const getMeetingsForDate = async (etDateStr: string): Promise<PublicMeeti
         recurrencePattern: meeting.recurrencePattern ?? null,
     }));
 };
+
+// Resolves a count-bounded series' (numberOfOccurrences set, no explicit endDate) real last
+// occurrence -- shared by write/meeting and update/meeting so a series' finite endpoint is
+// computed the same way whether it's being persisted or checked for room/zoomRoom conflicts.
+// Conflict checks in particular need this: expanding a candidate against a still-null endDate
+// treats it as unbounded out to OVERLAP_HORIZON_YEARS, which can produce a false conflict
+// against a booking that falls after the series' real end.
+export function calculateEndDateFromOccurrences(
+    startDate: Date,
+    daysOfWeek: string[],
+    numberOfOccurrences: number,
+    interval: number,
+    type: string,
+    weekOfMonth: number | null = null,
+    dayOfMonth: number | null = null,
+): Date {
+    const patternStartDate = new Date(startDate);
+
+    if (numberOfOccurrences <= 0) return patternStartDate;
+
+    const dayNameToIndex: Record<string, number> = {
+        "Sunday": 0, "Monday": 1, "Tuesday": 2, "Wednesday": 3,
+        "Thursday": 4, "Friday": 5, "Saturday": 6,
+    };
+
+    if (type === "monthly") {
+        // The Nth occurrence is (N-1) intervals after the start month
+        const rawMonth = patternStartDate.getUTCMonth() + (numberOfOccurrences - 1) * interval;
+        const targetYear = patternStartDate.getUTCFullYear() + Math.floor(rawMonth / 12);
+        const targetMonth = rawMonth % 12;
+
+        // 23:59:59 ET so the end date is inclusive of its full day
+        // even against a naive instant comparison (e.g. `meetingStart <= endDate`).
+        const toETDate = (day: number) => new Date(convertETToUTC(
+            `${targetYear}-${String(targetMonth + 1).padStart(2, '0')}-${String(day).padStart(2, '0')}T23:59:59`
+        ));
+
+        if (dayOfMonth != null) {
+            return toETDate(dayOfMonth);
+        }
+
+        if (weekOfMonth != null && daysOfWeek.length > 0) {
+            const targetDay = dayNameToIndex[daysOfWeek[0]];
+            const daysInMonth = new Date(Date.UTC(targetYear, targetMonth + 1, 0)).getUTCDate();
+
+            if (weekOfMonth === -1) {
+                for (let d = daysInMonth; d >= 1; d--) {
+                    if (new Date(Date.UTC(targetYear, targetMonth, d)).getUTCDay() === targetDay) {
+                        return toETDate(d);
+                    }
+                }
+            } else {
+                let count = 0;
+                for (let d = 1; d <= daysInMonth; d++) {
+                    if (new Date(Date.UTC(targetYear, targetMonth, d)).getUTCDay() === targetDay) {
+                        if (++count === weekOfMonth) {
+                            return toETDate(d);
+                        }
+                    }
+                }
+            }
+        }
+
+        return toETDate(patternStartDate.getUTCDate());
+    }
+
+    // Weekly
+    if (daysOfWeek.length === 0) return patternStartDate;
+
+    const recurrenceDays = daysOfWeek
+        .map(day => dayNameToIndex[day])
+        .filter(index => index !== undefined)
+        .sort((a, b) => a - b);
+
+    if (recurrenceDays.length === 0) return patternStartDate;
+
+    const endDate = new Date(patternStartDate);
+    let occurrenceCount = 0;
+    let currentWeek = 0;
+    const startDayOfWeek = patternStartDate.getUTCDay();
+
+    // The start date only counts as an occurrence if its weekday is in daysOfWeek.
+    if (recurrenceDays.includes(startDayOfWeek)) {
+        occurrenceCount++;
+        if (occurrenceCount >= numberOfOccurrences) return patternStartDate;
+    }
+
+    let nextDayIndex = recurrenceDays.findIndex(day => day > startDayOfWeek);
+    if (nextDayIndex === -1) { nextDayIndex = 0; currentWeek++; }
+
+    while (occurrenceCount < numberOfOccurrences) {
+        if (currentWeek % interval === 0) {
+            while (nextDayIndex < recurrenceDays.length) {
+                const daysToAdd = (currentWeek * 7) +
+                    (recurrenceDays[nextDayIndex] - startDayOfWeek + 7) % 7;
+                endDate.setUTCDate(patternStartDate.getUTCDate() + daysToAdd);
+                occurrenceCount++;
+                nextDayIndex++;
+                if (occurrenceCount >= numberOfOccurrences) return endDate;
+            }
+        }
+        currentWeek++;
+        nextDayIndex = 0;
+    }
+
+    return endDate;
+}

--- a/frontend/util/meetingValidation.ts
+++ b/frontend/util/meetingValidation.ts
@@ -43,6 +43,10 @@ export const meetingSchema = z.object({
   room: z.string(),
   status: z.string().optional(),
   isRecurring: z.boolean(),
+  // Set true to resubmit a payload that already saw (and was shown) a room/zoomRoom conflict --
+  // must be declared here or zod strips it from safeParse's output (see
+  // zoomHostAvailabilityCheckSchema's comment above for the same behavior).
+  confirmOverride: z.boolean().optional(),
   recurrencePattern: recurrencePatternSchema.nullable().optional(),
   googleCalendarEventId: z.string().nullable().optional(),
   googleCalendarEventIds: z.record(z.string(), z.string()).nullable().optional(),

--- a/frontend/util/models.ts
+++ b/frontend/util/models.ts
@@ -52,6 +52,9 @@ interface IMeeting {
   zoomSyncError?: string | null;
   deletedAt?: Date | null;
   updatedAt?: Date | null;
+  // Set true to resubmit a payload that already saw (and was shown) a room/zoomRoom conflict --
+  // never persisted, write/update strip it before the Prisma write.
+  confirmOverride?: boolean;
 }
 
 interface IRecurrencePattern {

--- a/frontend/util/resourceOverlap.ts
+++ b/frontend/util/resourceOverlap.ts
@@ -374,8 +374,7 @@ export async function findResourceConflictRows(
     ],
   };
 
-  const todayStr = formatETDateString(new Date());
-  const meetingsRaw = await prisma.meeting.findMany({
+  const meetings = await prisma.meeting.findMany({
     where,
     select: {
       mid: true,
@@ -388,11 +387,6 @@ export async function findResourceConflictRows(
       suspensions: true,
     },
   });
-  // Matches computeConflicts' own room/zoomRoom semantics, not the zoomHost check's
-  // includeSuspended: true -- a suspended meeting doesn't block a room/Zoom-room booking.
-  const meetings = opts.includeSuspended
-    ? meetingsRaw
-    : meetingsRaw.filter((m) => !isDateSuspended(m.suspensions, todayStr));
 
   const rows: ConflictRow[] = [];
   for (const meeting of meetings) {
@@ -410,7 +404,15 @@ export async function findResourceConflictRows(
       isRecurring: meeting.isRecurring,
       recurrencePattern: meeting.recurrencePattern,
     };
-    const occurrences = expandOccurrences(existingCandidate, rangeStart, rangeEnd);
+    let occurrences = expandOccurrences(existingCandidate, rangeStart, rangeEnd);
+    // Filtered per-occurrence, not per-meeting -- a meeting suspended today but resumed before
+    // a later candidate occurrence still genuinely occupies the room then, and a meeting with a
+    // future suspension window shouldn't block a booking that falls inside it. Matches
+    // computeConflicts' own room/zoomRoom semantics (a suspended meeting doesn't block a room),
+    // just evaluated against each occurrence's own date instead of today's.
+    if (!opts.includeSuspended) {
+      occurrences = occurrences.filter((occ) => !isDateSuspended(meeting.suspensions, formatETDateString(occ.start)));
+    }
     const pair = findOverlappingOccurrencePair(candidateOccurrences, occurrences);
     if (pair) {
       rows.push({

--- a/frontend/util/resourceOverlap.ts
+++ b/frontend/util/resourceOverlap.ts
@@ -345,3 +345,85 @@ export function computeConflicts(
 
   return conflicts;
 }
+
+// Single-candidate version of computeConflicts, scoped to one resource field/value -- used by
+// write/meeting and update/meeting to block a save that collides on room or zoomRoom, showing
+// what it collides with (unlike findResourceConflicts above, which only returns bare
+// {mid,title}[] and is used by the zoomHost check-and-defer path, a different, non-blocking
+// flow). Deliberately excludes "zoomHost" from `field` -- that check's semantics (includeSuspended
+// defaults true there, since a suspended meeting's Zoom host reservation is still live) differ
+// from room/zoomRoom's (a suspended meeting doesn't block a room, matching computeConflicts'
+// own activeMeetings filtering), so the two shouldn't be reachable through the same call shape.
+export async function findResourceConflictRows(
+  field: "room" | "zoomRoom",
+  value: string,
+  candidate: ConflictCandidateMeeting,
+  opts: FindConflictsOptions = {},
+): Promise<ConflictRow[]> {
+  if (!value) return [];
+
+  const [rangeStart, rangeEnd] = horizonRange(OVERLAP_HORIZON_YEARS);
+  const candidateOccurrences = expandOccurrences(candidate, rangeStart, rangeEnd);
+  if (candidateOccurrences.length === 0) return [];
+
+  const where: Prisma.MeetingWhereInput = {
+    AND: [
+      notDeleted,
+      fieldWhere(field, value),
+      ...(opts.excludeMid ? [{ mid: { not: opts.excludeMid } }] : []),
+    ],
+  };
+
+  const todayStr = formatETDateString(new Date());
+  const meetingsRaw = await prisma.meeting.findMany({
+    where,
+    select: {
+      mid: true,
+      title: true,
+      calType: true,
+      startDateTime: true,
+      endDateTime: true,
+      isRecurring: true,
+      recurrencePattern: true,
+      suspensions: true,
+    },
+  });
+  // Matches computeConflicts' own room/zoomRoom semantics, not the zoomHost check's
+  // includeSuspended: true -- a suspended meeting doesn't block a room/Zoom-room booking.
+  const meetings = opts.includeSuspended
+    ? meetingsRaw
+    : meetingsRaw.filter((m) => !isDateSuspended(m.suspensions, todayStr));
+
+  const rows: ConflictRow[] = [];
+  for (const meeting of meetings) {
+    // room/zoomRoom placeholders below are never read by toMeetingSummary/toRecurrenceSummary
+    // (mid/title/calType/isRecurring/recurrencePattern only) -- they exist purely to satisfy
+    // ConflictCandidateMeeting's required `room` field.
+    const existingCandidate: ConflictCandidateMeeting = {
+      mid: meeting.mid,
+      title: meeting.title,
+      room: field === "room" ? value : "",
+      zoomRoom: field === "zoomRoom" ? value : null,
+      calType: meeting.calType,
+      startDateTime: meeting.startDateTime,
+      endDateTime: meeting.endDateTime,
+      isRecurring: meeting.isRecurring,
+      recurrencePattern: meeting.recurrencePattern,
+    };
+    const occurrences = expandOccurrences(existingCandidate, rangeStart, rangeEnd);
+    const pair = findOverlappingOccurrencePair(candidateOccurrences, occurrences);
+    if (pair) {
+      rows.push({
+        field,
+        value,
+        overlap: {
+          start: pair.a.start > pair.b.start ? pair.a.start : pair.b.start,
+          end: pair.a.end < pair.b.end ? pair.a.end : pair.b.end,
+        },
+        meetings: [toMeetingSummary(candidate, pair.a), toMeetingSummary(existingCandidate, pair.b)],
+      });
+    }
+  }
+
+  return rows;
+}


### PR DESCRIPTION
@coderabbitai summary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added conflict detection when creating or updating meetings with occupied rooms or Zoom rooms.
  * Added a conflict review modal showing overlapping meetings and schedules.
  * Users can cancel or confirm saving despite detected conflicts.

* **Bug Fixes**
  * Prevented conflicting meeting changes from being saved unless explicitly overridden.
  * Preserved meeting data and conflict details when conflicts are detected.

* **Tests**
  * Added coverage for conflict detection, override behavior, and modal interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description
- **`util/resourceOverlap.ts`**: new `findResourceConflictRows(field, value, candidate, opts)` — a single-candidate version of `computeConflicts`, scoped to `"room"`/`"zoomRoom"`, returning the same `ConflictRow[]` shape the Diagnostics panel already uses. Filters suspended occurrences per-occurrence-date (not per-meeting-"today"), so a meeting that resumes before a future candidate occurrence still correctly conflicts, and a meeting with a future suspension window correctly doesn't.
- **`util/meetingOccurrences.ts`**: `calculateEndDateFromOccurrences` moved here (from `write/meeting/route.ts`) and exported, so both routes resolve a count-bounded recurrence's real finite end the same way before checking conflicts — checking against a still-null `endDate` would otherwise expand the series out to the full 2-year overlap horizon and risk a false conflict.
- **`app/api/write/meeting/route.ts`** / **`app/api/update/meeting/route.ts`**: both now run a synchronous room/zoomRoom conflict check before their Prisma write. A real conflict returns `409 { error, conflicts }` without writing, independent of the existing zoomHost check (which defers the calendar publish rather than rejecting the request). A new optional `confirmOverride: true` on the payload skips the check on resubmit.
- **`util/meetingValidation.ts`** / **`util/models.ts`**: added `confirmOverride?: boolean` to `meetingSchema`/`IMeeting`.
- **`util/conflictDisplay.ts`** (new): shared conflict types (`ConflictListRow`, `ConflictMeetingSummary`) and formatting helpers (`fieldLabel`, `formatOverlapSummary`, `formatMeetingSchedule`), pulled out of `app/components/admin/ConflictList.tsx` to break a circular import (`ConflictList` → `EditMeeting` → `ConflictOverrideModal` → `ConflictList`). `ConflictList.tsx` re-exports them for existing callers.
- **`app/components/meeting-form/ConflictOverrideModal.tsx`** (new): shown on a 409, listing the colliding meetings via the shared formatters. Has real dialog semantics (`role="dialog"`, `aria-modal`, initial focus, Escape-to-cancel, focus restoration — mirroring `BottomSheet.tsx`'s existing pattern) and a scrollable, viewport-clamped body so it can't get clipped on a short screen.
- **`app/components/meeting-form/NewMeeting.tsx`** / **`EditMeeting.tsx`**: hold the pending payload + conflict rows across the confirm round-trip; on 409, show the modal; on confirm, resubmit with `confirmOverride: true`.

## Testing
- [x] `npx tsc --noEmit -p .` — clean
- [x] `yarn test:all` (lint including `yarn lint:css`, unit, component, integration, e2e) — all green
- Repro: create/edit a meeting into a room or Zoom room that's already booked at an overlapping time → expect a 409 and the conflict modal, not a silent double-book; confirm through the modal → expect the save to go through. Covered end-to-end by new integration tests in `write-meeting-route.test.ts`/`update-meeting-route.test.ts` (including the count-bounded-recurrence and per-occurrence-suspension edge cases) and a component test for `ConflictOverrideModal`.

## Area(s) Touched
**Product areas**
- [x] ui/ux — frontend layout/styling not tied to a specific integration

**Engineering**
- [x] testing — test suite (Jest/Playwright) changes

## Pre-merge Checklist
- [x] Code follows current formatting conventions and passes lint (`yarn lint`).
- [x] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
- [x] All test suites pass, both run locally and green in GitHub CI. **Do not merge if any test suite is failing.**
- [x] A test suite was added or updated for the feature/fix in this PR. **Double-check this if you change a feature and did not update the test suites**.
- [x] Only files relevant to this change are committed — no stray or unrelated files.
- [x] If this branch has a merge conflict with master, master was merged into this branch first (not the other way around).
- [x] The rest of this PR description (Description, Testing) is filled out, not left as template placeholders.
