### PR TITLE
fix(tests): update e2e double-booking test for the new conflict-override modal

### DIFF
--- a/frontend/tests/e2e/02-meeting-creation.spec.ts
+++ b/frontend/tests/e2e/02-meeting-creation.spec.ts
@@ -84,7 +84,7 @@ test.describe("meeting creation", () => {
     expect(created?.calType.sort()).toEqual(["AA", "Other"]);
   });
 
-  test("2.5 double-booking a room/time already taken is allowed with no warning", async ({ adminPage }) => {
+  test("2.5 double-booking a room/time already taken is blocked by a conflict modal, which can be overridden", async ({ adminPage }) => {
     const { page } = adminPage;
     const existing = await seedMeeting({ title: "Already Booked", room: "Seeds of Hope Room" });
 
@@ -98,15 +98,49 @@ test.describe("meeting creation", () => {
     await toggleCalType(page, "AA");
     await page.getByPlaceholder("Email").fill("conflict@test.icr");
 
-    const dialogPromise = page.waitForEvent("dialog");
     await page.getByRole("button", { name: "Create Meeting" }).click();
+
+    // Blocked by the room conflict -- the override modal appears instead of the normal
+    // success alert, naming the meeting it collides with. Scoped to the dialog and exact-
+    // matched -- the seeded meeting's own calendar box (still visible behind the overlay) and
+    // the modal's own message text both otherwise also match "Already Booked" un-scoped.
+    const modal = page.getByRole("dialog");
+    await expect(modal.getByText("Scheduling conflict")).toBeVisible();
+    await expect(modal.getByText(existing.title, { exact: true })).toBeVisible();
+
+    const dialogPromise = page.waitForEvent("dialog");
+    await page.getByRole("button", { name: "Save anyway" }).click();
     const dialog = await dialogPromise;
-    // No conflict-specific wording — just the normal success alert.
     expect(dialog.message()).toContain("Meeting created successfully");
     await dialog.accept();
 
     const prisma = getTestPrismaClient();
     const room = await prisma.meeting.findMany({ where: { room: "Seeds of Hope Room" } });
     expect(room.map((m) => m.title)).toEqual(expect.arrayContaining([existing.title, "Conflicting Meeting"]));
+  });
+
+  test("2.6 canceling out of the conflict modal leaves the meeting unsaved", async ({ adminPage }) => {
+    const { page } = adminPage;
+    await seedMeeting({ title: "Already Booked", room: "Seeds of Hope Room" });
+
+    await page.goto("/");
+    await page.getByText("New Meeting").click();
+    await page.getByPlaceholder("Meeting title").fill("Unsaved Conflicting Meeting");
+    await page.getByRole("button", { name: "In Person" }).click();
+    await fillDatePicker(page, todayMMDDYYYY());
+    await fillTimeRange(page, "18:00", "19:00");
+    await selectFromDropdown(page, "Select Room", "Seeds of Hope Room");
+    await toggleCalType(page, "AA");
+    await page.getByPlaceholder("Email").fill("conflict2@test.icr");
+
+    await page.getByRole("button", { name: "Create Meeting" }).click();
+    await expect(page.getByText("Scheduling conflict")).toBeVisible();
+
+    await page.getByRole("button", { name: "Go back" }).click();
+    await expect(page.getByText("Scheduling conflict")).not.toBeVisible();
+
+    const prisma = getTestPrismaClient();
+    const created = await prisma.meeting.findFirst({ where: { title: "Unsaved Conflicting Meeting" } });
+    expect(created).toBeNull();
   });
 });


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Room scheduling conflicts now clearly identify the existing meeting in a confirmation modal.
  * You can choose **Save anyway** to proceed or **Go back** to cancel without creating the meeting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description
- **`frontend/tests/e2e/02-meeting-creation.spec.ts`**: §2.5 was titled "double-booking a room/time already taken is allowed with no warning" and asserted exactly that — the pre-#298 behavior. It wasn't updated when #298 shipped the room/zoomRoom conflict-override modal, so it deterministically failed on master's post-merge e2e run (`page.waitForEvent("dialog")` timing out, since a 409 + modal appears instead of the old success alert now). Rewritten to assert the new behavior: the conflict modal appears, naming the colliding meeting, and "Save anyway" completes the booking. Added a companion §2.6 test for the cancel ("Go back") path, asserting the meeting is never created.
- Scoped the modal's meeting-title assertion to `page.getByRole("dialog")` with an exact match — unscoped, `getByText("Already Booked")` also matched the modal's own message paragraph (case-insensitive substring hit on "...already booked...") and the seeded meeting's own calendar box still visible behind the overlay.

## Testing
- [x] `npx tsc --noEmit -p .` — clean
- [x] `yarn lint` / `yarn lint:css` — 0 errors
- [x] `yarn test:unit` / `yarn test:component` / `yarn test:integration` — all green (unaffected, no source changes)
- [x] `yarn test:e2e` — 94/94 passed (fresh run, not a stale dev server)
- Repro: on `master` before this fix, `yarn test:e2e` (or CI) fails deterministically on `02-meeting-creation.spec.ts:87` with a 30s `page.waitForEvent` timeout.

## Area(s) Touched
**Product areas**
- [ ] auth — sign-in, sessions, NextAuth, role-based access
- [ ] admin — /admin shell (Diagnostics, Users, Import, Export tabs)
- [ ] billing — lease export, XLSX import, anything affecting invoicing
- [ ] ui/ux — frontend layout/styling not tied to a specific integration

**Integrations**
- [ ] google-calendar — Google Calendar sync
- [ ] zoom-api — Zoom meeting/host sync

**Engineering**
- [ ] security — auth hardening, data exposure, dependency/security scanning
- [x] testing — test suite (Jest/Playwright) changes
- [ ] github-actions — workflows, Dependabot config, other .github/ CI tooling
- [ ] cleanup — refactor or dead-code removal, no behavior change
- [ ] documentation — docs/ or README changes only

## Pre-merge Checklist
- [x] Code follows current formatting conventions and passes lint (`yarn lint`).
- [x] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
- [x] All test suites pass, both run locally and green in GitHub CI. **Do not merge if any test suite is failing.**
- [x] A test suite was added or updated for the feature/fix in this PR. **Double-check this if you change a feature and did not update the test suites**.
- [x] Only files relevant to this change are committed — no stray or unrelated files.
- [x] If this branch has a merge conflict with master, master was merged into this branch first (not the other way around).
- [x] The rest of this PR description (Description, Testing) is filled out, not left as template placeholders.
