### PR TITLE
feat(meetings): block saving into a booked Zoom host, add to conflict-override modal

### DIFF
--- a/frontend/app/api/update/meeting/route.ts
+++ b/frontend/app/api/update/meeting/route.ts
@@ -214,9 +214,22 @@ const updateMeeting = async (request: Request): Promise<Response> => {
 
     const { mid, recurrencePattern, confirmOverride, ...meetingFields } = newMeeting;
 
-    // Blocks the save outright on a room/zoomRoom collision -- distinct from the zoomHost check
-    // below, which defers the calendar publish and stores the error on the meeting instead of
-    // rejecting the request. confirmOverride only bypasses this block, not zoomHost's handling.
+    // An explicit host reassignment (the Zoom Host dropdown set to a specific pool host,
+    // different from whatever's currently assigned) -- hoisted above the confirmOverride block
+    // below so the blocking conflict check can use it too, not just the resolution step further
+    // down. A blank/"Automatic" selection, or resubmitting the form with the same
+    // already-assigned host untouched, is NOT a reassignment.
+    const explicitHostChange = !!newMeeting.zoomHost && newMeeting.zoomHost !== existingMeeting.zoomHost;
+
+    // Blocks the save outright on a room/zoomRoom collision, or an explicit zoomHost
+    // reassignment that collides with another meeting's -- distinct from the pool-auto-
+    // assignment path below, which defers the calendar publish and stores the error on the
+    // meeting instead of rejecting the request (there's no "other host to pick instead" for a
+    // plain pool-exhaustion the way there is for a room or an explicit host choice).
+    // confirmOverride only bypasses this block, not the pool's handling. Deliberately scoped to
+    // explicitHostChange, not bare newMeeting.zoomHost -- an edit that leaves the Zoom Host
+    // dropdown on the meeting's own already-assigned host must not re-trigger this check just
+    // because the field happens to be populated in the resubmitted form.
     if (!confirmOverride) {
       // A count-bounded series (numberOfOccurrences set, no explicit endDate) has a real last
       // occurrence -- checking conflicts against the raw (still-null) endDate would expand it
@@ -247,9 +260,14 @@ const updateMeeting = async (request: Request): Promise<Response> => {
       if (newMeeting.zoomRoom) {
         conflictRows.push(...await findResourceConflictRows("zoomRoom", newMeeting.zoomRoom, conflictCandidate, { excludeMid: mid }));
       }
+      if (explicitHostChange && newMeeting.zoomHost) {
+        conflictRows.push(...await findResourceConflictRows(
+          "zoomHost", newMeeting.zoomHost, conflictCandidate, { excludeMid: mid, includeSuspended: true },
+        ));
+      }
       if (conflictRows.length > 0) {
         return NextResponse.json(
-          { error: "This meeting conflicts with an existing meeting's room or Zoom room.", conflicts: conflictRows },
+          { error: "This meeting conflicts with an existing meeting's room, Zoom room, or Zoom host.", conflicts: conflictRows },
           { status: 409 },
         );
       }
@@ -265,10 +283,9 @@ const updateMeeting = async (request: Request): Promise<Response> => {
     // claim), but it shrinks the window down to a single DB round trip.
     const zoomEnabled = newMeeting.status !== 'Suspended'
       && (newMeeting.modeType === 'Hybrid' || newMeeting.modeType === 'Remote');
-    // An explicit host reassignment (the Zoom Host dropdown set to a specific pool host,
-    // different from whatever's currently assigned) needs a fresh Zoom meeting too, same as
-    // a room change -- Zoom has no in-place host-transfer for this app's stable-meeting model.
-    const explicitHostChange = !!newMeeting.zoomHost && newMeeting.zoomHost !== existingMeeting.zoomHost;
+    // explicitHostChange (hoisted above, before the confirmOverride block) needs a fresh Zoom
+    // meeting too, same as a room change -- Zoom has no in-place host-transfer for this app's
+    // stable-meeting model.
     // Remote meetings submit zoomRoom as "" (no Zoom Room field at all), while older stored
     // rows may hold null for the same "no room" state -- normalize both sides so an unchanged
     // Remote meeting isn't misdetected as a room change and torn down/recreated for nothing.
@@ -282,10 +299,12 @@ const updateMeeting = async (request: Request): Promise<Response> => {
     let hostSyncError: string | null = null;
     if (needsNewHost) {
       if (newMeeting.zoomHost) {
-        // A manually-selected host still gets checked server-side -- see the matching comment
-        // in write/meeting/route.ts. A real conflict is treated the same as pool exhaustion
-        // below: nothing gets written to the external Zoom API, and the calendar publish is
-        // deferred until an admin picks a different host or the conflict clears.
+        // A conflicting explicitHostChange is already blocked with a 409 above unless
+        // confirmOverride was set. This branch also runs, non-blocking, for needsNewHost cases
+        // that aren't an explicit host change (e.g. a room change resubmitted with the same
+        // already-assigned host) -- either way, a real conflict here is treated the same as pool
+        // exhaustion below: nothing gets written to the external Zoom API, and the calendar
+        // publish is deferred until an admin picks a different host or the conflict clears.
         const conflicts = await findResourceConflicts(
           "zoomHost", newMeeting.zoomHost, newMeeting, { excludeMid: mid, includeSuspended: true },
         );

--- a/frontend/app/api/write/meeting/route.ts
+++ b/frontend/app/api/write/meeting/route.ts
@@ -164,9 +164,12 @@ const createMeeting = async (request: Request) => {
       );
     }
 
-    // Blocks the save outright on a room/zoomRoom collision -- distinct from the zoomHost check
-    // below, which defers the calendar publish and stores the error on the meeting instead of
-    // rejecting the request. confirmOverride only bypasses this block, not zoomHost's handling.
+    // Blocks the save outright on a room/zoomRoom collision, or a manually-picked zoomHost
+    // (Zoom Host dropdown set to a specific host, not "Automatic") colliding with another
+    // meeting's -- distinct from the pool-auto-assignment path below, which defers the calendar
+    // publish and stores the error on the meeting instead of rejecting the request (there's no
+    // "other host to pick instead" for a plain pool-exhaustion the way there is for a room or an
+    // explicit host choice). confirmOverride only bypasses this block, not the pool's handling.
     if (!confirmOverride) {
       const candidate = {
         ...meetingData,
@@ -180,9 +183,14 @@ const createMeeting = async (request: Request) => {
       if (meetingData.zoomRoom) {
         conflictRows.push(...await findResourceConflictRows("zoomRoom", meetingData.zoomRoom, candidate, { excludeMid: meetingData.mid }));
       }
+      if (meetingData.zoomHost) {
+        conflictRows.push(...await findResourceConflictRows(
+          "zoomHost", meetingData.zoomHost, candidate, { excludeMid: meetingData.mid, includeSuspended: true },
+        ));
+      }
       if (conflictRows.length > 0) {
         return NextResponse.json(
-          { error: "This meeting conflicts with an existing meeting's room or Zoom room.", conflicts: conflictRows },
+          { error: "This meeting conflicts with an existing meeting's room, Zoom room, or Zoom host.", conflicts: conflictRows },
           { status: 409 },
         );
       }
@@ -195,12 +203,13 @@ const createMeeting = async (request: Request) => {
     let zoomSyncError: string | null = null;
     if (zoomEnabled && !meetingData.zid && !meetingData.zoomLink) {
       if (meetingData.zoomHost) {
-        // A manually-selected host (see the Meeting Form's Zoom Host dropdown) still gets
-        // checked server-side -- the form's own "Check host availability" is easy to skip, and
-        // availability can shift between checking and submitting. A real conflict is treated
-        // the same as pool exhaustion below: nothing gets written to the external Zoom API, and
-        // the calendar publish is deferred (see zoomBlocking in syncNewMeeting) until an admin
-        // picks a different host or the conflict clears.
+        // A conflicting manually-selected host is already blocked with a 409 above unless
+        // confirmOverride was set -- reaching here with a real conflict only happens after that
+        // override, or if availability shifted between the form's own "Check host availability"
+        // and submission. Either way, nothing gets written to the external Zoom API (Zoom itself
+        // has no concept of "double-book this host anyway" the way a room label does), and the
+        // calendar publish is deferred (see zoomBlocking in syncNewMeeting) until an admin picks
+        // a different host or the conflict clears.
         const conflicts = await findResourceConflicts(
           "zoomHost", meetingData.zoomHost, { ...meetingData, isRecurring }, { excludeMid: meetingData.mid, includeSuspended: true },
         );

--- a/frontend/app/components/meeting-form/ConflictOverrideModal.tsx
+++ b/frontend/app/components/meeting-form/ConflictOverrideModal.tsx
@@ -10,11 +10,11 @@ interface ConflictOverrideModalProps {
   isConfirming?: boolean;
 }
 
-// Shown when a create/edit save collides on room or zoomRoom -- write/meeting and update/meeting
-// both reject the save with a 409 + these rows (see findResourceConflictRows) unless the payload
-// is resubmitted with confirmOverride: true. excludeMid already keeps the meeting being saved out
-// of its own conflict rows, so every meeting listed here is a genuine other meeting -- no
-// filtering needed before rendering.
+// Shown when a create/edit save collides on room, zoomRoom, or an explicitly-picked zoomHost --
+// write/meeting and update/meeting all reject the save with a 409 + these rows (see
+// findResourceConflictRows) unless the payload is resubmitted with confirmOverride: true.
+// excludeMid already keeps the meeting being saved out of its own conflict rows, so every
+// meeting listed here is a genuine other meeting -- no filtering needed before rendering.
 const ConflictOverrideModal: React.FC<ConflictOverrideModalProps> = ({
   isOpen,
   conflicts,
@@ -57,8 +57,8 @@ const ConflictOverrideModal: React.FC<ConflictOverrideModalProps> = ({
         </div>
 
         <p className={styles.message}>
-          This meeting&apos;s room or Zoom room is already booked at this time. You can save anyway,
-          or go back and change the room, Zoom room, or schedule.
+          This meeting&apos;s room, Zoom room, or Zoom host is already booked at this time. You can save
+          anyway, or go back and change the room, Zoom room, Zoom host, or schedule.
         </p>
 
         <div className={styles.conflictList}>

--- a/frontend/tests/integration/update-meeting-route.test.ts
+++ b/frontend/tests/integration/update-meeting-route.test.ts
@@ -384,9 +384,7 @@ test("an explicit host reassignment tears down the old Zoom meeting and creates 
   expect(afterSync?.zoomSyncStatus).toBe("synced");
 });
 
-test("an explicit host reassignment to an already-busy host is rejected without creating a new Zoom meeting", async () => {
-  mockedDeleteZoomMeeting.mockResolvedValue(true);
-
+test("an explicit host reassignment to an already-busy host is rejected with 409, and never reaches the Prisma update", async () => {
   const prisma = getTestPrismaClient();
   // Explicit, distinct time slot -- see the comment on the reassignment test above for why.
   const start = new Date("2026-10-02T15:00:00Z");
@@ -417,6 +415,55 @@ test("an explicit host reassignment to an already-busy host is rejected without 
   });
 
   const response = await PUT(request);
+  expect(response.status).toBe(409);
+  const body = await response.json();
+  expect(body.conflicts).toHaveLength(1);
+  expect(body.conflicts[0]).toMatchObject({ field: "zoomHost", value: busyHost });
+  expect(body.conflicts[0].meetings.map((m: { mid: string }) => m.mid)).toContain(busyMid);
+
+  // The reassignment never landed -- still the pre-update host, Zoom meeting untouched.
+  const unchanged = await prisma.meeting.findUnique({ where: { mid } });
+  expect(unchanged?.zoomHost).toBe("old-host-2@icr.test");
+  expect(unchanged?.zid).toBe("zid-original");
+  expect(mockedDeleteZoomMeeting).not.toHaveBeenCalled();
+  expect(mockedCreateZoomMeeting).not.toHaveBeenCalled();
+});
+
+test("confirmOverride: true bypasses the zoomHost reassignment block, tears down the old Zoom meeting, but still defers the new one (Zoom itself can't double-book a host)", async () => {
+  mockedDeleteZoomMeeting.mockResolvedValue(true);
+
+  const prisma = getTestPrismaClient();
+  const start = new Date("2026-10-02T17:00:00Z");
+  const end = new Date("2026-10-02T18:00:00Z");
+  const busyHost = "busy-reassign-host-2@icr.test";
+
+  const busyMid = `m-${randomUUID()}`;
+  const { recurrencePattern: _rpBusy, ...busyMeetingData } = buildMeetingPayload({
+    mid: busyMid, modeType: "Hybrid", room: "Fellowship Room", zoomRoom: "Fellowship Room - Zoom",
+    zid: "zid-busy-2", zoomHost: busyHost, startDateTime: start, endDateTime: end,
+  });
+  await prisma.meeting.create({ data: busyMeetingData });
+
+  const mid = `m-${randomUUID()}`;
+  const { recurrencePattern: _rp, ...existingMeetingData } = buildMeetingPayload({
+    mid, modeType: "Hybrid", room: "Serenity Room", zoomRoom: "Serenity Room - Zoom",
+    zid: "zid-original-2", zoomHost: "old-host-3@icr.test", startDateTime: start, endDateTime: end,
+  });
+  await prisma.meeting.create({ data: existingMeetingData });
+
+  const payload = {
+    ...buildMeetingPayload({
+      mid, modeType: "Hybrid", room: "Serenity Room", zoomRoom: "Serenity Room - Zoom",
+      zid: "zid-original-2", zoomHost: busyHost, startDateTime: start, endDateTime: end,
+    }),
+    confirmOverride: true,
+  };
+  const request = new Request("http://localhost/api/update/meeting", {
+    method: "PUT",
+    body: JSON.stringify(payload),
+  });
+
+  const response = await PUT(request);
   expect(response.status).toBe(200);
 
   const afterSync = await waitFor(async () => {
@@ -429,7 +476,6 @@ test("an explicit host reassignment to an already-busy host is rejected without 
   expect(afterSync?.zid).toBeNull();
   expect(afterSync?.zoomHost).toBeNull();
   expect(afterSync?.zoomSyncStatus).toBe("error");
-  // Specific reason, not the generic "pool exhausted" message the two code paths used to share.
   expect(afterSync?.zoomSyncError).toMatch(/conflicts with another meeting/i);
 });
 

--- a/frontend/tests/integration/write-meeting-route.test.ts
+++ b/frontend/tests/integration/write-meeting-route.test.ts
@@ -206,12 +206,11 @@ test("an exhausted Zoom host pool fails soft: the meeting is still created", asy
   expect(mockedCreateCalendarEvent).not.toHaveBeenCalled();
 });
 
-test("a manually-selected host that conflicts with another meeting is rejected without touching the external Zoom API or publishing to Google Calendar", async () => {
+test("a manually-selected host that conflicts with another meeting is rejected with 409, and never reaches the Prisma create", async () => {
   const prisma = getTestPrismaClient();
   // Explicit, distinct time slot -- buildMeetingPayload's default is shared by other tests in
-  // this file/suite, so reusing it here could make this new real conflict check (previously a
-  // manually-picked host was trusted unconditionally, so this path never ran) order-dependent
-  // on unrelated leftover data.
+  // this file/suite, so reusing it here could make this conflict check order-dependent on
+  // unrelated leftover data.
   const start = new Date("2026-11-01T18:00:00Z");
   const end = new Date("2026-11-01T19:00:00Z");
   const conflictHost = "conflict-host@icr.test";
@@ -236,11 +235,54 @@ test("a manually-selected host that conflicts with another meeting is rejected w
   });
 
   const response = await POST(request);
+  expect(response.status).toBe(409);
+  const body = await response.json();
+  expect(body.conflicts).toHaveLength(1);
+  expect(body.conflicts[0]).toMatchObject({ field: "zoomHost", value: conflictHost });
+  expect(body.conflicts[0].meetings.map((m: { mid: string }) => m.mid)).toContain(busyMid);
+
+  const created = await prisma.meeting.findUnique({ where: { mid: payload.mid } });
+  expect(created).toBeNull();
+  expect(mockedResolveZoomHost).not.toHaveBeenCalled();
+  expect(mockedCreateZoomMeeting).not.toHaveBeenCalled();
+  expect(mockedCreateCalendarEvent).not.toHaveBeenCalled();
+});
+
+test("confirmOverride: true bypasses the zoomHost conflict block, creates the meeting, but still defers its Zoom sync (Zoom itself can't double-book a host)", async () => {
+  const prisma = getTestPrismaClient();
+  const start = new Date("2026-11-01T20:00:00Z");
+  const end = new Date("2026-11-01T21:00:00Z");
+  const conflictHost = "conflict-host-2@icr.test";
+
+  const busyMid = `m-${randomUUID()}`;
+  await prisma.meeting.create({
+    data: {
+      mid: busyMid, title: "Busy Meeting 2", modeType: "Hybrid", description: "", creator: "Creator", group: "Group",
+      startDateTime: start, endDateTime: end, email: "busy@test.icr", zoomRoom: "Serenity Room - Zoom",
+      calType: ["AA"], status: "Active", room: "Serenity Room", isRecurring: false,
+      zid: "zid-busy-2", zoomHost: conflictHost,
+    },
+  });
+
+  const payload = {
+    ...buildMeetingPayload({
+      modeType: "Hybrid", room: "Fellowship Room", zoomRoom: "Fellowship Room - Zoom",
+      zoomHost: conflictHost, startDateTime: start, endDateTime: end,
+    }),
+    confirmOverride: true,
+  };
+  const request = new Request("http://localhost/api/write/meeting", {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+
+  const response = await POST(request);
   expect(response.status).toBe(201);
   const created = await response.json();
 
-  // Detected synchronously (same as the pool-exhaustion case above), and with the correct,
-  // specific reason -- not the generic "pool exhausted" message.
+  // The meeting itself saves (the admin's explicit override), but the conflict still genuinely
+  // exists at the Zoom-API level, so the host isn't committed and the Zoom sync is deferred with
+  // a specific error, not the generic "pool exhausted" one.
   expect(created.zoomHost).toBeNull();
   expect(created.zoomSyncError).toMatch(/conflicts with another meeting/i);
 

--- a/frontend/util/resourceOverlap.ts
+++ b/frontend/util/resourceOverlap.ts
@@ -347,15 +347,17 @@ export function computeConflicts(
 }
 
 // Single-candidate version of computeConflicts, scoped to one resource field/value -- used by
-// write/meeting and update/meeting to block a save that collides on room or zoomRoom, showing
-// what it collides with (unlike findResourceConflicts above, which only returns bare
-// {mid,title}[] and is used by the zoomHost check-and-defer path, a different, non-blocking
-// flow). Deliberately excludes "zoomHost" from `field` -- that check's semantics (includeSuspended
-// defaults true there, since a suspended meeting's Zoom host reservation is still live) differ
-// from room/zoomRoom's (a suspended meeting doesn't block a room, matching computeConflicts'
-// own activeMeetings filtering), so the two shouldn't be reachable through the same call shape.
+// write/meeting and update/meeting to block a save that collides on room, zoomRoom, or a
+// manually-picked zoomHost, showing what it collides with (unlike findResourceConflicts above,
+// which only returns bare {mid,title}[] and is used by the pool-auto-assignment check-and-defer
+// path, a different, non-blocking flow -- pool exhaustion has no "other value to pick instead"
+// the way a room/zoomHost conflict does, so it stays fail-soft). room/zoomRoom and zoomHost
+// differ in one respect the caller must get right: a suspended meeting doesn't block a room
+// (matching computeConflicts' own activeMeetings filtering), but its Zoom host reservation is
+// still live (sync is skipped while suspended, not torn down) -- callers must pass
+// `includeSuspended: true` for a `zoomHost` check, `false`/omitted for `room`/`zoomRoom`.
 export async function findResourceConflictRows(
-  field: "room" | "zoomRoom",
+  field: ResourceField,
   value: string,
   candidate: ConflictCandidateMeeting,
   opts: FindConflictsOptions = {},
@@ -390,14 +392,15 @@ export async function findResourceConflictRows(
 
   const rows: ConflictRow[] = [];
   for (const meeting of meetings) {
-    // room/zoomRoom placeholders below are never read by toMeetingSummary/toRecurrenceSummary
-    // (mid/title/calType/isRecurring/recurrencePattern only) -- they exist purely to satisfy
-    // ConflictCandidateMeeting's required `room` field.
+    // room/zoomRoom/zoomHost placeholders below are never read by toMeetingSummary/
+    // toRecurrenceSummary (mid/title/calType/isRecurring/recurrencePattern only) -- they exist
+    // purely to satisfy ConflictCandidateMeeting's required `room` field.
     const existingCandidate: ConflictCandidateMeeting = {
       mid: meeting.mid,
       title: meeting.title,
       room: field === "room" ? value : "",
       zoomRoom: field === "zoomRoom" ? value : null,
+      zoomHost: field === "zoomHost" ? value : null,
       calType: meeting.calType,
       startDateTime: meeting.startDateTime,
       endDateTime: meeting.endDateTime,


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Meeting creation and updates now detect conflicts with manually selected Zoom hosts.
  * Conflicts return clearer details and prevent unintended meeting or calendar changes.
  * Confirmed overrides allow the meeting to proceed while deferring affected Zoom synchronization.
  * Conflict warnings now include Zoom host conflicts alongside room and Zoom room conflicts.

* **Tests**
  * Expanded coverage for host conflicts, overrides, suspended meetings, and deferred synchronization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description
- **frontend/util/resourceOverlap.ts**: `findResourceConflictRows` now accepts `"zoomHost"` (was `"room" | "zoomRoom"` only) — the blocking single-candidate conflict check used by the save-time 409 flow. Callers must pass `includeSuspended: true` for a zoomHost check, since a suspended meeting's Zoom host reservation is still live (sync is skipped while suspended, not torn down), unlike room/zoomRoom where a suspended meeting doesn't block.
- **frontend/app/api/write/meeting/route.ts**: a manually-picked Zoom host (Zoom Host dropdown set to a specific host, not "Automatic") that collides with another meeting is now blocked with a 409 + `ConflictOverrideModal`, same as room/zoomRoom. Pool-auto-assignment exhaustion is untouched — no "other host to pick instead" the way there is for a room, so it still fails soft (defers the calendar publish, stores the error on the meeting).
- **frontend/app/api/update/meeting/route.ts**: same for an explicit host reassignment (`explicitHostChange`, hoisted earlier in the route so both the blocking check and the resolution step share it). An edit that leaves the Zoom Host dropdown on the meeting's own already-assigned host does **not** re-trigger this check just because the field is populated in the resubmitted form.
- **frontend/app/components/meeting-form/ConflictOverrideModal.tsx**: copy updated to mention Zoom host alongside room/Zoom room.
- One nuance: even after "Save anyway" on a Zoom-host conflict, the Zoom sync itself still won't go through — Zoom has no concept of double-booking a host the way a room label allows non-enforced double-booking, so the override saves the meeting but leaves the Zoom sync deferred until the conflict clears or the host changes. Room/Zoom room overrides don't have this asterisk since those are just internal labels with no external system enforcing exclusivity.
- **frontend/tests/integration/{write,update}-meeting-route.test.ts**: updated the two existing tests that documented the old fail-soft-only zoomHost behavior to assert the new 409 block instead, and added a companion `confirmOverride: true` test for each route covering the override-then-still-defers-sync path.

## Testing
- [x] `yarn test:all` — unit 118, component 76, integration 58 (+2 new), e2e 94, all passing
- [x] `yarn lint` — 0 errors (51 pre-existing warnings only)
- [x] `tsc --noEmit` — 0 errors
- [x] Searched the test suite for stale assertions on the old zoomHost fail-soft-only behavior (per this repo's PR convention) — the two integration tests documenting it were updated; no other test seeds a colliding manually-picked zoomHost through these routes

## Area(s) Touched
**Product areas**
- [ ] auth — sign-in, sessions, NextAuth, role-based access
- [ ] admin — /admin shell (Diagnostics, Users, Import, Export tabs)
- [ ] billing — lease export, XLSX import, anything affecting invoicing
- [x] ui/ux — frontend layout/styling not tied to a specific integration

**Integrations**
- [ ] google-calendar — Google Calendar sync
- [x] zoom-api — Zoom meeting/host sync

**Engineering**
- [ ] security — auth hardening, data exposure, dependency/security scanning
- [x] testing — test suite (Jest/Playwright) changes
- [ ] github-actions — workflows, Dependabot config, other .github/ CI tooling
- [ ] cleanup — refactor or dead-code removal, no behavior change
- [ ] documentation — docs/ or README changes only

## Pre-merge Checklist
- [x] Code follows current formatting conventions and passes lint (`yarn lint`).
- [x] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
- [x] All test suites pass, both run locally and green in GitHub CI. **Do not merge if any test suite is failing.**
- [x] A test suite was added or updated for the feature/fix in this PR.
- [x] Only files relevant to this change are committed — no stray or unrelated files.
- [ ] If this branch has a merge conflict with master, master was merged into this branch first (not the other way around).
- [x] The rest of this PR description (Description, Testing) is filled out, not left as template placeholders.