### PR TITLE
fix(meetings): stop write-time conflict checks from clipping already-elapsed same-day meetings

### DIFF
--- a/frontend/tests/integration/update-meeting-route.test.ts
+++ b/frontend/tests/integration/update-meeting-route.test.ts
@@ -275,10 +275,13 @@ test("a newly resolved Zoom host is persisted synchronously when a meeting first
 
   const prisma = getTestPrismaClient();
   const mid = `m-${randomUUID()}`;
-  const { recurrencePattern: _rp, ...existingMeetingData } = buildMeetingPayload({ mid, modeType: "Hybrid", zoomRoom: "" });
+  // Distinct room -- buildMeetingPayload's default ("Serenity Room") is shared by other tests
+  // in this suite that also create real rows at its default date, and the room conflict check
+  // would otherwise make this order-dependent on unrelated leftover data.
+  const { recurrencePattern: _rp, ...existingMeetingData } = buildMeetingPayload({ mid, modeType: "Hybrid", room: "Zoom Assign Room", zoomRoom: "" });
   await prisma.meeting.create({ data: existingMeetingData });
 
-  const payload = buildMeetingPayload({ mid, modeType: "Hybrid", zoomRoom: "Serenity Room - Zoom" });
+  const payload = buildMeetingPayload({ mid, modeType: "Hybrid", room: "Zoom Assign Room", zoomRoom: "Zoom Assign Room - Zoom" });
   const request = new Request("http://localhost/api/update/meeting", {
     method: "PUT",
     body: JSON.stringify(payload),
@@ -302,10 +305,13 @@ test("an exhausted Zoom host pool on update fails soft, synchronously, without t
 
   const prisma = getTestPrismaClient();
   const mid = `m-${randomUUID()}`;
-  const { recurrencePattern: _rp, ...existingMeetingData } = buildMeetingPayload({ mid, modeType: "Hybrid", zoomRoom: "" });
+  // Distinct room -- buildMeetingPayload's default ("Serenity Room") is shared by other tests
+  // in this suite that also create real rows at its default date, and the room conflict check
+  // would otherwise make this order-dependent on unrelated leftover data.
+  const { recurrencePattern: _rp, ...existingMeetingData } = buildMeetingPayload({ mid, modeType: "Hybrid", room: "Update Pool Exhaustion Room", zoomRoom: "" });
   await prisma.meeting.create({ data: existingMeetingData });
 
-  const payload = buildMeetingPayload({ mid, modeType: "Hybrid", zoomRoom: "Serenity Room - Zoom" });
+  const payload = buildMeetingPayload({ mid, modeType: "Hybrid", room: "Update Pool Exhaustion Room", zoomRoom: "Update Pool Exhaustion Room - Zoom" });
   const request = new Request("http://localhost/api/update/meeting", {
     method: "PUT",
     body: JSON.stringify(payload),
@@ -484,8 +490,12 @@ test("editing a meeting whose scheduled resume date has already passed promotes 
 
   const prisma = getTestPrismaClient();
   const mid = `m-${randomUUID()}`;
+  // Distinct room -- buildMeetingPayload's default ("Serenity Room") is shared by other tests
+  // in this suite that also create real rows at its default date, and the room conflict check
+  // would otherwise make this order-dependent on unrelated leftover data.
   const { recurrencePattern: _rp, ...existingMeetingData } = buildMeetingPayload({
     mid,
+    room: "Resume Promotion Room",
     googleCalendarEventIds: { AA: "stale-pre-suspend-event-id" },
   });
   await prisma.meeting.create({ data: existingMeetingData });
@@ -497,7 +507,7 @@ test("editing a meeting whose scheduled resume date has already passed promotes 
     promoted: false,
   });
 
-  const payload = buildMeetingPayload({ mid, title: "Edited Title" });
+  const payload = buildMeetingPayload({ mid, room: "Resume Promotion Room", title: "Edited Title" });
   const request = new Request("http://localhost/api/update/meeting", {
     method: "PUT",
     body: JSON.stringify(payload),

--- a/frontend/tests/integration/write-meeting-route.test.ts
+++ b/frontend/tests/integration/write-meeting-route.test.ts
@@ -95,7 +95,10 @@ test("the response resolves before Google Calendar sync completes, which runs in
     () => new Promise((resolve) => setTimeout(() => resolve({ id: "fake-event-id", error: null }), SYNC_DELAY_MS)),
   );
 
-  const payload = buildMeetingPayload();
+  // Distinct room -- buildMeetingPayload's default ("Serenity Room") is shared by other tests
+  // in this suite; the room conflict check would otherwise make this order-dependent on
+  // whichever test happens to run first (see the "Distinct room" comment further down).
+  const payload = buildMeetingPayload({ room: "Sync Timing Room" });
   const request = new Request("http://localhost/api/write/meeting", {
     method: "POST",
     body: JSON.stringify(payload),
@@ -126,7 +129,9 @@ test("a resolved Zoom host is persisted synchronously, before the deferred sync 
     () => new Promise((resolve) => setTimeout(() => resolve({ id: "fake-event-id", error: null }), SYNC_DELAY_MS)),
   );
 
-  const payload = buildMeetingPayload({ modeType: "Hybrid", zoomRoom: "Serenity Room - Zoom" });
+  // Distinct room -- buildMeetingPayload's default ("Serenity Room") is shared by other tests
+  // in this suite (see the "Distinct room" comment further down).
+  const payload = buildMeetingPayload({ modeType: "Hybrid", room: "Zoom Host Timing Room", zoomRoom: "Zoom Host Timing Room - Zoom" });
   const request = new Request("http://localhost/api/write/meeting", {
     method: "POST",
     body: JSON.stringify(payload),
@@ -171,7 +176,9 @@ test("a malformed body returns 400 with validation issues instead of a raw 500",
 test("an exhausted Zoom host pool fails soft: the meeting is still created", async () => {
   mockedResolveZoomHost.mockResolvedValue(null);
 
-  const payload = buildMeetingPayload({ modeType: "Hybrid", zoomRoom: "Serenity Room - Zoom" });
+  // Distinct room -- buildMeetingPayload's default ("Serenity Room") is shared by other tests
+  // in this suite (see the "Distinct room" comment further down).
+  const payload = buildMeetingPayload({ modeType: "Hybrid", room: "Pool Exhaustion Room", zoomRoom: "Pool Exhaustion Room - Zoom" });
   const request = new Request("http://localhost/api/write/meeting", {
     method: "POST",
     body: JSON.stringify(payload),
@@ -354,6 +361,45 @@ test("a room conflict is rejected with 409 + conflicts, and never reaches the Pr
   expect(created).toBeNull();
 });
 
+// Regression test for a bug where findResourceConflictRows/findResourceConflicts anchored their
+// overlap window's lower bound to `new Date()` ("now") -- a candidate or existing meeting whose
+// occurrence had already ended relative to the current instant expanded to zero occurrences, so
+// the conflict silently went undetected as soon as the clock passed the meeting's own end time.
+// Yesterday (not "today", which would only reproduce this after whatever time of day the suite
+// happens to run) keeps this deterministic regardless of wall-clock time, while staying well
+// within candidateHorizonRange's own bound so the test doesn't itself go stale years from now.
+test("a room conflict against an already-elapsed (past) time slot is still rejected with 409", async () => {
+  const prisma = getTestPrismaClient();
+  const yesterday = new Date();
+  yesterday.setUTCDate(yesterday.getUTCDate() - 1);
+  const dateStr = yesterday.toISOString().slice(0, 10);
+  const start = new Date(`${dateStr}T18:00:00Z`);
+  const end = new Date(`${dateStr}T19:00:00Z`);
+
+  const busyMid = `m-${randomUUID()}`;
+  await prisma.meeting.create({
+    data: {
+      mid: busyMid, title: "Past Room Conflict Meeting", modeType: "In Person", description: "", creator: "Creator", group: "Group",
+      startDateTime: start, endDateTime: end, email: "busy@test.icr",
+      calType: ["AA"], status: "Active", room: "Fellowship Room", isRecurring: false,
+    },
+  });
+
+  const payload = buildMeetingPayload({ room: "Fellowship Room", startDateTime: start, endDateTime: end });
+  const request = new Request("http://localhost/api/write/meeting", {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+
+  const response = await POST(request);
+  expect(response.status).toBe(409);
+  const body = await response.json();
+  expect(body.conflicts[0].meetings.map((m: { mid: string }) => m.mid)).toContain(busyMid);
+
+  const created = await prisma.meeting.findUnique({ where: { mid: payload.mid } });
+  expect(created).toBeNull();
+});
+
 test("confirmOverride: true bypasses the room conflict check and creates the meeting anyway", async () => {
   mockedCreateCalendarEvent.mockResolvedValue({ id: "fake-event-id", error: null });
 
@@ -504,7 +550,9 @@ test("a category with no configured calendar fails the meeting's sync, even if i
   // GOOGLE_CALENDAR_* env var isn't set, i.e. calendarIds never contains an "Other" entry.
   mockedCreateCalendarEvent.mockResolvedValue({ id: "fake-event-id", error: null });
 
-  const payload = buildMeetingPayload({ calType: ["AA", "Other"] });
+  // Distinct room -- buildMeetingPayload's default ("Serenity Room") is shared by other tests
+  // in this suite (see the "Distinct room" comment further down).
+  const payload = buildMeetingPayload({ calType: ["AA", "Other"], room: "Category Sync Room" });
   const request = new Request("http://localhost/api/write/meeting", {
     method: "POST",
     body: JSON.stringify(payload),

--- a/frontend/util/resourceOverlap.ts
+++ b/frontend/util/resourceOverlap.ts
@@ -132,13 +132,30 @@ export function occurrencesOverlap(a: Occurrence[], b: Occurrence[]): boolean {
   return findOverlappingOccurrencePair(a, b) !== null;
 }
 
-// [rangeStart, rangeEnd) shared by every conflict check in this module: from now out to the
-// 2-year horizon. Candidates and existing meetings alike are expected to be present/future —
-// a meeting that already started in the past falling outside this window is intentional, not
-// a bug (there's nothing to conflict with about a booking that's already happened).
+// [rangeStart, rangeEnd) used by computeConflicts (the Diagnostics dashboard scan): from now
+// out to the horizon. Candidates and existing meetings alike are expected to be present/future
+// there — a meeting that already started in the past falling outside this window is
+// intentional, not a bug (there's nothing to conflict with about a booking that's already
+// happened, and nobody needs Diagnostics to keep nagging about it).
 const horizonRange = (horizonYears: number): [Date, Date] => {
   const rangeStart = new Date();
   const rangeEnd = new Date(rangeStart);
+  rangeEnd.setUTCFullYear(rangeEnd.getUTCFullYear() + horizonYears);
+  return [rangeStart, rangeEnd];
+};
+
+// [rangeStart, rangeEnd) used by findResourceConflicts/findResourceConflictRows — the write/
+// update-time checks for one specific candidate's chosen room/zoomRoom/zoomHost. Unlike
+// computeConflicts above, these must still catch a conflict against a same-day slot that has
+// already elapsed by the time the request is checked (e.g. saving a 6-7pm meeting at 8pm) — the
+// two records genuinely overlap in the data regardless of the current wall-clock time.
+// horizonYears into the past is a generous, symmetric bound (matching the future side) rather
+// than a precisely-reasoned one; nothing bounds the loop tighter than that for a recurring
+// meeting anyway (see expandOccurrences' own patternStart-vs-rangeStart clamping).
+const candidateHorizonRange = (horizonYears: number): [Date, Date] => {
+  const rangeStart = new Date();
+  rangeStart.setUTCFullYear(rangeStart.getUTCFullYear() - horizonYears);
+  const rangeEnd = new Date();
   rangeEnd.setUTCFullYear(rangeEnd.getUTCFullYear() + horizonYears);
   return [rangeStart, rangeEnd];
 };
@@ -162,7 +179,7 @@ export type FindConflictsOptions = {
 };
 
 // Finds every existing meeting occupying `field = value` whose occurrences overlap
-// `candidate`'s, within the shared horizon window above.
+// `candidate`'s, within the candidate horizon window above.
 export async function findResourceConflicts(
   field: ResourceField,
   value: string,
@@ -171,7 +188,7 @@ export async function findResourceConflicts(
 ): Promise<{ mid: string; title: string }[]> {
   if (!value) return [];
 
-  const [rangeStart, rangeEnd] = horizonRange(OVERLAP_HORIZON_YEARS);
+  const [rangeStart, rangeEnd] = candidateHorizonRange(OVERLAP_HORIZON_YEARS);
   const candidateOccurrences = expandOccurrences(candidate, rangeStart, rangeEnd);
   if (candidateOccurrences.length === 0) return [];
 
@@ -364,7 +381,7 @@ export async function findResourceConflictRows(
 ): Promise<ConflictRow[]> {
   if (!value) return [];
 
-  const [rangeStart, rangeEnd] = horizonRange(OVERLAP_HORIZON_YEARS);
+  const [rangeStart, rangeEnd] = candidateHorizonRange(OVERLAP_HORIZON_YEARS);
   const candidateOccurrences = expandOccurrences(candidate, rangeStart, rangeEnd);
   if (candidateOccurrences.length === 0) return [];
 


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved meeting conflict detection across past and future time slots.
  * Prevented unrelated meetings from causing incorrect room-conflict errors.
  * Meeting creation now correctly rejects conflicts with previously scheduled time slots.

* **Tests**
  * Added regression coverage for historical time-slot conflicts.
  * Improved test reliability by isolating room assignments across scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description
- **util/resourceOverlap.ts**: `findResourceConflicts`/`findResourceConflictRows` (the write-time room/zoomRoom/zoomHost blocking checks from #298/#303) shared `horizonRange()` with `computeConflicts` (the Diagnostics dashboard scan), anchoring the overlap window's lower bound to `new Date()` — "now." A meeting whose occurrence had already ended today expanded to zero occurrences, so the conflict silently stopped being detected once the clock passed that meeting's end time. Added a separate `candidateHorizonRange()` (`[now - 2yr, now + 2yr]`) for the two write-time functions; `computeConflicts` keeps the original now-anchored `horizonRange()`, since Diagnostics intentionally only cares about present/future conflicts.
- **tests/integration/write-meeting-route.test.ts**: added a deterministic regression test seeding a same-day-but-already-elapsed (yesterday) room conflict, and gave 4 pre-existing tests that shared `buildMeetingPayload`'s default room/date a distinct room each — widening the horizon exposed that they were silently relying on the same bug to avoid colliding with each other's leftover DB rows.
- **tests/integration/update-meeting-route.test.ts**: same fixture-isolation fix for 3 pre-existing tests that shared the default room/date.

## Testing
- [x] `yarn tsc --noEmit` — clean
- [x] `yarn jest --config config/jest.config.ts` — 119/119 unit tests pass
- [x] `yarn test:integration` — 62/62 integration tests pass
- [x] `yarn test:e2e` — 94/94 e2e tests pass, run locally after 7pm ET (the exact time-of-day condition that broke this on master)
- [x] Reverted the `resourceOverlap.ts` fix locally and confirmed the new regression test (and the two originally-failing e2e tests, `02-meeting-creation.spec.ts` 2.5/2.6) fail without it

Root cause: master's CI run for PR #303 passed at 6:10pm ET (the seeded conflicting meeting's 6-7pm slot was still "current"); the very next push (an unrelated dependabot bump) ran CI at 8:10pm ET and failed, because by then that same slot had "ended" relative to `new Date()`.

## Area(s) Touched
**Product areas**
- [ ] auth
- [ ] admin
- [ ] billing
- [x] ui/ux

**Integrations**
- [ ] google-calendar
- [ ] zoom-api

**Engineering**
- [ ] security
- [x] testing
- [ ] github-actions
- [ ] cleanup
- [ ] documentation

## Pre-merge Checklist
- [x] Code follows current formatting conventions and passes lint (`yarn lint`).
- [x] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
- [x] All test suites pass, both run locally and green in GitHub CI. **Do not merge if any test suite is failing.**
- [x] A test suite was added or updated for the feature/fix in this PR.
- [x] Only files relevant to this change are committed — no stray or unrelated files.
- [x] If this branch has a merge conflict with master, master was merged into this branch first (not the other way around).
- [x] The rest of this PR description (Description, Testing) is filled out, not left as template placeholders.