### PR TITLE
feat(calendar): single-query week/range fetch + top loading bar

### DIFF
--- a/frontend/app/api/retrieve/meeting/range/route.ts
+++ b/frontend/app/api/retrieve/meeting/range/route.ts
@@ -1,6 +1,6 @@
 export const dynamic = 'force-dynamic';
 
-import { getMeetingsForDate } from "../../../../../util/meetingOccurrences";
+import { getMeetingsForRange } from "../../../../../util/meetingOccurrences";
 import { toETDateString, addDaysToETDateString } from "../../../../../util/timeUtils";
 import { NextRequest } from 'next/server';
 
@@ -52,15 +52,11 @@ const retrieveRangeMeetings = async (request: NextRequest) => {
             });
         }
 
-        // Inclusive day list from start to end -- same recurrence-expansion approach as
-        // week/route.ts's own loop, just over an arbitrary range instead of a fixed calendar
-        // week, so a caller needing e.g. a 4-day page doesn't have to over-fetch whole weeks
-        // around it. ET date strings compare lexicographically the same as chronologically
-        // (zero-padded "YYYY-MM-DD"), so plain string comparison is enough to bound the loop.
-        const dates: string[] = [];
+        // Counts inclusive days from start to end without building the list -- ET date strings
+        // compare lexicographically the same as chronologically (zero-padded "YYYY-MM-DD"), so
+        // plain string comparison is enough to bound the loop.
         let cursor = startEtDateStr;
         for (let i = 0; i < MAX_RANGE_DAYS && cursor <= endEtDateStr; i++) {
-            dates.push(cursor);
             cursor = addDaysToETDateString(cursor, 1);
         }
 
@@ -74,15 +70,11 @@ const retrieveRangeMeetings = async (request: NextRequest) => {
             });
         }
 
-        // Sequential, not Promise.all -- same reasoning as week/route.ts's own loop (concurrent
-        // per-day queries intermittently returned incomplete results under load).
-        const meetingsByDay = [];
-        for (const date of dates) {
-            const dayMeetings = await getMeetingsForDate(date);
-            meetingsByDay.push(dayMeetings.map(meeting => ({ ...meeting, date })));
-        }
+        // Single range query instead of one getMeetingsForDate call per day -- previously this
+        // re-ran an unbounded recurring-meetings scan once for every day in the range.
+        const meetings = await getMeetingsForRange(startEtDateStr, endEtDateStr);
 
-        return new Response(JSON.stringify(meetingsByDay.flat()), {
+        return new Response(JSON.stringify(meetings), {
             status: 200,
             headers: {
                 'Content-Type': 'application/json',

--- a/frontend/app/api/retrieve/meeting/week/route.ts
+++ b/frontend/app/api/retrieve/meeting/week/route.ts
@@ -1,6 +1,6 @@
 export const dynamic = 'force-dynamic';
 
-import { getMeetingsForDate } from "../../../../../util/meetingOccurrences";
+import { getMeetingsForRange } from "../../../../../util/meetingOccurrences";
 import { toETDateString, getWeekDatesET } from "../../../../../util/timeUtils";
 import { NextRequest } from 'next/server';
 
@@ -10,23 +10,14 @@ const retrieveWeekMeetings = async (request: NextRequest) => {
         const etDateStr = toETDateString(dateParam);
         const weekDates = getWeekDatesET(etDateStr);
 
-        // Expand recurrence per day of the week, tagging each occurrence with the ET date it
-        // was expanded onto. An overnight meeting overlaps two days, so it's tagged onto both —
-        // the client clips/labels each day's card (see WeekView.tsx), not this route.
-        //
-        // Sequential, not Promise.all: firing all 7 days' queries concurrently intermittently
-        // returned incomplete results under load (observed via CI-only e2e flakiness -- correct
-        // when run in isolation, wrong under contention). Each day already does 2 Mongo queries,
-        // so 7 in parallel is 14 concurrent queries per request; serializing trades some latency
-        // for correctness until the real fix (a single range query instead of N per-day ones) is
-        // built.
-        const meetingsByDay = [];
-        for (const date of weekDates) {
-            const dayMeetings = await getMeetingsForDate(date);
-            meetingsByDay.push(dayMeetings.map(meeting => ({ ...meeting, date })));
-        }
+        // A single range query covering the whole week, tagged with the ET date each occurrence
+        // was expanded onto (an overnight meeting overlaps two days, so it's tagged onto both --
+        // the client clips/labels each day's card, see WeekView.tsx). Previously this looped
+        // getMeetingsForDate per day, re-running its unbounded recurring-meetings scan 7 times
+        // over for the same week.
+        const meetings = await getMeetingsForRange(weekDates[0], weekDates[weekDates.length - 1]);
 
-        return new Response(JSON.stringify(meetingsByDay.flat()), {
+        return new Response(JSON.stringify(meetings), {
             status: 200,
             headers: {
                 'Content-Type': 'application/json',

--- a/frontend/app/components/atoms/TopLoadingBar.tsx
+++ b/frontend/app/components/atoms/TopLoadingBar.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import styles from "../../../styles/components/atoms/TopLoadingBar.module.scss";
+
+interface TopLoadingBarProps {
+  active: boolean;
+}
+
+// A thin sweeping bar along a container's top edge -- signals a background refetch (e.g.
+// paging to a new week/range) without dimming or covering the content still on screen. The
+// caller's own position: relative container is what anchors this; it's absolutely positioned
+// to span that container's full width.
+const TopLoadingBar: React.FC<TopLoadingBarProps> = ({ active }) => {
+  if (!active) return null;
+
+  return (
+    <div className={styles.track} role="progressbar" aria-label="Loading meetings">
+      <div className={styles.fill} />
+    </div>
+  );
+};
+
+export default TopLoadingBar;

--- a/frontend/app/components/calendar/desktop/CalendarNavbar.tsx
+++ b/frontend/app/components/calendar/desktop/CalendarNavbar.tsx
@@ -37,9 +37,12 @@ const CalendarNavbar: React.FC<CalendarNavbarProps> = ({ selectedDate, onDateCha
       onDateChange(new Date());
     };
   
+    // Jumps to today's date within whatever view is currently active -- must not touch
+    // selectedView (previously forced this to "Day" without telling the parent via
+    // onViewChange, desyncing CalendarHeader's date-range label and shiftSelectedDate's own
+    // day-vs-week step from whatever view was actually still rendered underneath).
     const handleToday = () => {
-      setSelectedView("Day");
-      onDateChange(new Date()); // Call the external function as well
+      onDateChange(new Date());
     };
 
     // Shifts the ET calendar date `selectedDate` represents by a day count (Day/Week) or month

--- a/frontend/app/components/calendar/desktop/WeekView.tsx
+++ b/frontend/app/components/calendar/desktop/WeekView.tsx
@@ -7,6 +7,7 @@ import { formatETDateString } from "../../../../util/timeUtils";
 import { layoutOverlappingMeetings } from "../../../../util/meetingOverlapLayout";
 import { getFirstDayOfWeek, getDaysOfWeek } from "../../../../util/weekDates";
 import { useWeekMeetings, WeekMeeting } from "../../../../hooks/useWeekMeetings";
+import TopLoadingBar from "../../atoms/TopLoadingBar";
 
 export { invalidateWeekCache } from "../../../../hooks/useWeekMeetings";
 
@@ -64,7 +65,7 @@ const WeekView: React.FC<WeekViewProps> = ({
     const [weekStartDate, setWeekStartDate] = useState<Date>(() => getFirstDayOfWeek(selectedDate));
     const [daysOfWeek, setDaysOfWeek] = useState<Date[]>(() => getDaysOfWeek(weekStartDate));
     const viewContainerRef = useRef<HTMLDivElement>(null);
-    const allMeetings = useWeekMeetings(weekStartDate, refreshTrigger);
+    const { meetings: allMeetings, isLoading } = useWeekMeetings(weekStartDate, refreshTrigger);
 
     // Format time slots for hour markers
     const formatTime = (hour: number): string => {
@@ -152,6 +153,7 @@ const WeekView: React.FC<WeekViewProps> = ({
 
     return (
         <div className={styles.outerContainer}>
+            <TopLoadingBar active={isLoading} />
             <div
                 className={styles.viewContainer}
                 ref={viewContainerRef}

--- a/frontend/app/components/calendar/mobile/DayLandscapeView.tsx
+++ b/frontend/app/components/calendar/mobile/DayLandscapeView.tsx
@@ -11,6 +11,7 @@ import { layoutOverlappingMeetings, OverlapMeeting } from "../../../../util/meet
 import { addDaysToDate } from "../../../../util/weekDates";
 import { useElementSize } from "../../../../hooks/useElementSize";
 import { useCalendarContext } from "../../../context/CalendarProvider";
+import TopLoadingBar from "../../atoms/TopLoadingBar";
 
 interface Meeting extends OverlapMeeting {
   syncError?: boolean;
@@ -151,6 +152,7 @@ const DayLandscapeView: React.FC<DayLandscapeViewProps> = ({
   const [prevMeetings, setPrevMeetings] = useState<Room[]>([]);
   const [currentMeetings, setCurrentMeetings] = useState<Room[]>([]);
   const [nextMeetings, setNextMeetings] = useState<Room[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
   const [currentTimePosition, setCurrentTimePosition] = useState<number | null>(null);
   const [scrollAreaRef, scrollAreaSize] = useElementSize<HTMLDivElement>();
   // ResizeObserver's initial callback can lag the first paint by a frame -- clamp to sensible
@@ -184,15 +186,22 @@ const DayLandscapeView: React.FC<DayLandscapeViewProps> = ({
       invalidateCache(next);
     }
     const requestId = ++fetchRequestIdRef.current;
-    const [prevData, currentData, nextData] = await Promise.all([
-      fetchMeetingsByDay(prev),
-      fetchMeetingsByDay(current),
-      fetchMeetingsByDay(next),
-    ]);
-    if (requestId === fetchRequestIdRef.current) {
-      setPrevMeetings(prevData);
-      setCurrentMeetings(currentData);
-      setNextMeetings(nextData);
+    setIsLoading(true);
+    try {
+      const [prevData, currentData, nextData] = await Promise.all([
+        fetchMeetingsByDay(prev),
+        fetchMeetingsByDay(current),
+        fetchMeetingsByDay(next),
+      ]);
+      if (requestId === fetchRequestIdRef.current) {
+        setPrevMeetings(prevData);
+        setCurrentMeetings(currentData);
+        setNextMeetings(nextData);
+      }
+    } finally {
+      if (requestId === fetchRequestIdRef.current) {
+        setIsLoading(false);
+      }
     }
   }, []);
 
@@ -211,24 +220,21 @@ const DayLandscapeView: React.FC<DayLandscapeViewProps> = ({
   // runs -- same flash desktop DayView's own scrollToCurrentTime has always had (a beat of
   // the wrong scroll position at hour 0 before JS jumps it to "now"), plus a wait for
   // scrollAreaSize.width's first real ResizeObserver measurement (desktop's own hourWidth is a
-  // hardcoded constant, always "ready"; this view's isn't). Scrolls exactly once per date --
-  // not on every later hourWidth recompute (e.g. filters changing room count) -- by tracking
-  // which date it already scrolled for. Resets (intentionally) on every date change, including
-  // ones from this view's own vertical drag -- a fresh day always opens scrolled to "now",
-  // matching desktop DayView's own per-day behavior, rather than carrying over whichever hour
-  // the previous day happened to be scrolled to.
+  // hardcoded constant, always "ready"; this view's isn't). Fires exactly once, on this view's
+  // first successful measurement -- not on every later date change (day-navigation swipe,
+  // "Today", mini-calendar pick), matching WeekView/DayPortraitView's own one-way
+  // initialScrollDone gate, rather than re-centering on "now" every time the day changes.
   const [initialScrollDone, setInitialScrollDone] = useState(false);
-  const scrolledForDateRef = useRef<string | null>(null);
+  const hasScrolledRef = useRef(false);
   useLayoutEffect(() => {
-    const dateKey = formatETDateString(selectedDate);
+    if (hasScrolledRef.current) return;
     if (scrollAreaSize.width === 0) {
       // No measurement yet -- still reveal the grid so a missing ResizeObserver or a
-      // never-resized hidden ancestor can't leave .scrollArea permanently invisible.
+      // never-resized hidden ancestor can't leave .scrollArea permanently invisible. Doesn't
+      // set hasScrolledRef, so the effect retries once a real width arrives.
       setInitialScrollDone(true);
       return;
     }
-    if (scrolledForDateRef.current === dateKey) return;
-    scrolledForDateRef.current = dateKey;
 
     const el = scrollAreaRef.current;
     if (el) {
@@ -236,8 +242,9 @@ const DayLandscapeView: React.FC<DayLandscapeViewProps> = ({
       const scrollOffset = (currentHour - START_HOUR - SCROLL_LEAD_HOURS) * hourWidth;
       el.scrollLeft = Math.max(0, scrollOffset);
     }
+    hasScrolledRef.current = true;
     setInitialScrollDone(true);
-  }, [selectedDate, scrollAreaSize.width, hourWidth, scrollAreaRef]);
+  }, [scrollAreaSize.width, hourWidth, scrollAreaRef]);
 
   // No bounds check needed here -- START_HOUR/END_HOUR span the full 0-24 day, so "now" is
   // always in range (unlike a business-hours-restricted range, where this would need to hide
@@ -439,6 +446,7 @@ const DayLandscapeView: React.FC<DayLandscapeViewProps> = ({
 
   return (
     <div className={styles.outerContainer}>
+      <TopLoadingBar active={isLoading} />
       <div
         className={styles.scrollArea}
         ref={scrollAreaRef}

--- a/frontend/app/components/calendar/mobile/DayPortraitView.tsx
+++ b/frontend/app/components/calendar/mobile/DayPortraitView.tsx
@@ -11,6 +11,7 @@ import { getFirstDayOfWeek, addDaysToDate } from "../../../../util/weekDates";
 import { useWeekMeetings } from "../../../../hooks/useWeekMeetings";
 import { useScrollNavHide } from "../../../../hooks/useScrollNavHide";
 import { useCalendarContext } from "../../../context/CalendarProvider";
+import TopLoadingBar from "../../atoms/TopLoadingBar";
 import styles from "../../../../styles/components/calendar/mobile/DayPortraitView.module.scss";
 
 interface Meeting extends OverlapMeeting {
@@ -90,8 +91,9 @@ const DayPortraitView: React.FC<DayPortraitViewProps> = ({
   // still exactly one network request.
   const prevDate = addDaysToDate(selectedDate, -1);
   const nextDate = addDaysToDate(selectedDate, 1);
-  const prevWeekMeetings = useWeekMeetings(getFirstDayOfWeek(prevDate), refreshTrigger);
-  const nextWeekMeetings = useWeekMeetings(getFirstDayOfWeek(nextDate), refreshTrigger);
+  const { meetings: prevWeekMeetings, isLoading: prevLoading } = useWeekMeetings(getFirstDayOfWeek(prevDate), refreshTrigger);
+  const { meetings: nextWeekMeetings, isLoading: nextLoading } = useWeekMeetings(getFirstDayOfWeek(nextDate), refreshTrigger);
+  const isLoading = prevLoading || nextLoading;
 
   const allMeetings = useMemo(() => {
     // Keyed on id+date, not id alone -- a recurring meeting occurring more than once in the
@@ -308,6 +310,7 @@ const DayPortraitView: React.FC<DayPortraitViewProps> = ({
 
   return (
     <div className={styles.container}>
+      <TopLoadingBar active={isLoading} />
       <WeekStrip />
       <CalendarHeader
         selectedDate={selectedDate}

--- a/frontend/app/components/calendar/mobile/MultiDayLandscapeView.tsx
+++ b/frontend/app/components/calendar/mobile/MultiDayLandscapeView.tsx
@@ -10,6 +10,7 @@ import { addDaysToDate, daysBetweenET } from "../../../../util/weekDates";
 import { useRangeMeetings } from "../../../../hooks/useRangeMeetings";
 import { useElementWidth } from "../../../../hooks/useElementWidth";
 import { useScrollNavHide } from "../../../../hooks/useScrollNavHide";
+import TopLoadingBar from "../../atoms/TopLoadingBar";
 
 interface Meeting extends OverlapMeeting {
   syncError?: boolean;
@@ -117,9 +118,12 @@ const MultiDayLandscapeView: React.FC<MultiDayLandscapeViewProps> = ({
   // date happened to land in a different one.
   const prevPageStart = addDaysToDate(pageStart, -days);
   const nextPageStart = addDaysToDate(pageStart, days);
-  const rangeA = useRangeMeetings(prevPageStart, days, refreshTrigger);
-  const rangeB = useRangeMeetings(pageStart, days, refreshTrigger);
-  const rangeC = useRangeMeetings(nextPageStart, days, refreshTrigger);
+  const { meetings: rangeA } = useRangeMeetings(prevPageStart, days, refreshTrigger);
+  // Only the current (center) page's own loading state drives the loading bar -- A/C are
+  // background prefetches for swipe-adjacent pages, and the currently-visible page can be
+  // fully ready even while a neighbor is still in flight.
+  const { meetings: rangeB, isLoading } = useRangeMeetings(pageStart, days, refreshTrigger);
+  const { meetings: rangeC } = useRangeMeetings(nextPageStart, days, refreshTrigger);
 
   const allMeetings = useMemo(() => {
     // Keyed on id+date, not id alone -- a recurring meeting occurring more than once across
@@ -295,6 +299,7 @@ const MultiDayLandscapeView: React.FC<MultiDayLandscapeViewProps> = ({
 
   return (
     <div className={styles.outerContainer}>
+      <TopLoadingBar active={isLoading} />
       <div
         className={styles.scrollArea}
         ref={scrollAreaRef}

--- a/frontend/hooks/useRangeMeetings.ts
+++ b/frontend/hooks/useRangeMeetings.ts
@@ -34,12 +34,21 @@ const fetchMeetingsByRange = async (startDate: Date, endDate: Date): Promise<Wee
     });
 };
 
+export interface UseRangeMeetingsResult {
+    meetings: WeekMeeting[];
+    // True while a fetch for the currently-requested range is in flight -- including a cache
+    // hit, since getOrFetch always returns a promise either way; a cache hit just resolves on
+    // the next microtask, so this flips back to false before paint and never visibly flashes.
+    isLoading: boolean;
+}
+
 // Fetches (and caches) meetings for exactly `days` consecutive ET days starting at
 // `startDate` -- unlike useWeekMeetings, this isn't aligned to a calendar week, so a caller
 // needing an arbitrary N-day window doesn't have to over-fetch whole weeks around it. Bump
 // `refreshTrigger` to force a cache-busting refetch (e.g. after a create/edit/delete).
-export function useRangeMeetings(startDate: Date, days: number, refreshTrigger: number = 0): WeekMeeting[] {
+export function useRangeMeetings(startDate: Date, days: number, refreshTrigger: number = 0): UseRangeMeetingsResult {
     const [allMeetings, setAllMeetings] = useState<WeekMeeting[]>([]);
+    const [isLoading, setIsLoading] = useState(true);
 
     // Ref instead of closing over startDate/days directly -- same reasoning as useWeekMeetings'
     // own weekStartDateRef: keeps fetchRangeMeetings' identity stable across range changes, so
@@ -73,6 +82,7 @@ export function useRangeMeetings(startDate: Date, days: number, refreshTrigger: 
         }
 
         const requestId = ++fetchRequestIdRef.current;
+        setIsLoading(true);
         // fetchMeetingsByRange now rejects on a failed request (so simpleCache evicts the
         // entry instead of caching an empty range) -- caught here, not left to propagate into
         // the effects below, which call this fire-and-forget with no .catch of their own.
@@ -83,6 +93,10 @@ export function useRangeMeetings(startDate: Date, days: number, refreshTrigger: 
             }
         } catch (error) {
             console.error("[useRangeMeetings] fetchRangeMeetings failed:", error instanceof Error ? error.message : String(error));
+        } finally {
+            if (requestId === fetchRequestIdRef.current) {
+                setIsLoading(false);
+            }
         }
     }, []);
 
@@ -96,5 +110,5 @@ export function useRangeMeetings(startDate: Date, days: number, refreshTrigger: 
         }
     }, [refreshTrigger, fetchRangeMeetings]);
 
-    return allMeetings;
+    return { meetings: allMeetings, isLoading };
 }

--- a/frontend/hooks/useWeekMeetings.ts
+++ b/frontend/hooks/useWeekMeetings.ts
@@ -120,10 +120,19 @@ export function useWeekMeetings(weekStartDate: Date, refreshTrigger: number = 0)
 
         const requestId = ++fetchRequestIdRef.current;
         setIsLoading(true);
-        const meetings = await fetchMeetingsByWeek(startDate, endDate);
-        if (requestId === fetchRequestIdRef.current) {
-            setAllMeetings(meetings);
-            setIsLoading(false);
+        // fetchMeetingsByWeek's own fetcher already catches and resolves to [] on failure, but
+        // isLoading is set/cleared here defensively in a try/finally anyway -- matching
+        // useRangeMeetings' own shape -- so this doesn't silently break if that internal
+        // catch-and-resolve behavior ever changes.
+        try {
+            const meetings = await fetchMeetingsByWeek(startDate, endDate);
+            if (requestId === fetchRequestIdRef.current) {
+                setAllMeetings(meetings);
+            }
+        } finally {
+            if (requestId === fetchRequestIdRef.current) {
+                setIsLoading(false);
+            }
         }
     }, []);
 

--- a/frontend/hooks/useWeekMeetings.ts
+++ b/frontend/hooks/useWeekMeetings.ts
@@ -75,10 +75,19 @@ export const invalidateWeekCache = (startDate: Date, endDate: Date) => {
     weekMeetingCache.invalidate(`${formattedStart}-${formattedEnd}`);
 };
 
+export interface UseWeekMeetingsResult {
+    meetings: WeekMeeting[];
+    // True while a fetch for the currently-requested week is in flight -- including a cache hit,
+    // since getOrFetch always returns a promise either way; a cache hit just resolves on the
+    // next microtask, so this flips back to false before paint and never visibly flashes.
+    isLoading: boolean;
+}
+
 // Fetches (and caches) all meetings for the ET week starting `weekStartDate` (a Sunday).
 // Bump `refreshTrigger` to force a cache-busting refetch (e.g. after a create/edit/delete).
-export function useWeekMeetings(weekStartDate: Date, refreshTrigger: number = 0): WeekMeeting[] {
+export function useWeekMeetings(weekStartDate: Date, refreshTrigger: number = 0): UseWeekMeetingsResult {
     const [allMeetings, setAllMeetings] = useState<WeekMeeting[]>([]);
+    const [isLoading, setIsLoading] = useState(true);
 
     // Ref instead of a `weekStartDate` closure/dependency so fetchWeekMeetings's identity
     // stays stable across week changes -- needed so the refreshTrigger effect below doesn't
@@ -110,9 +119,11 @@ export function useWeekMeetings(weekStartDate: Date, refreshTrigger: number = 0)
         }
 
         const requestId = ++fetchRequestIdRef.current;
+        setIsLoading(true);
         const meetings = await fetchMeetingsByWeek(startDate, endDate);
         if (requestId === fetchRequestIdRef.current) {
             setAllMeetings(meetings);
+            setIsLoading(false);
         }
     }, []);
 
@@ -128,5 +139,5 @@ export function useWeekMeetings(weekStartDate: Date, refreshTrigger: number = 0)
         }
     }, [refreshTrigger, fetchWeekMeetings]);
 
-    return allMeetings;
+    return { meetings: allMeetings, isLoading };
 }

--- a/frontend/styles/components/atoms/BoxText.module.scss
+++ b/frontend/styles/components/atoms/BoxText.module.scss
@@ -69,8 +69,16 @@
     font-weight: 400;
     margin: 0;
     padding: 0;
-    color: #3A3E49;
-    overflow-x: hidden;
+    color: $navy-color;
+
+    // The shorthand, not overflow-x alone -- per the CSS Overflow spec, setting only
+    // overflow-x to a non-visible value forces the browser to also compute overflow-y as
+    // auto (never a bare "visible" left alongside a clipped axis). Combined with
+    // .timeRowWithPlace's flex-wrap: wrap below, that forced auto turned this into a
+    // genuinely vertically-scrollable box whenever wrapped content came out a hair taller
+    // than the row (font-metric rounding) -- showing a real, native (and often grey, easy to
+    // mistake for a rendering glitch) scrollbar with no DOM node of its own to inspect.
+    overflow: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;
     flex-shrink: 0;

--- a/frontend/styles/components/atoms/TopLoadingBar.module.scss
+++ b/frontend/styles/components/atoms/TopLoadingBar.module.scss
@@ -1,0 +1,41 @@
+@import '../../Variables.module.scss';
+
+.track {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 3px;
+  overflow: hidden;
+  z-index: $z-index-sticky;
+  pointer-events: none;
+}
+
+.fill {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: -40%;
+  width: 40%;
+  background: $brand-pink-color;
+  border-radius: 0 $radius-sm $radius-sm 0;
+  animation: sweep 1.1s ease-in-out infinite;
+}
+
+@keyframes sweep {
+  0% {
+    left: -40%;
+  }
+
+  100% {
+    left: 100%;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .fill {
+    animation: none;
+    left: 0;
+    width: 100%;
+  }
+}

--- a/frontend/styles/components/calendar/desktop/WeekView.module.scss
+++ b/frontend/styles/components/calendar/desktop/WeekView.module.scss
@@ -6,6 +6,7 @@
   flex-direction: column;
   width: 100%;
   font-family: 'Source Sans Pro', sans-serif;
+  position: relative; // anchors TopLoadingBar's absolute positioning to this view's own bounds
 
   // Fills whatever's left under CalendarNavbar in .primaryCalendar (page.module.scss), not
   // this element's full containing-block height -- see DayView.module.scss's matching

--- a/frontend/styles/components/calendar/mobile/DayLandscapeView.module.scss
+++ b/frontend/styles/components/calendar/mobile/DayLandscapeView.module.scss
@@ -7,6 +7,7 @@
   flex-direction: column;
   overflow: hidden;
   background-color: $white-color;
+  position: relative; // anchors TopLoadingBar's absolute positioning to this view's own bounds
 }
 
 // Horizontal-only: the room axis (vertical) always fits exactly, never scrolls -- rowHeight

--- a/frontend/styles/components/calendar/mobile/DayPortraitView.module.scss
+++ b/frontend/styles/components/calendar/mobile/DayPortraitView.module.scss
@@ -5,6 +5,7 @@
     flex-direction: column;
     height: 100%;
     background-color: $white-color;
+    position: relative; // anchors TopLoadingBar's absolute positioning to this view's own bounds
 
     // WeekStrip and CalendarHeader are plain flex siblings above this, not part of
     // .scrollArea's own scroll container -- so they never scroll with it, no CSS

--- a/frontend/styles/components/calendar/mobile/MultiDayLandscapeView.module.scss
+++ b/frontend/styles/components/calendar/mobile/MultiDayLandscapeView.module.scss
@@ -57,7 +57,6 @@
   display: flex;
   flex-direction: column;
   padding-left: max(16px, env(safe-area-inset-left));
-  border-right: 1px solid $grey-border-color;
   background-color: $white-color;
 }
 

--- a/frontend/styles/components/calendar/mobile/MultiDayLandscapeView.module.scss
+++ b/frontend/styles/components/calendar/mobile/MultiDayLandscapeView.module.scss
@@ -7,6 +7,7 @@
   flex-direction: column;
   overflow: hidden;
   background-color: $white-color;
+  position: relative; // anchors TopLoadingBar's absolute positioning to this view's own bounds
 }
 
 // The only scroll container -- vertical (native) and horizontal (clipped, not scrolled: the

--- a/frontend/tests/component/CalendarNavbar.test.tsx
+++ b/frontend/tests/component/CalendarNavbar.test.tsx
@@ -1,0 +1,44 @@
+import React, { useState } from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import CalendarNavbar from "../../app/components/calendar/desktop/CalendarNavbar";
+import { formatETDateString, addDaysToETDateString } from "../../util/timeUtils";
+
+// Wraps CalendarNavbar with the controlled selectedDate state a real parent would own, so
+// clicking Today/arrows and re-rendering with the updated date exercises the same loop the
+// real app does, not just the callback's argument in isolation. Renders selectedDate as text
+// (ET date string) so the test can assert on it without reaching into CalendarNavbar's
+// internals.
+const Harness: React.FC = () => {
+  const [selectedDate, setSelectedDate] = useState(new Date());
+  return (
+    <>
+      <div data-testid="selected-date">{formatETDateString(selectedDate)}</div>
+      <CalendarNavbar selectedDate={selectedDate} onDateChange={setSelectedDate} onViewChange={() => {}} />
+    </>
+  );
+};
+
+// Regression test for a bug where clicking "Today" force-set the view dropdown's internal
+// selectedView to "Day" without telling the parent (onViewChange was never called) -- this
+// desynced shiftSelectedDate's own day-vs-week step from whatever view (e.g. Week) was
+// actually still rendered, so the arrows silently started moving a Week view by a single day
+// instead of by a week after Today was clicked.
+test("clicking Today while in Week view keeps arrow navigation stepping by week, not by day", () => {
+  render(<Harness />);
+
+  fireEvent.click(screen.getByRole("button", { name: "Day" }));
+  fireEvent.click(screen.getByRole("option", { name: "Week" }));
+
+  fireEvent.click(screen.getByText("Today"));
+  const today = screen.getByTestId("selected-date").textContent;
+
+  fireEvent.click(screen.getByAltText("Right Arrow"));
+
+  const afterOneClick = screen.getByTestId("selected-date").textContent;
+  expect(afterOneClick).toBe(addDaysToETDateString(today as string, 7));
+  expect(afterOneClick).not.toBe(addDaysToETDateString(today as string, 1));
+
+  // The view dropdown itself must still read "Week" -- proves Today never silently reset it
+  // to "Day" in the first place, which is the actual root cause the arrow-step above depends on.
+  expect(screen.getByRole("button", { name: "Week" })).toBeInTheDocument();
+});

--- a/frontend/tests/integration/meeting-occurrences-range.test.ts
+++ b/frontend/tests/integration/meeting-occurrences-range.test.ts
@@ -1,0 +1,93 @@
+import { seedMeeting, seedRecurringMeeting } from "../factories/meeting";
+import { disconnectTestPrismaClient } from "../factories/db";
+import { getMeetingsForRange } from "../../util/meetingOccurrences";
+import { convertETToUTC, addDaysToETDateString, formatETDateString } from "../../util/timeUtils";
+
+afterAll(async () => {
+  await disconnectTestPrismaClient();
+});
+
+const weekdayOf = (etDateStr: string): string =>
+  new Date(convertETToUTC(`${etDateStr}T12:00:00`)).toLocaleDateString("en-US", { weekday: "long", timeZone: "America/New_York" });
+
+const ALL_DAYS = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
+
+test("expands a weekly recurring meeting across a 7-day range", async () => {
+  const today = formatETDateString(new Date());
+  const { meeting } = await seedRecurringMeeting(
+    { title: "Weekly Range Meeting", startDateTime: new Date(convertETToUTC(`${today}T18:00:00`)), endDateTime: new Date(convertETToUTC(`${today}T19:00:00`)) },
+    { daysOfWeek: ALL_DAYS },
+  );
+
+  const rangeEnd = addDaysToETDateString(today, 6);
+  const results = await getMeetingsForRange(today, rangeEnd);
+  const own = results.filter(r => r.mid === meeting.mid);
+  expect(own.length).toBe(7);
+  expect(new Set(own.map(r => r.date)).size).toBe(7);
+});
+
+test("excludes a recurring series whose span doesn't overlap the range", async () => {
+  const farFuture = formatETDateString(new Date(Date.now() + 1000 * 60 * 60 * 24 * 400));
+  const { meeting } = await seedRecurringMeeting(
+    { title: "Far Future Range Meeting", startDateTime: new Date(convertETToUTC(`${farFuture}T18:00:00`)), endDateTime: new Date(convertETToUTC(`${farFuture}T19:00:00`)) },
+    { startDate: new Date(convertETToUTC(`${farFuture}T18:00:00`)), daysOfWeek: ALL_DAYS },
+  );
+
+  const today = formatETDateString(new Date());
+  const rangeEnd = addDaysToETDateString(today, 6);
+  const results = await getMeetingsForRange(today, rangeEnd);
+  expect(results.some(r => r.mid === meeting.mid)).toBe(false);
+});
+
+test("includes a one-time meeting only on the day it overlaps", async () => {
+  const today = formatETDateString(new Date());
+  const tomorrow = addDaysToETDateString(today, 1);
+  const meeting = await seedMeeting({
+    title: "One Time Range Meeting",
+    startDateTime: new Date(convertETToUTC(`${tomorrow}T10:00:00`)),
+    endDateTime: new Date(convertETToUTC(`${tomorrow}T11:00:00`)),
+  });
+
+  const rangeEnd = addDaysToETDateString(today, 6);
+  const results = await getMeetingsForRange(today, rangeEnd);
+  const own = results.filter(r => r.mid === meeting.mid);
+  expect(own.length).toBe(1);
+  expect(own[0].date).toBe(tomorrow);
+});
+
+test("doesn't double-count an overnight recurring meeting on its own anchor day", async () => {
+  const today = formatETDateString(new Date());
+  const { meeting } = await seedRecurringMeeting(
+    { title: "Overnight Anchor Meeting", startDateTime: new Date(convertETToUTC(`${today}T23:30:00`)), endDateTime: new Date(convertETToUTC(`${addDaysToETDateString(today, 1)}T00:30:00`)) },
+    { daysOfWeek: ALL_DAYS },
+  );
+
+  const rangeEnd = addDaysToETDateString(today, 6);
+  const results = await getMeetingsForRange(today, rangeEnd);
+  const own = results.filter(r => r.mid === meeting.mid);
+  expect(own.length).toBe(7);
+  expect(new Set(own.map(r => r.date)).size).toBe(7);
+});
+
+test("catches a non-anchor overnight occurrence spilling in from the day before the range", async () => {
+  const today = formatETDateString(new Date());
+  // rangeStart is queried alone (a 1-day range) so the "lead-in day" (rangeStart - 1) is the
+  // only day whose pattern match matters -- rangeStart itself is a different weekday, so it
+  // won't also match and produce a second, unrelated occurrence to disambiguate from.
+  const rangeStart = addDaysToETDateString(today, 10);
+  const leadInDay = addDaysToETDateString(rangeStart, -1);
+  // The meeting's own literal DB row is anchored 2 weeks before the lead-in day -- far outside
+  // [rangeStart, rangeStart], so directlyScheduledMeetings can't be what catches this; only the
+  // pattern-matched (non-anchor) expansion for a *later* week's occurrence can.
+  const anchorDay = addDaysToETDateString(leadInDay, -14);
+
+  const { meeting } = await seedRecurringMeeting(
+    { title: "Non-Anchor Overnight Spillover Meeting", startDateTime: new Date(convertETToUTC(`${anchorDay}T23:30:00`)), endDateTime: new Date(convertETToUTC(`${addDaysToETDateString(anchorDay, 1)}T00:30:00`)) },
+    { startDate: new Date(convertETToUTC(`${anchorDay}T23:30:00`)), daysOfWeek: [weekdayOf(anchorDay)] },
+  );
+
+  const results = await getMeetingsForRange(rangeStart, rangeStart);
+  const own = results.filter(r => r.mid === meeting.mid);
+  expect(own.length).toBe(1);
+  expect(own[0].date).toBe(rangeStart);
+});

--- a/frontend/util/meetingOccurrences.ts
+++ b/frontend/util/meetingOccurrences.ts
@@ -228,31 +228,44 @@ export const getMeetingsForRange = async (
     });
 
     const results: (PublicMeeting & { date: string })[] = [];
-    let etDateStr = startEtDateStr;
+    // Starts one ET day before the range: a recurring occurrence whose pattern anchors it on
+    // that lead-in day can still roll past midnight into startEtDateStr (adjustOccurrenceToDate
+    // rolls an overnight end onto the next ET day), and that's the only pass that can produce
+    // it -- allRecurringMeetings is otherwise only pattern-matched against days from
+    // startEtDateStr onward. Nothing anchored ON the lead-in day itself is kept; it's evaluated
+    // only to catch a spillover into the real range.
+    let etDateStr = addDaysToETDateString(startEtDateStr, -1);
     while (etDateStr <= endEtDateStr) {
         const [startOfDay, endOfDay] = getETDayBounds(etDateStr);
+        const isLeadInDay = etDateStr < startEtDateStr;
 
         // localDate is used only for day-of-week and recurring-pattern comparisons;
         // represent the ET calendar date as UTC midnight so getUTCDay() is correct.
         const [etYear, etMonth, etDay] = etDateStr.split('-').map(Number);
         const localDate = new Date(Date.UTC(etYear, etMonth - 1, etDay));
 
-        for (const meeting of directlyScheduledMeetings) {
-            // A meeting overlapping the whole fetched range doesn't necessarily overlap this
-            // specific day within it -- re-check per day against the range-wide result set.
-            if (meeting.startDateTime > endOfDay || meeting.endDateTime < startOfDay) continue;
-            if (isDateSuspended(meeting.suspensions, etDateStr)) continue;
+        // directlyScheduledMeetings is already fetched range-wide (its own query overlaps
+        // [startOfRange, endOfRange], not per day), so a lead-in-day pass adds nothing new here
+        // -- an anchor row spilling into startEtDateStr is already covered on the real
+        // startEtDateStr iteration below via the same per-day overlap check.
+        if (!isLeadInDay) {
+            for (const meeting of directlyScheduledMeetings) {
+                // A meeting overlapping the whole fetched range doesn't necessarily overlap this
+                // specific day within it -- re-check per day against the range-wide result set.
+                if (meeting.startDateTime > endOfDay || meeting.endDateTime < startOfDay) continue;
+                if (isDateSuspended(meeting.suspensions, etDateStr)) continue;
 
-            if (meeting.isRecurring) {
-                const recurrence = meeting.recurrencePattern;
-                if (isAfterSeriesEnd(recurrence?.endDate ?? null, etDateStr)) continue;
-                if (recurrence?.excludedDates?.length && isDateExcluded(recurrence.excludedDates, etDateStr)) continue;
+                if (meeting.isRecurring) {
+                    const recurrence = meeting.recurrencePattern;
+                    if (isAfterSeriesEnd(recurrence?.endDate ?? null, etDateStr)) continue;
+                    if (recurrence?.excludedDates?.length && isDateExcluded(recurrence.excludedDates, etDateStr)) continue;
+                }
+
+                results.push({
+                    ...toPublicMeeting({ ...meeting, recurrencePattern: meeting.recurrencePattern ?? null }),
+                    date: etDateStr,
+                });
             }
-
-            results.push({
-                ...toPublicMeeting({ ...meeting, recurrencePattern: meeting.recurrencePattern ?? null }),
-                date: etDateStr,
-            });
         }
 
         for (const meeting of allRecurringMeetings) {
@@ -267,6 +280,11 @@ export const getMeetingsForRange = async (
             if (!matchesRecurrencePattern(recurrence, etDateStr, localDate)) continue;
 
             const { start, end } = adjustOccurrenceToDate(meeting, etDateStr);
+            // Only relevant on the lead-in day if it actually spills into the requested range --
+            // otherwise this occurrence belongs entirely to the lead-in day, which is outside
+            // what the caller asked for.
+            if (isLeadInDay && end <= startOfRange) continue;
+
             results.push({
                 ...toPublicMeeting({
                     ...meeting,
@@ -274,7 +292,7 @@ export const getMeetingsForRange = async (
                     startDateTime: start,
                     endDateTime: end,
                 }),
-                date: etDateStr,
+                date: isLeadInDay ? startEtDateStr : etDateStr,
             });
         }
 

--- a/frontend/util/meetingOccurrences.ts
+++ b/frontend/util/meetingOccurrences.ts
@@ -1,4 +1,4 @@
-import { getETDayBounds, convertETToUTC } from "./timeUtils";
+import { getETDayBounds, convertETToUTC, addDaysToETDateString } from "./timeUtils";
 import { prisma } from "../lib/prisma";
 import { PublicMeeting, toPublicMeeting } from "./publicMeeting";
 
@@ -169,21 +169,23 @@ export const firstOccurrenceOnOrAfter = (
 };
 
 /**
- * Returns every meeting occurrence (one-time + recurring, expanded) that falls on the given
- * ET calendar date, with recurring occurrences' start/end times adjusted onto that date.
- * Shared by the day and week retrieval routes so recurrence rules are only implemented once.
+ * Returns every meeting occurrence (one-time + recurring, expanded) that falls within
+ * [startEtDateStr, endEtDateStr] (inclusive), one entry per (meeting, date) pair, tagged with
+ * the ET date it was expanded onto. Both underlying queries run exactly once for the whole
+ * range -- not once per day -- so a multi-day fetch doesn't repeat the same table scan for
+ * every day it covers. Shared by the day, week, and range retrieval routes so recurrence rules
+ * are only implemented once.
  */
-export const getMeetingsForDate = async (etDateStr: string): Promise<PublicMeeting[]> => {
-    const [startOfDay, endOfDay] = getETDayBounds(etDateStr);
-
-    // localDate is used only for day-of-week and recurring-pattern comparisons;
-    // represent the ET calendar date as UTC midnight so getUTCDay() is correct.
-    const [etYear, etMonth, etDay] = etDateStr.split('-').map(Number);
-    const localDate = new Date(Date.UTC(etYear, etMonth - 1, etDay));
+export const getMeetingsForRange = async (
+    startEtDateStr: string,
+    endEtDateStr: string,
+): Promise<(PublicMeeting & { date: string })[]> => {
+    const [startOfRange] = getETDayBounds(startEtDateStr);
+    const [, endOfRange] = getETDayBounds(endEtDateStr);
 
     const directlyScheduledMeetings = await prisma.meeting.findMany({
         where: {
-            AND: [notDeleted, { startDateTime: { lte: endOfDay }, endDateTime: { gte: startOfDay } }]
+            AND: [notDeleted, { startDateTime: { lte: endOfRange }, endDateTime: { gte: startOfRange } }]
         },
         include: {
             recurrencePattern: true,
@@ -191,60 +193,103 @@ export const getMeetingsForDate = async (etDateStr: string): Promise<PublicMeeti
         }
     });
 
-    const regularMeetings = directlyScheduledMeetings.filter(meeting =>
-        !meeting.isRecurring && !isDateSuspended(meeting.suspensions, etDateStr));
-    const originalDayRecurringMeetings = directlyScheduledMeetings.filter(meeting => {
-        if (!meeting.isRecurring) return false;
-        if (isDateSuspended(meeting.suspensions, etDateStr)) return false;
-        const recurrence = meeting.recurrencePattern;
-        if (isAfterSeriesEnd(recurrence?.endDate ?? null, etDateStr)) return false;
-        if (recurrence?.excludedDates?.length && isDateExcluded(recurrence.excludedDates, etDateStr)) return false;
-        return true;
-    });
-
-    // "Other" occurrences of a recurring series — i.e. every occurrence except the one
-    // already covered by directlyScheduledMeetings above. Must exclude by the same overlap
-    // condition as that query (not just "fully contained in today"), or an overnight
-    // occurrence (whose anchor overlaps today without being contained in it) slips through
-    // and gets counted twice: once via originalDayRecurringMeetings, once again here.
-    const otherRecurringMeetings = await prisma.meeting.findMany({
+    // Every recurring meeting whose pattern could produce an occurrence anywhere in the range --
+    // unlike the single-day version this replaces, this can't exclude "the occurrence already
+    // covered by directlyScheduledMeetings" at the query level: that exclusion has to be
+    // per-day (a meeting's own stored row only ever lands on one specific day, not the whole
+    // range), so it's applied inside the loop below instead. Bounded by the recurrence's own
+    // span overlapping the range: a series that starts after endOfRange or ended before
+    // startOfRange can't produce an occurrence anywhere in this window no matter what its
+    // weekly/monthly pattern is, so there's no reason to pull it into app memory just to check.
+    const allRecurringMeetings = await prisma.meeting.findMany({
         where: {
             AND: [
                 notDeleted,
                 { isRecurring: true },
-                { NOT: { AND: [{ startDateTime: { lte: endOfDay } }, { endDateTime: { gte: startOfDay } }] } }
+                {
+                    recurrencePattern: {
+                        is: {
+                            startDate: { lte: endOfRange },
+                            // endDate is optional and, for an unbounded series, often never set
+                            // at all rather than explicitly null -- same Mongo-connector quirk
+                            // as `deletedAt` (see `notDeleted` above): a bare `endDate: null`
+                            // filter does not match a document where the field key is absent.
+                            OR: [
+                                { endDate: null },
+                                { endDate: { isSet: false } },
+                                { endDate: { gte: startOfRange } },
+                            ]
+                        }
+                    }
+                }
             ]
         },
         include: { recurrencePattern: true, suspensions: true }
     });
 
-    const patternDayMeetings = otherRecurringMeetings.filter(meeting => {
-        if (isDateSuspended(meeting.suspensions, etDateStr)) return false;
-        const recurrence = meeting.recurrencePattern;
-        if (!recurrence) return false;
-        return matchesRecurrencePattern(recurrence, etDateStr, localDate);
-    });
+    const results: (PublicMeeting & { date: string })[] = [];
+    let etDateStr = startEtDateStr;
+    while (etDateStr <= endEtDateStr) {
+        const [startOfDay, endOfDay] = getETDayBounds(etDateStr);
 
-    const adjustedPatternMeetings = patternDayMeetings.map(meeting => {
-        const { start, end } = adjustOccurrenceToDate(meeting, etDateStr);
+        // localDate is used only for day-of-week and recurring-pattern comparisons;
+        // represent the ET calendar date as UTC midnight so getUTCDay() is correct.
+        const [etYear, etMonth, etDay] = etDateStr.split('-').map(Number);
+        const localDate = new Date(Date.UTC(etYear, etMonth - 1, etDay));
 
-        return {
-            ...meeting,
-            startDateTime: start,
-            endDateTime: end,
-        };
-    });
+        for (const meeting of directlyScheduledMeetings) {
+            // A meeting overlapping the whole fetched range doesn't necessarily overlap this
+            // specific day within it -- re-check per day against the range-wide result set.
+            if (meeting.startDateTime > endOfDay || meeting.endDateTime < startOfDay) continue;
+            if (isDateSuspended(meeting.suspensions, etDateStr)) continue;
 
-    const allMeetings = [
-        ...regularMeetings,
-        ...originalDayRecurringMeetings,
-        ...adjustedPatternMeetings
-    ];
+            if (meeting.isRecurring) {
+                const recurrence = meeting.recurrencePattern;
+                if (isAfterSeriesEnd(recurrence?.endDate ?? null, etDateStr)) continue;
+                if (recurrence?.excludedDates?.length && isDateExcluded(recurrence.excludedDates, etDateStr)) continue;
+            }
 
-    return allMeetings.map((meeting) => toPublicMeeting({
-        ...meeting,
-        recurrencePattern: meeting.recurrencePattern ?? null,
-    }));
+            results.push({
+                ...toPublicMeeting({ ...meeting, recurrencePattern: meeting.recurrencePattern ?? null }),
+                date: etDateStr,
+            });
+        }
+
+        for (const meeting of allRecurringMeetings) {
+            // Already added above via directlyScheduledMeetings for this specific day -- must
+            // exclude by the same overlap condition as that loop (not just "starts on this
+            // day"), or an overnight occurrence (whose anchor overlaps today without starting
+            // on it) slips through and gets counted twice.
+            if (meeting.startDateTime <= endOfDay && meeting.endDateTime >= startOfDay) continue;
+            if (isDateSuspended(meeting.suspensions, etDateStr)) continue;
+            const recurrence = meeting.recurrencePattern;
+            if (!recurrence) continue;
+            if (!matchesRecurrencePattern(recurrence, etDateStr, localDate)) continue;
+
+            const { start, end } = adjustOccurrenceToDate(meeting, etDateStr);
+            results.push({
+                ...toPublicMeeting({
+                    ...meeting,
+                    recurrencePattern: recurrence,
+                    startDateTime: start,
+                    endDateTime: end,
+                }),
+                date: etDateStr,
+            });
+        }
+
+        etDateStr = addDaysToETDateString(etDateStr, 1);
+    }
+
+    return results;
+};
+
+// Single-day convenience wrapper over getMeetingsForRange, kept for the day route and any
+// other single-date caller -- strips the `date` tag since it's redundant when every result is
+// already known to be on the one requested day.
+export const getMeetingsForDate = async (etDateStr: string): Promise<PublicMeeting[]> => {
+    const results = await getMeetingsForRange(etDateStr, etDateStr);
+    return results.map(({ date: _date, ...meeting }) => meeting);
 };
 
 // Resolves a count-bounded series' (numberOfOccurrences set, no explicit endDate) real last


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a visible loading indicator to calendar views while meeting data is retrieved.
  * Loading animations respect reduced-motion accessibility preferences.

* **Performance Improvements**
  * Calendar date and week views now retrieve meetings through a single date-range request.
  * Background prefetching remains separate from the active view’s loading indicator.

* **Bug Fixes**
  * Improved handling of overlapping requests and outdated results.
  * Improved recurring-event expansion, overnight spillover, exclusions, and overlap handling across date ranges.
  * Selecting “Today” now preserves the current calendar view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description
- **util/meetingOccurrences.ts**: added `getMeetingsForRange`, replacing the per-day `getMeetingsForDate` loop that `week`/`range` routes previously ran — each day re-executed an unbounded recurring-meetings scan, so a 7-day week view repeated the same table scan 7x over. The new function fetches both underlying queries exactly once for the whole range and applies the same overlap/dedup logic per day in memory instead of per DB round-trip. Also bounds the recurring-meetings query by the pattern's own start/end date overlapping the requested range, and catches a recurring occurrence whose pattern-matching day falls one day before the range but rolls (overnight) into it. `getMeetingsForDate` now delegates to it for the single-day case.
- **app/api/retrieve/meeting/{week,range}/route.ts**: call `getMeetingsForRange` once instead of looping.
- **hooks/{useWeekMeetings,useRangeMeetings}.ts**: now return `{ meetings, isLoading }` instead of a bare array.
- **app/components/atoms/TopLoadingBar.tsx** (new): a thin sweeping bar along a view's top edge, matching GitHub/YouTube-style progress indicators. Chosen over a skeleton-block treatment since the meeting cache is in-memory only (not persisted across sessions), so there's nothing to size placeholder blocks from on a fresh session.
- **WeekView.tsx / DayPortraitView.tsx / MultiDayLandscapeView.tsx / DayLandscapeView.tsx**: wired in `TopLoadingBar`, driven by the currently-visible page/week's own loading state (not background prefetches of adjacent pages).
- **DayLandscapeView.tsx**: scroll-to-current-time now fires once (matching WeekView/DayPortraitView's `initialScrollDone` gate) instead of re-centering on "now" every day-navigation change.
- **app/components/calendar/desktop/CalendarNavbar.tsx**: fixed the Today button silently forcing `selectedView` to "Day" without telling the parent — this desynced `CalendarHeader`'s date-range label and `shiftSelectedDate`'s day-vs-week step from whichever view (e.g. Week) was actually still rendered, so clicking Today while in Week view broke the header label and made the arrow buttons step by a day instead of a week.
- **styles/components/atoms/BoxText.module.scss**: fixed `.time` setting only `overflow-x: hidden` — per the CSS Overflow spec, that forces the browser to compute `overflow-y` as `auto` instead of `visible`, and combined with the mobile time-row's `flex-wrap: wrap`, intermittently showed a real native scrollbar (no DOM node of its own) whenever wrapped content came out a hair taller than the row.
- **styles/.../MultiDayLandscapeView.module.scss**: dropped the landscape time column's right border (visual polish).

## Testing
- [x] `yarn tsc --noEmit` — clean
- [x] `yarn test:all` (lint + unit + component + integration + e2e) — all green: 118/118 unit, 77/77 component, 64/64 integration, 94/94 e2e
- [x] `yarn lint:css` — clean
- Added integration tests for `getMeetingsForRange` (weekly recurrence across 7 days, out-of-span series excluded, one-time meeting on the right day only, overnight-anchor-day not double-counted, and a non-anchor overnight occurrence spilling in from the day before the range).
- Added a component test for the Today-button fix (reverted the fix locally and confirmed it fails without it, passes with it).

## Area(s) Touched
**Product areas**
- [ ] auth
- [ ] admin
- [ ] billing
- [x] ui/ux

**Integrations**
- [ ] google-calendar
- [ ] zoom-api

**Engineering**
- [ ] security
- [x] testing
- [ ] github-actions
- [ ] cleanup
- [ ] documentation

## Pre-merge Checklist
- [x] Code follows current formatting conventions and passes lint (`yarn lint`).
- [x] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
- [x] All test suites pass, both run locally and green in GitHub CI. **Do not merge if any test suite is failing.**
- [x] A test suite was added or updated for the feature/fix in this PR.
- [x] Only files relevant to this change are committed — no stray or unrelated files.
- [x] If this branch has a merge conflict with master, master was merged into this branch first (not the other way around).
- [x] The rest of this PR description (Description, Testing) is filled out, not left as template placeholders.