### PR TITLE
fix(diagnostics): surface conflicts for meetings with a failed zoomHost pick

### DIFF
--- a/frontend/app/api/admin/conflict-mids/route.ts
+++ b/frontend/app/api/admin/conflict-mids/route.ts
@@ -34,8 +34,9 @@ export const GET = async () => {
   const meetings = await prisma.meeting.findMany({
     where: notDeleted,
     select: {
-      mid: true, title: true, room: true, zoomRoom: true, zoomHost: true, status: true,
-      calType: true, startDateTime: true, endDateTime: true, isRecurring: true, recurrencePattern: true,
+      mid: true, title: true, room: true, zoomRoom: true, zoomHost: true, attemptedZoomHost: true,
+      status: true, calType: true, startDateTime: true, endDateTime: true, isRecurring: true,
+      recurrencePattern: true,
     },
   });
 

--- a/frontend/app/api/admin/conflict-mids/route.ts
+++ b/frontend/app/api/admin/conflict-mids/route.ts
@@ -36,7 +36,7 @@ export const GET = async () => {
     select: {
       mid: true, title: true, room: true, zoomRoom: true, zoomHost: true, attemptedZoomHost: true,
       status: true, calType: true, startDateTime: true, endDateTime: true, isRecurring: true,
-      recurrencePattern: true,
+      recurrencePattern: true, suspensions: true,
     },
   });
 

--- a/frontend/app/api/admin/diagnostics/route.ts
+++ b/frontend/app/api/admin/diagnostics/route.ts
@@ -53,7 +53,8 @@ export const GET = async () => {
       where: notDeleted,
       select: {
         mid: true, title: true, group: true, status: true, calType: true, isRecurring: true,
-        googleSyncStatus: true, zoomRoom: true, zoomHost: true, zoomSyncStatus: true, zoomSyncError: true,
+        googleSyncStatus: true, zoomRoom: true, zoomHost: true, attemptedZoomHost: true,
+        zoomSyncStatus: true, zoomSyncError: true,
         room: true, modeType: true, startDateTime: true, endDateTime: true,
         recurrencePattern: true, updatedAt: true, suspensions: true,
       },

--- a/frontend/app/api/update/meeting/route.ts
+++ b/frontend/app/api/update/meeting/route.ts
@@ -297,6 +297,9 @@ const updateMeeting = async (request: Request): Promise<Response> => {
 
     let resolvedHost: string | null = null;
     let hostSyncError: string | null = null;
+    // The specific pool host an explicit pick collided with (kept even though resolvedHost
+    // stays null) -- see the attemptedZoomHost field comment in schema.prisma for why.
+    let attemptedZoomHost: string | null = null;
     if (needsNewHost) {
       if (newMeeting.zoomHost) {
         // A conflicting explicitHostChange is already blocked with a 409 above unless
@@ -312,6 +315,7 @@ const updateMeeting = async (request: Request): Promise<Response> => {
           resolvedHost = newMeeting.zoomHost;
         } else {
           hostSyncError = "This time conflicts with another meeting using the same Zoom host.";
+          attemptedZoomHost = newMeeting.zoomHost;
         }
       } else {
         resolvedHost = await resolveZoomHost(newMeeting, { excludeMid: mid });
@@ -341,6 +345,7 @@ const updateMeeting = async (request: Request): Promise<Response> => {
         ...(needsNewHost
           ? {
               zoomHost: resolvedHost,
+              attemptedZoomHost,
               ...(hostSyncError ? { zoomSyncStatus: 'error', zoomSyncError: hostSyncError } : {}),
             }
           : {}),

--- a/frontend/app/api/update/meeting/route.ts
+++ b/frontend/app/api/update/meeting/route.ts
@@ -348,7 +348,9 @@ const updateMeeting = async (request: Request): Promise<Response> => {
               attemptedZoomHost,
               ...(hostSyncError ? { zoomSyncStatus: 'error', zoomSyncError: hostSyncError } : {}),
             }
-          : {}),
+          : !zoomEnabled
+            ? { attemptedZoomHost: null }
+            : {}),
         recurrencePattern: recurrencePattern
           ? {
               upsert: {

--- a/frontend/app/api/write/meeting/route.ts
+++ b/frontend/app/api/write/meeting/route.ts
@@ -201,6 +201,9 @@ const createMeeting = async (request: Request) => {
 
     let resolvedHost: string | null = null;
     let zoomSyncError: string | null = null;
+    // The specific pool host an explicit pick collided with (kept even though resolvedHost
+    // stays null) -- see the attemptedZoomHost field comment in schema.prisma for why.
+    let attemptedZoomHost: string | null = null;
     if (zoomEnabled && !meetingData.zid && !meetingData.zoomLink) {
       if (meetingData.zoomHost) {
         // A conflicting manually-selected host is already blocked with a 409 above unless
@@ -217,6 +220,7 @@ const createMeeting = async (request: Request) => {
           resolvedHost = meetingData.zoomHost;
         } else {
           zoomSyncError = "This time conflicts with another meeting using the same Zoom host.";
+          attemptedZoomHost = meetingData.zoomHost;
         }
       } else {
         resolvedHost = await resolveZoomHost({ ...meetingData, isRecurring }, { excludeMid: meetingData.mid });
@@ -233,6 +237,7 @@ const createMeeting = async (request: Request) => {
       googleCalendarEventIds: meetingDetails.googleCalendarEventIds ?? Prisma.DbNull,
       isRecurring,
       zoomHost: resolvedHost,
+      attemptedZoomHost,
       ...(zoomSyncError ? { zoomSyncStatus: 'error', zoomSyncError } : {}),
     };
 

--- a/frontend/prisma/migrations/20260806093057_add_attempted_zoom_host/migration.sql
+++ b/frontend/prisma/migrations/20260806093057_add_attempted_zoom_host/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Meeting" ADD COLUMN     "attemptedZoomHost" TEXT;

--- a/frontend/prisma/schema.prisma
+++ b/frontend/prisma/schema.prisma
@@ -52,6 +52,11 @@ model Meeting {
   zoomCalendarEventId    String?
   zoomSyncStatus         String?
   zoomHost               String?
+  // The specific pool host an explicit (non-"Automatic") host pick collided with, kept even
+  // though zoomHost itself is null on that failure -- lets computeConflicts (util/
+  // resourceOverlap.ts) still bucket this meeting against whichever meeting holds that host,
+  // instead of the conflict silently vanishing because zoomHost has nothing to bucket on.
+  attemptedZoomHost      String?
   zoomSyncError          String?
   deletedAt              DateTime?
   updatedAt              DateTime?            @updatedAt

--- a/frontend/tests/integration/update-meeting-route.test.ts
+++ b/frontend/tests/integration/update-meeting-route.test.ts
@@ -483,6 +483,11 @@ test("confirmOverride: true bypasses the zoomHost reassignment block, tears down
   expect(afterSync?.zoomHost).toBeNull();
   expect(afterSync?.zoomSyncStatus).toBe("error");
   expect(afterSync?.zoomSyncError).toMatch(/conflicts with another meeting/i);
+  // Regression coverage: the losing host pick must still be recorded so the Diagnostics
+  // Conflicts panel can bucket this meeting against busyHost's holder (see computeConflicts'
+  // attemptedZoomHost fallback in util/resourceOverlap.ts) — previously this was discarded
+  // entirely, leaving a real conflict invisible in that panel.
+  expect(afterSync?.attemptedZoomHost).toBe(busyHost);
 });
 
 test("editing a meeting whose scheduled resume date has already passed promotes the pre-created resume series first", async () => {

--- a/frontend/tests/integration/write-meeting-route.test.ts
+++ b/frontend/tests/integration/write-meeting-route.test.ts
@@ -292,6 +292,11 @@ test("confirmOverride: true bypasses the zoomHost conflict block, creates the me
   // a specific error, not the generic "pool exhausted" one.
   expect(created.zoomHost).toBeNull();
   expect(created.zoomSyncError).toMatch(/conflicts with another meeting/i);
+  // Regression coverage: the losing host pick must still be recorded so the Diagnostics
+  // Conflicts panel can bucket this meeting against conflictHost's holder (see
+  // computeConflicts' attemptedZoomHost fallback in util/resourceOverlap.ts) — previously this
+  // was discarded entirely, leaving a real conflict invisible in that panel.
+  expect(created.attemptedZoomHost).toBe(conflictHost);
 
   const afterSync = await waitForGoogleSyncStatus(created.mid);
   expect(afterSync?.googleSyncStatus).toBe("pending");

--- a/frontend/tests/unit/resourceOverlap.test.ts
+++ b/frontend/tests/unit/resourceOverlap.test.ts
@@ -238,6 +238,30 @@ describe("computeConflicts", () => {
     expect(conflicts[0].field).toBe("zoomHost");
   });
 
+  it("flags a zoomHost conflict via attemptedZoomHost when the losing meeting's zoomHost is null", () => {
+    // Reproduces the ABC/MRAO bug: an explicit host pick that lost out to another meeting is
+    // persisted with zoomHost: null (see write/meeting/route.ts), so it has nothing to bucket
+    // on under the raw "zoomHost" field despite already carrying a recorded zoomSyncError for
+    // exactly this collision. attemptedZoomHost is the fallback that keeps it visible here.
+    const withHost: ConflictCandidateMeeting = { ...baseMeeting, zoomHost: "host1@icr.test" };
+    const losingMeeting: ConflictCandidateMeeting = {
+      ...baseMeeting,
+      mid: "m2",
+      title: "Meeting Two",
+      room: "Unity Room",
+      zoomHost: null,
+      attemptedZoomHost: "host1@icr.test",
+      startDateTime: utcDate(2026, 7, 6, 19, 30),
+      endDateTime: utcDate(2026, 7, 6, 20, 30),
+    };
+
+    const conflicts = computeConflicts([withHost, losingMeeting]);
+    expect(conflicts).toHaveLength(1);
+    expect(conflicts[0].field).toBe("zoomHost");
+    expect(conflicts[0].value).toBe("host1@icr.test");
+    expect(conflicts[0].meetings.map((m) => m.mid).sort()).toEqual(["m1", "m2"]);
+  });
+
   it("does not flag two suspended meetings sharing a room (room conflicts still exclude suspended)", () => {
     const meetingOne: ConflictCandidateMeeting = { ...baseMeeting, suspensions: suspendedIndefinitely };
     const meetingTwo: ConflictCandidateMeeting = {

--- a/frontend/util/resourceOverlap.ts
+++ b/frontend/util/resourceOverlap.ts
@@ -51,6 +51,10 @@ export type ConflictCandidateMeeting = OccurrenceInput & {
   room: string;
   zoomRoom?: string | null;
   zoomHost?: string | null;
+  // The pool host an explicit pick collided with when zoomHost itself is null -- see the
+  // attemptedZoomHost field comment in schema.prisma. Only ever a fallback: real zoomHost
+  // values always take precedence when bucketing conflicts by field below.
+  attemptedZoomHost?: string | null;
   status?: string | null;
   calType?: string[];
   suspensions?: SuspensionWindow[];
@@ -325,7 +329,11 @@ export function computeConflicts(
   (["room", "zoomRoom", "zoomHost"] as const).forEach((field) => {
     const buckets = new Map<string, ConflictCandidateMeeting[]>();
     for (const meeting of fieldMeetings[field]) {
-      const value = meeting[field];
+      // A meeting whose explicit zoomHost pick lost out to another meeting has zoomHost: null
+      // (nothing was actually assigned) but still real-y wants that host -- bucket it under
+      // attemptedZoomHost so it still pairs up against whoever holds it, instead of the
+      // already-known conflict (see its zoomSyncError) silently vanishing from this panel.
+      const value = field === "zoomHost" ? (meeting.zoomHost ?? meeting.attemptedZoomHost) : meeting[field];
       if (!value) continue;
       const bucket = buckets.get(value);
       if (bucket) bucket.push(meeting);


### PR DESCRIPTION
Resolves #315

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Zoom host conflict detection and diagnostics, including cases where a selected host could not be assigned.
  * Preserved the attempted Zoom host when scheduling or updating meetings with conflicting selections.
* **Bug Fixes**
  * Conflict reports now correctly identify collisions involving unassigned Zoom hosts.
  * Clearing Zoom from a meeting now removes its attempted host selection.
* **Tests**
  * Added coverage for host conflicts during meeting creation, updates, and conflict computation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description
- **prisma/schema.prisma, prisma/migrations/20260806093057_add_attempted_zoom_host/**: added `Meeting.attemptedZoomHost` — the specific pool host an explicit (non-"Automatic") pick collided with, kept even though `zoomHost` itself is null on that failure.
- **util/resourceOverlap.ts**: `computeConflicts` falls back to `attemptedZoomHost` when bucketing by `zoomHost` and the real value is null, so a meeting whose host pick lost a collision still pairs against whoever holds that host instead of silently vanishing from the Diagnostics Conflicts panel.
- **app/api/write/meeting/route.ts, update/meeting/route.ts**: persist `attemptedZoomHost` alongside the existing zoomHost-conflict handling.
- **app/api/admin/diagnostics/route.ts, admin/conflict-mids/route.ts**: added `attemptedZoomHost` to the `select` so the panel-facing routes actually return it.
- **tests/unit/resourceOverlap.test.ts, tests/integration/{write,update}-meeting-route.test.ts**: regression coverage — reproduces the bug directly (a losing host pick with `zoomHost: null` must still bucket via `attemptedZoomHost`) and confirms the field is actually persisted end-to-end.

Reimplements a fix originally built on Mongo (parked, unmerged, on `fix/diagnostics-conflicts-null-zoom-host`) against the Postgres schema from #306. Considered and rejected implementing this as a Postgres `EXCLUDE USING gist` constraint instead — this is a read-side display bug, not a write-time integrity gap, so there's no invalid row for a DB constraint to reject. See #317 / `docs/02-handoff/technical-decisions.md`'s "Write-Time Conflict Race" section for the fuller reasoning (that section covers the actual write-time constraint question this one doesn't need).

## Testing
- [x] `yarn test:unit` — new `resourceOverlap.test.ts` case: a losing host pick (`zoomHost: null`, `attemptedZoomHost` set) is correctly bucketed against the winning meeting
- [x] `yarn test:integration` — new assertions in `write-meeting-route.test.ts`/`update-meeting-route.test.ts` confirming `attemptedZoomHost` is actually persisted after a real 409-then-override round trip
- [x] Full `yarn test:all` green

## Area(s) Touched
**Product areas**
- [x] admin

**Integrations**
- [x] zoom-api

**Engineering**
- [ ] security
- [x] testing
- [ ] github-actions
- [ ] cleanup
- [ ] documentation

## Pre-merge Checklist
- [x] Code follows current formatting conventions and passes lint (`yarn lint`).
- [x] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
- [x] All test suites pass, both run locally and green in GitHub CI. **Do not merge if any test suite is failing.**
- [x] A test suite was added or updated for the feature/fix in this PR.
- [x] Only files relevant to this change are committed — no stray or unrelated files.
- [x] If this branch has a merge conflict with master, master was merged into this branch first (not the other way around).
- [x] The rest of this PR description (Description, Testing) is filled out, not left as template placeholders.
