### PR TITLE
feat(export): add field-selection config to Export Meetings XLSX

### DIFF
--- a/frontend/app/api/export/meetings/route.ts
+++ b/frontend/app/api/export/meetings/route.ts
@@ -1,7 +1,12 @@
 import * as XLSX from "xlsx";
 import { Role } from "@prisma/client";
 import { requireRole } from "../../../../services/auth";
-import { formatDayColumn, formatFrequencyColumn } from "../../../../util/recurrenceDisplay";
+import { formatRecurrencePattern } from "../../../../util/recurrenceDisplay";
+import {
+  ALL_MEETING_EXPORT_FIELD_KEYS,
+  sanitizeMeetingExportFields,
+  type MeetingExportFieldKey,
+} from "../../../../util/meetingExportFields";
 import { prisma } from "../../../../lib/prisma";
 
 const notDeleted = { deletedAt: null };
@@ -28,18 +33,6 @@ function formatETDate(date: Date): string {
   }).format(date);
 }
 
-// Combines the per-category GCal event ID map into one cell (e.g. "AA: abc123, Al-Anon: def456").
-// Falls back to the legacy singular googleCalendarEventId for meetings synced before the
-// per-category map existed, since a "full backup" should still capture those IDs.
-function formatGoogleCalendarEventIds(meeting: MeetingWithRecurrence): string {
-  const map = (meeting.googleCalendarEventIds ?? {}) as Record<string, string>;
-  const entries = Object.entries(map).filter(([, id]) => id);
-  if (entries.length > 0) {
-    return entries.map(([category, id]) => `${category}: ${id}`).join(", ");
-  }
-  return meeting.googleCalendarEventId ?? "";
-}
-
 function formatETTime(date: Date): string {
   const parts = new Intl.DateTimeFormat("en-US", {
     timeZone: "America/New_York",
@@ -52,6 +45,29 @@ function formatETTime(date: Date): string {
   const dayPeriod = (parts.find((p) => p.type === "dayPeriod")?.value ?? "AM").toUpperCase();
   return `${hour}:${minute} ${dayPeriod}`;
 }
+
+// One entry per optional field key -- the export route and the config UI both derive their
+// column list from util/meetingExportFields.ts, so this is the only place that needs to know
+// how to actually compute a given field's cell value.
+const FIELD_COLUMN: Record<MeetingExportFieldKey, { label: string; value: (m: MeetingWithRecurrence) => string }> = {
+  status: { label: "Status", value: (m) => m.status ?? "Active" },
+  category: { label: "Category", value: (m) => m.calType.map((c) => CATEGORY_LABELS[c] ?? c).join(", ") },
+  locationType: { label: "Location Type", value: (m) => LOCATION_TYPE_LABELS[m.modeType] ?? m.modeType },
+  physicalRoom: { label: "Physical Room", value: (m) => m.room },
+  zoomRoom: { label: "Zoom Room", value: (m) => m.zoomRoom ?? "" },
+  zoomLink: { label: "Zoom Link", value: (m) => m.zoomLink ?? "" },
+  zoomHost: { label: "Zoom Host", value: (m) => m.zoomHost ?? "" },
+  description: { label: "Description", value: (m) => m.description },
+  // Bundled rather than two separate Day/Frequency columns -- an every-day pattern used to
+  // render as the contradictory "Daily" (Day) / "Weekly" (Frequency) pair; this reuses the
+  // same recurrence-summary logic as ViewMeeting.tsx's own recurrence line.
+  dayFrequency: { label: "Day / Frequency", value: (m) => formatRecurrencePattern(m.recurrencePattern) },
+  startDate: { label: "Start Date", value: (m) => formatETDate(m.startDateTime) },
+  startTime: { label: "Start Time", value: (m) => formatETTime(m.startDateTime) },
+  endDate: { label: "End Date", value: (m) => formatETDate(m.endDateTime) },
+  endTime: { label: "End Time", value: (m) => formatETTime(m.endDateTime) },
+  contactEmail: { label: "Contact Email", value: (m) => m.email },
+};
 
 async function loadMeetings() {
   return prisma.meeting.findMany({
@@ -66,27 +82,29 @@ export const GET = async () => {
     const auth = await requireRole(Role.SUPER_ADMIN);
     if (auth instanceof Response) return auth;
 
-    const meetings = await loadMeetings();
+    const [meetings, settings] = await Promise.all([
+      loadMeetings(),
+      prisma.meetingExportSettings.findFirst(),
+    ]);
+    const selectedFields = new Set(
+      settings ? sanitizeMeetingExportFields(settings.fields) : ALL_MEETING_EXPORT_FIELD_KEYS,
+    );
 
-    const rows = meetings.map((meeting, i) => ({
-      "Meeting ID": `M${String(i + 1).padStart(3, "0")}`,
-      "Meeting Name": meeting.title,
-      Status: meeting.status ?? "Active",
-      Category: meeting.calType.map((c) => CATEGORY_LABELS[c] ?? c).join(", "),
-      Day: formatDayColumn(meeting.recurrencePattern),
-      Frequency: formatFrequencyColumn(meeting.recurrencePattern),
-      "Start Date": formatETDate(meeting.startDateTime),
-      "Start Time": formatETTime(meeting.startDateTime),
-      "End Date": formatETDate(meeting.endDateTime),
-      "End Time": formatETTime(meeting.endDateTime),
-      "Location Type": LOCATION_TYPE_LABELS[meeting.modeType] ?? meeting.modeType,
-      "Physical Room": meeting.room,
-      "Zoom Room": meeting.zoomRoom ?? "",
-      "Contact Email": meeting.email,
-      Description: meeting.description,
-      "Google Calendar Event ID": formatGoogleCalendarEventIds(meeting),
-      "Zoom Meeting ID": meeting.zid ?? "",
-    }));
+    const rows = meetings.map((meeting, i) => {
+      // Meeting ID and Meeting Name are never optional -- everything else is only included if
+      // selected, in the same order as the field registry (matching the config UI's grouping).
+      const row: Record<string, string> = {
+        "Meeting ID": `M${String(i + 1).padStart(3, "0")}`,
+        "Meeting Name": meeting.title,
+      };
+      for (const key of ALL_MEETING_EXPORT_FIELD_KEYS) {
+        if (selectedFields.has(key)) {
+          const column = FIELD_COLUMN[key];
+          row[column.label] = column.value(meeting);
+        }
+      }
+      return row;
+    });
 
     const worksheet = XLSX.utils.json_to_sheet(rows);
     const workbook = XLSX.utils.book_new();

--- a/frontend/app/api/retrieve/meeting-export-settings/route.ts
+++ b/frontend/app/api/retrieve/meeting-export-settings/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from "next/server";
+import { Role } from "@prisma/client";
+import { requireRole } from "../../../../services/auth";
+import { ALL_MEETING_EXPORT_FIELD_KEYS, sanitizeMeetingExportFields } from "../../../../util/meetingExportFields";
+import { prisma } from "../../../../lib/prisma";
+
+export const GET = async () => {
+  try {
+    const auth = await requireRole(Role.SUPER_ADMIN);
+    if (auth instanceof Response) return auth;
+
+    const [settings, total] = await Promise.all([
+      prisma.meetingExportSettings.findFirst(),
+      prisma.meeting.count({ where: { deletedAt: null } }),
+    ]);
+
+    // No saved row yet -- default to every field selected, matching the export's prior
+    // unconditional "full backup" behavior until a Super Admin narrows it down.
+    const fields = settings ? sanitizeMeetingExportFields(settings.fields) : ALL_MEETING_EXPORT_FIELD_KEYS;
+
+    return NextResponse.json({ fields, total });
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+  }
+};

--- a/frontend/app/api/update/meeting-export-settings/route.ts
+++ b/frontend/app/api/update/meeting-export-settings/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from "next/server";
+import { Role } from "@prisma/client";
+import { requireRole } from "../../../../services/auth";
+import { sanitizeMeetingExportFields } from "../../../../util/meetingExportFields";
+import { prisma } from "../../../../lib/prisma";
+
+// Singleton settings row — updates the existing row if one exists, else creates it.
+export const PUT = async (request: Request) => {
+  try {
+    const auth = await requireRole(Role.SUPER_ADMIN);
+    if (auth instanceof Response) return auth;
+
+    const body = await request.json() as { fields: string[] };
+    // Sanitized, not trusted as-is -- drops anything that isn't a currently-known field key
+    // (e.g. a stale client sending a since-removed key).
+    const fields = sanitizeMeetingExportFields(body.fields ?? []);
+
+    const existing = await prisma.meetingExportSettings.findFirst();
+    const saved = existing
+      ? await prisma.meetingExportSettings.update({ where: { id: existing.id }, data: { fields } })
+      : await prisma.meetingExportSettings.create({ data: { fields } });
+
+    return NextResponse.json({ fields: saved.fields });
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+  }
+};

--- a/frontend/app/api/update/meeting-export-settings/route.ts
+++ b/frontend/app/api/update/meeting-export-settings/route.ts
@@ -10,10 +10,13 @@ export const PUT = async (request: Request) => {
     const auth = await requireRole(Role.SUPER_ADMIN);
     if (auth instanceof Response) return auth;
 
-    const body = await request.json() as { fields: string[] };
+    const body = await request.json() as { fields?: unknown };
+    if (body.fields !== undefined && !Array.isArray(body.fields)) {
+      return NextResponse.json({ error: "fields must be an array." }, { status: 400 });
+    }
     // Sanitized, not trusted as-is -- drops anything that isn't a currently-known field key
     // (e.g. a stale client sending a since-removed key).
-    const fields = sanitizeMeetingExportFields(body.fields ?? []);
+    const fields = sanitizeMeetingExportFields((body.fields as string[] | undefined) ?? []);
 
     const existing = await prisma.meetingExportSettings.findFirst();
     const saved = existing

--- a/frontend/app/components/admin/export/ExportTab.tsx
+++ b/frontend/app/components/admin/export/ExportTab.tsx
@@ -439,19 +439,24 @@ const ExportTab: React.FC = () => {
   };
 
   const handleSaveMeetingExportFields = async (fields: MeetingExportFieldKey[]) => {
-    const response = await fetch("/api/update/meeting-export-settings", {
-      method: "PUT",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ fields }),
-    });
-    if (!response.ok) {
-      const json = await response.json().catch(() => ({}));
-      alert(json.error ?? "Failed to save export field settings.");
-      return;
+    try {
+      const response = await fetch("/api/update/meeting-export-settings", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ fields }),
+      });
+      if (!response.ok) {
+        const json = await response.json().catch(() => ({}));
+        alert(json.error ?? "Failed to save export field settings.");
+        return;
+      }
+      const saved: { fields: MeetingExportFieldKey[] } = await response.json();
+      setMeetingExportFields(saved.fields);
+      setMeetingConfigOpen(false);
+    } catch (err) {
+      console.error("Error saving meeting export settings:", err);
+      alert("Failed to save export field settings.");
     }
-    const saved: { fields: MeetingExportFieldKey[] } = await response.json();
-    setMeetingExportFields(saved.fields);
-    setMeetingConfigOpen(false);
   };
 
   const meetingsFilename = `ithaca-recovery-meetings-${todayISO()}.xlsx`;

--- a/frontend/app/components/admin/export/ExportTab.tsx
+++ b/frontend/app/components/admin/export/ExportTab.tsx
@@ -13,9 +13,11 @@ import {
 } from "../../../../util/signageFilters";
 import { ROOM_COLORS, ZOOM_ROOM_COLOR, CATEGORY_COLOR } from "../../../../util/filterColors";
 import type { ILeaseSettings, IRoomRate } from "../../../../util/models";
+import { ALL_MEETING_EXPORT_FIELD_KEYS, type MeetingExportFieldKey } from "../../../../util/meetingExportFields";
 import FilterGroup, { FilterGroupItem } from "../../shared/FilterGroup";
 import Card from "../shared/Card";
 import CardHeader from "../shared/CardHeader";
+import MeetingExportConfigModal from "./MeetingExportConfigModal";
 import { flags } from "../../../../lib/flags";
 import styles from "../../../../styles/components/admin/ExportTab.module.scss";
 
@@ -360,6 +362,10 @@ const ExportTab: React.FC = () => {
   const [downloading, setDownloading] = useState<ExportKind | null>(null);
   const [downloaded, setDownloaded] = useState<ExportKind | null>(null);
   const [exportError, setExportError] = useState<string | null>(null);
+  const [meetingExportFields, setMeetingExportFields] = useState<MeetingExportFieldKey[] | null>(null);
+  const [meetingExportTotal, setMeetingExportTotal] = useState(0);
+  const [meetingSettingsError, setMeetingSettingsError] = useState<string | null>(null);
+  const [meetingConfigOpen, setMeetingConfigOpen] = useState(false);
 
   const loadLeaseSettings = async () => {
     try {
@@ -374,13 +380,27 @@ const ExportTab: React.FC = () => {
     }
   };
 
+  const loadMeetingExportSettings = async () => {
+    try {
+      const response = await fetch("/api/retrieve/meeting-export-settings");
+      if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
+      const json: { fields: MeetingExportFieldKey[]; total: number } = await response.json();
+      setMeetingExportFields(json.fields);
+      setMeetingExportTotal(json.total);
+      setMeetingSettingsError(null);
+    } catch (err) {
+      console.error("Error loading meeting export settings:", err);
+      setMeetingSettingsError("Failed to load export field settings.");
+    }
+  };
+
   useEffect(() => {
-    if (!flags.exportCsv) return;
-    
     // Async fetch-then-set; the lint rule can't see the setState calls sit after an
     // await, so this is a false positive for the standard "load on mount" pattern.
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    loadLeaseSettings();
+    /* eslint-disable react-hooks/set-state-in-effect */
+    if (flags.exportCsv) loadLeaseSettings();
+    if (flags.exportXlsx) loadMeetingExportSettings();
+    /* eslint-enable react-hooks/set-state-in-effect */
   }, []);
 
   const handleExport = async (kind: ExportKind) => {
@@ -418,6 +438,22 @@ const ExportTab: React.FC = () => {
     setConfigOpen(false);
   };
 
+  const handleSaveMeetingExportFields = async (fields: MeetingExportFieldKey[]) => {
+    const response = await fetch("/api/update/meeting-export-settings", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ fields }),
+    });
+    if (!response.ok) {
+      const json = await response.json().catch(() => ({}));
+      alert(json.error ?? "Failed to save export field settings.");
+      return;
+    }
+    const saved: { fields: MeetingExportFieldKey[] } = await response.json();
+    setMeetingExportFields(saved.fields);
+    setMeetingConfigOpen(false);
+  };
+
   const meetingsFilename = `ithaca-recovery-meetings-${todayISO()}.xlsx`;
   const leaseFilename = leaseSettings
     ? `${new Date(leaseSettings.leaseStartDate).getUTCFullYear()} - ${new Date(leaseSettings.leaseEndDate).getUTCFullYear()} Bulk Send Lease.csv`
@@ -425,18 +461,35 @@ const ExportTab: React.FC = () => {
   const leaseSummary = leaseSettings
     ? `Currently: ${formatDateShort(leaseSettings.leaseStartDate)} – ${formatDateShort(leaseSettings.leaseEndDate)} · ${leaseSettings.rooms.length} room rates configured`
     : "Loading settings…";
+  const meetingExportSummary = meetingExportFields
+    ? `Currently: ${meetingExportTotal} meetings · ${meetingExportFields.length} of ${ALL_MEETING_EXPORT_FIELD_KEYS.length} fields`
+    : "Loading settings…";
 
   return (
     <div className={styles.container}>
       {exportError && <div className={styles.errorBanner}>{exportError}</div>}
       {settingsError && <div className={styles.errorBanner}>{settingsError}</div>}
+      {meetingSettingsError && <div className={styles.errorBanner}>{meetingSettingsError}</div>}
 
       <div className={styles.grid}>
         {flags.exportXlsx && (
           <Card className={styles.exportCard}>
-            <CardHeader icon={<BackupIcon />} title="Export Meetings (XLSX)" />
+            <CardHeader
+              icon={<BackupIcon />}
+              title="Export Meetings (XLSX)"
+              action={{
+                label: "Configure",
+                onClick: () => setMeetingConfigOpen(true),
+                ariaLabel: "Configure export fields",
+                title: "Configure export fields…",
+                disabled: !meetingExportFields,
+              }}
+            />
             <div className={styles.cardDesc}>
               Full backup of every meeting. Include meeting mode, room, contact, and schedule fields.
+            </div>
+            <div className={styles.summaryRow}>
+              <span className={styles.summaryText}>{meetingExportSummary}</span>
             </div>
             <div className={styles.cardFooter}>
               <div className={styles.filename}>{meetingsFilename}</div>
@@ -507,6 +560,14 @@ const ExportTab: React.FC = () => {
           initial={leaseSettings}
           onCancel={() => setConfigOpen(false)}
           onSave={handleSaveSettings}
+        />
+      )}
+
+      {meetingConfigOpen && meetingExportFields && (
+        <MeetingExportConfigModal
+          initialFields={meetingExportFields}
+          onCancel={() => setMeetingConfigOpen(false)}
+          onSave={handleSaveMeetingExportFields}
         />
       )}
     </div>

--- a/frontend/app/components/admin/export/MeetingExportConfigModal.tsx
+++ b/frontend/app/components/admin/export/MeetingExportConfigModal.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import React, { useState } from "react";
+import FilterGroup, { FilterGroupItem } from "../../shared/FilterGroup";
+import { MEETING_EXPORT_FIELD_GROUPS, type MeetingExportFieldKey } from "../../../../util/meetingExportFields";
+import styles from "../../../../styles/components/admin/ExportTab.module.scss";
+
+interface MeetingExportConfigModalProps {
+  initialFields: MeetingExportFieldKey[];
+  onCancel: () => void;
+  onSave: (fields: MeetingExportFieldKey[]) => Promise<void>;
+}
+
+// A single neutral color for every checkbox's checked-state fill -- these are field toggles,
+// not a color-coded palette like FilterGroup's usual room/category filter chips.
+const FIELD_CHECKBOX_COLOR = "#CC3366";
+
+const groupItems = (name: string): FilterGroupItem[] =>
+  (MEETING_EXPORT_FIELD_GROUPS.find((g) => g.group === name)?.fields ?? []).map((f) => ({
+    key: f.key,
+    label: f.label,
+    color: FIELD_CHECKBOX_COLOR,
+  }));
+
+const MEETING_FIELDS = groupItems("Meeting");
+const SCHEDULE_FIELDS = groupItems("Schedule");
+const CONTACT_FIELDS = groupItems("Contact");
+
+const MeetingExportConfigModal: React.FC<MeetingExportConfigModalProps> = ({ initialFields, onCancel, onSave }) => {
+  const [checked, setChecked] = useState<Record<string, boolean>>(() =>
+    Object.fromEntries(initialFields.map((f) => [f, true])),
+  );
+  const [saving, setSaving] = useState(false);
+
+  const toggle = (key: string, value: boolean) => setChecked((prev) => ({ ...prev, [key]: value }));
+
+  const handleSave = async () => {
+    setSaving(true);
+    try {
+      const fields = Object.entries(checked)
+        .filter(([, isChecked]) => isChecked)
+        .map(([key]) => key) as MeetingExportFieldKey[];
+      await onSave(fields);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className={styles.modalOverlay} onClick={onCancel}>
+      <div className={styles.modal} onClick={(e) => e.stopPropagation()}>
+        <h3 className={styles.modalTitle}>Configure meeting export</h3>
+        <p className={styles.modalIntro}>
+          Meeting ID and Meeting Name are always included. Pick which other fields the export should have.
+        </p>
+
+        <div className={styles.filterGrid}>
+          <FilterGroup title="MEETING" items={MEETING_FIELDS} checked={checked} onToggle={toggle} />
+          <div>
+            <FilterGroup title="SCHEDULE" items={SCHEDULE_FIELDS} checked={checked} onToggle={toggle} />
+            <div className={styles.stackedGroup}>
+              <FilterGroup title="CONTACT" items={CONTACT_FIELDS} checked={checked} onToggle={toggle} />
+            </div>
+          </div>
+        </div>
+
+        <div className={styles.modalActions}>
+          <button className={styles.cancelButton} onClick={onCancel}>Cancel</button>
+          <button className={styles.saveButton} onClick={handleSave} disabled={saving}>
+            {saving ? "Saving…" : "Save"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default MeetingExportConfigModal;

--- a/frontend/app/components/admin/shared/CardHeader.tsx
+++ b/frontend/app/components/admin/shared/CardHeader.tsx
@@ -4,7 +4,12 @@ import React from "react";
 import styles from "../../../../styles/components/admin/CardHeader.module.scss";
 
 interface CardHeaderAction {
-  icon: React.ReactNode;
+  // Icon-only kebab-style button when `icon` is set; a labeled brand-pink button when `label`
+  // is set instead. A kebab implies a menu of choices -- when a card only ever has exactly one
+  // action (e.g. "Configure"), a labeled button is the honest affordance, not a kebab hiding one
+  // item.
+  icon?: React.ReactNode;
+  label?: string;
   onClick: () => void;
   ariaLabel: string;
   title?: string;
@@ -23,13 +28,13 @@ const CardHeader: React.FC<CardHeaderProps> = ({ icon, title, action }) => (
     <div className={styles.cardTitle}>{title}</div>
     {action && (
       <button
-        className={styles.menuButton}
+        className={action.label ? styles.configureButton : styles.menuButton}
         aria-label={action.ariaLabel}
         title={action.title ?? action.ariaLabel}
         onClick={action.onClick}
         disabled={action.disabled}
       >
-        {action.icon}
+        {action.label ?? action.icon}
       </button>
     )}
   </div>

--- a/frontend/prisma/migrations/20260807120000_add_meeting_export_settings/migration.sql
+++ b/frontend/prisma/migrations/20260807120000_add_meeting_export_settings/migration.sql
@@ -1,0 +1,8 @@
+-- CreateTable
+CREATE TABLE "MeetingExportSettings" (
+    "id" TEXT NOT NULL,
+    "fields" TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "MeetingExportSettings_pkey" PRIMARY KEY ("id")
+);

--- a/frontend/prisma/schema.prisma
+++ b/frontend/prisma/schema.prisma
@@ -131,3 +131,11 @@ model LeaseSettings {
   emailTemplate   String
   updatedAt       DateTime @updatedAt
 }
+
+// Singleton — which optional columns the Export Meetings (XLSX) download includes. Meeting ID
+// and Meeting Name are always exported regardless of this list, so they're never stored here.
+model MeetingExportSettings {
+  id        String   @id @default(cuid())
+  fields    String[] @default([])
+  updatedAt DateTime @updatedAt
+}

--- a/frontend/styles/components/admin/CardHeader.module.scss
+++ b/frontend/styles/components/admin/CardHeader.module.scss
@@ -38,3 +38,25 @@
     opacity: 0.5;
   }
 }
+
+.configureButton {
+  background: $brand-pink-color;
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  padding: 6px 14px;
+  font-family: inherit;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+
+  &:hover:not(:disabled) {
+    background: $brand-pink-secondary;
+  }
+
+  &:disabled {
+    background: $light-grey-color;
+    cursor: not-allowed;
+  }
+}

--- a/frontend/styles/components/admin/ExportTab.module.scss
+++ b/frontend/styles/components/admin/ExportTab.module.scss
@@ -352,6 +352,13 @@
   }
 }
 
+// Spacing between two caption-variant FilterGroups stacked in one .filterGrid column --
+// FilterGroup's own .groupSpaced margin is tied to the bigger "title" heading variant, which
+// we don't want here.
+.stackedGroup {
+  margin-top: 20px;
+}
+
 .viewToggle {
   display: inline-flex;
   gap: 8px;

--- a/frontend/styles/components/shared/FilterGroup.module.scss
+++ b/frontend/styles/components/shared/FilterGroup.module.scss
@@ -36,16 +36,13 @@
 .selectAllToggle {
   background: none;
   border: none;
-  color: $brand-pink-color;
+  color: $medium-grey-color;
   font-family: inherit;
   font-size: 12px;
   font-weight: 600;
   cursor: pointer;
   padding: 0;
-
-  &:hover {
-    text-decoration: underline;
-  }
+  text-decoration: underline;
 }
 
 .coloredRow {

--- a/frontend/util/meetingExportFields.ts
+++ b/frontend/util/meetingExportFields.ts
@@ -1,0 +1,69 @@
+// Shared by the Export Meetings config UI and the export route itself, so the two can never
+// drift on what a field key means or which group it belongs to. Meeting ID and Meeting Name
+// are exported unconditionally and intentionally have no entry here -- they aren't a choice.
+
+export type MeetingExportFieldKey =
+  | "status"
+  | "category"
+  | "locationType"
+  | "physicalRoom"
+  | "zoomRoom"
+  | "zoomLink"
+  | "zoomHost"
+  | "description"
+  | "dayFrequency"
+  | "startDate"
+  | "startTime"
+  | "endDate"
+  | "endTime"
+  | "contactEmail";
+
+interface MeetingExportFieldGroup {
+  group: string;
+  fields: { key: MeetingExportFieldKey; label: string }[];
+}
+
+// Grouped by the three things an admin thinks in -- what the meeting is, when it happens, who
+// to contact -- rather than one flat list of fourteen checkboxes.
+export const MEETING_EXPORT_FIELD_GROUPS: MeetingExportFieldGroup[] = [
+  {
+    group: "Meeting",
+    fields: [
+      { key: "status", label: "Status" },
+      { key: "category", label: "Category" },
+      { key: "locationType", label: "Location Type" },
+      { key: "physicalRoom", label: "Physical Room" },
+      { key: "zoomRoom", label: "Zoom Room" },
+      { key: "zoomLink", label: "Zoom Link" },
+      { key: "zoomHost", label: "Zoom Host" },
+      { key: "description", label: "Description" },
+    ],
+  },
+  {
+    group: "Schedule",
+    fields: [
+      { key: "dayFrequency", label: "Day / Frequency" },
+      { key: "startDate", label: "Start Date" },
+      { key: "startTime", label: "Start Time" },
+      { key: "endDate", label: "End Date" },
+      { key: "endTime", label: "End Time" },
+    ],
+  },
+  {
+    group: "Contact",
+    fields: [
+      { key: "contactEmail", label: "Contact Email" },
+    ],
+  },
+];
+
+export const ALL_MEETING_EXPORT_FIELD_KEYS: MeetingExportFieldKey[] =
+  MEETING_EXPORT_FIELD_GROUPS.flatMap((g) => g.fields.map((f) => f.key));
+
+const VALID_KEYS = new Set<string>(ALL_MEETING_EXPORT_FIELD_KEYS);
+
+// Drops anything that isn't a currently-known field key -- guards against a stale saved
+// selection referencing a field that's since been renamed or removed from the registry above.
+export function sanitizeMeetingExportFields(fields: string[]): MeetingExportFieldKey[] {
+  return fields.filter((f): f is MeetingExportFieldKey => VALID_KEYS.has(f));
+}


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable meeting XLSX exports, allowing administrators to choose fields grouped by Meeting, Schedule, and Contact.
  * Added a configuration dialog with field selection, save, cancel, loading, and error states.
  * Export files now include only selected optional columns while always including meeting ID and name.
* **UI Improvements**
  * Added configuration styling and clearer export field summaries.
  * Updated selection controls for improved visibility and consistency.
* **Bug Fixes**
  * Export formatting now consistently handles recurrence, dates, times, locations, links, and contact details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description
- **util/meetingExportFields.ts**: new field registry — 13 optional fields grouped Meeting/Schedule/Contact (Meeting ID and Meeting Name are always included, never optional); Day/Frequency bundled into one field reusing the existing `formatRecurrencePattern()` so a daily meeting shows "Daily" once instead of the contradictory Day/Frequency pair a naive split would produce.
- **app/api/retrieve|update/meeting-export-settings/route.ts**: new SUPER_ADMIN-gated routes for the singleton field-selection settings row (same pattern as the existing `LeaseSettings` singleton).
- **app/api/export/meetings/route.ts**: rewritten to read the saved field selection and conditionally include columns; dropped the opaque Google Calendar Event ID / Zoom Meeting ID columns in favor of Zoom Link / Zoom Host, since this export's users are mostly non-technical.
- **app/components/admin/export/MeetingExportConfigModal.tsx**: new modal reusing the existing `FilterGroup`/`LabeledCheckbox` components for the grouped checkboxes, laid out in a 2-column grid (mirrors the Signage URL card's existing paired-groups pattern).
- **app/components/admin/shared/CardHeader.tsx**: `action` prop now supports a labeled brand-pink button (`label`) alongside the existing icon-only kebab (`icon`) — a kebab implies a menu of choices, which is misleading when a card only ever has one action.
- **app/components/admin/export/ExportTab.tsx**: wires up the Configure button, modal, and a "Currently: X meetings · Y of Z fields" summary line on the Export Meetings card.
- **prisma/schema.prisma + migration**: new `MeetingExportSettings` model. The migration file is hand-written rather than `prisma migrate dev`-generated, because the shared dev database had a pre-existing, unrelated checksum-drift issue on an already-applied migration; applied via `prisma migrate deploy` (production-safe path) instead, and later corrected to add `@default([])` on `fields` so the schema matches the DB with zero drift (`prisma migrate diff` confirmed empty).
- **styles/components/shared/FilterGroup.module.scss**: "Select all"/"Clear all" toggle changed from brand-pink to medium-grey + underline (applies to every `FilterGroup` consumer, incl. the Signage URL card and calendar sidebar filters).

## Testing
- `yarn test:all` (362 tests: unit/component/integration/e2e) — all green.
- `yarn lint:css` run explicitly since `.scss` files were touched.
- A dedicated review-agent pass caught a schema/migration default mismatch, fixed and re-verified (`prisma migrate diff` confirms zero drift).
- Manually verified in-browser: Configure modal opens with the 3 grouped sections, toggling fields + Save persists and updates the "Currently:" summary, PandaDocs Lease card is unaffected by this change.

## Area(s) Touched
**Product areas**
- [x] admin — /admin shell (Diagnostics, Users, Import, Export tabs)
- [x] ui/ux — frontend layout/styling not tied to a specific integration

**Integrations**

**Engineering**

## Pre-merge Checklist
- [x] Code follows current formatting conventions and passes lint (`yarn lint`).
- [x] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
- [ ] All test suites pass, both run locally and green in GitHub CI. **Do not merge if any test suite is failing.**
- [ ] A test suite was added or updated for the feature/fix in this PR. **Double-check this if you change a feature and did not update the test suites**.
- [x] Only files relevant to this change are committed — no stray or unrelated files.
- [x] If this branch has a merge conflict with master, master was merged into this branch first (not the other way around).
- [x] The rest of this PR description (Description, Testing) is filled out, not left as template placeholders.

No dedicated test file was added for the field-selection modal itself — covered indirectly by the existing e2e export flow test and the full suite passing, not by new targeted assertions. Flagging per the "search for stale old-behavior assertions" convention rather than checking the box inaccurately.