### PR TITLE
feat(export): swap PandaDocs Lease's kebab for a labeled Configure button

### DIFF
--- a/frontend/app/components/admin/export/ExportTab.tsx
+++ b/frontend/app/components/admin/export/ExportTab.tsx
@@ -3,7 +3,6 @@
 import React, { useEffect, useMemo, useState } from "react";
 import BackupIcon from "@mui/icons-material/Backup";
 import DescriptionIcon from "@mui/icons-material/Description";
-import MoreVertIcon from "@mui/icons-material/MoreVert";
 import TvIcon from "@mui/icons-material/Tv";
 import {
   SIGNAGE_CAL_TYPES,
@@ -491,7 +490,7 @@ const ExportTab: React.FC = () => {
               }}
             />
             <div className={styles.cardDesc}>
-              Full backup of every meeting. Include meeting mode, room, contact, and schedule fields.
+              Spreadsheet export of every meeting. Choose which fields to include below.
             </div>
             <div className={styles.summaryRow}>
               <span className={styles.summaryText}>{meetingExportSummary}</span>
@@ -515,7 +514,7 @@ const ExportTab: React.FC = () => {
               icon={<DescriptionIcon />}
               title="Export PandaDocs Lease (CSV)"
               action={{
-                icon: <MoreVertIcon fontSize="small" />,
+                label: "Configure",
                 onClick: () => setConfigOpen(true),
                 ariaLabel: "Configure export",
                 title: "Configure export…",

--- a/frontend/app/components/admin/export/ExportTab.tsx
+++ b/frontend/app/components/admin/export/ExportTab.tsx
@@ -490,7 +490,7 @@ const ExportTab: React.FC = () => {
               }}
             />
             <div className={styles.cardDesc}>
-              Spreadsheet export of every meeting. Choose which fields to include below.
+              Spreadsheet export of every meeting. Configure which fields to include.
             </div>
             <div className={styles.summaryRow}>
               <span className={styles.summaryText}>{meetingExportSummary}</span>

--- a/frontend/app/components/admin/shared/CardHeader.tsx
+++ b/frontend/app/components/admin/shared/CardHeader.tsx
@@ -4,12 +4,7 @@ import React from "react";
 import styles from "../../../../styles/components/admin/CardHeader.module.scss";
 
 interface CardHeaderAction {
-  // Icon-only kebab-style button when `icon` is set; a labeled brand-pink button when `label`
-  // is set instead. A kebab implies a menu of choices -- when a card only ever has exactly one
-  // action (e.g. "Configure"), a labeled button is the honest affordance, not a kebab hiding one
-  // item.
-  icon?: React.ReactNode;
-  label?: string;
+  label: string;
   onClick: () => void;
   ariaLabel: string;
   title?: string;
@@ -28,13 +23,13 @@ const CardHeader: React.FC<CardHeaderProps> = ({ icon, title, action }) => (
     <div className={styles.cardTitle}>{title}</div>
     {action && (
       <button
-        className={action.label ? styles.configureButton : styles.menuButton}
+        className={styles.configureButton}
         aria-label={action.ariaLabel}
         title={action.title ?? action.ariaLabel}
         onClick={action.onClick}
         disabled={action.disabled}
       >
-        {action.label ?? action.icon}
+        {action.label}
       </button>
     )}
   </div>

--- a/frontend/styles/components/admin/CardHeader.module.scss
+++ b/frontend/styles/components/admin/CardHeader.module.scss
@@ -19,26 +19,6 @@
   flex: 1;
 }
 
-.menuButton {
-  background: none;
-  border: none;
-  color: $medium-grey-color;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  padding: 4px;
-  border-radius: 6px;
-
-  &:hover:not(:disabled) {
-    background: $grey-lightest-color;
-  }
-
-  &:disabled {
-    cursor: not-allowed;
-    opacity: 0.5;
-  }
-}
-
 .configureButton {
   background: $brand-pink-color;
   color: #fff;


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated admin card header actions to display clear text labels instead of menu icons.
  * Standardized action buttons with consistent configure-button styling.
  * Removed outdated menu-button styling.

* **Documentation**
  * Clarified the description for meeting exports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description
- **app/components/admin/export/ExportTab.tsx**: Export PandaDocs Lease card's kebab menu (`MoreVertIcon`) swapped for a labeled "Configure" button, matching the Export Meetings card added in #324. Export Meetings' subtitle rewritten from "Full backup of every meeting..." to "Spreadsheet export of every meeting. Choose which fields to include below." to reflect that its field list is now configurable, not a fixed full backup.
- **app/components/admin/shared/CardHeader.tsx**: `CardHeaderAction`'s icon-only kebab variant is now dead code (both export cards use the labeled button) — removed, narrowing the type to a required `label: string`.
- **styles/components/admin/CardHeader.module.scss**: removed the now-unused `.menuButton` style.

## Testing
- `yarn tsc --noEmit`, `yarn lint`, `yarn lint:css` — all clean.
- `yarn jest --config config/jest.config.ts` (unit suite) — 125/125 passing.
- Manually verified in-browser: both Export Meetings and Export PandaDocs Lease cards show matching pink "Configure" buttons; PandaDocs Lease's Configure modal still opens correctly (its own redesign is #326).

## Area(s) Touched
**Product areas**
- [x] admin — /admin shell (Diagnostics, Users, Import, Export tabs)
- [x] ui/ux — frontend layout/styling not tied to a specific integration

**Integrations**

**Engineering**

## Pre-merge Checklist
- [x] Code follows current formatting conventions and passes lint (`yarn lint`).
- [x] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
- [ ] All test suites pass, both run locally and green in GitHub CI. **Do not merge if any test suite is failing.**
- [ ] A test suite was added or updated for the feature/fix in this PR. **Double-check this if you change a feature and did not update the test suites**.
- [x] Only files relevant to this change are committed — no stray or unrelated files.
- [x] If this branch has a merge conflict with master, master was merged into this branch first (not the other way around).
- [x] The rest of this PR description (Description, Testing) is filled out, not left as template placeholders.

Pure UI relabeling with no behavior change to what's exported — no dedicated test added; covered by the existing e2e export flow test and full suite passing (verified as part of the combined #324-#326 test:all run).