### PR TITLE
feat(export): redesign PandaDocs lease config modal, remove feature gates

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -34,7 +34,3 @@ GOOGLE_CALENDAR_ZOOM_CHILDRENS_ROOM_518=
 # Zoom Host Pool (comma-separated licensed Zoom user emails, shared across all rooms —
 # each meeting is assigned an available host at creation time, not tied to a fixed room)
 ZOOM_HOSTS=
-
-# Feature Flags (set to "true" to enable; anything else, including unset, is disabled)
-NEXT_PUBLIC_FEATURE_EXPORT_XLSX=
-NEXT_PUBLIC_FEATURE_EXPORT_CSV=

--- a/frontend/app/api/retrieve/lease-settings/route.ts
+++ b/frontend/app/api/retrieve/lease-settings/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { Role } from "@prisma/client";
 import { requireRole } from "../../../../services/auth";
 import { defaultLeaseSettings } from "../../../../util/leaseDefaults";
+import { computeLeaseYearCycles } from "../../../../util/leaseYearCycles";
 import type { IRoomRate } from "../../../../util/models";
 import { prisma } from "../../../../lib/prisma";
 
@@ -10,15 +11,24 @@ export const GET = async () => {
     const auth = await requireRole(Role.SUPER_ADMIN);
     if (auth instanceof Response) return auth;
 
-    const settings = await prisma.leaseSettings.findFirst();
-    if (!settings) {
-      return NextResponse.json(defaultLeaseSettings());
-    }
+    const [settingsRow, meetingDateRange] = await Promise.all([
+      prisma.leaseSettings.findFirst(),
+      prisma.meeting.aggregate({
+        where: { deletedAt: null },
+        _min: { startDateTime: true },
+        _max: { startDateTime: true },
+      }),
+    ]);
 
-    return NextResponse.json({
-      ...settings,
-      rooms: settings.rooms as unknown as IRoomRate[],
-    });
+    const meetingDates = [meetingDateRange._min.startDateTime, meetingDateRange._max.startDateTime]
+      .filter((date): date is Date => date !== null);
+    const cycles = computeLeaseYearCycles(meetingDates, new Date());
+
+    const settings = settingsRow
+      ? { ...settingsRow, rooms: settingsRow.rooms as unknown as IRoomRate[] }
+      : defaultLeaseSettings();
+
+    return NextResponse.json({ settings, cycles });
   } catch (error) {
     console.error(error);
     return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });

--- a/frontend/app/components/admin/export/ExportTab.tsx
+++ b/frontend/app/components/admin/export/ExportTab.tsx
@@ -11,13 +11,14 @@ import {
   SIGNAGE_ZOOM_SLUGS,
 } from "../../../../util/signageFilters";
 import { ROOM_COLORS, ZOOM_ROOM_COLOR, CATEGORY_COLOR } from "../../../../util/filterColors";
-import type { ILeaseSettings, IRoomRate } from "../../../../util/models";
+import type { ILeaseSettings } from "../../../../util/models";
 import { ALL_MEETING_EXPORT_FIELD_KEYS, type MeetingExportFieldKey } from "../../../../util/meetingExportFields";
+import type { LeaseYearCycle } from "../../../../util/leaseYearCycles";
 import FilterGroup, { FilterGroupItem } from "../../shared/FilterGroup";
 import Card from "../shared/Card";
 import CardHeader from "../shared/CardHeader";
 import MeetingExportConfigModal from "./MeetingExportConfigModal";
-import { flags } from "../../../../lib/flags";
+import LeaseConfigModal from "./LeaseConfigModal";
 import styles from "../../../../styles/components/admin/ExportTab.module.scss";
 
 type ExportKind = "meetings" | "lease";
@@ -57,10 +58,6 @@ function formatDateShort(value: Date | string): string {
     .format(new Date(value));
 }
 
-function toDateInputValue(value: Date | string): string {
-  return new Date(value).toISOString().slice(0, 10);
-}
-
 async function downloadExport(url: string, fallbackFilename: string) {
   const response = await fetch(url);
   if (!response.ok) {
@@ -79,173 +76,6 @@ async function downloadExport(url: string, fallbackFilename: string) {
   document.body.removeChild(link);
   URL.revokeObjectURL(blobUrl);
 }
-
-interface LeaseConfigModalProps {
-  initial: ILeaseSettings;
-  onCancel: () => void;
-  onSave: (next: ILeaseSettings) => Promise<void>;
-}
-
-const LeaseConfigModal: React.FC<LeaseConfigModalProps> = ({ initial, onCancel, onSave }) => {
-  const [draft, setDraft] = useState<ILeaseSettings>(initial);
-  const [saving, setSaving] = useState(false);
-
-  const dateError = new Date(draft.leaseStartDate) >= new Date(draft.leaseEndDate)
-    ? "Lease start date must be before the end date."
-    : null;
-
-  const updateRoom = (index: number, patch: Partial<IRoomRate>) => {
-    setDraft((prev) => ({
-      ...prev,
-      rooms: prev.rooms.map((room, i) => (i === index ? { ...room, ...patch } : room)),
-    }));
-  };
-
-  const handleSave = async () => {
-    if (dateError) return;
-    setSaving(true);
-    try {
-      await onSave(draft);
-    } finally {
-      setSaving(false);
-    }
-  };
-
-  return (
-    <div className={styles.modalOverlay} onClick={onCancel}>
-      <div className={styles.modal} onClick={(e) => e.stopPropagation()}>
-        <h3 className={styles.modalTitle}>Configure PandaDocs lease export</h3>
-        <p className={styles.modalIntro}>
-          These settings control the lease period, rates, rental agent contact, and email wording used when
-          generating the export. Per-meeting details (group name, contact email, schedule) always come from the
-          meeting itself and aren&apos;t set here.
-        </p>
-
-        <div className={styles.sectionLabel}>Lease period</div>
-        <div className={styles.dateRow}>
-          <label className={styles.fieldLabel}>
-            Start
-            <input
-              type="date"
-              className={styles.input}
-              value={toDateInputValue(draft.leaseStartDate)}
-              onChange={(e) => setDraft((prev) => ({ ...prev, leaseStartDate: new Date(`${e.target.value}T00:00:00Z`) }))}
-            />
-          </label>
-          <label className={styles.fieldLabel}>
-            End
-            <input
-              type="date"
-              className={styles.input}
-              value={toDateInputValue(draft.leaseEndDate)}
-              onChange={(e) => setDraft((prev) => ({ ...prev, leaseEndDate: new Date(`${e.target.value}T00:00:00Z`) }))}
-            />
-          </label>
-        </div>
-        {dateError && <p className={styles.dateError}>{dateError}</p>}
-
-        <div className={styles.sectionLabel}>Rooms &amp; rates</div>
-        <div className={styles.ratesTableWrapper}>
-          <table className={styles.ratesTable}>
-            <thead>
-              <tr>
-                <th>Room / Zoom account</th>
-                <th>Rate</th>
-                <th>Unit</th>
-              </tr>
-            </thead>
-            <tbody>
-              {draft.rooms.map((room, i) => (
-                <tr key={room.room}>
-                  <td>{room.room}</td>
-                  <td>
-                    <input
-                      type="number"
-                      min={0}
-                      step="0.01"
-                      className={styles.rateInput}
-                      value={room.rate}
-                      onChange={(e) => updateRoom(i, { rate: Number(e.target.value) })}
-                    />
-                  </td>
-                  <td>
-                    <select
-                      className={styles.input}
-                      value={room.unit}
-                      onChange={(e) => updateRoom(i, { unit: e.target.value as IRoomRate["unit"] })}
-                    >
-                      <option value="hr">/hr</option>
-                      <option value="month">/month</option>
-                    </select>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-
-        <div className={styles.sectionLabel}>Rental agent contact</div>
-        <p className={styles.fieldHint}>Printed on every lease as the ICR contact — update when staff changes.</p>
-        <div className={styles.contactGrid}>
-          <label className={styles.fieldLabel}>
-            First name
-            <input className={styles.input} value={draft.agentFirstName} onChange={(e) => setDraft((p) => ({ ...p, agentFirstName: e.target.value }))} />
-          </label>
-          <label className={styles.fieldLabel}>
-            Last name
-            <input className={styles.input} value={draft.agentLastName} onChange={(e) => setDraft((p) => ({ ...p, agentLastName: e.target.value }))} />
-          </label>
-          <label className={styles.fieldLabel}>
-            Title
-            <input className={styles.input} value={draft.agentTitle} onChange={(e) => setDraft((p) => ({ ...p, agentTitle: e.target.value }))} />
-          </label>
-          <label className={styles.fieldLabel}>
-            Email
-            <input className={styles.input} value={draft.agentEmail} onChange={(e) => setDraft((p) => ({ ...p, agentEmail: e.target.value }))} />
-          </label>
-          <label className={styles.fieldLabel}>
-            Phone
-            <input className={styles.input} value={draft.agentPhone} onChange={(e) => setDraft((p) => ({ ...p, agentPhone: e.target.value }))} />
-          </label>
-          <label className={styles.fieldLabel}>
-            Street address
-            <input className={styles.input} value={draft.agentStreetAddress} onChange={(e) => setDraft((p) => ({ ...p, agentStreetAddress: e.target.value }))} />
-          </label>
-          <label className={styles.fieldLabel}>
-            City
-            <input className={styles.input} value={draft.agentCity} onChange={(e) => setDraft((p) => ({ ...p, agentCity: e.target.value }))} />
-          </label>
-          <label className={styles.fieldLabel}>
-            State
-            <input className={styles.input} value={draft.agentState} onChange={(e) => setDraft((p) => ({ ...p, agentState: e.target.value }))} />
-          </label>
-          <label className={styles.fieldLabel}>
-            ZIP
-            <input className={styles.input} value={draft.agentZip} onChange={(e) => setDraft((p) => ({ ...p, agentZip: e.target.value }))} />
-          </label>
-        </div>
-
-        <div className={styles.sectionLabel}>Email message template</div>
-        <textarea
-          className={styles.textarea}
-          rows={5}
-          value={draft.emailTemplate}
-          onChange={(e) => setDraft((p) => ({ ...p, emailTemplate: e.target.value }))}
-        />
-        <p className={styles.fieldHint}>
-          Sent with every lease. <code className={styles.code}>{"{group}"}</code> is replaced with each group&apos;s name.
-        </p>
-
-        <div className={styles.modalActions}>
-          <button className={styles.cancelButton} onClick={onCancel} disabled={saving}>Cancel</button>
-          <button className={styles.saveButton} onClick={handleSave} disabled={saving || !!dateError}>
-            {saving ? "Saving…" : "Save"}
-          </button>
-        </div>
-      </div>
-    </div>
-  );
-};
 
 const SignageUrlCard: React.FC = () => {
   const [checkedRooms, setCheckedRooms] = useState<Record<string, boolean>>(() =>
@@ -355,6 +185,7 @@ const SignageUrlCard: React.FC = () => {
 
 const ExportTab: React.FC = () => {
   const [leaseSettings, setLeaseSettings] = useState<ILeaseSettings | null>(null);
+  const [leaseCycles, setLeaseCycles] = useState<LeaseYearCycle[]>([]);
   const [settingsError, setSettingsError] = useState<string | null>(null);
   const [configOpen, setConfigOpen] = useState(false);
   const [ratesOpen, setRatesOpen] = useState(false);
@@ -370,8 +201,9 @@ const ExportTab: React.FC = () => {
     try {
       const response = await fetch("/api/retrieve/lease-settings");
       if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
-      const json: ILeaseSettings = await response.json();
-      setLeaseSettings(json);
+      const json: { settings: ILeaseSettings; cycles: LeaseYearCycle[] } = await response.json();
+      setLeaseSettings(json.settings);
+      setLeaseCycles(json.cycles);
       setSettingsError(null);
     } catch (err) {
       console.error("Error loading lease settings:", err);
@@ -397,8 +229,8 @@ const ExportTab: React.FC = () => {
     // Async fetch-then-set; the lint rule can't see the setState calls sit after an
     // await, so this is a false positive for the standard "load on mount" pattern.
     /* eslint-disable react-hooks/set-state-in-effect */
-    if (flags.exportCsv) loadLeaseSettings();
-    if (flags.exportXlsx) loadMeetingExportSettings();
+    loadLeaseSettings();
+    loadMeetingExportSettings();
     /* eslint-enable react-hooks/set-state-in-effect */
   }, []);
 
@@ -476,85 +308,81 @@ const ExportTab: React.FC = () => {
       {meetingSettingsError && <div className={styles.errorBanner}>{meetingSettingsError}</div>}
 
       <div className={styles.grid}>
-        {flags.exportXlsx && (
-          <Card className={styles.exportCard}>
-            <CardHeader
-              icon={<BackupIcon />}
-              title="Export Meetings (XLSX)"
-              action={{
-                label: "Configure",
-                onClick: () => setMeetingConfigOpen(true),
-                ariaLabel: "Configure export fields",
-                title: "Configure export fields…",
-                disabled: !meetingExportFields,
-              }}
-            />
-            <div className={styles.cardDesc}>
-              Spreadsheet export of every meeting. Configure which fields to include.
-            </div>
-            <div className={styles.summaryRow}>
-              <span className={styles.summaryText}>{meetingExportSummary}</span>
-            </div>
-            <div className={styles.cardFooter}>
-              <div className={styles.filename}>{meetingsFilename}</div>
-              <button
-                className={styles.exportButton}
-                onClick={() => handleExport("meetings")}
-                disabled={downloading === "meetings"}
-              >
-                {downloaded === "meetings" ? "Downloaded ✓" : downloading === "meetings" ? "Exporting…" : "Export Meetings"}
-              </button>
-            </div>
-          </Card>
-        )}
+        <Card className={styles.exportCard}>
+          <CardHeader
+            icon={<BackupIcon />}
+            title="Export Meetings (XLSX)"
+            action={{
+              label: "Configure",
+              onClick: () => setMeetingConfigOpen(true),
+              ariaLabel: "Configure export fields",
+              title: "Configure export fields…",
+              disabled: !meetingExportFields,
+            }}
+          />
+          <div className={styles.cardDesc}>
+            Spreadsheet export of every meeting. Configure which fields to include.
+          </div>
+          <div className={styles.summaryRow}>
+            <span className={styles.summaryText}>{meetingExportSummary}</span>
+          </div>
+          <div className={styles.cardFooter}>
+            <div className={styles.filename}>{meetingsFilename}</div>
+            <button
+              className={styles.exportButton}
+              onClick={() => handleExport("meetings")}
+              disabled={downloading === "meetings"}
+            >
+              {downloaded === "meetings" ? "Downloaded ✓" : downloading === "meetings" ? "Exporting…" : "Export Meetings"}
+            </button>
+          </div>
+        </Card>
 
-        {flags.exportCsv && (
-          <Card className={styles.exportCard}>
-            <CardHeader
-              icon={<DescriptionIcon />}
-              title="Export PandaDocs Lease (CSV)"
-              action={{
-                label: "Configure",
-                onClick: () => setConfigOpen(true),
-                ariaLabel: "Configure export",
-                title: "Configure export…",
-                disabled: !leaseSettings,
-              }}
-            />
-            <div className={styles.cardDesc}>
-              Billing fields formatted for the PandaDocs lease-renewal mail merge.
-              Include room rate, billable time, rent charge, and client contact per group.
-            </div>
-            {leaseSettings && (
-              <div className={styles.summaryRow}>
-                <span className={styles.summaryText}>{leaseSummary}</span>
-                <button className={styles.viewRatesButton} onClick={() => setRatesOpen((v) => !v)}>
-                  View rates
-                </button>
-                {ratesOpen && (
-                  <div className={styles.ratesPopover}>
-                    {leaseSettings.rooms.map((room) => (
-                      <div key={room.room} className={styles.ratesPopoverRow}>
-                        <span>{room.room}</span>
-                        <span>${room.rate}/{room.unit}</span>
-                      </div>
-                    ))}
-                  </div>
-                )}
-              </div>
-            )}
-            <div className={styles.cardFooter}>
-              <div className={styles.filename}>{leaseFilename}</div>
-              <button
-                className={styles.exportButton}
-                onClick={() => handleExport("lease")}
-                disabled={downloading === "lease" || !leaseSettings}
-              >
-                {downloaded === "lease" ? "Downloaded ✓" : downloading === "lease" ? "Exporting…" : "Export Lease CSV"}
+        <Card className={styles.exportCard}>
+          <CardHeader
+            icon={<DescriptionIcon />}
+            title="Export PandaDocs Lease (CSV)"
+            action={{
+              label: "Configure",
+              onClick: () => setConfigOpen(true),
+              ariaLabel: "Configure export",
+              title: "Configure export…",
+              disabled: !leaseSettings,
+            }}
+          />
+          <div className={styles.cardDesc}>
+            Billing fields formatted for the PandaDocs lease-renewal mail merge.
+            Include room rate, billable time, rent charge, and client contact per group.
+          </div>
+          {leaseSettings && (
+            <div className={styles.summaryRow}>
+              <span className={styles.summaryText}>{leaseSummary}</span>
+              <button className={styles.viewRatesButton} onClick={() => setRatesOpen((v) => !v)}>
+                View rates
               </button>
+              {ratesOpen && (
+                <div className={styles.ratesPopover}>
+                  {leaseSettings.rooms.map((room) => (
+                    <div key={room.room} className={styles.ratesPopoverRow}>
+                      <span>{room.room}</span>
+                      <span>${room.rate}/{room.unit}</span>
+                    </div>
+                  ))}
+                </div>
+              )}
             </div>
-          </Card>
-        )}
+          )}
+          <div className={styles.cardFooter}>
+            <div className={styles.filename}>{leaseFilename}</div>
+            <button
+              className={styles.exportButton}
+              onClick={() => handleExport("lease")}
+              disabled={downloading === "lease" || !leaseSettings}
+            >
+              {downloaded === "lease" ? "Downloaded ✓" : downloading === "lease" ? "Exporting…" : "Export Lease CSV"}
+            </button>
+          </div>
+        </Card>
       </div>
 
       <SignageUrlCard />
@@ -562,6 +390,7 @@ const ExportTab: React.FC = () => {
       {configOpen && leaseSettings && (
         <LeaseConfigModal
           initial={leaseSettings}
+          cycles={leaseCycles}
           onCancel={() => setConfigOpen(false)}
           onSave={handleSaveSettings}
         />

--- a/frontend/app/components/admin/export/ExportTab.tsx
+++ b/frontend/app/components/admin/export/ExportTab.tsx
@@ -203,7 +203,15 @@ const ExportTab: React.FC = () => {
       if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
       const json: { settings: ILeaseSettings; cycles: LeaseYearCycle[] } = await response.json();
       setLeaseSettings(json.settings);
-      setLeaseCycles(json.cycles);
+      // fetch/JSON.parse hands back ISO strings for Date fields despite the LeaseYearCycle type,
+      // so callers comparing against `new Date(...)` values (LeaseConfigModal's cycle picker) need real Dates here.
+      setLeaseCycles(
+        json.cycles.map((cycle) => ({
+          ...cycle,
+          startDate: new Date(cycle.startDate),
+          endDate: new Date(cycle.endDate),
+        })),
+      );
       setSettingsError(null);
     } catch (err) {
       console.error("Error loading lease settings:", err);

--- a/frontend/app/components/admin/export/LeaseConfigModal.tsx
+++ b/frontend/app/components/admin/export/LeaseConfigModal.tsx
@@ -1,0 +1,264 @@
+"use client";
+
+import React, { useState } from "react";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import CheckCircleIcon from "@mui/icons-material/CheckCircle";
+import type { ILeaseSettings, IRoomRate } from "../../../../util/models";
+import type { LeaseYearCycle } from "../../../../util/leaseYearCycles";
+import styles from "../../../../styles/components/admin/ExportTab.module.scss";
+
+interface LeaseConfigModalProps {
+  initial: ILeaseSettings;
+  cycles: LeaseYearCycle[];
+  onCancel: () => void;
+  onSave: (next: ILeaseSettings) => Promise<void>;
+}
+
+interface CollapsibleSectionProps {
+  title: string;
+  summary: string;
+  defaultOpen?: boolean;
+  children: React.ReactNode;
+}
+
+// Shared shell for the modal's three sections -- only "Rooms & rates" starts open, so Save
+// stays reachable without scrolling past the ~12 rental-agent address fields underneath it.
+const CollapsibleSection: React.FC<CollapsibleSectionProps> = ({ title, summary, defaultOpen = false, children }) => {
+  const [open, setOpen] = useState(defaultOpen);
+
+  return (
+    <div className={styles.collapsibleSection}>
+      <button
+        type="button"
+        className={styles.collapsibleHeader}
+        onClick={() => setOpen((o) => !o)}
+        aria-expanded={open}
+      >
+        <span className={styles.collapsibleTitleRow}>
+          <span className={styles.sectionLabel}>{title}</span>
+          {!open && <span className={styles.collapsibleSummary}>{summary}</span>}
+        </span>
+        <ExpandMoreIcon
+          fontSize="small"
+          className={`${styles.collapsibleChevron} ${open ? styles.collapsibleChevronOpen : ""}`}
+        />
+      </button>
+      <div className={`${styles.collapsibleBody} ${open ? styles.collapsibleBodyOpen : ""}`}>
+        <div className={styles.collapsibleBodyInner}>{children}</div>
+      </div>
+    </div>
+  );
+};
+
+// Splits on the literal "{group}" placeholder and highlights each substituted occurrence, so a
+// preview reads as "here's what a real recipient sees" rather than a plain copy of the template.
+function renderTemplatePreview(template: string): React.ReactNode {
+  const parts = template.split("{group}");
+  return parts.map((part, i) => (
+    <React.Fragment key={i}>
+      {part}
+      {i < parts.length - 1 && <span className={styles.previewHighlight}>Sample Group</span>}
+    </React.Fragment>
+  ));
+}
+
+const LeaseConfigModal: React.FC<LeaseConfigModalProps> = ({ initial, cycles, onCancel, onSave }) => {
+  const [draft, setDraft] = useState<ILeaseSettings>(initial);
+  const [saving, setSaving] = useState(false);
+  const [templatePreview, setTemplatePreview] = useState(false);
+
+  const updateRoom = (index: number, patch: Partial<IRoomRate>) => {
+    setDraft((prev) => ({
+      ...prev,
+      rooms: prev.rooms.map((room, i) => (i === index ? { ...room, ...patch } : room)),
+    }));
+  };
+
+  const selectCycle = (cycle: LeaseYearCycle) => {
+    setDraft((prev) => ({ ...prev, leaseStartDate: cycle.startDate, leaseEndDate: cycle.endDate }));
+  };
+
+  const handleSave = async () => {
+    setSaving(true);
+    try {
+      await onSave(draft);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const roomsSummary = `${draft.rooms.length} room ${draft.rooms.length === 1 ? "rate" : "rates"} configured`;
+  const contactSummary = `${draft.agentFirstName} ${draft.agentLastName} · ${draft.agentEmail}`;
+  const templateSummary = draft.emailTemplate.split("\n")[0]?.slice(0, 60) || "No message set";
+
+  return (
+    <div className={styles.modalOverlay} onClick={onCancel}>
+      <div className={styles.modal} onClick={(e) => e.stopPropagation()}>
+        <h3 className={styles.modalTitle}>Configure PandaDocs lease export</h3>
+        <p className={styles.modalIntro}>
+          These settings control the lease period, rates, rental agent contact, and email wording used when
+          generating the export. Per-meeting details (group name, contact email, schedule) always come from the
+          meeting itself and aren&apos;t set here.
+        </p>
+
+        <div className={styles.sectionLabel}>Lease period</div>
+        <div className={styles.cycleList}>
+          {cycles.map((cycle) => {
+            // Containment, not exact-match -- a pre-existing saved lease period may predate this
+            // picker and not land exactly on a cycle boundary; falling inside a cycle's range
+            // still highlights that cycle instead of leaving every row unselected.
+            const draftStart = new Date(draft.leaseStartDate);
+            const isSelected = draftStart >= cycle.startDate && draftStart <= cycle.endDate;
+            return (
+              <label
+                key={cycle.label}
+                className={`${styles.cycleRow} ${isSelected ? styles.cycleRowSelected : ""}`}
+              >
+                <input
+                  type="radio"
+                  name="lease-year-cycle"
+                  className={styles.cycleRadioInput}
+                  checked={isSelected}
+                  onChange={() => selectCycle(cycle)}
+                />
+                <span className={styles.cycleRadioIcon}>
+                  {isSelected ? <CheckCircleIcon fontSize="small" /> : <span className={styles.cycleRadioEmpty} />}
+                </span>
+                <span className={`${styles.cycleLabel} ${cycle.status === "current" ? styles.cycleLabelCurrent : ""}`}>
+                  {cycle.label}
+                </span>
+                {cycle.status !== "current" && (
+                  <span className={styles.cycleStatusTag}>
+                    {cycle.status === "past" ? "Past" : "Not started"}
+                  </span>
+                )}
+              </label>
+            );
+          })}
+        </div>
+
+        <CollapsibleSection title="Rooms & rates" summary={roomsSummary} defaultOpen>
+          <div className={styles.ratesTableWrapper}>
+            <table className={styles.ratesTable}>
+              <thead>
+                <tr>
+                  <th>Room / Zoom account</th>
+                  <th>Rate</th>
+                  <th>Unit</th>
+                </tr>
+              </thead>
+              <tbody>
+                {draft.rooms.map((room, i) => (
+                  <tr key={room.room}>
+                    <td>{room.room}</td>
+                    <td>
+                      <input
+                        type="number"
+                        min={0}
+                        step="0.01"
+                        className={styles.rateInput}
+                        value={room.rate}
+                        onChange={(e) => updateRoom(i, { rate: Number(e.target.value) })}
+                      />
+                    </td>
+                    <td>
+                      <select
+                        className={styles.input}
+                        value={room.unit}
+                        onChange={(e) => updateRoom(i, { unit: e.target.value as IRoomRate["unit"] })}
+                      >
+                        <option value="hr">/hr</option>
+                        <option value="month">/month</option>
+                      </select>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </CollapsibleSection>
+
+        <CollapsibleSection title="Rental agent contact" summary={contactSummary}>
+          <p className={styles.fieldHint}>Printed on every lease as the ICR contact — update when staff changes.</p>
+          <div className={styles.contactGrid}>
+            <label className={styles.fieldLabel}>
+              First name
+              <input className={styles.input} value={draft.agentFirstName} onChange={(e) => setDraft((p) => ({ ...p, agentFirstName: e.target.value }))} />
+            </label>
+            <label className={styles.fieldLabel}>
+              Last name
+              <input className={styles.input} value={draft.agentLastName} onChange={(e) => setDraft((p) => ({ ...p, agentLastName: e.target.value }))} />
+            </label>
+            <label className={styles.fieldLabel}>
+              Title
+              <input className={styles.input} value={draft.agentTitle} onChange={(e) => setDraft((p) => ({ ...p, agentTitle: e.target.value }))} />
+            </label>
+            <label className={styles.fieldLabel}>
+              Email
+              <input className={styles.input} value={draft.agentEmail} onChange={(e) => setDraft((p) => ({ ...p, agentEmail: e.target.value }))} />
+            </label>
+            <label className={styles.fieldLabel}>
+              Phone
+              <input className={styles.input} value={draft.agentPhone} onChange={(e) => setDraft((p) => ({ ...p, agentPhone: e.target.value }))} />
+            </label>
+            <label className={styles.fieldLabel}>
+              Street address
+              <input className={styles.input} value={draft.agentStreetAddress} onChange={(e) => setDraft((p) => ({ ...p, agentStreetAddress: e.target.value }))} />
+            </label>
+            <label className={styles.fieldLabel}>
+              City
+              <input className={styles.input} value={draft.agentCity} onChange={(e) => setDraft((p) => ({ ...p, agentCity: e.target.value }))} />
+            </label>
+            <label className={styles.fieldLabel}>
+              State
+              <input className={styles.input} value={draft.agentState} onChange={(e) => setDraft((p) => ({ ...p, agentState: e.target.value }))} />
+            </label>
+            <label className={styles.fieldLabel}>
+              ZIP
+              <input className={styles.input} value={draft.agentZip} onChange={(e) => setDraft((p) => ({ ...p, agentZip: e.target.value }))} />
+            </label>
+          </div>
+        </CollapsibleSection>
+
+        <CollapsibleSection title="Email message template" summary={templateSummary}>
+          <div className={styles.templateHeaderRow}>
+            <span className={styles.templateStateLabel}>
+              {templatePreview
+                ? <>Previewing — <code className={styles.code}>{"{group}"}</code> shown as a sample group name</>
+                : "Editing template"}
+            </span>
+            <button
+              type="button"
+              className={styles.previewToggleButton}
+              onClick={() => setTemplatePreview((v) => !v)}
+            >
+              {templatePreview ? "Edit" : "Preview"}
+            </button>
+          </div>
+          {templatePreview ? (
+            <div className={styles.textareaPreview}>{renderTemplatePreview(draft.emailTemplate)}</div>
+          ) : (
+            <textarea
+              className={styles.textarea}
+              rows={5}
+              value={draft.emailTemplate}
+              onChange={(e) => setDraft((p) => ({ ...p, emailTemplate: e.target.value }))}
+            />
+          )}
+          <p className={styles.fieldHint}>
+            Sent with every lease. <code className={styles.code}>{"{group}"}</code> is replaced with each group&apos;s name.
+          </p>
+        </CollapsibleSection>
+
+        <div className={styles.modalActions}>
+          <button className={styles.cancelButton} onClick={onCancel} disabled={saving}>Cancel</button>
+          <button className={styles.saveButton} onClick={handleSave} disabled={saving}>
+            {saving ? "Saving…" : "Save"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default LeaseConfigModal;

--- a/frontend/lib/flags.ts
+++ b/frontend/lib/flags.ts
@@ -1,8 +1,0 @@
-function flag(envVar: string | undefined): boolean {
-  return envVar === "true";
-}
-
-export const flags = {
-  exportXlsx: flag(process.env.NEXT_PUBLIC_FEATURE_EXPORT_XLSX),
-  exportCsv: flag(process.env.NEXT_PUBLIC_FEATURE_EXPORT_CSV),
-};

--- a/frontend/styles/components/admin/ExportTab.module.scss
+++ b/frontend/styles/components/admin/ExportTab.module.scss
@@ -185,20 +185,202 @@
   margin: 0 0 8px;
 }
 
-.dateRow {
-  display: flex;
-  gap: 16px;
+// Lease-year cycle picker (replaces two free-text date inputs -- every selectable option is a
+// real Jul 1 -> Jun 30 cycle derived from actual meeting data, so there's no invalid range to
+// guard against here the way the old start/end inputs needed).
 
-  @media (width <= $breakpoint-phone) {
-    flex-direction: column;
-    gap: 12px;
+.cycleList {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 20px;
+}
+
+.cycleRow {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 10px;
+  border: 1.5px solid #E5E5E5;
+  border-radius: 8px;
+  cursor: pointer;
+
+  &:hover {
+    border-color: $brand-pink-color;
   }
 }
 
-.dateError {
-  font-size: 12px;
+.cycleRowSelected {
+  border-color: $brand-pink-color;
+  background: #FBE1E7;
+}
+
+.cycleRadioInput {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.cycleRadioIcon {
+  display: inline-flex;
+  align-items: center;
   color: $brand-pink-color;
-  margin: 6px 0 0;
+}
+
+.cycleRadioEmpty {
+  display: inline-block;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  border: 1.5px solid $light-grey-color;
+  box-sizing: border-box;
+}
+
+.cycleLabel {
+  flex: 1;
+  font-size: 14px;
+  color: $black-color;
+}
+
+.cycleLabelCurrent {
+  font-weight: 700;
+}
+
+.cycleStatusTag {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+  color: $medium-grey-color;
+  background: $grey-lightest-color;
+  border-radius: 4px;
+  padding: 3px 8px;
+  white-space: nowrap;
+}
+
+// Collapsible modal sections -- same grid-template-rows accordion technique as
+// ConflictList.module.scss's .editPanel, so height animates without a measured pixel value.
+
+.collapsibleSection {
+  border-top: 1px solid $grey-lightest-color;
+  padding-top: 12px;
+  margin-top: 12px;
+
+  &:first-of-type {
+    border-top: none;
+    padding-top: 0;
+    margin-top: 0;
+  }
+}
+
+.collapsibleHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  width: 100%;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  font-family: inherit;
+  text-align: left;
+}
+
+.collapsibleTitleRow {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  min-width: 0;
+}
+
+.collapsibleSummary {
+  font-size: 13px;
+  color: $medium-grey-color;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.collapsibleChevron {
+  flex-shrink: 0;
+  color: $medium-grey-color;
+  transition: transform 0.2s ease;
+}
+
+.collapsibleChevronOpen {
+  transform: rotate(180deg);
+}
+
+.collapsibleBody {
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows 0.2s ease;
+}
+
+.collapsibleBodyOpen {
+  grid-template-rows: 1fr;
+}
+
+.collapsibleBodyInner {
+  overflow: hidden;
+  min-height: 0;
+}
+
+.collapsibleBodyOpen .collapsibleBodyInner {
+  padding-top: 12px;
+}
+
+// Email template preview/edit toggle
+
+.templateHeaderRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 8px;
+}
+
+.templateStateLabel {
+  font-size: 12px;
+  color: $medium-grey-color;
+}
+
+.previewToggleButton {
+  background: none;
+  border: 1.5px solid #E5E5E5;
+  border-radius: 6px;
+  color: $black-color;
+  font-family: inherit;
+  font-size: 12px;
+  padding: 4px 10px;
+  cursor: pointer;
+  white-space: nowrap;
+
+  &:hover {
+    border-color: $brand-pink-color;
+  }
+}
+
+.textareaPreview {
+  width: 100%;
+  min-height: 110px;
+  font-size: 13px;
+  color: $black-color;
+  background: $grey-lightest-color;
+  border: 1.5px solid #E5E5E5;
+  border-radius: 6px;
+  padding: 8px 10px;
+  box-sizing: border-box;
+  white-space: pre-wrap;
+}
+
+.previewHighlight {
+  background: #FBE1E7;
+  color: $brand-pink-color;
+  font-weight: 600;
+  border-radius: 4px;
+  padding: 0 3px;
 }
 
 .fieldLabel {

--- a/frontend/tests/e2e/global-setup.ts
+++ b/frontend/tests/e2e/global-setup.ts
@@ -56,10 +56,6 @@ export default async function globalSetup(): Promise<void> {
       DATABASE_URL: uri,
       NEXTAUTH_SECRET: TEST_NEXTAUTH_SECRET,
       NEXTAUTH_URL: TEST_BASE_URL,
-      // Feature flags (lib/flags.ts) only gate end-user visibility, not correctness —
-      // e2e always exercises the real behavior behind them regardless of the prod default.
-      NEXT_PUBLIC_FEATURE_EXPORT_XLSX: "true",
-      NEXT_PUBLIC_FEATURE_EXPORT_CSV: "true",
     },
     3000,
   );

--- a/frontend/tests/unit/leaseYearCycles.test.ts
+++ b/frontend/tests/unit/leaseYearCycles.test.ts
@@ -1,0 +1,63 @@
+import { computeLeaseYearCycles } from "../../util/leaseYearCycles";
+
+const d = (iso: string) => new Date(iso);
+
+describe("computeLeaseYearCycles", () => {
+  it("with no meeting data, returns just the current cycle and the one after it", () => {
+    const cycles = computeLeaseYearCycles([], d("2026-08-07T00:00:00Z"));
+    expect(cycles.map((c) => c.label)).toEqual([
+      "Jul 1, 2026 – Jun 30, 2027",
+      "Jul 1, 2027 – Jun 30, 2028",
+    ]);
+    expect(cycles.map((c) => c.status)).toEqual(["current", "upcoming"]);
+  });
+
+  it("marks the cycle containing `now` as current regardless of month", () => {
+    // January falls inside the lease year that started the previous July.
+    const cycles = computeLeaseYearCycles([], d("2027-01-15T00:00:00Z"));
+    expect(cycles[0].label).toBe("Jul 1, 2026 – Jun 30, 2027");
+    expect(cycles[0].status).toBe("current");
+  });
+
+  it("includes every cycle with meeting data, marking earlier ones past", () => {
+    const cycles = computeLeaseYearCycles(
+      [d("2024-09-01T00:00:00Z"), d("2025-03-01T00:00:00Z")],
+      d("2026-08-07T00:00:00Z"),
+    );
+    expect(cycles.map((c) => c.label)).toEqual([
+      "Jul 1, 2024 – Jun 30, 2025",
+      "Jul 1, 2025 – Jun 30, 2026",
+      "Jul 1, 2026 – Jun 30, 2027",
+      "Jul 1, 2027 – Jun 30, 2028",
+    ]);
+    expect(cycles.map((c) => c.status)).toEqual(["past", "past", "current", "upcoming"]);
+  });
+
+  it("extends the upcoming cycle past the latest meeting data when data reaches further than current", () => {
+    // A meeting already scheduled two lease years out shouldn't be swallowed by the
+    // "current + 1" default -- the option list must reach at least as far as real data does.
+    const cycles = computeLeaseYearCycles([d("2028-10-01T00:00:00Z")], d("2026-08-07T00:00:00Z"));
+    expect(cycles.map((c) => c.label)).toEqual([
+      "Jul 1, 2026 – Jun 30, 2027",
+      "Jul 1, 2027 – Jun 30, 2028",
+      "Jul 1, 2028 – Jun 30, 2029",
+      "Jul 1, 2029 – Jun 30, 2030",
+    ]);
+    expect(cycles.map((c) => c.status)).toEqual(["current", "upcoming", "upcoming", "upcoming"]);
+  });
+
+  it("cycle boundaries are exactly Jul 1 and Jun 30", () => {
+    const [cycle] = computeLeaseYearCycles([], d("2026-08-07T00:00:00Z"));
+    expect(cycle.startDate.toISOString()).toBe("2026-07-01T00:00:00.000Z");
+    expect(cycle.endDate.toISOString()).toBe("2027-06-30T00:00:00.000Z");
+  });
+
+  it("reads the ET calendar date, not the UTC instant, for the Jul 1 boundary", () => {
+    // Jul 1 00:00 UTC is still Jun 30, evening in ET (UTC is ahead of ET) -- the cycle that
+    // just ended must still read as current at that instant, not the new one that hasn't
+    // actually started yet locally.
+    const cycles = computeLeaseYearCycles([], d("2026-07-01T00:00:00Z"));
+    expect(cycles[0].label).toBe("Jul 1, 2025 – Jun 30, 2026");
+    expect(cycles[0].status).toBe("current");
+  });
+});

--- a/frontend/util/leaseDefaults.ts
+++ b/frontend/util/leaseDefaults.ts
@@ -1,14 +1,17 @@
 import type { ILeaseSettings } from "./models";
+import { cycleStartYear } from "./leaseYearCycles";
 
 // Ground-truth defaults: room rates/names match the current room list used by
 // NewMeeting.tsx/EditMeeting.tsx and DayView.tsx's defaultRooms; rental-agent/email
 // wording ported from the pre-B.1 PandaDocButton.tsx — used until a Super Admin saves
 // real settings.
 export function defaultLeaseSettings(): ILeaseSettings {
-  const currentYear = new Date().getFullYear();
+  // The lease year containing today, not the calendar year -- Jan-Jun would otherwise default
+  // to next Jul's cycle instead of the one that's actually current (see leaseYearCycles.ts).
+  const currentLeaseYear = cycleStartYear(new Date());
   return {
-    leaseStartDate: new Date(Date.UTC(currentYear, 6, 1)),
-    leaseEndDate: new Date(Date.UTC(currentYear + 1, 5, 30)),
+    leaseStartDate: new Date(Date.UTC(currentLeaseYear, 6, 1)),
+    leaseEndDate: new Date(Date.UTC(currentLeaseYear + 1, 5, 30)),
     rooms: [
       { room: "Serenity Room", rate: 15, unit: "hr" },
       { room: "Seeds of Hope Room", rate: 10, unit: "hr" },

--- a/frontend/util/leaseYearCycles.ts
+++ b/frontend/util/leaseYearCycles.ts
@@ -1,0 +1,53 @@
+import { formatETDateString } from "./timeUtils";
+
+// Lease years run Jul 1 -> Jun 30 (matches util/leaseDefaults.ts's default settings), stored as
+// UTC dates like the rest of LeaseSettings.
+
+export interface LeaseYearCycle {
+  startDate: Date;
+  endDate: Date;
+  label: string;
+  status: "past" | "current" | "upcoming";
+}
+
+// Reads the ET calendar date, not the UTC instant -- the org operates in America/New_York, and
+// UTC is ahead of ET, so a raw UTC read would flip "current" to the next lease year several
+// hours before it's actually Jul 1 in Ithaca.
+export function cycleStartYear(date: Date): number {
+  const [yearStr, monthStr] = formatETDateString(date).split("-");
+  const year = Number(yearStr);
+  return Number(monthStr) >= 7 ? year : year - 1;
+}
+
+function buildCycle(startYear: number, currentStartYear: number): LeaseYearCycle {
+  const status: LeaseYearCycle["status"] =
+    startYear < currentStartYear ? "past" : startYear > currentStartYear ? "upcoming" : "current";
+  return {
+    startDate: new Date(Date.UTC(startYear, 6, 1)),
+    endDate: new Date(Date.UTC(startYear + 1, 5, 30)),
+    label: `Jul 1, ${startYear} – Jun 30, ${startYear + 1}`,
+    status,
+  };
+}
+
+// Derives the selectable lease-year cycles from actual meeting activity, rather than hard-coding
+// a fixed window: every cycle that has at least one meeting in it, plus the current cycle (even
+// if it has no meetings yet) and the cycle after current (so next year's lease can be prepared
+// ahead of any meeting data existing in it). The list naturally grows by one cycle each time `now`
+// crosses into a new lease year, since both the current cycle and the "one after current" shift
+// forward together.
+export function computeLeaseYearCycles(meetingDates: Date[], now: Date): LeaseYearCycle[] {
+  const currentStartYear = cycleStartYear(now);
+  const dataYears = meetingDates.map(cycleStartYear);
+  const minDataYear = dataYears.length ? Math.min(...dataYears) : currentStartYear;
+  const maxDataYear = dataYears.length ? Math.max(...dataYears) : currentStartYear;
+
+  const firstYear = Math.min(minDataYear, currentStartYear);
+  const lastYear = Math.max(maxDataYear, currentStartYear) + 1;
+
+  const cycles: LeaseYearCycle[] = [];
+  for (let year = firstYear; year <= lastYear; year++) {
+    cycles.push(buildCycle(year, currentStartYear));
+  }
+  return cycles;
+}


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added lease-year cycle selection for export configuration, covering past, current, upcoming, and meeting-related cycles.
  - Added a lease configuration modal with editable room rates, rental-agent details, email templates, preview mode, and collapsible sections.
  - Export settings now load and display consistently without feature-flag requirements.

- **Improvements**
  - Lease defaults and date ranges now follow July–June lease years.
  - Export configuration uses clearer cycle selection and status indicators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description
- **util/leaseYearCycles.ts**: new pure function deriving selectable Jul1→Jun30 lease-year cycles from actual meeting data — every cycle with meeting activity, plus the current cycle and the one after it. Reads the ET calendar date (not the raw UTC instant) to avoid misclassifying the current cycle a few hours early near the Jul 1 boundary.
- **app/api/retrieve/lease-settings/route.ts**: GET now also aggregates the meeting date range and returns `{settings, cycles}` instead of the bare settings object (verified no other consumer depends on the old shape).
- **app/components/admin/export/LeaseConfigModal.tsx**: extracted into its own file (was inline in `ExportTab.tsx`) and redesigned — the two free-text lease-date inputs are replaced by a list of cycle rows (checkmark + pink highlight when selected, bold when that cycle is the real current one regardless of selection, "Past"/"Not started" tag otherwise); Rooms & Rates / Rental Agent Contact / Email Message Template are each wrapped in a collapsible section (only Rooms & Rates open by default, each showing a one-line summary collapsed) so Save stays reachable without scrolling past the ~12 rental-agent address fields; the email template gained a Preview/Edit toggle that renders `{group}` as a highlighted "Sample Group" in a read-only preview.
- **util/leaseDefaults.ts**: fixed a pre-existing bug where the no-settings-saved-yet default computed the wrong lease-year cycle for Jan–Jun (calendar year instead of lease-year-start) — now reuses the same boundary logic as `leaseYearCycles.ts`.
- **lib/flags.ts** (deleted), **.env.example**, **tests/e2e/global-setup.ts**: removed `NEXT_PUBLIC_FEATURE_EXPORT_XLSX`/`NEXT_PUBLIC_FEATURE_EXPORT_CSV` entirely now that both export cards are complete and verified — these were the module's only two flags.

## Testing
- `yarn test:all` — 368/368 passing (unit/component/integration/e2e), including a final clean re-run after the flag removal specifically.
- `yarn tsc --noEmit`, `yarn lint`, `yarn lint:css` — all clean.
- `tests/unit/leaseYearCycles.test.ts` — 6 new unit tests, including a regression test locking in the ET-boundary fix.
- A dedicated review-agent pass caught the Jan–Jun default-cycle bug and the ET/UTC boundary issue above; both fixed and re-verified.
- Manually verified in-browser: cycle picker renders correctly (current cycle bold+checkmarked by default), selecting a non-current cycle and saving updates the card's "Currently:" line and filename, then reverted back to the real current cycle to leave the shared dev DB clean; collapsible sections expand/collapse independently; Preview toggle renders the `{group}` → "Sample Group" substitution correctly and Edit switches back; both export cards render with no feature flags set at all in `.env.local`, confirming the gate removal works.

## Area(s) Touched
**Product areas**
- [x] admin — /admin shell (Diagnostics, Users, Import, Export tabs)
- [x] billing — lease export, XLSX import, anything affecting invoicing
- [x] ui/ux — frontend layout/styling not tied to a specific integration

**Integrations**

**Engineering**
- [x] testing — test suite (Jest/Playwright) changes

## Pre-merge Checklist
- [x] Code follows current formatting conventions and passes lint (`yarn lint`).
- [x] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
- [ ] All test suites pass, both run locally and green in GitHub CI. **Do not merge if any test suite is failing.**
- [x] A test suite was added or updated for the feature/fix in this PR. **Double-check this if you change a feature and did not update the test suites**.
- [x] Only files relevant to this change are committed — no stray or unrelated files.
- [x] If this branch has a merge conflict with master, master was merged into this branch first (not the other way around).
- [x] The rest of this PR description (Description, Testing) is filled out, not left as template placeholders.