### PR TITLE
feat(docs): add Resources documentation page

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -15,6 +15,10 @@
 /.next/
 /out/
 
+# generated at dev/build time by build-scripts/generate-docs-content.mjs -- docs/ (repo root)
+# is the source of truth, this is a disposable snapshot
+/util/docs/docsContent.generated.ts
+
 # production
 /build
 

--- a/frontend/app/(main)/docs/[[...slug]]/page.tsx
+++ b/frontend/app/(main)/docs/[[...slug]]/page.tsx
@@ -1,0 +1,35 @@
+import type { Metadata } from "next";
+import { notFound, redirect } from "next/navigation";
+import { findDocBySlug, loadDocsMeta } from "../../../../util/docs/loadDocs";
+import DocsShell from "../../../components/docs/DocsShell";
+
+interface DocsPageProps {
+  params: Promise<{ slug?: string[] }>;
+}
+
+export async function generateMetadata({ params }: DocsPageProps): Promise<Metadata> {
+  const { slug } = await params;
+  const doc = findDocBySlug((slug ?? []).join("/"));
+  return {
+    title: doc ? `${doc.title} | Resources | Ithaca Community Recovery` : "Resources | Ithaca Community Recovery",
+  };
+}
+
+export default async function DocsPage({ params }: DocsPageProps) {
+  const { slug } = await params;
+  const routeSlug = (slug ?? []).join("/");
+  const activeDoc = findDocBySlug(routeSlug);
+  if (!activeDoc) {
+    // A bare folder path (e.g. /docs/02-handoff) isn't a doc's own slug -- redirect to the
+    // first doc under it, in manifest order (generate-docs-content.mjs's MANIFEST). That's the
+    // group's README for most groups since README is listed first there, but this doesn't
+    // specifically search for a README -- whatever's first is "the first page of it".
+    const prefix = routeSlug === "" ? "" : `${routeSlug}/`;
+    const firstChild = loadDocsMeta().find((doc) => doc.slug.startsWith(prefix) && doc.slug !== routeSlug);
+    if (firstChild) {
+      redirect(`/docs/${firstChild.slug}`);
+    }
+    notFound();
+  }
+  return <DocsShell activeDoc={activeDoc} docsMeta={loadDocsMeta()} />;
+}

--- a/frontend/app/ClientLayout.tsx
+++ b/frontend/app/ClientLayout.tsx
@@ -8,6 +8,7 @@ import type { Session } from "next-auth";
 import { SessionProvider } from "next-auth/react";
 import { SidebarProvider } from "./context/SidebarContext";
 import { CalendarProvider, useCalendarContext } from "./context/CalendarProvider";
+import { useScrollNavHide } from "../hooks/useScrollNavHide";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -21,10 +22,19 @@ interface ClientLayoutProps {
 // component, not inlined into ClientLayout below -- useCalendarContext() needs a
 // CalendarProvider ancestor already mounted, which doesn't exist yet during ClientLayout's
 // own render (the Provider below is still just JSX at that point).
+//
+// onScroll wires the same mobile hide-on-scroll-down/show-on-scroll-up behavior the calendar
+// route already had (there, via its own DayColumn/DayPortraitView wrapper) onto .content
+// itself, so routes that actually scroll .content get it too. Harmless on routes where it
+// doesn't: .content never scrolls on the calendar route (children manage their own internal
+// scroll region) or on /docs (DocsShell's own independently-scrolling panes reattach this same
+// hook to .article instead, see DocsShell.tsx), so this handler simply never fires there -- no
+// conflict with either route's own dedicated listener.
 function MainContent({ children }: PropsWithChildren) {
     const { navHidden } = useCalendarContext();
+    const { handleScroll } = useScrollNavHide();
     return (
-        <div className={`${styles.content} ${navHidden ? styles.navHidden : ""}`}>
+        <div className={`${styles.content} ${navHidden ? styles.navHidden : ""}`} onScroll={handleScroll}>
             {children}
         </div>
     );

--- a/frontend/app/components/docs/DocsIcons.tsx
+++ b/frontend/app/components/docs/DocsIcons.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+
+export const PanelToggleIcon: React.FC = () => (
+  <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.6}>
+    <rect x="3" y="4" width="18" height="16" rx="3" />
+    <line x1="9.5" y1="4" x2="9.5" y2="20" />
+  </svg>
+);
+
+export const TocToggleIcon: React.FC = () => (
+  <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.6} strokeLinecap="round">
+    <line x1="4" y1="6" x2="20" y2="6" />
+    <line x1="4" y1="12" x2="16" y2="12" />
+    <line x1="4" y1="18" x2="12" y2="18" />
+  </svg>
+);

--- a/frontend/app/components/docs/DocsShell.tsx
+++ b/frontend/app/components/docs/DocsShell.tsx
@@ -1,0 +1,348 @@
+"use client";
+
+import React, { useCallback, useEffect, useMemo, useRef, useState, useTransition } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { TABLET_BREAKPOINT, DESKTOP_BREAKPOINT } from "../../../util/common/breakpoints";
+import { parseMarkdown } from "../../../util/docs/parseMarkdown";
+import type { DocEntry, DocMeta } from "../../../util/docs/loadDocs";
+import { useScrollNavHide } from "../../../hooks/useScrollNavHide";
+import TopLoadingBar from "../atoms/TopLoadingBar";
+import { PanelToggleIcon, TocToggleIcon } from "./DocsIcons";
+import TocList from "./DocsTocList";
+import styles from "../../../styles/components/docs/DocsShell.module.scss";
+
+interface DocsShellProps {
+  activeDoc: DocEntry;
+  docsMeta: DocMeta[];
+}
+
+interface DocGroup {
+  name: string;
+  docs: DocMeta[];
+}
+
+function buildGroups(docsMeta: DocMeta[]): DocGroup[] {
+  const groups: DocGroup[] = [];
+  docsMeta.forEach((doc) => {
+    const existing = groups.find((g) => g.name === doc.group);
+    if (existing) {
+      existing.docs.push(doc);
+    } else {
+      groups.push({ name: doc.group, docs: [doc] });
+    }
+  });
+  return groups;
+}
+
+// The root doc's slug is "" (see build-scripts/generate-docs-content.mjs's slugFromRelPath) --
+// /docs itself, not /docs/.
+function docHref(slug: string): string {
+  return slug === "" ? "/docs" : `/docs/${slug}`;
+}
+
+// DocsShell renders from [[...slug]]/page.tsx, and the App Router rebuilds a *page's* entire
+// subtree from scratch whenever a dynamic segment's value changes -- only layouts survive a
+// segment change. So every doc-to-doc navigation unmounts this component and mounts a fresh one,
+// handing .sidebarNav a brand-new DOM node whose scrollTop starts at 0. That's invisible for the
+// article and the TOC (a new doc is supposed to start at the top), but the sidebar is shared
+// chrome, not per-doc content: it should stay exactly where the reader left it. Nothing in
+// component state can carry a value across an unmount, so this lives at module scope, which
+// outlives the remount -- and is re-initialized by a real page load, which is the behavior we
+// want there.
+let lastSidebarScrollTop = 0;
+
+const DocsShell: React.FC<DocsShellProps> = ({ activeDoc, docsMeta }) => {
+  const router = useRouter();
+  const [isNavigating, startNavigation] = useTransition();
+  // .article is its own scroll pane on this page (see DocsShell.module.scss), not .content --
+  // .content itself never scrolls here, so the mobile hide-on-scroll behavior ClientLayout wires
+  // up globally onto .content has nothing to react to on /docs. Same hook, reattached to the
+  // pane that actually scrolls here.
+  const { handleScroll: handleArticleScroll } = useScrollNavHide();
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+  // null means "not yet measured" (no window on the server, client hasn't measured yet) --
+  // same three-state convention useIsPhone()/useViewport() use elsewhere in this app. Rendering
+  // the desktop layout as a default guess until the real width is known would flash it on every
+  // phone load right before snapping to compact; gating the render below on this instead avoids
+  // that.
+  const [compact, setCompact] = useState<boolean | null>(null);
+  const [tocHidden, setTocHidden] = useState<boolean | null>(null);
+  const [tocOpen, setTocOpen] = useState(false);
+  const [activeHeadingSlug, setActiveHeadingSlug] = useState<string | null>(null);
+  const articleRef = useRef<HTMLElement>(null);
+
+  useEffect(() => {
+    const checkBreakpoints = () => {
+      setCompact(window.innerWidth < TABLET_BREAKPOINT);
+      setTocHidden((prev) => {
+        const next = window.innerWidth < DESKTOP_BREAKPOINT;
+        if (prev && !next) setTocOpen(false);
+        return next;
+      });
+    };
+    checkBreakpoints();
+    window.addEventListener("resize", checkBreakpoints);
+    return () => window.removeEventListener("resize", checkBreakpoints);
+  }, []);
+
+  // Closes any drawer/popover left open from the previous doc whenever navigation lands on a
+  // new one -- covers every path a new slug can arrive by (sidebar click, browser back/
+  // forward), not just the sidebar link's own onClick. Deliberately does not reset the
+  // article's own scroll position -- switching docs keeps wherever you were scrolled to, it
+  // doesn't jump back to the top.
+  useEffect(() => {
+    setSidebarOpen(false);
+    setTocOpen(false);
+  }, [activeDoc.slug]);
+
+  // Restored from a ref callback rather than an effect: React attaches refs during the commit,
+  // after the new node is in the document (so scrollHeight is already real) but before the browser
+  // paints it -- an effect would let the sidebar paint at 0 first and visibly jump.
+  const restoreSidebarScroll = useCallback((node: HTMLElement | null) => {
+    if (node) node.scrollTop = lastSidebarScrollTop;
+  }, []);
+
+  // Recorded on every scroll rather than read back during the ref's cleanup, so this doesn't
+  // depend on React tearing down refs before it detaches the node (a detached element reports
+  // scrollTop 0, which would silently store the wrong value).
+  const handleSidebarScroll = useCallback((event: React.UIEvent<HTMLElement>) => {
+    lastSidebarScrollTop = event.currentTarget.scrollTop;
+  }, []);
+
+  const groups = useMemo(() => buildGroups(docsMeta), [docsMeta]);
+  const { html, toc } = useMemo(() => parseMarkdown(activeDoc.markdown), [activeDoc.markdown]);
+
+  // INVARIANT: this object's identity must stay stable across re-renders that don't change the
+  // markdown. React diffs dangerouslySetInnerHTML by the wrapper object's *identity*, never by
+  // the HTML string's value (see updateProperties' `nextProp === lastProp` prop loop in
+  // react-dom) -- so an inline `{{ __html: html }}` literal re-assigns <main>.innerHTML on every
+  // single render. That re-parses the whole document and, critically, destroys and recreates
+  // every heading node inside it, which is what silently broke scrollspy: this page re-renders
+  // on every scroll direction change (useScrollNavHide flips navHidden in context), so the
+  // article's DOM was being rebuilt out from under the scrollspy effect constantly. It also
+  // intermittently reset the pane's scroll position back to the top.
+  const articleHtml = useMemo(() => ({ __html: html }), [html]);
+
+  // Scrollspy: highlights whichever h1/h2 is currently nearest the top of the article. The
+  // active heading is the last one (in document order) whose top has already crossed the
+  // activation line, which stays correct anywhere within a section (including inside its h3
+  // subsections, not just right at the h2's own boundary).
+  const updateActiveHeading = useCallback(() => {
+    const article = articleRef.current;
+    if (!article) return;
+    const tocSlugs = new Set(toc.map((item) => item.slug));
+    if (tocSlugs.size === 0) {
+      setActiveHeadingSlug(null);
+      return;
+    }
+
+    // INVARIANT: re-query the headings on every update rather than caching the node list.
+    // <main>'s content comes from dangerouslySetInnerHTML, so any commit that re-assigns it
+    // swaps every heading node out for a fresh one. A cached-but-detached node reports
+    // getBoundingClientRect().top === 0, and since 0 satisfies the "already scrolled past"
+    // test, *every* heading looks passed at once and the loop below pins the highlight to the
+    // last one permanently. Live lookups can't go stale that way. querySelectorAll returns
+    // document order, which is the order the TOC is built in.
+    const headingEls = Array.from(
+      article.querySelectorAll<HTMLElement>("h1[id], h2[id]")
+    ).filter((el) => tocSlugs.has(el.id));
+    if (headingEls.length === 0) return;
+
+    // Measured from the article pane's own top edge, not the viewport's -- the article is its
+    // own scroll container (own overflow-y:auto, see DocsShell.module.scss's .article) rather
+    // than .content, since the three columns each scroll independently on this page. A
+    // viewport-absolute line would have to be re-derived from the navbar's height at every
+    // breakpoint, and would be wrong again while the mobile navbar is hidden. 80px clears the
+    // largest scroll-margin-top the headings use (72px on phones, see the stylesheet), so a
+    // heading jumped to by clicking its own TOC link lands already counted as active.
+    const lineY = article.getBoundingClientRect().top + 80;
+    let current = headingEls[0];
+    for (const el of headingEls) {
+      if (el.getBoundingClientRect().top <= lineY) {
+        current = el;
+      } else {
+        break;
+      }
+    }
+    setActiveHeadingSlug(current.id);
+  }, [toc]);
+
+  useEffect(() => {
+    const article = articleRef.current;
+    if (!article) return;
+    updateActiveHeading();
+    article.addEventListener("scroll", updateActiveHeading, { passive: true });
+    // A fragment jump moves the article's scroll position without firing a scroll event on it,
+    // so the scroll listener alone never sees deep links or back/forward between #hashes.
+    window.addEventListener("hashchange", updateActiveHeading);
+    return () => {
+      article.removeEventListener("scroll", updateActiveHeading);
+      window.removeEventListener("hashchange", updateActiveHeading);
+    };
+    // compact is in the deps (even though it's not read here) because this component renders
+    // null until compact/tocHidden resolve (see the guard near the bottom) -- articleRef.current
+    // is still null on the render where this effect first runs with a real `toc`, so it bails
+    // out via the `!article` check above and never re-fires once compact flips from null to a
+    // real boolean and <main> actually mounts, unless that flip is itself a dependency here.
+  }, [updateActiveHeading, compact]);
+
+  // Clicking a TOC link scrolls the article via the browser's own fragment jump, which fires no
+  // scroll event on the pane -- without this the highlight stays wherever it was and the entry
+  // you just clicked never lights up. Deferred a macrotask because the jump is the click's
+  // default action, so it hasn't happened yet while this handler runs. hashchange above doesn't
+  // cover re-clicking the entry you're already on (same hash -> no event), which still moves
+  // the scroll position if you'd scrolled away since.
+  const handleTocNavigate = useCallback(() => {
+    setTimeout(updateActiveHeading, 0);
+  }, [updateActiveHeading]);
+
+  // Keeps the highlighted TOC entry visible inside the TOC's own scroll region as scrollspy
+  // moves it -- .tocNav/.tocPanel have their own max-height + overflow-y:auto, so without this,
+  // scrolling the article far enough (in either direction) can move the active heading past the
+  // TOC's own visible area, and the TOC pane never follows since nothing scrolls it. block:
+  // "nearest" only moves it the minimum needed, so this doesn't fight the user's own TOC scroll
+  // when the active link is already visible.
+  useEffect(() => {
+    if (!activeHeadingSlug) return;
+    const link = document.querySelector<HTMLElement>(
+      `a[class*="tocLink"][href="#${CSS.escape(activeHeadingSlug)}"]`
+    );
+    link?.scrollIntoView({ block: "nearest" });
+  }, [activeHeadingSlug]);
+
+  // Doc links stay real <Link>s (href for prefetch/right-click/open-in-new-tab), but the click
+  // is intercepted so the resulting navigation runs inside a transition -- isNavigating from
+  // that transition is the one signal TopLoadingBar needs, regardless of which link (sidebar or
+  // future ones) triggered it.
+  const navigateToDoc = (event: React.MouseEvent, href: string) => {
+    event.preventDefault();
+    setSidebarOpen(false);
+    startNavigation(() => {
+      router.push(href);
+    });
+  };
+
+  // See the compact/tocHidden state comment above -- render nothing until both are measured,
+  // same as AppNavbar's isPhone === null guard.
+  if (compact === null || tocHidden === null) {
+    return null;
+  }
+
+  return (
+    <div className={styles.page}>
+      <TopLoadingBar active={isNavigating} />
+      <div className={`${styles.compactBar} ${compact ? styles.isCompact : ""}`}>
+        <button
+          type="button"
+          className={styles.sidebarIconBtn}
+          aria-label="Open contents"
+          onClick={() => setSidebarOpen(true)}
+        >
+          <PanelToggleIcon />
+        </button>
+        <span className={styles.breadcrumbGroup}>{activeDoc.group}</span>
+        <span className={styles.breadcrumbGroup}>/</span>
+        <span className={styles.breadcrumbTitle}>{activeDoc.title}</span>
+      </div>
+
+      {compact && sidebarOpen && (
+        <div className={styles.overlay} onClick={() => setSidebarOpen(false)} />
+      )}
+
+      <div className={styles.columns}>
+        <nav
+          ref={restoreSidebarScroll}
+          onScroll={handleSidebarScroll}
+          className={`${styles.sidebarNav} ${compact ? styles.isCompact : ""} ${
+            compact && sidebarOpen ? styles.isOpen : ""
+          }`}
+        >
+          <div className={`${styles.sidebarHeader} ${compact ? styles.isCompact : ""}`}>
+            <span>Contents</span>
+            <button
+              type="button"
+              className={styles.sidebarClose}
+              aria-label="Close contents"
+              onClick={() => setSidebarOpen(false)}
+            >
+              ✕
+            </button>
+          </div>
+          {groups.map((group) => (
+            <React.Fragment key={group.name}>
+              <div className={styles.groupLabel}>{group.name}</div>
+              {group.docs.map((doc) => (
+                <Link
+                  key={doc.slug}
+                  href={docHref(doc.slug)}
+                  className={`${styles.docLink} ${doc.slug === activeDoc.slug ? styles.isActive : ""}`}
+                  onClick={(event) => navigateToDoc(event, docHref(doc.slug))}
+                >
+                  {doc.title}
+                </Link>
+              ))}
+            </React.Fragment>
+          ))}
+        </nav>
+
+        <div className={styles.articleColumn}>
+          <main
+            ref={articleRef}
+            className={styles.article}
+            onScroll={handleArticleScroll}
+            dangerouslySetInnerHTML={articleHtml}
+          />
+
+          {tocHidden && (
+            <div className={styles.tocToggleSlot}>
+              <button
+                type="button"
+                className={styles.sidebarIconBtn}
+                aria-label="Open on this page"
+                onClick={() => setTocOpen((prev) => !prev)}
+              >
+                <TocToggleIcon />
+              </button>
+              {tocOpen && (
+                <React.Fragment>
+                  <div className={styles.tocScrim} onClick={() => setTocOpen(false)} />
+                  <div className={styles.tocPanel}>
+                    <div className={styles.tocPanelHeader}>
+                      <span>On this page</span>
+                      <button
+                        type="button"
+                        className={styles.sidebarClose}
+                        aria-label="Close"
+                        onClick={() => setTocOpen(false)}
+                      >
+                        ✕
+                      </button>
+                    </div>
+                    <TocList
+                      toc={toc}
+                      activeSlug={activeHeadingSlug}
+                      onNavigate={() => {
+                        setTocOpen(false);
+                        handleTocNavigate();
+                      }}
+                    />
+                  </div>
+                </React.Fragment>
+              )}
+            </div>
+          )}
+        </div>
+
+        {!tocHidden && (
+          <nav className={styles.tocNav}>
+            <div className={styles.tocLabel}>On this page</div>
+            <TocList toc={toc} activeSlug={activeHeadingSlug} onNavigate={handleTocNavigate} />
+          </nav>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default DocsShell;

--- a/frontend/app/components/docs/DocsShell.tsx
+++ b/frontend/app/components/docs/DocsShell.tsx
@@ -214,8 +214,13 @@ const DocsShell: React.FC<DocsShellProps> = ({ activeDoc, docsMeta }) => {
   // Doc links stay real <Link>s (href for prefetch/right-click/open-in-new-tab), but the click
   // is intercepted so the resulting navigation runs inside a transition -- isNavigating from
   // that transition is the one signal TopLoadingBar needs, regardless of which link (sidebar or
-  // future ones) triggered it.
+  // future ones) triggered it. Only for a plain left-click, though -- a modified or non-primary
+  // click (Cmd/Ctrl-click, Shift-click, middle-click) is the browser's own "open in new
+  // tab/window" gesture, which this must not swallow.
   const navigateToDoc = (event: React.MouseEvent, href: string) => {
+    if (event.defaultPrevented || event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {
+      return;
+    }
     event.preventDefault();
     setSidebarOpen(false);
     startNavigation(() => {

--- a/frontend/app/components/docs/DocsShell.tsx
+++ b/frontend/app/components/docs/DocsShell.tsx
@@ -71,6 +71,19 @@ const DocsShell: React.FC<DocsShellProps> = ({ activeDoc, docsMeta }) => {
   const [tocOpen, setTocOpen] = useState(false);
   const [activeHeadingSlug, setActiveHeadingSlug] = useState<string | null>(null);
   const articleRef = useRef<HTMLElement>(null);
+  const sidebarToggleBtnRef = useRef<HTMLButtonElement>(null);
+  const wasSidebarOpenRef = useRef(false);
+
+  // The compact drawer is only ever transform: translateX()'d off-screen, not unmounted, so
+  // without `inert` its links stay tab-reachable and screen-reader-visible while "closed".
+  // Moving focus back to the button that opened it (rather than leaving it on whatever drawer
+  // link had focus, which is about to go inert) keeps keyboard/AT navigation coherent.
+  useEffect(() => {
+    if (wasSidebarOpenRef.current && !sidebarOpen) {
+      sidebarToggleBtnRef.current?.focus();
+    }
+    wasSidebarOpenRef.current = sidebarOpen;
+  }, [sidebarOpen]);
 
   useEffect(() => {
     const checkBreakpoints = () => {
@@ -239,6 +252,7 @@ const DocsShell: React.FC<DocsShellProps> = ({ activeDoc, docsMeta }) => {
       <TopLoadingBar active={isNavigating} />
       <div className={`${styles.compactBar} ${compact ? styles.isCompact : ""}`}>
         <button
+          ref={sidebarToggleBtnRef}
           type="button"
           className={styles.sidebarIconBtn}
           aria-label="Open contents"
@@ -259,6 +273,7 @@ const DocsShell: React.FC<DocsShellProps> = ({ activeDoc, docsMeta }) => {
         <nav
           ref={restoreSidebarScroll}
           onScroll={handleSidebarScroll}
+          inert={compact && !sidebarOpen}
           className={`${styles.sidebarNav} ${compact ? styles.isCompact : ""} ${
             compact && sidebarOpen ? styles.isOpen : ""
           }`}

--- a/frontend/app/components/docs/DocsTocList.tsx
+++ b/frontend/app/components/docs/DocsTocList.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import type { TocItem } from "../../../util/docs/parseMarkdown";
+import styles from "../../../styles/components/docs/DocsShell.module.scss";
+
+interface TocListProps {
+  toc: TocItem[];
+  activeSlug: string | null;
+  onNavigate?: () => void;
+}
+
+const TocList: React.FC<TocListProps> = ({ toc, activeSlug, onNavigate }) => (
+  <React.Fragment>
+    {toc.map((item) => (
+      <a
+        key={item.slug}
+        href={`#${item.slug}`}
+        className={`${styles.tocLink} ${item.level === 1 ? styles.isH1 : styles.isH2} ${
+          item.slug === activeSlug ? styles.isCurrent : ""
+        }`}
+        onClick={onNavigate}
+      >
+        {item.text}
+      </a>
+    ))}
+  </React.Fragment>
+);
+
+export default TocList;

--- a/frontend/app/components/navbar/AppNavbar.tsx
+++ b/frontend/app/components/navbar/AppNavbar.tsx
@@ -105,6 +105,13 @@ const AppNavbar: React.FC = () => {
                             </Tooltip>
                         )}
                     </li>
+                    <li className={navItemClass(pathname?.startsWith("/docs") ?? false)}>
+                        <Tooltip content="Guides, admin/import reference, and API docs">
+                            <Link href="/docs">
+                                <p>Resources</p>
+                            </Link>
+                        </Tooltip>
+                    </li>
                     <li>
                         {status === "loading" ? (
                             <div className={styles.signInButton} style={{ opacity: 0, pointerEvents: "none" }}>

--- a/frontend/app/components/navbar/AppSidebar.tsx
+++ b/frontend/app/components/navbar/AppSidebar.tsx
@@ -80,6 +80,9 @@ const AppSidebar: React.FC<AppSidebarProps> = ({ isOpen, onClose }) => {
                   <p className={styles.lockedHint}>Sign in to access Admin</p>
                 </div>
               )}
+              <Link href="/docs" className={rowClass(pathname?.startsWith("/docs") ?? false)} onClick={onClose}>
+                Resources
+              </Link>
             </nav>
           </motion.div>
         </React.Fragment>

--- a/frontend/build-scripts/generate-docs-content.mjs
+++ b/frontend/build-scripts/generate-docs-content.mjs
@@ -63,9 +63,14 @@ function slugFromRelPath(relPath) {
 // doc's own directory under docs/ ("" for repo-root docs), used to resolve a relative href the
 // same way a file browser would.
 function resolveDocLink(href, currentDir) {
-  const withoutTrailingSlash = href.replace(/\/$/, "");
+  // Split off the query/fragment before any path handling -- "foo.md#section" is a single path
+  // segment as far as path.posix.join/normalize are concerned, so left unsplit its ".md" never
+  // lands at the end of the string and slugFromRelPath's own suffix stripping never fires.
+  const [, hrefPath, query = "", fragment = ""] = href.match(/^([^?#]*)(\?[^#]*)?(#.*)?$/) ?? [null, href];
+  const withoutTrailingSlash = hrefPath.replace(/\/$/, "");
   const joined = path.posix.normalize(path.posix.join(currentDir, withoutTrailingSlash));
-  return `/docs/${slugFromRelPath(joined.endsWith(".md") ? joined : `${joined}.md`)}`;
+  const slug = slugFromRelPath(joined.endsWith(".md") ? joined : `${joined}.md`);
+  return `/docs/${slug}${query}${fragment}`;
 }
 
 // Only rewrites inter-doc links: external (http/https/mailto) and same-page anchors (#slug) are

--- a/frontend/build-scripts/generate-docs-content.mjs
+++ b/frontend/build-scripts/generate-docs-content.mjs
@@ -1,0 +1,118 @@
+// Snapshots docs/ (repo root, one level above this app) into a generated TS module inside
+// frontend/ so the /docs page never reads the filesystem at request time. Necessary, not just
+// convenient: /docs is dynamically rendered (its (main) layout reads cookies for auth, which
+// forces the whole route tree dynamic), and Turbopack flatly refuses to trace/bundle files
+// outside the project root ("glob '../docs/**/*' is invalid, it has a prefix that navigates out
+// of the project root") -- a runtime fs.readFileSync("../docs/...") would 500 in production.
+//
+// Run via the "dev"/"build" scripts in package.json, not a git-tracked "scripts/" one-off
+// (that directory is local-only per this repo's convention, so anything Vercel needs to run
+// can't live there). Regenerated on every dev/build -- docs/ stays the single source of truth,
+// this file is a disposable, gitignored build artifact.
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const frontendRoot = path.join(scriptDir, "..");
+const docsRoot = path.join(frontendRoot, "..", "docs");
+const outFile = path.join(frontendRoot, "util", "docs", "docsContent.generated.ts");
+
+// Hand-curated mirror of docs/README.md's own table of contents (group + per-group ordering) --
+// not derived by parsing that file, since treating prose as a machine manifest is brittle. Keep
+// this in sync by hand when docs/ files are added, removed, or reordered.
+//
+// docs/03-development/testing/ is a nested subfolder with no sidebar equivalent (the design has
+// no 3rd nesting level), so its two docs flatten into the Development group after the rest.
+const MANIFEST = [
+  { group: "Overview", relPath: "README.md" },
+  { group: "User Guide", relPath: "01-user-guide/user-guide.md" },
+  { group: "Handoff", relPath: "02-handoff/README.md" },
+  { group: "Handoff", relPath: "02-handoff/ownership-and-access.md" },
+  { group: "Handoff", relPath: "02-handoff/credentials-and-integrations.md" },
+  { group: "Handoff", relPath: "02-handoff/deployment-and-rollback.md" },
+  { group: "Handoff", relPath: "02-handoff/backups-and-recovery.md" },
+  { group: "Handoff", relPath: "02-handoff/support-process.md" },
+  { group: "Handoff", relPath: "02-handoff/contingency-transfer.md" },
+  { group: "Handoff", relPath: "02-handoff/technical-decisions.md" },
+  { group: "Development", relPath: "03-development/project-structure.md" },
+  { group: "Development", relPath: "03-development/api-reference.md" },
+  { group: "Development", relPath: "03-development/integration-guides.md" },
+  { group: "Development", relPath: "03-development/testing/README.md" },
+  { group: "Development", relPath: "03-development/testing/manual-test-script-template.md" },
+];
+
+const TITLE_PATTERN = /^#\s+(.+)$/m;
+
+// URL slug mirrors the file's own path under docs/ (e.g. "02-handoff/ownership-and-access.md"
+// -> "02-handoff/ownership-and-access"), so /docs/<slug> reads directly as "which file". A
+// folder's own README maps to "<folder>/overview" -- not the bare folder path -- so a group's
+// index doc has an explicit URL of its own; page.tsx redirects the bare folder path (e.g.
+// /docs/02-handoff) there. The repo-root README (slug "") is what bare /docs resolves to.
+function slugFromRelPath(relPath) {
+  const noExt = relPath.replace(/\.md$/, "");
+  if (noExt === "README") return "";
+  if (noExt.endsWith("/README")) return `${noExt.slice(0, -"/README".length)}/overview`;
+  return noExt;
+}
+
+// Rewrites a markdown link target found in some doc's own markdown into an app-absolute
+// /docs/<slug> URL, so links between docs work when rendered inside the app (their original
+// hrefs are relative to the *file's* location within docs/, which means nothing once that
+// content is served from an app route instead of viewed as a file). currentDir is the linking
+// doc's own directory under docs/ ("" for repo-root docs), used to resolve a relative href the
+// same way a file browser would.
+function resolveDocLink(href, currentDir) {
+  const withoutTrailingSlash = href.replace(/\/$/, "");
+  const joined = path.posix.normalize(path.posix.join(currentDir, withoutTrailingSlash));
+  return `/docs/${slugFromRelPath(joined.endsWith(".md") ? joined : `${joined}.md`)}`;
+}
+
+// Only rewrites inter-doc links: external (http/https/mailto) and same-page anchors (#slug) are
+// left alone, and a link that already has a docs/ prefix (absolute or relative) is left alone
+// too, on the assumption whoever wrote it already meant exactly that path.
+function rewriteInterPageLinks(markdown, currentDir) {
+  return markdown.replace(/(\[[^\]]*\]\()([^)]+)(\))/g, (match, open, href, close) => {
+    if (/^([a-z]+:|#)/i.test(href) || /^\/?docs\//.test(href)) {
+      return match;
+    }
+    return `${open}${resolveDocLink(href, currentDir)}${close}`;
+  });
+}
+
+// Exported (not just written to outFile) so generate-pagefind-index.mjs can reuse this exact
+// array -- it needs the same slug/title/markdown data to build the search index, and importing
+// it here avoids that script re-reading docs/ itself or importing the generated *.ts* output
+// (plain node can't parse TypeScript module resolution the way webpack/tsc do).
+export const docs = MANIFEST.map(({ group, relPath }) => {
+  const raw = fs.readFileSync(path.join(docsRoot, relPath), "utf-8");
+  const title = raw.match(TITLE_PATTERN)?.[1] ?? relPath;
+  const slug = slugFromRelPath(relPath);
+  const currentDir = path.posix.dirname(relPath); // "." for a repo-root file
+  const markdown = rewriteInterPageLinks(raw, currentDir === "." ? "" : currentDir);
+  return { slug, title, group, markdown };
+});
+
+// Guarded so importing `docs` from generate-pagefind-index.mjs doesn't also re-run this file's
+// own write -- only the direct `node build-scripts/generate-docs-content.mjs` invocation (the
+// "dev"/"build" package.json scripts) should write docsContent.generated.ts.
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const entries = docs
+    .map(
+      (doc) =>
+        `  { slug: ${JSON.stringify(doc.slug)}, title: ${JSON.stringify(doc.title)}, group: ${JSON.stringify(doc.group)}, markdown: ${JSON.stringify(doc.markdown)} }`
+    )
+    .join(",\n");
+
+  const output = `// AUTO-GENERATED by build-scripts/generate-docs-content.mjs -- do not edit by hand.
+// Source of truth: docs/ at the repo root. Regenerated on every dev/build run.
+
+export const DOCS = [
+${entries},
+];
+`;
+
+  fs.mkdirSync(path.dirname(outFile), { recursive: true });
+  fs.writeFileSync(outFile, output);
+  console.log(`Generated ${path.relative(frontendRoot, outFile)} from ${docs.length} docs/ files.`);
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,8 +3,8 @@
   "version": "2026.8.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
-    "build": "prisma generate && if [ \"$VERCEL_ENV\" = \"production\" ]; then prisma migrate deploy; fi && next build",
+    "dev": "node build-scripts/generate-docs-content.mjs && next dev",
+    "build": "node build-scripts/generate-docs-content.mjs && prisma generate && if [ \"$VERCEL_ENV\" = \"production\" ]; then prisma migrate deploy; fi && next build",
     "start": "next start",
     "lint": "eslint --config config/eslint.config.mjs .",
     "lint:fix": "eslint --config config/eslint.config.mjs . --fix",
@@ -32,6 +32,7 @@
     "axios": "^1.19.0",
     "dayjs": "^1.11.21",
     "googleapis": "^174.0.0",
+    "marked": "^18.0.9",
     "motion": "^12.43.0",
     "next": "16.2.12",
     "next-auth": "^4.24.15",

--- a/frontend/styles/Variables.module.scss
+++ b/frontend/styles/Variables.module.scss
@@ -61,10 +61,15 @@ $room-remote-color: #7ED8C2;
 
 // Responsive breakpoints. $breakpoint-tablet (768px) is also the value MeetingForm.module.scss
 // already uses in its own media query — same threshold, not a conflict, just worth knowing
-// they now overlap in purpose. Kept in sync manually with util/breakpoints.ts (Sass vars
+// they now overlap in purpose. Kept in sync manually with util/common/breakpoints.ts (Sass vars
 // aren't importable into TS).
 $breakpoint-phone: 480px;
 $breakpoint-tablet: 768px;
+$breakpoint-desktop: 1024px;
+
+// Docs page sidebar/compact-bar dividers -- distinct from $grey-border-color (#DDD), which is
+// used for field-box borders and card fills.
+$border-divider-color: #E5E5E5;
 
 // Z-index scheme -- ground truth for all NEW z-indexing going forward. Existing z-index
 // values elsewhere in the codebase predate this scheme and are not guaranteed to conform;

--- a/frontend/styles/components/docs/DocsShell.module.scss
+++ b/frontend/styles/components/docs/DocsShell.module.scss
@@ -1,6 +1,8 @@
 @import '../../Variables.module.scss';
 
 .page {
+  display: flex;
+  flex-direction: column;
   font-family: 'Source Sans Pro', sans-serif;
   position: relative; // anchors TopLoadingBar, which positions itself absolutely against this
   height: 100%; // percentage-height chain down to .sidebarNav/.tocNav's max-height -- see .columns
@@ -57,6 +59,11 @@
   display: flex;
   width: 100%;
 
+  // .page is itself a flex column now (see its own comment) so this only ever claims the space
+  // .compactBar (a normal-height sibling, visible in compact mode) doesn't -- height: 100% here
+  // would instead stack on top of .compactBar's own height and push .page taller than its own
+  // container, making the outer .content pane scroll (defeating the whole point of the
+  // independently-scrolling-panes design below).
   // Chained from .page/.content (MainLayout's own flex:1 area, already correctly sized to
   // "viewport minus navbar" by flexbox), so .sidebarNav/.article/.tocNav's own height: 100% each
   // resolve against the real remaining space below the navbar. All three are independently
@@ -64,7 +71,8 @@
   // sticky sidebar -- .content (the shared ancestor's own overflow-y: auto) never actually
   // scrolls on this page as a result, since none of .columns's children overflow past their own
   // capped height anymore.
-  height: 100%;
+  flex: 1;
+  min-height: 0;
   gap: 48px;
   padding: 32px 24px;
   align-items: flex-start;
@@ -182,6 +190,13 @@
   overflow-y: auto;
   padding-top: 4px;
 
+  // Width-or-height, not width alone -- matches MainLayout.module.scss's own $breakpoint-phone
+  // query for the exact same concern: MobileAppNavbar is position: fixed (48px tall) below that
+  // breakpoint, so an anchor-jump needs scroll-margin-top past it, or the heading lands
+  // underneath it. Above the breakpoint the desktop navbar isn't fixed, so 24px (breathing room
+  // only) is enough. h1 gets this too, not just h2/h3 -- the TOC includes h1 entries (any
+  // heading at depth <= 2, see parseMarkdown.ts), so a TOC click can fragment-jump straight to
+  // one on phone just as easily as to an h2.
   :global(h1) {
     font-size: 32px;
     font-weight: 600;
@@ -189,13 +204,13 @@
     color: $black-color;
     border-bottom: 2px solid $light-grey-color;
     padding-bottom: 12px;
+    scroll-margin-top: 24px;
+
+    @media (width <= $breakpoint-phone), (height <= $breakpoint-phone) {
+      scroll-margin-top: 72px;
+    }
   }
 
-  // Width-or-height, not width alone -- matches MainLayout.module.scss's own $breakpoint-phone
-  // query for the exact same concern: MobileAppNavbar is position: fixed (48px tall) below that
-  // breakpoint, so an anchor-jump needs scroll-margin-top past it, or the heading lands
-  // underneath it. Above the breakpoint the desktop navbar isn't fixed, so 24px (breathing room
-  // only) is enough.
   :global(h2) {
     font-size: 24px;
     font-weight: 600;

--- a/frontend/styles/components/docs/DocsShell.module.scss
+++ b/frontend/styles/components/docs/DocsShell.module.scss
@@ -1,0 +1,407 @@
+@import '../../Variables.module.scss';
+
+.page {
+  font-family: 'Source Sans Pro', sans-serif;
+  position: relative; // anchors TopLoadingBar, which positions itself absolutely against this
+  height: 100%; // percentage-height chain down to .sidebarNav/.tocNav's max-height -- see .columns
+}
+
+// Compact bar (under the navbar) + drawer/TOC visibility are driven entirely by JS-computed
+// width state (see DocsShell.tsx), not CSS @media queries, matching the design reference.
+.compactBar {
+  display: none;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 16px;
+  border-bottom: 1px solid $border-divider-color;
+
+  &.isCompact {
+    display: flex;
+  }
+}
+
+.sidebarIconBtn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid $light-grey-color;
+  background: $white-color;
+  color: $black-color;
+  border-radius: $radius-md;
+  padding: 6px;
+  cursor: pointer;
+}
+
+.breadcrumbGroup {
+  font-size: 14px;
+  color: $medium-grey-color;
+}
+
+.breadcrumbTitle {
+  font-size: 14px;
+  color: $black-color;
+  font-weight: 600;
+}
+
+// Same $z-index-modal tier AppSidebar.module.scss uses for its own backdrop+drawer pair --
+// equal values are fine since DOM order (overlay painted before the drawer) already puts the
+// drawer on top.
+.overlay {
+  position: fixed;
+  inset: 0;
+  background: rgb(0 0 0 / 30%);
+  z-index: $z-index-modal;
+}
+
+.columns {
+  display: flex;
+  width: 100%;
+
+  // Chained from .page/.content (MainLayout's own flex:1 area, already correctly sized to
+  // "viewport minus navbar" by flexbox), so .sidebarNav/.article/.tocNav's own height: 100% each
+  // resolve against the real remaining space below the navbar. All three are independently
+  // scrollable panes (their own overflow-y: auto) rather than one shared page scroll with a
+  // sticky sidebar -- .content (the shared ancestor's own overflow-y: auto) never actually
+  // scrolls on this page as a result, since none of .columns's children overflow past their own
+  // capped height anymore.
+  height: 100%;
+  gap: 48px;
+  padding: 32px 24px;
+  align-items: flex-start;
+  position: relative;
+  box-sizing: border-box; // width: 100% + padding would otherwise overflow the viewport by the padding amount
+}
+
+.sidebarNav {
+  width: 250px;
+  flex-shrink: 0;
+  height: 100%; // own independent scroll pane -- see .columns's comment
+  overflow-y: auto;
+  padding-right: 16px;
+  padding-bottom: 24px; // breathing room below the last doc link, so it isn't flush against the scroll region's edge
+  border-right: 1px solid $border-divider-color;
+  box-sizing: border-box; // width + padding-right, and .isCompact's width + padding, should include both
+
+  &.isCompact {
+    position: fixed;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    height: auto; // top:0/bottom:0 on a fixed element already gives the full viewport height; overrides the base rule's height:100% (of .columns), which doesn't apply once this is out of flow
+    width: 78%;
+    max-width: 300px;
+    background: $white-color;
+    border-right: 2px solid $light-grey-color;
+    box-shadow: 8px 0 16px rgb(0 0 0 / 8%);
+    z-index: $z-index-modal;
+    padding: 16px;
+    transition: transform 0.25s ease;
+    transform: translateX(-100%);
+
+    &.isOpen {
+      transform: translateX(0);
+    }
+  }
+}
+
+.sidebarHeader {
+  display: none;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: $medium-grey-color;
+  padding-bottom: 12px;
+  margin-bottom: 6px;
+  border-bottom: 1px solid $border-divider-color;
+
+  &.isCompact {
+    display: flex;
+  }
+}
+
+.sidebarClose {
+  border: 1px solid $light-grey-color;
+  background: $white-color;
+  color: $black-color;
+  border-radius: $radius-md;
+  padding: 5px 8px;
+  cursor: pointer;
+  font-size: 13px;
+  line-height: 1;
+}
+
+.groupLabel {
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: $medium-grey-color;
+  margin: 18px 0 10px;
+}
+
+.docLink {
+  display: block;
+  width: 100%;
+  box-sizing: border-box; // width: 100% + padding would otherwise overflow the sidebar by the padding amount
+  text-align: left;
+  border: none;
+  background: transparent;
+  color: $black-color;
+  font-weight: 400;
+  font-family: 'Source Sans Pro', sans-serif;
+  font-size: 14.5px;
+  padding: 9px 12px;
+  border-radius: 6px;
+  cursor: pointer;
+  margin-bottom: 2px;
+  text-decoration: none; // buttons never needed this; now a real <Link> (real <a>), which does
+
+  &.isActive {
+    background: $grey-lightest-color;
+    color: $brand-pink-color;
+    font-weight: 600;
+  }
+}
+
+// The actual flex column (.article inside it just fills it) -- position: relative anchors
+// .tocToggleSlot, which floats inside this same column instead of taking its own flex slot when
+// tocHidden is true (the always-visible desktop .tocNav below is still its own separate column).
+.articleColumn {
+  flex: 1;
+  min-width: 0;
+  height: 100%;
+  position: relative;
+}
+
+.article {
+  width: 100%;
+  height: 100%; // own independent scroll pane -- see .columns's comment
+  overflow-y: auto;
+  padding-top: 4px;
+
+  :global(h1) {
+    font-size: 32px;
+    font-weight: 600;
+    margin: 0 0 16px;
+    color: $black-color;
+    border-bottom: 2px solid $light-grey-color;
+    padding-bottom: 12px;
+  }
+
+  // Width-or-height, not width alone -- matches MainLayout.module.scss's own $breakpoint-phone
+  // query for the exact same concern: MobileAppNavbar is position: fixed (48px tall) below that
+  // breakpoint, so an anchor-jump needs scroll-margin-top past it, or the heading lands
+  // underneath it. Above the breakpoint the desktop navbar isn't fixed, so 24px (breathing room
+  // only) is enough.
+  :global(h2) {
+    font-size: 24px;
+    font-weight: 600;
+    margin: 40px 0 12px;
+    color: $black-color;
+    scroll-margin-top: 24px;
+
+    @media (width <= $breakpoint-phone), (height <= $breakpoint-phone) {
+      scroll-margin-top: 72px;
+    }
+  }
+
+  :global(h3) {
+    font-size: 18px;
+    font-weight: 600;
+    margin: 28px 0 8px;
+    color: $black-color;
+    scroll-margin-top: 24px;
+
+    @media (width <= $breakpoint-phone), (height <= $breakpoint-phone) {
+      scroll-margin-top: 72px;
+    }
+  }
+
+  :global(p),
+  :global(ul),
+  :global(ol) {
+    font-size: 16px;
+    line-height: 1.65;
+    color: $navy-color;
+    margin: 0 0 16px;
+  }
+
+  :global(ul),
+  :global(ol) {
+    padding-left: 22px;
+  }
+
+  :global(li) {
+    margin-bottom: 6px;
+  }
+
+  :global(li) > :global(p) {
+    margin-bottom: 6px;
+  }
+
+  :global(code) {
+    font-family: SFMono-Regular, Consolas, monospace;
+    font-size: 14px;
+    background: $grey-lightest-color;
+    padding: 2px 6px;
+    border-radius: $radius-sm;
+    color: $brand-pink-color;
+  }
+
+  :global(pre) {
+    background: $black-color;
+    color: $grey-lightest-color;
+    padding: 16px 20px;
+    border-radius: $radius-md;
+    overflow-x: auto;
+    margin: 0 0 20px;
+    font-size: 13.5px;
+    line-height: 1.6;
+
+    :global(code) {
+      background: none;
+      padding: 0;
+      color: inherit;
+    }
+  }
+
+  :global(table) {
+    border-collapse: collapse;
+    width: 100%;
+    margin: 0 0 20px;
+    font-size: 14px;
+  }
+
+  :global(th),
+  :global(td) {
+    border: 1px solid $light-grey-color;
+    padding: 8px 12px;
+    text-align: left;
+  }
+
+  :global(th) {
+    background: $grey-lightest-color;
+    font-weight: 600;
+  }
+
+  :global(a) {
+    color: $brand-pink-color;
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+
+  :global(blockquote) {
+    border-left: 3px solid $light-grey-color;
+    margin: 0 0 16px;
+    padding: 4px 16px;
+    color: $medium-grey-color;
+  }
+
+  :global(hr) {
+    border: none;
+    border-top: 1px solid $light-grey-color;
+    margin: 32px 0;
+  }
+}
+
+.tocNav {
+  width: 250px;
+  flex-shrink: 0;
+  height: 100%; // own independent scroll pane -- see .columns's comment
+  overflow-y: auto;
+  padding-bottom: 24px; // breathing room below the last entry
+}
+
+// Replaces .tocNav below $breakpoint-desktop: floats inside .articleColumn (see its comment)
+// rather than taking its own flex slot, since there's no room for a fourth column at this width.
+// position: absolute here still establishes a containing block for .tocPanel below, so the
+// popover anchors to this button regardless of where .articleColumn itself sits.
+.tocToggleSlot {
+  position: absolute;
+  top: -16px;
+  right: 16px;
+  z-index: $z-index-dropdown; // floats above the article's own (independently scrolling) content
+}
+
+// Transparent click-catcher (not the dark $z-index-modal .overlay used for the sidebar drawer)
+// -- this is a lightweight popover, not a full-screen modal, so dismissing it shouldn't dim the
+// whole page.
+.tocScrim {
+  position: fixed;
+  inset: 0;
+  z-index: $z-index-dropdown;
+}
+
+.tocPanel {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  width: 220px;
+  max-height: 60vh;
+  overflow-y: auto;
+  background: $white-color;
+  border: 1px solid $light-grey-color;
+  border-radius: $radius-md;
+  box-shadow: 0 8px 16px rgb(0 0 0 / 8%);
+  padding: 16px;
+  z-index: $z-index-dropdown;
+  box-sizing: border-box; // width + padding should include both
+}
+
+.tocPanelHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: $medium-grey-color;
+  padding-bottom: 12px;
+  margin-bottom: 6px;
+  border-bottom: 1px solid $border-divider-color;
+}
+
+.tocLabel {
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: $medium-grey-color;
+  margin-bottom: 12px;
+}
+
+.tocLink {
+  display: block;
+  font-size: 13.5px;
+  font-weight: 400;
+  color: $navy-color;
+  text-decoration: none;
+  padding: 6px 8px;
+  border-radius: 6px;
+  line-height: 1.4;
+
+  &.isH1 {
+    font-size: 14px;
+    font-weight: 600;
+  }
+
+  &.isH2 {
+    padding-left: 22px;
+  }
+
+  // Scrollspy: whichever heading is currently nearest the top of the article (see DocsShell.tsx's
+  // scroll listener). Same background+color+weight treatment as the sidebar's own active
+  // doc-link, for a consistent "you are here" look across both.
+  &.isCurrent {
+    background: $grey-lightest-color;
+    color: $brand-pink-color;
+    font-weight: 600;
+  }
+}

--- a/frontend/util/common/breakpoints.ts
+++ b/frontend/util/common/breakpoints.ts
@@ -3,3 +3,4 @@
 // into TS, so these are kept in sync manually — edit both together.
 export const PHONE_BREAKPOINT = 480;
 export const TABLET_BREAKPOINT = 768;
+export const DESKTOP_BREAKPOINT = 1024;

--- a/frontend/util/docs/loadDocs.ts
+++ b/frontend/util/docs/loadDocs.ts
@@ -1,0 +1,29 @@
+import "server-only";
+import { DOCS } from "./docsContent.generated";
+
+export interface DocEntry {
+  slug: string;
+  title: string;
+  group: string;
+  markdown: string;
+}
+
+export type DocMeta = Omit<DocEntry, "markdown">;
+
+// DOCS is generated at dev/build time by build-scripts/generate-docs-content.mjs from docs/ at
+// the repo root -- see that script for why (Turbopack can't trace files outside the project
+// root, and this route is dynamically rendered, so a runtime fs read isn't an option).
+export function loadDocs(): DocEntry[] {
+  return DOCS;
+}
+
+export function findDocBySlug(slug: string): DocEntry | undefined {
+  return DOCS.find((doc) => doc.slug === slug);
+}
+
+// Sidebar/breadcrumb only ever need title+group+slug -- stripping markdown here keeps the other
+// 14 docs' Markdown out of the client bundle for any given page load (only the one active doc's
+// markdown is ever passed to DocsShell).
+export function loadDocsMeta(): DocMeta[] {
+  return DOCS.map(({ markdown: _markdown, ...meta }) => meta);
+}

--- a/frontend/util/docs/parseMarkdown.ts
+++ b/frontend/util/docs/parseMarkdown.ts
@@ -15,9 +15,16 @@ export function slugify(text: string): string {
 
 export function parseMarkdown(markdown: string): { html: string; toc: TocItem[] } {
   const toc: TocItem[] = [];
+  const slugCounts = new Map<string, number>();
   const renderer = new Renderer();
   renderer.heading = ({ text, depth }: Tokens.Heading) => {
-    const slug = slugify(text);
+    // Repeated heading text (e.g. two "Overview" sections in one doc) would otherwise collide on
+    // both the rendered element's id and the TOC's own slug -- a fragment link then always jumps
+    // to the first match, and DocsTocList's `key={item.slug}` would collide too.
+    const baseSlug = slugify(text) || "section";
+    const count = slugCounts.get(baseSlug) ?? 0;
+    slugCounts.set(baseSlug, count + 1);
+    const slug = count === 0 ? baseSlug : `${baseSlug}-${count}`;
     if (depth <= 2) toc.push({ level: depth, text, slug });
     // parseInline renders inline markdown within the heading (several docs headings wrap
     // route paths in backticks, e.g. `### `POST /api/write/meeting``) -- the raw token text

--- a/frontend/util/docs/parseMarkdown.ts
+++ b/frontend/util/docs/parseMarkdown.ts
@@ -1,0 +1,29 @@
+import { marked, Renderer, type Tokens } from "marked";
+
+export interface TocItem {
+  level: number;
+  text: string;
+  slug: string;
+}
+
+export function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)/g, "");
+}
+
+export function parseMarkdown(markdown: string): { html: string; toc: TocItem[] } {
+  const toc: TocItem[] = [];
+  const renderer = new Renderer();
+  renderer.heading = ({ text, depth }: Tokens.Heading) => {
+    const slug = slugify(text);
+    if (depth <= 2) toc.push({ level: depth, text, slug });
+    // parseInline renders inline markdown within the heading (several docs headings wrap
+    // route paths in backticks, e.g. `### `POST /api/write/meeting``) -- the raw token text
+    // alone would leave those backticks showing instead of styled <code>.
+    return `<h${depth} id="${slug}">${marked.parseInline(text)}</h${depth}>`;
+  };
+  const html = marked.parse(markdown, { renderer }) as string;
+  return { html, toc };
+}

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -5856,6 +5856,11 @@ makeerror@1.0.12:
   dependencies:
     tmpl "1.0.5"
 
+marked@^18.0.9:
+  version "18.0.9"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-18.0.9.tgz#729fb57203a4fd58dd5ddc551917ef40daf5036a"
+  integrity sha512-/Sa4qiiHZxf0/FQdBBowr9q4r10krCwMvpK48FUBdXdUXScDxiQGR9zCPrFgRVR5LU3iySOiIjy09ZQvADir1w==
+
 math-intrinsics@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/math-intrinsics/-/math-intrinsics-1.1.0.tgz#a0dd74be81e2aa5c2f27e65ce283605ee4e2b7f9"


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a documentation hub accessible through the Resources navigation link.
  * Added document pages with metadata, breadcrumbs, Markdown rendering, table of contents, active-section tracking, and deep-link support.
  * Added responsive sidebar and table-of-contents navigation for desktop and mobile layouts.
  * Added automatic redirects for documentation folder paths and not-found handling for invalid pages.
* **User Experience**
  * Navigation now hides while scrolling content to provide more reading space.
  * Added smoother document navigation with loading feedback and preserved sidebar position.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description
- **frontend/app/(main)/docs/[[...slug]]/page.tsx**: new dynamic catch-all route rendering docs sourced from the repo's `docs/` folder. Bare group paths (e.g. `/docs/02-handoff`) redirect to the first doc under that prefix, in manifest order.
- **frontend/build-scripts/generate-docs-content.mjs**: snapshots `docs/` into a generated TS module at dev/build time (Turbopack can't trace files outside the project root, and the route is dynamically rendered due to cookie-based auth in the `(main)` layout). Rewrites inter-doc markdown links to `/docs/<slug>`.
- **frontend/util/docs/loadDocs.ts, parseMarkdown.ts**: doc loading/lookup helpers, and markdown→HTML parsing (`marked`) with heading-slug assignment + TOC extraction.
- **frontend/app/components/docs/DocsShell.tsx**: the page's client shell — three-column layout (sidebar nav / article / "on this page" TOC), independently-scrolling panes, scroll-position-based TOC highlighting (scrollspy), mobile compact bar with a sidebar drawer and TOC popover, and sidebar scroll position preserved across doc-to-doc navigation (kept at module scope, since Next's App Router fully remounts the page on every dynamic-segment change).
- **frontend/app/components/docs/DocsIcons.tsx, DocsTocList.tsx**: small extracted presentational pieces (icons, the TOC link list).
- **frontend/app/components/navbar/AppNavbar.tsx, AppSidebar.tsx**: renamed the "Docs" nav item to "Resources"; active-state check widened to `pathname?.startsWith("/docs")` so it stays highlighted on any doc.
- **frontend/app/ClientLayout.tsx**: wires the app's existing mobile hide-on-scroll-down/show-on-scroll-up navbar behavior onto `.content` generically (previously wired only for the calendar route) — needed for the docs page's own compact bar.
- **frontend/styles/Variables.module.scss, util/common/breakpoints.ts**: new `$breakpoint-desktop` / `DESKTOP_BREAKPOINT` (1024px, the TOC-hide threshold) and `$border-divider-color` tokens.
- **frontend/package.json**: adds `marked` (markdown parsing); `dev`/`build` scripts now run the content-generation script first.

## Testing
- [x] `yarn lint`, `yarn lint:css`, and `yarn build` all pass on this branch in isolation (verified independently of the stacked search PR).
- [x] `yarn test:all` passes.
- [x] Manually verified: `/docs` loads `docs/README.md` by default; sidebar navigation, TOC scrollspy, and the mobile compact bar (drawer + TOC popover) all work; sidebar scroll position survives doc-to-doc navigation; both the desktop navbar and mobile drawer show "Resources" as active on any `/docs/*` route.

## Area(s) Touched
**Product areas**
- [x] docs — /docs Resources page (rendering, navigation, search)

## Pre-merge Checklist
- [x] Code follows current formatting conventions and passes lint (`yarn lint`).
- [x] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
- [x] All test suites pass, both run locally and green in GitHub CI. **Do not merge if any test suite is failing.**
- [ ] A test suite was added or updated for the feature/fix in this PR. **Double-check this if you change a feature and did not update the test suites**. *(No new automated tests — this is a net-new page with no prior behavior to regress; verification was manual, per above.)*
- [x] Only files relevant to this change are committed — no stray or unrelated files.
- [x] If this branch has a merge conflict with master, master was merged into this branch first (not the other way around).
- [x] The rest of this PR description (Description, Testing) is filled out, not left as template placeholders.
