### PR TITLE
chore(github): replace billing product area with docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -43,7 +43,7 @@ labels: "type: bug"
 **Product areas**
 - [ ] auth — sign-in, sessions, NextAuth, role-based access
 - [ ] admin — /admin shell (Diagnostics, Users, Import, Export tabs)
-- [ ] billing — lease export, XLSX import, anything affecting invoicing
+- [ ] docs — /docs Resources page (rendering, navigation, search)
 - [ ] ui/ux — frontend layout/styling not tied to a specific integration
 
 **Integrations**

--- a/.github/ISSUE_TEMPLATE/epic.md
+++ b/.github/ISSUE_TEMPLATE/epic.md
@@ -36,7 +36,7 @@ Request: concrete and independently verifiable, not vague. -->
 **Product areas**
 - [ ] auth — sign-in, sessions, NextAuth, role-based access
 - [ ] admin — /admin shell (Diagnostics, Users, Import, Export tabs)
-- [ ] billing — lease export, XLSX import, anything affecting invoicing
+- [ ] docs — /docs Resources page (rendering, navigation, search)
 - [ ] ui/ux — frontend layout/styling not tied to a specific integration
 
 **Integrations**

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -44,7 +44,7 @@ what "correctly" actually means here. -->
 **Product areas**
 - [ ] auth — sign-in, sessions, NextAuth, role-based access
 - [ ] admin — /admin shell (Diagnostics, Users, Import, Export tabs)
-- [ ] billing — lease export, XLSX import, anything affecting invoicing
+- [ ] docs — /docs Resources page (rendering, navigation, search)
 - [ ] ui/ux — frontend layout/styling not tied to a specific integration
 
 **Integrations**

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -39,6 +39,9 @@
   from: admin
   color: "0052CC"
   description: "/admin shell — Diagnostics, Users, Import, Export tabs"
+- name: "scope: docs"
+  color: "006B75"
+  description: "/docs Resources page — rendering, navigation, search"
 - name: "scope: google-calendar"
   from: google-calendar
   color: "4285F4"
@@ -47,10 +50,6 @@
   from: zoom-api
   color: "2D8CFF"
   description: Zoom meeting/host sync (services/zoom.ts)
-- name: "scope: billing"
-  from: billing
-  color: "B60205"
-  description: Lease export, XLSX import, anything affecting invoicing
 - name: "scope: ui/ux"
   from: ui/ux
   color: "D93F0B"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,7 +21,7 @@ A best guess is fine; this gets corrected during triage if wrong. -->
 **Product areas**
 - [ ] auth — sign-in, sessions, NextAuth, role-based access
 - [ ] admin — /admin shell (Diagnostics, Users, Import, Export tabs)
-- [ ] billing — lease export, XLSX import, anything affecting invoicing
+- [ ] docs — /docs Resources page (rendering, navigation, search)
 - [ ] ui/ux — frontend layout/styling not tied to a specific integration
 
 **Integrations**

--- a/.github/workflows/label-from-checklist.yml
+++ b/.github/workflows/label-from-checklist.yml
@@ -29,7 +29,7 @@ jobs:
               // Area(s) Touched -- Product areas / Integrations
               { text: 'auth', label: 'scope: auth' },
               { text: 'admin', label: 'scope: admin' },
-              { text: 'billing', label: 'scope: billing' },
+              { text: 'docs', label: 'scope: docs' },
               { text: 'ui/ux', label: 'scope: ui/ux' },
               { text: 'google-calendar', label: 'scope: google-calendar' },
               { text: 'zoom-api', label: 'scope: zoom-api' },


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated issue, epic, feature request, and pull request templates to use a documentation scope option.
  * Added a documentation label for tracking Resources page work.
  * Updated automatic checklist labeling to apply the documentation scope.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description
- **.github/labels.yml**: replaces the `scope: billing` label with `scope: docs` — billing never accumulated enough distinct PR/issue volume to justify its own scope, while the new `/docs` Resources page (#343, #344) is a standalone product area comparable to `admin`.
- **.github/pull_request_template.md, .github/ISSUE_TEMPLATE/{bug_report,feature_request,epic}.md**: same swap in the "Product areas" checklist all four templates share, so PR/issue authors and the label-sync workflow stay consistent.
- **.github/workflows/label-from-checklist.yml**: updates the checkbox-text → label mapping accordingly (`docs` → `scope: docs`, `billing` mapping removed).

Not a behavior change to the app itself — GitHub repo configuration only. Existing issues/PRs already carrying a `scope: billing` label keep it (the label-sync tool runs with skip-delete); it just won't be offered or auto-applied going forward.

## Testing
- [x] Verified `.github/labels.yml` is valid YAML.
- [x] Grepped `.github/` for any remaining "billing" reference — none.
- [x] Confirmed the `docs` checkbox text doesn't collide with the separate `documentation` checkbox/label (which covers editing `docs/` markdown content, not this page) — the label-sync regex anchors to the start of the checkbox text, so `docs` and `documentation` can't cross-match.

## Area(s) Touched
**Engineering**
- [x] github-actions — workflows, Dependabot config, other .github/ CI tooling

## Pre-merge Checklist
- [x] Code follows current formatting conventions and passes lint (`yarn lint`). *(N/A — no app code touched.)*
- [x] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
- [x] All test suites pass, both run locally and green in GitHub CI. **Do not merge if any test suite is failing.** *(N/A — no app code touched.)*
- [ ] A test suite was added or updated for the feature/fix in this PR. *(N/A — repo config, not app behavior.)*
- [x] Only files relevant to this change are committed — no stray or unrelated files.
- [x] If this branch has a merge conflict with master, master was merged into this branch first (not the other way around).
- [x] The rest of this PR description (Description, Testing) is filled out, not left as template placeholders.
