### PR TITLE
feat(navbar): reorder links, hide Admin from non-admins, tighten bar

### DIFF
--- a/frontend/app/components/atoms/Logo.tsx
+++ b/frontend/app/components/atoms/Logo.tsx
@@ -1,14 +1,18 @@
 import Image from "next/image";
 import IcrLogo from "../../assets/icr.png"
 
-const Logo = () => {
+interface LogoProps {
+  height?: number;
+}
+
+const Logo = ({ height = 50 }: LogoProps) => {
 
   return (
     <>
         <Image
           src={IcrLogo}
           alt="Logo"
-          style={{ height: '50px', width: 'auto', padding: '6px' }}
+          style={{ height: `${height}px`, width: 'auto', padding: '6px' }}
         />
     </>
   );

--- a/frontend/app/components/navbar/AppNavbar.tsx
+++ b/frontend/app/components/navbar/AppNavbar.tsx
@@ -75,13 +75,6 @@ const AppNavbar: React.FC = () => {
                             </Link>
                         </Tooltip>
                     </li>
-                    <li className={navItemClass(pathname === "/signage")}>
-                        <Tooltip content="Read-only calendar view for signage">
-                            <Link href="/signage">
-                                <p>Signage</p>
-                            </Link>
-                        </Tooltip>
-                    </li>
                     <li className={navItemClass(pathname?.startsWith("/docs") ?? false)}>
                         <Tooltip content="Guides, admin/import reference, and API docs">
                             <Link href="/docs">

--- a/frontend/app/components/navbar/AppNavbar.tsx
+++ b/frontend/app/components/navbar/AppNavbar.tsx
@@ -65,7 +65,7 @@ const AppNavbar: React.FC = () => {
         <div className={styles.navbar}>
             <div className={styles.navcontainer}>
                 <div className={styles.navLeft}>
-                    <Logo />
+                    <Logo height={32} />
                 </div>
                 <ul className={styles.navigationlist}>
                     <li className={navItemClass(pathname === "/")}>
@@ -82,29 +82,6 @@ const AppNavbar: React.FC = () => {
                             </Link>
                         </Tooltip>
                     </li>
-                    <li className={navItemClass(pathname?.startsWith("/admin") ?? false)}>
-                        {isAdmin ? (
-                            <Tooltip content="Manage users, imports, exports, and diagnostics">
-                                <Link href="/admin">
-                                    <p>Admin</p>
-                                </Link>
-                            </Tooltip>
-                        ) : session ? (
-                            <Tooltip content="Requires admin access">
-                                <button className={styles.navLocked} disabled>
-                                    <p>Admin</p>
-                                    <img src="/svg/lock-icon.svg" alt="" className={styles.lockIcon} />
-                                </button>
-                            </Tooltip>
-                        ) : (
-                            <Tooltip content="Sign in to access Admin">
-                                <Link href="/login" className={styles.navLockedLink}>
-                                    <p>Admin</p>
-                                    <img src="/svg/lock-icon.svg" alt="" className={styles.lockIcon} />
-                                </Link>
-                            </Tooltip>
-                        )}
-                    </li>
                     <li className={navItemClass(pathname?.startsWith("/docs") ?? false)}>
                         <Tooltip content="Guides, admin/import reference, and API docs">
                             <Link href="/docs">
@@ -112,43 +89,52 @@ const AppNavbar: React.FC = () => {
                             </Link>
                         </Tooltip>
                     </li>
-                    <li>
-                        {status === "loading" ? (
-                            <div className={styles.signInButton} style={{ opacity: 0, pointerEvents: "none" }}>
-                                <p>Loading...</p>
-                            </div>
-                        ) : session && session.user ? (
-                            <div className={styles.flyoutAnchor} ref={flyoutRef}>
-                                <Tooltip content="User menu">
-                                    <button
-                                        ref={buttonRef}
-                                        type="button"
-                                        aria-label="User menu"
-                                        aria-haspopup="dialog"
-                                        aria-expanded={openFlyout}
-                                        aria-controls="user-profile-flyout"
-                                        className={styles.profileButton}
-                                        onClick={() => setOpenFlyout((prev) => !prev)}
-                                    >
-                                        {userAvatar}
-                                    </button>
-                                </Tooltip>
-                                {openFlyout && (
-                                    <div
-                                        id="user-profile-flyout"
-                                        className={styles.flyout}
-                                    >
-                                        <ProfileCard session={session} userAvatar={userAvatar} />
-                                    </div>
-                                )}
-                            </div>
-                        ) : (
-                            <Link className={styles.signInButton} href="/login">
-                                <p>Sign In</p>
-                            </Link>
-                        )}
-                    </li>
+                    {isAdmin && (
+                        <li className={navItemClass(pathname?.startsWith("/admin") ?? false)}>
+                            <Tooltip content="Manage users, imports, exports, and diagnostics">
+                                <Link href="/admin">
+                                    <p>Admin</p>
+                                </Link>
+                            </Tooltip>
+                        </li>
+                    )}
                 </ul>
+                <div className={styles.navRight}>
+                    {status === "loading" ? (
+                        <div className={styles.signInButton} style={{ opacity: 0, pointerEvents: "none" }}>
+                            <p>Loading...</p>
+                        </div>
+                    ) : session && session.user ? (
+                        <div className={styles.flyoutAnchor} ref={flyoutRef}>
+                            <Tooltip content="User menu">
+                                <button
+                                    ref={buttonRef}
+                                    type="button"
+                                    aria-label="User menu"
+                                    aria-haspopup="dialog"
+                                    aria-expanded={openFlyout}
+                                    aria-controls="user-profile-flyout"
+                                    className={styles.profileButton}
+                                    onClick={() => setOpenFlyout((prev) => !prev)}
+                                >
+                                    {userAvatar}
+                                </button>
+                            </Tooltip>
+                            {openFlyout && (
+                                <div
+                                    id="user-profile-flyout"
+                                    className={styles.flyout}
+                                >
+                                    <ProfileCard session={session} userAvatar={userAvatar} />
+                                </div>
+                            )}
+                        </div>
+                    ) : (
+                        <Link className={styles.signInButton} href="/login">
+                            <p>Sign In</p>
+                        </Link>
+                    )}
+                </div>
             </div>
         </div>
     );

--- a/frontend/app/components/navbar/AppSidebar.tsx
+++ b/frontend/app/components/navbar/AppSidebar.tsx
@@ -55,7 +55,13 @@ const AppSidebar: React.FC<AppSidebarProps> = ({ isOpen, onClose }) => {
               <Link href="/" className={rowClass(pathname === "/")} onClick={onClose}>
                 Main Calendar
               </Link>
-              {isAdmin ? (
+              <Link href="/signage" className={rowClass(pathname === "/signage")} onClick={onClose}>
+                Signage
+              </Link>
+              <Link href="/docs" className={rowClass(pathname?.startsWith("/docs") ?? false)} onClick={onClose}>
+                Resources
+              </Link>
+              {isAdmin && (
                 <Link
                   href="/admin"
                   className={rowClass(pathname?.startsWith("/admin") ?? false)}
@@ -63,26 +69,12 @@ const AppSidebar: React.FC<AppSidebarProps> = ({ isOpen, onClose }) => {
                 >
                   Admin
                 </Link>
-              ) : session ? (
-                <div className={styles.lockedGroup}>
-                  <button className={`${styles.row} ${styles.locked}`} disabled>
-                    <span>Admin</span>
-                    <img src="/svg/lock-icon.svg" alt="" className={styles.lockIcon} />
-                  </button>
-                  <p className={styles.lockedHint}>Requires admin access</p>
-                </div>
-              ) : (
-                <div className={styles.lockedGroup}>
-                  <Link href="/login" className={`${styles.row} ${styles.locked}`} onClick={onClose}>
-                    <span>Admin</span>
-                    <img src="/svg/lock-icon.svg" alt="" className={styles.lockIcon} />
-                  </Link>
-                  <p className={styles.lockedHint}>Sign in to access Admin</p>
-                </div>
               )}
-              <Link href="/docs" className={rowClass(pathname?.startsWith("/docs") ?? false)} onClick={onClose}>
-                Resources
-              </Link>
+              {!session && (
+                <Link href="/login" className={rowClass(false)} onClick={onClose}>
+                  Sign In
+                </Link>
+              )}
             </nav>
           </motion.div>
         </React.Fragment>

--- a/frontend/app/components/navbar/AppSidebar.tsx
+++ b/frontend/app/components/navbar/AppSidebar.tsx
@@ -55,9 +55,6 @@ const AppSidebar: React.FC<AppSidebarProps> = ({ isOpen, onClose }) => {
               <Link href="/" className={rowClass(pathname === "/")} onClick={onClose}>
                 Main Calendar
               </Link>
-              <Link href="/signage" className={rowClass(pathname === "/signage")} onClick={onClose}>
-                Signage
-              </Link>
               <Link href="/docs" className={rowClass(pathname?.startsWith("/docs") ?? false)} onClick={onClose}>
                 Resources
               </Link>

--- a/frontend/app/components/navbar/AppSidebar.tsx
+++ b/frontend/app/components/navbar/AppSidebar.tsx
@@ -18,7 +18,7 @@ interface AppSidebarProps {
 // AppNavbar.tsx's desktop nav list already has (session-derived, not prop-driven) so the two
 // stay in lockstep without duplicating auth state through props.
 const AppSidebar: React.FC<AppSidebarProps> = ({ isOpen, onClose }) => {
-  const { data: session } = useSession();
+  const { data: session, status } = useSession();
   const isAdmin = session?.user?.role === "ADMIN" || session?.user?.role === "SUPER_ADMIN";
   const pathname = usePathname();
 
@@ -67,7 +67,7 @@ const AppSidebar: React.FC<AppSidebarProps> = ({ isOpen, onClose }) => {
                   Admin
                 </Link>
               )}
-              {!session && (
+              {status === "unauthenticated" && (
                 <Link href="/login" className={rowClass(false)} onClick={onClose}>
                   Sign In
                 </Link>

--- a/frontend/styles/components/atoms/Tooltip.module.scss
+++ b/frontend/styles/components/atoms/Tooltip.module.scss
@@ -5,11 +5,14 @@
     display: inline-flex;
     align-items: center;
 
-    &:hover .tooltip,  
-    &:focus-within .tooltip {  
-        opacity: 1;  
-        visibility: visible;  
-    }  
+    // :focus-visible (not :focus-within) so a mouse click doesn't leave the tooltip stuck open
+    // until the user clicks elsewhere -- clicking focuses the trigger but isn't :focus-visible
+    // in browsers' focus heuristics, while real keyboard-tab focus still shows it.
+    &:hover .tooltip,
+    &:has(:focus-visible) .tooltip {
+        opacity: 1;
+        visibility: visible;
+    }
 }
 
 .tooltip {

--- a/frontend/styles/components/navbar/AppNavbar.module.scss
+++ b/frontend/styles/components/navbar/AppNavbar.module.scss
@@ -3,8 +3,9 @@
 
 .navbar {
     width: 100%;
+    height: 64px;
     background-color: #fff;
-    border-bottom: 2px solid $light-grey-color;
+    border-bottom: 1px solid $border-divider-color;
 }
 
 .logo {
@@ -24,9 +25,10 @@
     display: flex;
     flex-direction: row;
     align-items: center;
-    justify-content: space-between;
     width: 100%;
+    height: 100%;
     padding-right: 12px;
+    gap: 28px;
     box-sizing: border-box;
 }
 
@@ -38,7 +40,11 @@
 }
 
 .navigationlist {
-    display: contents;
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+    flex: 1 1 auto;
+    gap: 24px;
     color: #000;
     list-style-type: none;
     padding: 0;
@@ -48,76 +54,62 @@
         button,
         a {
             display: inline-block;
-            padding: 5px 10px;
-            border: 2px solid transparent;
-            border-radius: 8px;
+            padding: 4px 2px;
+            border: none;
+            border-bottom: 2.5px solid transparent;
             text-decoration: none;
             color: #000;
             background-color: transparent;
             font: inherit;
+            font-weight: 400;
             cursor: pointer;
-            transition: background-color 0.3s, color 0.3s, border-color 0.3s;
+            transition: color 0.15s, border-color 0.15s;
 
             &:hover,
             &:focus {
-                color: #000;
-                border-color: #000;
+                color: $brand-pink-color;
+                border-bottom-color: $light-grey-color;
             }
         }
 
         &.active {
             a {
-                color: #000;
-                background-color: #e9d8a6;
-                border-color: #000;
-            }
-        }
-
-        .navLocked {
-            display: inline-flex;
-            align-items: center;
-            gap: 4px;
-            color: $light-grey-color;
-
-            &:hover,
-            &:focus {
-                color: $light-grey-color;
-                border-color: transparent;
-            }
-        }
-
-        .navLockedLink {
-            display: inline-flex;
-            align-items: center;
-            gap: 4px;
-            color: $light-grey-color;
-        }
-
-        a.signInButton {
-            background-color: $brand-pink-color;
-            border-color: $brand-pink-color;
-            color: #fff;
-            font-weight: 600;
-            font-size: 16px;
-            padding: 8px 18px;
-
-            p {
-                margin: 0;
-            }
-
-            &:hover,
-            &:focus {
-                background-color: color.adjust($brand-pink-color, $lightness: -8%);
-                border-color: color.adjust($brand-pink-color, $lightness: -8%);
-                color: #fff;
+                color: $brand-pink-color;
+                border-bottom-color: $brand-pink-color;
+                font-weight: 600;
             }
         }
     }
 }
 
-.lockIcon {
-    width: 14px;
-    height: 14px;
+.navRight {
+    display: flex;
+    align-items: center;
+    flex-shrink: 0;
+}
+
+.signInButton {
+    display: inline-block;
+    background-color: $brand-pink-color;
+    border: 2px solid $brand-pink-color;
+    border-radius: 20px;
+    color: #fff;
+    font-weight: 600;
+    font-size: 16px;
+    padding: 8px 18px;
+    text-decoration: none;
+    cursor: pointer;
+
+    p {
+        margin: 0;
+    }
+
+    &:hover,
+    &:focus {
+        background-color: color.adjust($brand-pink-color, $lightness: -8%);
+        border-color: color.adjust($brand-pink-color, $lightness: -8%);
+        color: #fff;
+    }
 }
 
 // Anchor for profile icon flyout -- position: relative (no transform) so it doesn't

--- a/frontend/styles/components/navbar/AppSidebar.module.scss
+++ b/frontend/styles/components/navbar/AppSidebar.module.scss
@@ -66,29 +66,4 @@
         background-color: $grey-lightest-color;
         font-weight: 600;
     }
-
-    &.locked {
-        color: $light-grey-color;
-
-        &:hover,
-        &:focus {
-            color: $light-grey-color;
-        }
-    }
-}
-
-.lockIcon {
-    width: 14px;
-    height: 14px;
-}
-
-.lockedGroup {
-    display: flex;
-    flex-direction: column;
-}
-
-.lockedHint {
-    margin: 0 0 4px 14px;
-    font-size: 12px;
-    color: $medium-grey-color;
 }

--- a/frontend/tests/component/AppSidebar.test.tsx
+++ b/frontend/tests/component/AppSidebar.test.tsx
@@ -21,7 +21,7 @@ describe("AppSidebar", () => {
   });
 
   it("renders nothing when isOpen is false", () => {
-    mockUseSession.mockReturnValue({ data: null });
+    mockUseSession.mockReturnValue({ data: null, status: "unauthenticated" });
     mockUsePathname.mockReturnValue("/");
 
     render(<AppSidebar isOpen={false} onClose={jest.fn()} />);
@@ -30,7 +30,7 @@ describe("AppSidebar", () => {
   });
 
   it("highlights Main Calendar as active on /", () => {
-    mockUseSession.mockReturnValue({ data: null });
+    mockUseSession.mockReturnValue({ data: null, status: "unauthenticated" });
     mockUsePathname.mockReturnValue("/");
 
     render(<AppSidebar isOpen onClose={jest.fn()} />);
@@ -39,7 +39,10 @@ describe("AppSidebar", () => {
   });
 
   it("shows a real Admin link, highlighted, for an admin user", () => {
-    mockUseSession.mockReturnValue({ data: { user: { name: "Admin User", role: "ADMIN" } } });
+    mockUseSession.mockReturnValue({
+      data: { user: { name: "Admin User", role: "ADMIN" } },
+      status: "authenticated",
+    });
     mockUsePathname.mockReturnValue("/admin");
 
     render(<AppSidebar isOpen onClose={jest.fn()} />);
@@ -50,7 +53,10 @@ describe("AppSidebar", () => {
   });
 
   it("hides the Admin link entirely for a signed-in non-admin", () => {
-    mockUseSession.mockReturnValue({ data: { user: { name: "Regular User", role: "USER" } } });
+    mockUseSession.mockReturnValue({
+      data: { user: { name: "Regular User", role: "USER" } },
+      status: "authenticated",
+    });
     mockUsePathname.mockReturnValue("/");
 
     render(<AppSidebar isOpen onClose={jest.fn()} />);
@@ -59,7 +65,7 @@ describe("AppSidebar", () => {
   });
 
   it("hides the Admin link and shows a Sign In link to /login for a signed-out visitor", () => {
-    mockUseSession.mockReturnValue({ data: null });
+    mockUseSession.mockReturnValue({ data: null, status: "unauthenticated" });
     mockUsePathname.mockReturnValue("/");
 
     render(<AppSidebar isOpen onClose={jest.fn()} />);
@@ -68,8 +74,17 @@ describe("AppSidebar", () => {
     expect(screen.getByRole("link", { name: "Sign In" })).toHaveAttribute("href", "/login");
   });
 
+  it("hides the Sign In link while the session is still loading", () => {
+    mockUseSession.mockReturnValue({ data: null, status: "loading" });
+    mockUsePathname.mockReturnValue("/");
+
+    render(<AppSidebar isOpen onClose={jest.fn()} />);
+
+    expect(screen.queryByRole("link", { name: "Sign In" })).not.toBeInTheDocument();
+  });
+
   it("does not show a Signage link", () => {
-    mockUseSession.mockReturnValue({ data: null });
+    mockUseSession.mockReturnValue({ data: null, status: "unauthenticated" });
     mockUsePathname.mockReturnValue("/");
 
     render(<AppSidebar isOpen onClose={jest.fn()} />);
@@ -78,7 +93,7 @@ describe("AppSidebar", () => {
   });
 
   it("calls onClose when the backdrop is clicked", () => {
-    mockUseSession.mockReturnValue({ data: null });
+    mockUseSession.mockReturnValue({ data: null, status: "unauthenticated" });
     mockUsePathname.mockReturnValue("/");
     const onClose = jest.fn();
 
@@ -89,7 +104,7 @@ describe("AppSidebar", () => {
   });
 
   it("calls onClose when a nav row is tapped", () => {
-    mockUseSession.mockReturnValue({ data: null });
+    mockUseSession.mockReturnValue({ data: null, status: "unauthenticated" });
     mockUsePathname.mockReturnValue("/admin");
     const onClose = jest.fn();
 

--- a/frontend/tests/component/AppSidebar.test.tsx
+++ b/frontend/tests/component/AppSidebar.test.tsx
@@ -68,13 +68,13 @@ describe("AppSidebar", () => {
     expect(screen.getByRole("link", { name: "Sign In" })).toHaveAttribute("href", "/login");
   });
 
-  it("shows the Signage link", () => {
+  it("does not show a Signage link", () => {
     mockUseSession.mockReturnValue({ data: null });
-    mockUsePathname.mockReturnValue("/signage");
+    mockUsePathname.mockReturnValue("/");
 
     render(<AppSidebar isOpen onClose={jest.fn()} />);
 
-    expect(screen.getByRole("link", { name: "Signage" })).toHaveAttribute("href", "/signage");
+    expect(screen.queryByRole("link", { name: "Signage" })).not.toBeInTheDocument();
   });
 
   it("calls onClose when the backdrop is clicked", () => {

--- a/frontend/tests/component/AppSidebar.test.tsx
+++ b/frontend/tests/component/AppSidebar.test.tsx
@@ -49,24 +49,32 @@ describe("AppSidebar", () => {
     expect(adminLink.className).toMatch(/active/);
   });
 
-  it("shows a disabled locked Admin button for a signed-in non-admin", () => {
+  it("hides the Admin link entirely for a signed-in non-admin", () => {
     mockUseSession.mockReturnValue({ data: { user: { name: "Regular User", role: "USER" } } });
     mockUsePathname.mockReturnValue("/");
 
     render(<AppSidebar isOpen onClose={jest.fn()} />);
 
-    const adminButton = screen.getByRole("button", { name: "Admin" });
-    expect(adminButton).toBeDisabled();
+    expect(screen.queryByText("Admin")).not.toBeInTheDocument();
   });
 
-  it("shows a locked Admin link to /login for a signed-out visitor", () => {
+  it("hides the Admin link and shows a Sign In link to /login for a signed-out visitor", () => {
     mockUseSession.mockReturnValue({ data: null });
     mockUsePathname.mockReturnValue("/");
 
     render(<AppSidebar isOpen onClose={jest.fn()} />);
 
-    const adminLink = screen.getByRole("link", { name: "Admin" });
-    expect(adminLink).toHaveAttribute("href", "/login");
+    expect(screen.queryByText("Admin")).not.toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Sign In" })).toHaveAttribute("href", "/login");
+  });
+
+  it("shows the Signage link", () => {
+    mockUseSession.mockReturnValue({ data: null });
+    mockUsePathname.mockReturnValue("/signage");
+
+    render(<AppSidebar isOpen onClose={jest.fn()} />);
+
+    expect(screen.getByRole("link", { name: "Signage" })).toHaveAttribute("href", "/signage");
   });
 
   it("calls onClose when the backdrop is clicked", () => {

--- a/frontend/tests/e2e/00-smoke.spec.ts
+++ b/frontend/tests/e2e/00-smoke.spec.ts
@@ -3,10 +3,10 @@ import { test, expect } from "./support/fixtures";
 // Validates the whole infra chain end-to-end before relying on it in the real
 // suite: embedded Postgres server, prisma migrate deploy, seeded Admin row, minted
 // session cookie, and the real Next.js server all working together.
-test("unauthenticated visitor sees the public calendar with a locked admin nav", async ({ page }) => {
+test("unauthenticated visitor sees the public calendar with no admin nav", async ({ page }) => {
   await page.goto("/");
   await expect(page.locator("body")).toBeVisible();
-  await expect(page.getByRole("link", { name: /admin/i })).toHaveAttribute("href", "/login");
+  await expect(page.getByRole("link", { name: /admin/i })).not.toBeVisible();
 });
 
 test("signed-in admin sees an authenticated session", async ({ adminPage }) => {


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added flexible logo sizing.
  * Updated navigation to show Admin only to administrators and Sign In only when unauthenticated.
  * Reorganized navbar and sidebar navigation for a clearer layout.

* **Bug Fixes**
  * Improved tooltip behavior for keyboard focus and hover interactions.

* **Style**
  * Refined navbar sizing, spacing, borders, active states, and sign-in button styling.
  * Removed outdated locked-navigation presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description
- **app/components/navbar/AppNavbar.tsx**: reordered desktop nav to Main Calendar, Resources, Admin (Signage removed from the nav entirely — not something users need to discover through navigation, and an accidental click on it was a UX papercut; the `/signage` route itself is unchanged); Admin `<li>` now only renders `{isAdmin && ...}` instead of falling back to a disabled/locked state for signed-in non-admins or a locked login link for signed-out visitors. Sign-in/profile block moved out of the nav `<ul>` into its own right-aligned wrapper so the nav links stay grouped and left-flushed against the logo instead of being spread by `justify-content: space-between`. Logo now requests 32px height for this bar.
- **app/components/navbar/AppSidebar.tsx**: reordered to Main Calendar, Resources, Admin (no Signage, matching the desktop nav); Admin only renders for `isAdmin`; the locked-Admin hint text is gone, replaced by a plain "Sign In" row (linking to `/login`) shown when there's no session.
- **app/components/atoms/Logo.tsx**: added an optional `height` prop (default 50, unchanged for existing callers) so AppNavbar can request 32px without affecting AppSidebar's drawer header or the signage page.
- **styles/components/navbar/AppNavbar.module.scss**: fixed 64px bar height, 1px hairline border-bottom (was 2px), nav links restyled from a pill/box treatment to a 2.5px pink underline on hover/active, `.navRight` added for the right-pinned sign-in/profile block, removed now-unused `.navLocked`/`.navLockedLink`/`.lockIcon` rules.
- **styles/components/navbar/AppSidebar.module.scss**: removed now-unused `.locked`/`.lockedGroup`/`.lockedHint`/`.lockIcon` rules (only consumers were the deleted locked-Admin branch).
- **tests/component/AppSidebar.test.tsx**, **tests/e2e/00-smoke.spec.ts**: updated two pre-existing tests that asserted the old locked-Admin-link behavior to instead assert the Admin link/text is absent for non-admins; added coverage confirming Signage is not rendered as a nav link.
- **styles/components/atoms/Tooltip.module.scss**: swapped `:focus-within` for `:has(:focus-visible)` so a mouse click on a nav item no longer pins its tooltip open until the user clicks elsewhere — hover and keyboard-tab focus still show it, a lingering click-focus no longer does.

## Testing
- [x] `yarn lint:css` — clean
- [x] `yarn test:all` — 131 unit / 78 component / 68 integration / 92 e2e, all passing
- [x] Manually verified in-browser (desktop, admin and signed-out states) against the "Ithaca Recovery Design System" navbar-variants mockup: link order, left-flushed grouping, 64px bar, 32px logo, hairline border, pink underline active state, Admin fully absent when signed out

## Area(s) Touched
**Product areas**
- [x] auth — sign-in, sessions, NextAuth, role-based access
- [x] ui/ux — frontend layout/styling not tied to a specific integration

**Engineering**
- [x] testing — test suite (Jest/Playwright) changes

## Pre-merge Checklist
- [x] Code follows current formatting conventions and passes lint (`yarn lint`).
- [x] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
- [x] All test suites pass, both run locally and green in GitHub CI. **Do not merge if any test suite is failing.**
- [x] A test suite was added or updated for the feature/fix in this PR.
- [x] Only files relevant to this change are committed — no stray or unrelated files.
- [ ] If this branch has a merge conflict with master, master was merged into this branch first (not the other way around).
- [x] The rest of this PR description (Description, Testing) is filled out, not left as template placeholders.
