### PR TITLE
fix(docs): keep pagefind search mounted across doc navigation

### DIFF
--- a/frontend/app/(main)/docs/[[...slug]]/page.tsx
+++ b/frontend/app/(main)/docs/[[...slug]]/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import { notFound, redirect } from "next/navigation";
 import { findDocBySlug, loadDocsMeta } from "../../../../util/docs/loadDocs";
-import DocsShell from "../../../components/docs/DocsShell";
+import DocsArticle from "../../../components/docs/DocsArticle";
 
 interface DocsPageProps {
   params: Promise<{ slug?: string[] }>;
@@ -31,5 +31,5 @@ export default async function DocsPage({ params }: DocsPageProps) {
     }
     notFound();
   }
-  return <DocsShell activeDoc={activeDoc} docsMeta={loadDocsMeta()} />;
+  return <DocsArticle activeDoc={activeDoc} />;
 }

--- a/frontend/app/(main)/docs/layout.tsx
+++ b/frontend/app/(main)/docs/layout.tsx
@@ -1,0 +1,9 @@
+import { PropsWithChildren } from "react";
+import { loadDocsMeta } from "../../../util/docs/loadDocs";
+import DocsShell from "../../components/docs/DocsShell";
+
+// Layouts survive a dynamic-segment change (only pages remount) -- DocsShell relies on that to
+// keep Pagefind's search modal/trigger mounted exactly once per docs session. See DocsShell.tsx.
+export default function DocsLayout({ children }: PropsWithChildren) {
+  return <DocsShell docsMeta={loadDocsMeta()}>{children}</DocsShell>;
+}

--- a/frontend/app/components/docs/DocsArticle.tsx
+++ b/frontend/app/components/docs/DocsArticle.tsx
@@ -1,0 +1,222 @@
+"use client";
+
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { DESKTOP_BREAKPOINT } from "../../../util/common/breakpoints";
+import { parseMarkdown } from "../../../util/docs/parseMarkdown";
+import type { DocEntry } from "../../../util/docs/loadDocs";
+import { useScrollNavHide } from "../../../hooks/useScrollNavHide";
+import { TocToggleIcon } from "./DocsIcons";
+import TocList from "./DocsTocList";
+import styles from "../../../styles/components/docs/DocsShell.module.scss";
+
+interface DocsArticleProps {
+  activeDoc: DocEntry;
+}
+
+// Rendered from [[...slug]]/page.tsx -- the part of the docs page that's SUPPOSED to remount on
+// every doc-to-doc navigation (a new doc starts at the top, gets a fresh TOC, etc). The
+// surrounding chrome (sidebar, search) lives in docs/layout.tsx's DocsShell instead, precisely
+// so it doesn't remount along with this -- see DocsShell.tsx's own comment for why.
+const DocsArticle: React.FC<DocsArticleProps> = ({ activeDoc }) => {
+  // .article is its own scroll pane on this page (see DocsShell.module.scss), not .content --
+  // .content itself never scrolls here, so the mobile hide-on-scroll behavior ClientLayout wires
+  // up globally onto .content has nothing to react to on /docs. Same hook, reattached to the
+  // pane that actually scrolls here.
+  const { handleScroll: handleArticleScroll } = useScrollNavHide();
+  // null means "not yet measured" (no window on the server, client hasn't measured yet) -- same
+  // three-state convention DocsShell's own `compact` uses.
+  const [tocHidden, setTocHidden] = useState<boolean | null>(null);
+  const [tocOpen, setTocOpen] = useState(false);
+  const [activeHeadingSlug, setActiveHeadingSlug] = useState<string | null>(null);
+  const articleRef = useRef<HTMLElement>(null);
+
+  useEffect(() => {
+    const checkBreakpoint = () => {
+      setTocHidden((prev) => {
+        const next = window.innerWidth < DESKTOP_BREAKPOINT;
+        if (prev && !next) setTocOpen(false);
+        return next;
+      });
+    };
+    checkBreakpoint();
+    window.addEventListener("resize", checkBreakpoint);
+    return () => window.removeEventListener("resize", checkBreakpoint);
+  }, []);
+
+  // Closes the "on this page" popover left open from the previous doc -- this component remounts
+  // fresh per doc, so tocOpen's own initial state already handles that; this only matters for the
+  // rare case where activeDoc.slug changes without a full remount (there isn't one today, but
+  // matching the reset explicitly here costs nothing and protects against that assumption
+  // silently breaking later).
+  useEffect(() => {
+    setTocOpen(false);
+  }, [activeDoc.slug]);
+
+  const { html, toc } = useMemo(() => parseMarkdown(activeDoc.markdown), [activeDoc.markdown]);
+
+  // INVARIANT: this object's identity must stay stable across re-renders that don't change the
+  // markdown. React diffs dangerouslySetInnerHTML by the wrapper object's *identity*, never by
+  // the HTML string's value (see updateProperties' `nextProp === lastProp` prop loop in
+  // react-dom) -- so an inline `{{ __html: html }}` literal re-assigns <main>.innerHTML on every
+  // single render. That re-parses the whole document and, critically, destroys and recreates
+  // every heading node inside it, which is what silently broke scrollspy: this page re-renders
+  // on every scroll direction change (useScrollNavHide flips navHidden in context), so the
+  // article's DOM was being rebuilt out from under the scrollspy effect constantly. It also
+  // intermittently reset the pane's scroll position back to the top.
+  const articleHtml = useMemo(() => ({ __html: html }), [html]);
+
+  // Scrollspy: highlights whichever h1/h2 is currently nearest the top of the article. The
+  // active heading is the last one (in document order) whose top has already crossed the
+  // activation line, which stays correct anywhere within a section (including inside its h3
+  // subsections, not just right at the h2's own boundary).
+  const updateActiveHeading = useCallback(() => {
+    const article = articleRef.current;
+    if (!article) return;
+    const tocSlugs = new Set(toc.map((item) => item.slug));
+    if (tocSlugs.size === 0) {
+      setActiveHeadingSlug(null);
+      return;
+    }
+
+    // INVARIANT: re-query the headings on every update rather than caching the node list.
+    // <main>'s content comes from dangerouslySetInnerHTML, so any commit that re-assigns it
+    // swaps every heading node out for a fresh one. A cached-but-detached node reports
+    // getBoundingClientRect().top === 0, and since 0 satisfies the "already scrolled past"
+    // test, *every* heading looks passed at once and the loop below pins the highlight to the
+    // last one permanently. Live lookups can't go stale that way. querySelectorAll returns
+    // document order, which is the order the TOC is built in.
+    const headingEls = Array.from(
+      article.querySelectorAll<HTMLElement>("h1[id], h2[id]")
+    ).filter((el) => tocSlugs.has(el.id));
+    if (headingEls.length === 0) return;
+
+    // Measured from the article pane's own top edge, not the viewport's -- the article is its
+    // own scroll container (own overflow-y:auto, see DocsShell.module.scss's .article) rather
+    // than .content, since the three columns each scroll independently on this page. A
+    // viewport-absolute line would have to be re-derived from the navbar's height at every
+    // breakpoint, and would be wrong again while the mobile navbar is hidden. 80px clears the
+    // largest scroll-margin-top the headings use (72px on phones, see the stylesheet), so a
+    // heading jumped to by clicking its own TOC link lands already counted as active.
+    const lineY = article.getBoundingClientRect().top + 80;
+    let current = headingEls[0];
+    for (const el of headingEls) {
+      if (el.getBoundingClientRect().top <= lineY) {
+        current = el;
+      } else {
+        break;
+      }
+    }
+    setActiveHeadingSlug(current.id);
+  }, [toc]);
+
+  useEffect(() => {
+    const article = articleRef.current;
+    if (!article) return;
+    updateActiveHeading();
+    article.addEventListener("scroll", updateActiveHeading, { passive: true });
+    // A fragment jump moves the article's scroll position without firing a scroll event on it,
+    // so the scroll listener alone never sees deep links or back/forward between #hashes -- this
+    // also covers a search result's native anchor-link navigation landing on this doc.
+    window.addEventListener("hashchange", updateActiveHeading);
+    return () => {
+      article.removeEventListener("scroll", updateActiveHeading);
+      window.removeEventListener("hashchange", updateActiveHeading);
+    };
+    // tocHidden is in the deps (even though it's not read here) because this component renders
+    // null until it resolves (see the guard near the bottom) -- articleRef.current is still null
+    // on the render where this effect first runs with a real `toc`, so it bails out via the
+    // `!article` check above and never re-fires once tocHidden flips from null to a real boolean
+    // and <main> actually mounts, unless that flip is itself a dependency here.
+  }, [updateActiveHeading, tocHidden]);
+
+  // Clicking a TOC link scrolls the article via the browser's own fragment jump, which fires no
+  // scroll event on the pane -- without this the highlight stays wherever it was and the entry
+  // you just clicked never lights up. Deferred a macrotask because the jump is the click's
+  // default action, so it hasn't happened yet while this handler runs. hashchange above doesn't
+  // cover re-clicking the entry you're already on (same hash -> no event), which still moves
+  // the scroll position if you'd scrolled away since.
+  const handleTocNavigate = useCallback(() => {
+    setTimeout(updateActiveHeading, 0);
+  }, [updateActiveHeading]);
+
+  // Keeps the highlighted TOC entry visible inside the TOC's own scroll region as scrollspy
+  // moves it -- .tocNav/.tocPanel have their own max-height + overflow-y:auto, so without this,
+  // scrolling the article far enough (in either direction) can move the active heading past the
+  // TOC's own visible area, and the TOC pane never follows since nothing scrolls it. block:
+  // "nearest" only moves it the minimum needed, so this doesn't fight the user's own TOC scroll
+  // when the active link is already visible.
+  useEffect(() => {
+    if (!activeHeadingSlug) return;
+    const link = document.querySelector<HTMLElement>(
+      `a[class*="tocLink"][href="#${CSS.escape(activeHeadingSlug)}"]`
+    );
+    link?.scrollIntoView({ block: "nearest" });
+  }, [activeHeadingSlug]);
+
+  // See tocHidden's own state comment above -- render nothing until it's measured, same as
+  // DocsShell's own compact === null guard.
+  if (tocHidden === null) {
+    return null;
+  }
+
+  return (
+    <React.Fragment>
+      <div className={styles.articleColumn}>
+        <main
+          ref={articleRef}
+          className={styles.article}
+          onScroll={handleArticleScroll}
+          dangerouslySetInnerHTML={articleHtml}
+        />
+
+        {tocHidden && (
+          <div className={styles.tocToggleSlot}>
+            <button
+              type="button"
+              className={styles.sidebarIconBtn}
+              aria-label="Open on this page"
+              onClick={() => setTocOpen((prev) => !prev)}
+            >
+              <TocToggleIcon />
+            </button>
+            {tocOpen && (
+              <React.Fragment>
+                <div className={styles.tocScrim} onClick={() => setTocOpen(false)} />
+                <div className={styles.tocPanel}>
+                  <div className={styles.tocPanelHeader}>
+                    <span>On this page</span>
+                    <button
+                      type="button"
+                      className={styles.sidebarClose}
+                      aria-label="Close"
+                      onClick={() => setTocOpen(false)}
+                    >
+                      ✕
+                    </button>
+                  </div>
+                  <TocList
+                    toc={toc}
+                    activeSlug={activeHeadingSlug}
+                    onNavigate={() => {
+                      setTocOpen(false);
+                      handleTocNavigate();
+                    }}
+                  />
+                </div>
+              </React.Fragment>
+            )}
+          </div>
+        )}
+      </div>
+
+      {!tocHidden && (
+        <nav className={styles.tocNav}>
+          <div className={styles.tocLabel}>On this page</div>
+          <TocList toc={toc} activeSlug={activeHeadingSlug} onNavigate={handleTocNavigate} />
+        </nav>
+      )}
+    </React.Fragment>
+  );
+};
+
+export default DocsArticle;

--- a/frontend/app/components/docs/DocsArticle.tsx
+++ b/frontend/app/components/docs/DocsArticle.tsx
@@ -29,14 +29,16 @@ const DocsArticle: React.FC<DocsArticleProps> = ({ activeDoc }) => {
   const [tocOpen, setTocOpen] = useState(false);
   const [activeHeadingSlug, setActiveHeadingSlug] = useState<string | null>(null);
   const articleRef = useRef<HTMLElement>(null);
+  const tocPanelRef = useRef<HTMLDivElement>(null);
+  const tocNavRef = useRef<HTMLElement>(null);
+  const prevTocHiddenRef = useRef<boolean | null>(null);
 
   useEffect(() => {
     const checkBreakpoint = () => {
-      setTocHidden((prev) => {
-        const next = window.innerWidth < DESKTOP_BREAKPOINT;
-        if (prev && !next) setTocOpen(false);
-        return next;
-      });
+      const next = window.innerWidth < DESKTOP_BREAKPOINT;
+      if (prevTocHiddenRef.current && !next) setTocOpen(false);
+      prevTocHiddenRef.current = next;
+      setTocHidden(next);
     };
     checkBreakpoint();
     window.addEventListener("resize", checkBreakpoint);
@@ -147,8 +149,9 @@ const DocsArticle: React.FC<DocsArticleProps> = ({ activeDoc }) => {
   // when the active link is already visible.
   useEffect(() => {
     if (!activeHeadingSlug) return;
-    const link = document.querySelector<HTMLElement>(
-      `a[class*="tocLink"][href="#${CSS.escape(activeHeadingSlug)}"]`
+    const container = tocPanelRef.current ?? tocNavRef.current;
+    const link = container?.querySelector<HTMLElement>(
+      `a[href="#${CSS.escape(activeHeadingSlug)}"]`
     );
     link?.scrollIntoView({ block: "nearest" });
   }, [activeHeadingSlug]);
@@ -182,7 +185,7 @@ const DocsArticle: React.FC<DocsArticleProps> = ({ activeDoc }) => {
             {tocOpen && (
               <React.Fragment>
                 <div className={styles.tocScrim} onClick={() => setTocOpen(false)} />
-                <div className={styles.tocPanel}>
+                <div className={styles.tocPanel} ref={tocPanelRef}>
                   <div className={styles.tocPanelHeader}>
                     <span>On this page</span>
                     <button
@@ -210,7 +213,7 @@ const DocsArticle: React.FC<DocsArticleProps> = ({ activeDoc }) => {
       </div>
 
       {!tocHidden && (
-        <nav className={styles.tocNav}>
+        <nav className={styles.tocNav} ref={tocNavRef}>
           <div className={styles.tocLabel}>On this page</div>
           <TocList toc={toc} activeSlug={activeHeadingSlug} onNavigate={handleTocNavigate} />
         </nav>

--- a/frontend/app/components/docs/DocsShell.tsx
+++ b/frontend/app/components/docs/DocsShell.tsx
@@ -2,20 +2,17 @@
 
 import React, { useCallback, useEffect, useMemo, useRef, useState, useTransition } from "react";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
-import { TABLET_BREAKPOINT, DESKTOP_BREAKPOINT } from "../../../util/common/breakpoints";
-import { parseMarkdown } from "../../../util/docs/parseMarkdown";
-import type { DocEntry, DocMeta } from "../../../util/docs/loadDocs";
-import { useScrollNavHide } from "../../../hooks/useScrollNavHide";
+import { useRouter, usePathname } from "next/navigation";
+import { TABLET_BREAKPOINT } from "../../../util/common/breakpoints";
+import type { DocMeta } from "../../../util/docs/loadDocs";
 import { usePagefindComponentUI } from "../../../hooks/usePagefindComponentUI";
 import TopLoadingBar from "../atoms/TopLoadingBar";
-import { PanelToggleIcon, TocToggleIcon, SearchIcon, CloseIcon } from "./DocsIcons";
-import TocList from "./DocsTocList";
+import { PanelToggleIcon, SearchIcon, CloseIcon } from "./DocsIcons";
 import styles from "../../../styles/components/docs/DocsShell.module.scss";
 
 interface DocsShellProps {
-  activeDoc: DocEntry;
   docsMeta: DocMeta[];
+  children: React.ReactNode;
 }
 
 interface DocGroup {
@@ -42,26 +39,21 @@ function docHref(slug: string): string {
   return slug === "" ? "/docs" : `/docs/${slug}`;
 }
 
-// DocsShell renders from [[...slug]]/page.tsx, and the App Router rebuilds a *page's* entire
-// subtree from scratch whenever a dynamic segment's value changes -- only layouts survive a
-// segment change. So every doc-to-doc navigation unmounts this component and mounts a fresh one,
-// handing .sidebarNav a brand-new DOM node whose scrollTop starts at 0. That's invisible for the
-// article and the TOC (a new doc is supposed to start at the top), but the sidebar is shared
-// chrome, not per-doc content: it should stay exactly where the reader left it. Nothing in
-// component state can carry a value across an unmount, so this lives at module scope, which
-// outlives the remount -- and is re-initialized by a real page load, which is the behavior we
-// want there.
-let lastSidebarScrollTop = 0;
-
-const DocsShell: React.FC<DocsShellProps> = ({ activeDoc, docsMeta }) => {
+// DocsShell is rendered from docs/layout.tsx, not from [[...slug]]/page.tsx -- layouts survive
+// a dynamic-segment change, pages don't. This is deliberate: pagefind-modal and
+// pagefind-modal-trigger below pair themselves up via generated IDs (aria-controls on the
+// trigger's button, matched against the modal dialog's own id) the first time each connects to
+// the DOM, and that pairing does not survive being torn down and recreated -- a second mount
+// within the same document leaves the trigger pointing at a dialog id that no longer exists, so
+// clicking it silently does nothing (no console error). Rendering both from a layout instead of
+// the page means they mount exactly once per docs session (only a real page load, i.e. a fresh
+// document, resets that), regardless of how many times the reader navigates between docs. See
+// DocsArticle.tsx for the per-doc content (article + TOC) that's supposed to remount each time.
+const DocsShell: React.FC<DocsShellProps> = ({ docsMeta, children }) => {
   const router = useRouter();
+  const pathname = usePathname();
   const [isNavigating, startNavigation] = useTransition();
   usePagefindComponentUI();
-  // .article is its own scroll pane on this page (see DocsShell.module.scss), not .content --
-  // .content itself never scrolls here, so the mobile hide-on-scroll behavior ClientLayout wires
-  // up globally onto .content has nothing to react to on /docs. Same hook, reattached to the
-  // pane that actually scrolls here.
-  const { handleScroll: handleArticleScroll } = useScrollNavHide();
   const [sidebarOpen, setSidebarOpen] = useState(false);
   // null means "not yet measured" (no window on the server, client hasn't measured yet) --
   // same three-state convention useIsPhone()/useViewport() use elsewhere in this app. Rendering
@@ -69,9 +61,6 @@ const DocsShell: React.FC<DocsShellProps> = ({ activeDoc, docsMeta }) => {
   // phone load right before snapping to compact; gating the render below on this instead avoids
   // that.
   const [compact, setCompact] = useState<boolean | null>(null);
-  const [tocHidden, setTocHidden] = useState<boolean | null>(null);
-  const [tocOpen, setTocOpen] = useState(false);
-  const [activeHeadingSlug, setActiveHeadingSlug] = useState<string | null>(null);
   const [searchOpen, setSearchOpen] = useState(false);
   // Stays true through the close animation so <pagefind-input> and <pagefind-results> (the
   // full-bleed results panel) have something to animate out -- searchOpen alone flips instantly,
@@ -85,7 +74,6 @@ const DocsShell: React.FC<DocsShellProps> = ({ activeDoc, docsMeta }) => {
   // article underneath while open, so nothing scrolls behind it that would move this in the
   // meantime.
   const [compactBarBottom, setCompactBarBottom] = useState(0);
-  const articleRef = useRef<HTMLElement>(null);
   const sidebarToggleBtnRef = useRef<HTMLButtonElement>(null);
   const wasSidebarOpenRef = useRef(false);
   const compactBarRef = useRef<HTMLDivElement>(null);
@@ -103,7 +91,7 @@ const DocsShell: React.FC<DocsShellProps> = ({ activeDoc, docsMeta }) => {
   }, [sidebarOpen]);
 
   useEffect(() => {
-    const checkBreakpoints = () => {
+    const checkBreakpoint = () => {
       setCompact((prev) => {
         const next = window.innerWidth < TABLET_BREAKPOINT;
         // .compactBar (the only place mobile search lives) is display: none whenever !compact --
@@ -119,15 +107,10 @@ const DocsShell: React.FC<DocsShellProps> = ({ activeDoc, docsMeta }) => {
         }
         return next;
       });
-      setTocHidden((prev) => {
-        const next = window.innerWidth < DESKTOP_BREAKPOINT;
-        if (prev && !next) setTocOpen(false);
-        return next;
-      });
     };
-    checkBreakpoints();
-    window.addEventListener("resize", checkBreakpoints);
-    return () => window.removeEventListener("resize", checkBreakpoints);
+    checkBreakpoint();
+    window.addEventListener("resize", checkBreakpoint);
+    return () => window.removeEventListener("resize", checkBreakpoint);
   }, []);
 
   // Keeps .mobileSearchResults's top offset in sync with the compact bar's real position while
@@ -145,16 +128,13 @@ const DocsShell: React.FC<DocsShellProps> = ({ activeDoc, docsMeta }) => {
     return () => window.removeEventListener("resize", updateCompactBarBottom);
   }, [searchOpen]);
 
-  // Closes any drawer/popover left open from the previous doc whenever navigation lands on a
-  // new one -- covers every path a new slug can arrive by (sidebar click, browser back/
-  // forward), not just the sidebar link's own onClick. Deliberately does not reset the
-  // article's own scroll position -- switching docs keeps wherever you were scrolled to, it
-  // doesn't jump back to the top.
+  // Closes any drawer/search session left open from the previous doc whenever navigation lands
+  // on a new one -- covers every path a new slug can arrive by (sidebar click, browser back/
+  // forward), not just the sidebar link's own onClick.
   useEffect(() => {
     setSidebarOpen(false);
-    setTocOpen(false);
     setSearchOpen(false);
-  }, [activeDoc.slug]);
+  }, [pathname]);
 
   // Measures the compact bar's own bottom edge right as search opens, in viewport coordinates --
   // see compactBarBottom's own comment above for why the full-bleed results panel needs this
@@ -234,10 +214,10 @@ const DocsShell: React.FC<DocsShellProps> = ({ activeDoc, docsMeta }) => {
     [searchOpen]
   );
 
-  // The activeDoc.slug effect above only closes search on a real doc-to-doc navigation -- a
-  // result link to the doc already open, or a same-page anchor within it, never changes that
-  // slug, so without this the results panel would stay open (and cover the article) even after
-  // the reader picked a result. Delegated on the wrapper rather than per-result, since
+  // The pathname effect above only closes search on a real doc-to-doc navigation -- a result
+  // link to the doc already open, or a same-page anchor within it, never changes the pathname,
+  // so without this the results panel would stay open (and cover the article) even after the
+  // reader picked a result. Delegated on the wrapper rather than per-result, since
   // pagefind-results renders its own result links internally.
   const handleMobileResultsClick = useCallback(
     (event: React.MouseEvent<HTMLDivElement>) => {
@@ -246,128 +226,18 @@ const DocsShell: React.FC<DocsShellProps> = ({ activeDoc, docsMeta }) => {
     [closeSearch]
   );
 
-  // Restored from a ref callback rather than an effect: React attaches refs during the commit,
-  // after the new node is in the document (so scrollHeight is already real) but before the browser
-  // paints it -- an effect would let the sidebar paint at 0 first and visibly jump.
-  const restoreSidebarScroll = useCallback((node: HTMLElement | null) => {
-    if (node) node.scrollTop = lastSidebarScrollTop;
-  }, []);
-
-  // Recorded on every scroll rather than read back during the ref's cleanup, so this doesn't
-  // depend on React tearing down refs before it detaches the node (a detached element reports
-  // scrollTop 0, which would silently store the wrong value).
-  const handleSidebarScroll = useCallback((event: React.UIEvent<HTMLElement>) => {
-    lastSidebarScrollTop = event.currentTarget.scrollTop;
-  }, []);
-
   const groups = useMemo(() => buildGroups(docsMeta), [docsMeta]);
-  const { html, toc } = useMemo(() => parseMarkdown(activeDoc.markdown), [activeDoc.markdown]);
-
-  // INVARIANT: this object's identity must stay stable across re-renders that don't change the
-  // markdown. React diffs dangerouslySetInnerHTML by the wrapper object's *identity*, never by
-  // the HTML string's value (see updateProperties' `nextProp === lastProp` prop loop in
-  // react-dom) -- so an inline `{{ __html: html }}` literal re-assigns <main>.innerHTML on every
-  // single render. That re-parses the whole document and, critically, destroys and recreates
-  // every heading node inside it, which is what silently broke scrollspy: this page re-renders
-  // on every scroll direction change (useScrollNavHide flips navHidden in context), so the
-  // article's DOM was being rebuilt out from under the scrollspy effect constantly. It also
-  // intermittently reset the pane's scroll position back to the top.
-  const articleHtml = useMemo(() => ({ __html: html }), [html]);
-
-  // Scrollspy: highlights whichever h1/h2 is currently nearest the top of the article. The
-  // active heading is the last one (in document order) whose top has already crossed the
-  // activation line, which stays correct anywhere within a section (including inside its h3
-  // subsections, not just right at the h2's own boundary).
-  const updateActiveHeading = useCallback(() => {
-    const article = articleRef.current;
-    if (!article) return;
-    const tocSlugs = new Set(toc.map((item) => item.slug));
-    if (tocSlugs.size === 0) {
-      setActiveHeadingSlug(null);
-      return;
-    }
-
-    // INVARIANT: re-query the headings on every update rather than caching the node list.
-    // <main>'s content comes from dangerouslySetInnerHTML, so any commit that re-assigns it
-    // swaps every heading node out for a fresh one. A cached-but-detached node reports
-    // getBoundingClientRect().top === 0, and since 0 satisfies the "already scrolled past"
-    // test, *every* heading looks passed at once and the loop below pins the highlight to the
-    // last one permanently. Live lookups can't go stale that way. querySelectorAll returns
-    // document order, which is the order the TOC is built in.
-    const headingEls = Array.from(
-      article.querySelectorAll<HTMLElement>("h1[id], h2[id]")
-    ).filter((el) => tocSlugs.has(el.id));
-    if (headingEls.length === 0) return;
-
-    // Measured from the article pane's own top edge, not the viewport's -- the article is its
-    // own scroll container (own overflow-y:auto, see DocsShell.module.scss's .article) rather
-    // than .content, since the three columns each scroll independently on this page. A
-    // viewport-absolute line would have to be re-derived from the navbar's height at every
-    // breakpoint, and would be wrong again while the mobile navbar is hidden. 80px clears the
-    // largest scroll-margin-top the headings use (72px on phones, see the stylesheet), so a
-    // heading jumped to by clicking its own TOC link lands already counted as active.
-    const lineY = article.getBoundingClientRect().top + 80;
-    let current = headingEls[0];
-    for (const el of headingEls) {
-      if (el.getBoundingClientRect().top <= lineY) {
-        current = el;
-      } else {
-        break;
-      }
-    }
-    setActiveHeadingSlug(current.id);
-  }, [toc]);
-
-  useEffect(() => {
-    const article = articleRef.current;
-    if (!article) return;
-    updateActiveHeading();
-    article.addEventListener("scroll", updateActiveHeading, { passive: true });
-    // A fragment jump moves the article's scroll position without firing a scroll event on it,
-    // so the scroll listener alone never sees deep links or back/forward between #hashes -- this
-    // also covers a search result's native anchor-link navigation landing on this doc.
-    window.addEventListener("hashchange", updateActiveHeading);
-    return () => {
-      article.removeEventListener("scroll", updateActiveHeading);
-      window.removeEventListener("hashchange", updateActiveHeading);
-    };
-    // compact is in the deps (even though it's not read here) because this component renders
-    // null until compact/tocHidden resolve (see the guard near the bottom) -- articleRef.current
-    // is still null on the render where this effect first runs with a real `toc`, so it bails
-    // out via the `!article` check above and never re-fires once compact flips from null to a
-    // real boolean and <main> actually mounts, unless that flip is itself a dependency here.
-  }, [updateActiveHeading, compact]);
-
-  // Clicking a TOC link scrolls the article via the browser's own fragment jump, which fires no
-  // scroll event on the pane -- without this the highlight stays wherever it was and the entry
-  // you just clicked never lights up. Deferred a macrotask because the jump is the click's
-  // default action, so it hasn't happened yet while this handler runs. hashchange above doesn't
-  // cover re-clicking the entry you're already on (same hash -> no event), which still moves
-  // the scroll position if you'd scrolled away since.
-  const handleTocNavigate = useCallback(() => {
-    setTimeout(updateActiveHeading, 0);
-  }, [updateActiveHeading]);
-
-  // Keeps the highlighted TOC entry visible inside the TOC's own scroll region as scrollspy
-  // moves it -- .tocNav/.tocPanel have their own max-height + overflow-y:auto, so without this,
-  // scrolling the article far enough (in either direction) can move the active heading past the
-  // TOC's own visible area, and the TOC pane never follows since nothing scrolls it. block:
-  // "nearest" only moves it the minimum needed, so this doesn't fight the user's own TOC scroll
-  // when the active link is already visible.
-  useEffect(() => {
-    if (!activeHeadingSlug) return;
-    const link = document.querySelector<HTMLElement>(
-      `a[class*="tocLink"][href="#${CSS.escape(activeHeadingSlug)}"]`
-    );
-    link?.scrollIntoView({ block: "nearest" });
-  }, [activeHeadingSlug]);
+  const activeMeta = useMemo(
+    () => docsMeta.find((doc) => docHref(doc.slug) === pathname),
+    [docsMeta, pathname]
+  );
 
   // Doc links stay real <Link>s (href for prefetch/right-click/open-in-new-tab), but the click
   // is intercepted so the resulting navigation runs inside a transition -- isNavigating from
-  // that transition is the one signal TopLoadingBar needs, regardless of which link (sidebar or
-  // future ones) triggered it. Only for a plain left-click, though -- a modified or non-primary
-  // click (Cmd/Ctrl-click, Shift-click, middle-click) is the browser's own "open in new
-  // tab/window" gesture, which this must not swallow.
+  // that transition is the one signal TopLoadingBar needs, regardless of which link triggered
+  // it. Only for a plain left-click, though -- a modified or non-primary click (Cmd/Ctrl-click,
+  // Shift-click, middle-click) is the browser's own "open in new tab/window" gesture, which this
+  // must not swallow.
   const navigateToDoc = (event: React.MouseEvent, href: string) => {
     if (event.defaultPrevented || event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {
       return;
@@ -379,17 +249,19 @@ const DocsShell: React.FC<DocsShellProps> = ({ activeDoc, docsMeta }) => {
     });
   };
 
-  // See the compact/tocHidden state comment above -- render nothing until both are measured,
-  // same as AppNavbar's isPhone === null guard.
-  if (compact === null || tocHidden === null) {
+  // See compact's own state comment above -- render nothing until it's measured, same as
+  // AppNavbar's isPhone === null guard.
+  if (compact === null) {
     return null;
   }
 
   return (
     <div className={styles.page}>
       <TopLoadingBar active={isNavigating} />
-      {/* Single instance for the whole page -- pagefind-modal-trigger (in the sidebar below)
-          and this connect automatically by sharing Pagefind's default "instance". */}
+      {/* Single instance for the whole docs session -- pagefind-modal-trigger (in the sidebar
+          below) and this connect automatically by sharing Pagefind's default "instance". Both
+          live here, in the layout-rendered shell, specifically so they never remount -- see this
+          component's own comment above. */}
       <pagefind-modal reset-on-close="true" />
       <div ref={compactBarRef} className={`${styles.compactBar} ${compact ? styles.isCompact : ""}`}>
         {/* Panel-toggle + breadcrumb animate out together as search opens, freeing the whole bar
@@ -404,9 +276,9 @@ const DocsShell: React.FC<DocsShellProps> = ({ activeDoc, docsMeta }) => {
           >
             <PanelToggleIcon />
           </button>
-          <span className={styles.breadcrumbGroup}>{activeDoc.group}</span>
+          <span className={styles.breadcrumbGroup}>{activeMeta?.group}</span>
           <span className={styles.breadcrumbGroup}>/</span>
-          <span className={styles.breadcrumbTitle}>{activeDoc.title}</span>
+          <span className={styles.breadcrumbTitle}>{activeMeta?.title}</span>
         </div>
         {/* pagefind-input, not pagefind-searchbox -- decoupled from its own attached dropdown on
             purpose, since that dropdown is deeply, deliberately hard to restyle (Pagefind wraps
@@ -441,8 +313,6 @@ const DocsShell: React.FC<DocsShellProps> = ({ activeDoc, docsMeta }) => {
 
       <div className={styles.columns}>
         <nav
-          ref={restoreSidebarScroll}
-          onScroll={handleSidebarScroll}
           inert={compact && !sidebarOpen}
           className={`${styles.sidebarNav} ${compact ? styles.isCompact : ""} ${
             compact && sidebarOpen ? styles.isOpen : ""
@@ -472,7 +342,7 @@ const DocsShell: React.FC<DocsShellProps> = ({ activeDoc, docsMeta }) => {
                 <Link
                   key={doc.slug}
                   href={docHref(doc.slug)}
-                  className={`${styles.docLink} ${doc.slug === activeDoc.slug ? styles.isActive : ""}`}
+                  className={`${styles.docLink} ${doc.slug === activeMeta?.slug ? styles.isActive : ""}`}
                   onClick={(event) => navigateToDoc(event, docHref(doc.slug))}
                 >
                   {doc.title}
@@ -482,60 +352,7 @@ const DocsShell: React.FC<DocsShellProps> = ({ activeDoc, docsMeta }) => {
           ))}
         </nav>
 
-        <div className={styles.articleColumn}>
-          <main
-            ref={articleRef}
-            className={styles.article}
-            onScroll={handleArticleScroll}
-            dangerouslySetInnerHTML={articleHtml}
-          />
-
-          {tocHidden && (
-            <div className={styles.tocToggleSlot}>
-              <button
-                type="button"
-                className={styles.sidebarIconBtn}
-                aria-label="Open on this page"
-                onClick={() => setTocOpen((prev) => !prev)}
-              >
-                <TocToggleIcon />
-              </button>
-              {tocOpen && (
-                <React.Fragment>
-                  <div className={styles.tocScrim} onClick={() => setTocOpen(false)} />
-                  <div className={styles.tocPanel}>
-                    <div className={styles.tocPanelHeader}>
-                      <span>On this page</span>
-                      <button
-                        type="button"
-                        className={styles.sidebarClose}
-                        aria-label="Close"
-                        onClick={() => setTocOpen(false)}
-                      >
-                        ✕
-                      </button>
-                    </div>
-                    <TocList
-                      toc={toc}
-                      activeSlug={activeHeadingSlug}
-                      onNavigate={() => {
-                        setTocOpen(false);
-                        handleTocNavigate();
-                      }}
-                    />
-                  </div>
-                </React.Fragment>
-              )}
-            </div>
-          )}
-        </div>
-
-        {!tocHidden && (
-          <nav className={styles.tocNav}>
-            <div className={styles.tocLabel}>On this page</div>
-            <TocList toc={toc} activeSlug={activeHeadingSlug} onNavigate={handleTocNavigate} />
-          </nav>
-        )}
+        {children}
       </div>
 
       {/* Renders over .columns (not inside it) while mobile search is open, filling the exact

--- a/frontend/hooks/usePagefindComponentUI.ts
+++ b/frontend/hooks/usePagefindComponentUI.ts
@@ -5,11 +5,12 @@ import { useEffect } from "react";
 const STYLESHEET_HREF = "/pagefind/pagefind-component-ui.css";
 const SCRIPT_SRC = "/pagefind/pagefind-component-ui.js";
 
-// Module scope, not a ref/state -- DocsShell fully unmounts/remounts on every doc-to-doc
-// navigation (see its own module-scope-variable comments for why), so a per-component guard
-// would re-inject the tags on every navigation. Injecting is idempotent either way (duplicate
-// <link>/<script> tags wouldn't break anything), but there's no reason to ask the browser to
-// refetch and re-register the same custom elements repeatedly.
+// Module scope, not a ref/state -- DocsShell (docs/layout.tsx) is the only caller, and while it
+// stays mounted for an entire docs session (see its own top-of-file comment), leaving /docs
+// entirely and coming back still unmounts/remounts it. A per-component guard would re-inject the
+// tags on that round trip. Injecting is idempotent either way (duplicate <link>/<script> tags
+// wouldn't break anything), but there's no reason to ask the browser to refetch and re-register
+// the same custom elements repeatedly.
 let injected = false;
 
 // Lazily loads Pagefind's prebuilt Component UI (pagefind-modal-trigger, pagefind-modal,


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved documentation navigation with smoother transitions between articles.
  * Added responsive table-of-contents behavior for desktop and mobile layouts.
  * The active heading is now highlighted as you scroll, with automatic URL fragment updates.
  * Mobile navigation supports opening, closing, scrim dismissal, and automatic closure after selecting a link.
  * Documentation breadcrumbs and sidebar selections now stay synchronized with the current page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description
- **frontend/app/(main)/docs/layout.tsx**: new — thin server component wrapping the docs route. Layouts survive dynamic-segment changes (only pages remount), which is what this fix relies on.
- **frontend/app/components/docs/DocsShell.tsx**: now the persistent docs "chrome" (sidebar, Pagefind search modal/trigger, mobile compact bar), rendered from the new layout instead of the page. It used to render from `[[...slug]]/page.tsx`, which the App Router fully remounts on every doc-to-doc navigation — Pagefind pairs `pagefind-modal-trigger` to `pagefind-modal` via generated IDs the first time each connects, and that pairing didn't survive the remount, silently breaking the search button (no console error) until a hard refresh. As a side effect, this also removes the `lastSidebarScrollTop` module-scope hack that worked around the same remounting — no longer needed now that the sidebar is a real persistent DOM node.
- **frontend/app/components/docs/DocsArticle.tsx**: new — the per-doc content (article + TOC) that's *supposed* to remount on every doc, rendered from the page.
- **frontend/app/(main)/docs/[[...slug]]/page.tsx**: now renders `DocsArticle` instead of the old `DocsShell`.
- **frontend/hooks/usePagefindComponentUI.ts**: corrected a comment left stale by the above split (still described DocsShell as remounting per-doc, and pointed at the now-deleted `lastSidebarScrollTop` comment).

## Testing
- No existing automated test suite covers `/docs` (rendering/navigation/search) to extend — verified manually instead:
  - `yarn build && yarn start`, then in a browser: navbar Main Calendar → Resources → Main Calendar → Resources, and separately clicking between two docs in the sidebar (e.g. "User Guide" → a search hit). Confirmed via devtools that `pagefind-modal-trigger`'s `aria-controls` stays matched to `pagefind-modal`'s dialog `id` across navigations, search returns results every time, no console errors.
  - Full suite green on this branch: `yarn test:all` (lint/unit/component/integration/e2e) — 131 unit + 79 component + 68 integration + 92 e2e, all passing, no regressions.
  - `/code-review` (medium, Opus) run on the diff; one stale-comment finding, fixed in the second commit.

## Area(s) Touched
**Product areas**
- [x] docs — /docs Resources page (rendering, navigation, search)

**Engineering**
- [x] cleanup — refactor or dead-code removal, no behavior change

## Pre-merge Checklist
- [x] Code follows current formatting conventions and passes lint (`yarn lint`).
- [x] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
- [x] All test suites pass, both run locally and green in GitHub CI. **Do not merge if any test suite is failing.**
- [x] A test suite was added or updated for the feature/fix in this PR. **Double-check this if you change a feature and did not update the test suites**. — N/A, see Testing above: no existing suite covers `/docs`; verified manually.
- [x] Only files relevant to this change are committed — no stray or unrelated files.
- [x] If this branch has a merge conflict with master, master was merged into this branch first (not the other way around).
- [x] The rest of this PR description (Description, Testing) is filled out, not left as template placeholders.