### PR TITLE
feat(shared): add Toast notification component

### DIFF
--- a/frontend/app/ClientLayout.tsx
+++ b/frontend/app/ClientLayout.tsx
@@ -8,6 +8,7 @@ import type { Session } from "next-auth";
 import { SessionProvider } from "next-auth/react";
 import { SidebarProvider } from "./context/SidebarContext";
 import { CalendarProvider, useCalendarContext } from "./context/CalendarProvider";
+import { ToastProvider } from "./components/shared/ToastProvider";
 import { useScrollNavHide } from "../hooks/useScrollNavHide";
 
 const inter = Inter({ subsets: ["latin"] });
@@ -51,12 +52,14 @@ export default function ClientLayout({
                 <SessionProvider session={session}>
                     <SidebarProvider>
                         <CalendarProvider>
-                            <div className={styles.mainlayout}>
-                                <div className={styles.navigation}>
-                                    <AppNavbar />
+                            <ToastProvider>
+                                <div className={styles.mainlayout}>
+                                    <div className={styles.navigation}>
+                                        <AppNavbar />
+                                    </div>
+                                    <MainContent>{children}</MainContent>
                                 </div>
-                                <MainContent>{children}</MainContent>
-                            </div>
+                            </ToastProvider>
                         </CalendarProvider>
                     </SidebarProvider>
                 </SessionProvider>

--- a/frontend/app/components/shared/Toast.tsx
+++ b/frontend/app/components/shared/Toast.tsx
@@ -1,12 +1,16 @@
 import React from "react";
-import CheckCircleOutlineIcon from "@mui/icons-material/CheckCircleOutline";
-import ErrorOutlineIcon from "@mui/icons-material/ErrorOutline";
+import CheckIcon from "@mui/icons-material/Check";
+import CloseIcon from "@mui/icons-material/Close";
 import WarningAmberIcon from "@mui/icons-material/WarningAmber";
 import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
-import CloseIcon from "@mui/icons-material/Close";
 import styles from "../../../styles/components/shared/Toast.module.scss";
 
 export type ToastVariant = "success" | "error" | "warning" | "info";
+
+export interface ToastAction {
+  label: string;
+  onClick: () => void;
+}
 
 const VARIANT_CLASS: Record<ToastVariant, string> = {
   success: styles.success,
@@ -15,20 +19,25 @@ const VARIANT_CLASS: Record<ToastVariant, string> = {
   info: styles.info,
 };
 
+// Error reuses CloseIcon (an X) rather than a distinct "error" glyph -- same shape the
+// dismiss button uses, but rendered in the variant's accent color at the opposite corner,
+// which is how the design reference distinguishes the two.
 const VARIANT_ICON: Record<ToastVariant, React.ElementType> = {
-  success: CheckCircleOutlineIcon,
-  error: ErrorOutlineIcon,
+  success: CheckIcon,
+  error: CloseIcon,
   warning: WarningAmberIcon,
   info: InfoOutlinedIcon,
 };
 
 export interface ToastProps {
   variant: ToastVariant;
-  message: string | string[];
+  title: string;
+  description?: string | string[];
+  actions?: ToastAction[];
   onClose: () => void;
 }
 
-const Toast: React.FC<ToastProps> = ({ variant, message, onClose }) => {
+const Toast: React.FC<ToastProps> = ({ variant, title, description, actions, onClose }) => {
   const Icon = VARIANT_ICON[variant];
   return (
     <div
@@ -36,18 +45,29 @@ const Toast: React.FC<ToastProps> = ({ variant, message, onClose }) => {
       role={variant === "error" ? "alert" : "status"}
       aria-live={variant === "error" ? "assertive" : "polite"}
     >
-      <span className={styles.iconCircle}>
+      <span className={styles.icon}>
         <Icon fontSize="small" />
       </span>
       <div className={styles.body}>
-        {Array.isArray(message) ? (
-          <ul className={styles.messageList}>
-            {message.map((line, index) => (
-              <li key={index}>{line}</li>
+        <p className={styles.title}>{title}</p>
+        {description &&
+          (Array.isArray(description) ? (
+            <ul className={styles.messageList}>
+              {description.map((line, index) => (
+                <li key={index}>{line}</li>
+              ))}
+            </ul>
+          ) : (
+            <p className={styles.description}>{description}</p>
+          ))}
+        {actions && actions.length > 0 && (
+          <div className={styles.actions}>
+            {actions.map((action, index) => (
+              <button key={index} type="button" className={styles.actionLink} onClick={action.onClick}>
+                {action.label}
+              </button>
             ))}
-          </ul>
-        ) : (
-          message
+          </div>
         )}
       </div>
       <button className={styles.closeButton} aria-label="Dismiss" onClick={onClose}>

--- a/frontend/app/components/shared/Toast.tsx
+++ b/frontend/app/components/shared/Toast.tsx
@@ -1,0 +1,56 @@
+import React from "react";
+import CheckCircleOutlineIcon from "@mui/icons-material/CheckCircleOutline";
+import ErrorOutlineIcon from "@mui/icons-material/ErrorOutline";
+import WarningAmberIcon from "@mui/icons-material/WarningAmber";
+import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
+import CloseIcon from "@mui/icons-material/Close";
+import styles from "../../../styles/components/shared/Toast.module.scss";
+
+export type ToastVariant = "success" | "error" | "warning" | "info";
+
+const VARIANT_CLASS: Record<ToastVariant, string> = {
+  success: styles.success,
+  error: styles.error,
+  warning: styles.warning,
+  info: styles.info,
+};
+
+const VARIANT_ICON: Record<ToastVariant, React.ElementType> = {
+  success: CheckCircleOutlineIcon,
+  error: ErrorOutlineIcon,
+  warning: WarningAmberIcon,
+  info: InfoOutlinedIcon,
+};
+
+export interface ToastProps {
+  variant: ToastVariant;
+  message: string | string[];
+  onClose: () => void;
+}
+
+const Toast: React.FC<ToastProps> = ({ variant, message, onClose }) => {
+  const Icon = VARIANT_ICON[variant];
+  return (
+    <div className={`${styles.toast} ${VARIANT_CLASS[variant]}`} role="status">
+      <span className={styles.iconCircle}>
+        <Icon fontSize="small" />
+      </span>
+      <div className={styles.body}>
+        {Array.isArray(message) ? (
+          <ul className={styles.messageList}>
+            {message.map((line, index) => (
+              <li key={index}>{line}</li>
+            ))}
+          </ul>
+        ) : (
+          message
+        )}
+      </div>
+      <button className={styles.closeButton} aria-label="Dismiss" onClick={onClose}>
+        <CloseIcon fontSize="small" />
+      </button>
+    </div>
+  );
+};
+
+export default Toast;

--- a/frontend/app/components/shared/Toast.tsx
+++ b/frontend/app/components/shared/Toast.tsx
@@ -31,7 +31,11 @@ export interface ToastProps {
 const Toast: React.FC<ToastProps> = ({ variant, message, onClose }) => {
   const Icon = VARIANT_ICON[variant];
   return (
-    <div className={`${styles.toast} ${VARIANT_CLASS[variant]}`} role="status">
+    <div
+      className={`${styles.toast} ${VARIANT_CLASS[variant]}`}
+      role={variant === "error" ? "alert" : "status"}
+      aria-live={variant === "error" ? "assertive" : "polite"}
+    >
       <span className={styles.iconCircle}>
         <Icon fontSize="small" />
       </span>

--- a/frontend/app/components/shared/ToastProvider.tsx
+++ b/frontend/app/components/shared/ToastProvider.tsx
@@ -55,6 +55,19 @@ export function ToastProvider({ children }: { children: React.ReactNode }) {
   const timers = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
   const viewport = useViewport();
   const prefersReducedMotion = useReducedMotion();
+  // The portal must not render during the initial client render -- `document` is undefined
+  // during SSR but defined on the client, so gating on `typeof document` directly flips
+  // between server and client output on the very first paint and triggers a hydration
+  // mismatch. Delaying to a post-mount effect keeps first paint identical to SSR (no portal
+  // either way); the portal then appears via ordinary reconciliation, which isn't subject to
+  // hydration diffing.
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => {
+    // Deliberately just flips a flag to trigger the post-mount render described above --
+    // not synchronizing with any external system, so this doesn't fit the rule's usual case.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setMounted(true);
+  }, []);
 
   const dismiss = useCallback((id: string) => {
     const timer = timers.current.get(id);
@@ -109,7 +122,7 @@ export function ToastProvider({ children }: { children: React.ReactNode }) {
   return (
     <ToastContext.Provider value={{ showToast }}>
       {children}
-      {typeof document !== "undefined" &&
+      {mounted &&
         createPortal(
           <div className={`${styles.container} ${positionClass}`}>
             <AnimatePresence>

--- a/frontend/app/components/shared/ToastProvider.tsx
+++ b/frontend/app/components/shared/ToastProvider.tsx
@@ -4,12 +4,17 @@ import React, { createContext, useCallback, useContext, useEffect, useRef, useSt
 import { createPortal } from "react-dom";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import { useViewport } from "../../../hooks/useViewport";
-import Toast, { type ToastVariant } from "./Toast";
+import Toast, { type ToastAction, type ToastVariant } from "./Toast";
 import styles from "../../../styles/components/shared/Toast.module.scss";
 
 export interface ToastOptions {
   variant: ToastVariant;
-  message: string | string[];
+  title: string;
+  description?: string | string[];
+  // Inline links below the description (e.g. "Retry Zoom" / "View meeting") -- not used by any
+  // call site yet, but part of the design so a future flow can attach follow-up actions without
+  // a Toast/ToastProvider API change.
+  actions?: ToastAction[];
   // Overrides the variant's default dismiss behavior (success/info auto-dismiss, warning/error
   // stay until closed) -- e.g. forcing a persistent info toast for AdminShell's responsive
   // notice, or forcing a non-persistent error for a case that genuinely doesn't need one.
@@ -134,7 +139,13 @@ export function ToastProvider({ children }: { children: React.ReactNode }) {
                   exit={prefersReducedMotion ? { opacity: 0 } : { opacity: 0, y: 8 }}
                   transition={{ duration: prefersReducedMotion ? 0.01 : 0.2, ease: "easeOut" }}
                 >
-                  <Toast variant={toast.variant} message={toast.message} onClose={() => dismiss(toast.id)} />
+                  <Toast
+                    variant={toast.variant}
+                    title={toast.title}
+                    description={toast.description}
+                    actions={toast.actions}
+                    onClose={() => dismiss(toast.id)}
+                  />
                 </motion.div>
               ))}
             </AnimatePresence>

--- a/frontend/app/components/shared/ToastProvider.tsx
+++ b/frontend/app/components/shared/ToastProvider.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import React, { createContext, useCallback, useContext, useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
+import { useViewport } from "../../../hooks/useViewport";
+import Toast, { type ToastVariant } from "./Toast";
+import styles from "../../../styles/components/shared/Toast.module.scss";
+
+export interface ToastOptions {
+  variant: ToastVariant;
+  message: string | string[];
+  // Overrides the variant's default dismiss behavior (success/info auto-dismiss, warning/error
+  // stay until closed) -- e.g. forcing a persistent info toast for AdminShell's responsive
+  // notice, or forcing a non-persistent error for a case that genuinely doesn't need one.
+  persistent?: boolean;
+  duration?: number;
+}
+
+interface ToastEntry extends ToastOptions {
+  id: string;
+}
+
+// Newest visually on top, oldest nearest the corner anchor -- a 4th toast evicts the oldest
+// rather than queuing behind it, since warning/error toasts are persistent-until-closed and an
+// unbounded queue of those would never drain on its own.
+const MAX_TOASTS = 3;
+const DEFAULT_DURATION_MS = 4000;
+
+// success/info are transient status updates; warning/error need explicit acknowledgment since
+// they're persistent-until-closed by default.
+const DEFAULT_PERSISTENT: Record<ToastVariant, boolean> = {
+  success: false,
+  info: false,
+  warning: true,
+  error: true,
+};
+
+let nextId = 0;
+
+interface ToastContextValue {
+  showToast: (options: ToastOptions) => string;
+}
+
+const ToastContext = createContext<ToastContextValue | null>(null);
+
+export function useToast(): ToastContextValue {
+  const context = useContext(ToastContext);
+  if (!context) throw new Error("useToast must be used within a ToastProvider");
+  return context;
+}
+
+export function ToastProvider({ children }: { children: React.ReactNode }) {
+  const [toasts, setToasts] = useState<ToastEntry[]>([]);
+  const timers = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
+  const viewport = useViewport();
+  const prefersReducedMotion = useReducedMotion();
+
+  const dismiss = useCallback((id: string) => {
+    const timer = timers.current.get(id);
+    if (timer) {
+      clearTimeout(timer);
+      timers.current.delete(id);
+    }
+    setToasts((prev) => prev.filter((toast) => toast.id !== id));
+  }, []);
+
+  const showToast = useCallback((options: ToastOptions) => {
+    const id = `toast-${nextId++}`;
+    const persistent = options.persistent ?? DEFAULT_PERSISTENT[options.variant];
+    const entry: ToastEntry = { ...options, id, persistent };
+
+    setToasts((prev) => {
+      const next = [entry, ...prev];
+      const evicted = next.slice(MAX_TOASTS);
+      evicted.forEach((toast) => {
+        const timer = timers.current.get(toast.id);
+        if (timer) {
+          clearTimeout(timer);
+          timers.current.delete(toast.id);
+        }
+      });
+      return next.slice(0, MAX_TOASTS);
+    });
+
+    if (!persistent) {
+      const timer = setTimeout(() => dismiss(id), options.duration ?? DEFAULT_DURATION_MS);
+      timers.current.set(id, timer);
+    }
+
+    return id;
+  }, [dismiss]);
+
+  useEffect(() => {
+    const activeTimers = timers.current;
+    return () => {
+      activeTimers.forEach((timer) => clearTimeout(timer));
+      activeTimers.clear();
+    };
+  }, []);
+
+  const positionClass =
+    viewport?.device === "phone"
+      ? viewport.orientation === "landscape"
+        ? styles.positionPhoneLandscape
+        : styles.positionPhonePortrait
+      : styles.positionDesktop;
+
+  return (
+    <ToastContext.Provider value={{ showToast }}>
+      {children}
+      {typeof document !== "undefined" &&
+        createPortal(
+          <div className={`${styles.container} ${positionClass}`}>
+            <AnimatePresence>
+              {toasts.map((toast) => (
+                <motion.div
+                  key={toast.id}
+                  initial={prefersReducedMotion ? false : { opacity: 0, y: 16 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  exit={prefersReducedMotion ? { opacity: 0 } : { opacity: 0, y: 8 }}
+                  transition={{ duration: prefersReducedMotion ? 0.01 : 0.2, ease: "easeOut" }}
+                >
+                  <Toast variant={toast.variant} message={toast.message} onClose={() => dismiss(toast.id)} />
+                </motion.div>
+              ))}
+            </AnimatePresence>
+          </div>,
+          document.body
+        )}
+    </ToastContext.Provider>
+  );
+}

--- a/frontend/styles/Variables.module.scss
+++ b/frontend/styles/Variables.module.scss
@@ -28,6 +28,12 @@ $danger-color: #C62828;
 // = color-mix(in srgb, $danger-color 8%, white), precomputed -- this file is plain SCSS vars,
 // not CSS custom properties, so color-mix() can't reference $danger-color at runtime here.
 $danger-bg-color: #FAEEEE;
+
+// = color-mix(in srgb, $danger-color 22%, white), precomputed -- a stronger tint than
+// $danger-bg-color, which is meant as a subtle pill/badge wash. At full-card scale (Toast's
+// filled background, not just an icon accent) that pale a mix reads as pink rather than red;
+// this saturation keeps the same hue but reads unambiguously as red.
+$danger-bg-strong-color: #F4D4D4;
 $link-color: #007BFF;
 $warning-bg-color: #FDF3DC;
 $warning-text-color: #B4790A;

--- a/frontend/styles/Variables.module.scss
+++ b/frontend/styles/Variables.module.scss
@@ -32,6 +32,11 @@ $link-color: #007BFF;
 $warning-bg-color: #FDF3DC;
 $warning-text-color: #B4790A;
 
+// Deliberately not $link-color (#007BFF) -- that's reserved for hyperlink text, and reusing it
+// here would make an info toast/banner read as a clickable link. #1976D2 is a distinct blue.
+$info-bg-color: #E8F1FB;
+$info-text-color: #1976D2;
+
 // Secondary text tones used by ViewMeeting's demoted metadata rows (contact info, room line,
 // recurrence line) -- distinct from $medium-grey-color (#848484, used for icon tints) and
 // $black-color (primary text).

--- a/frontend/styles/components/shared/Toast.module.scss
+++ b/frontend/styles/components/shared/Toast.module.scss
@@ -43,48 +43,65 @@
   gap: 10px;
   width: 100%;
   box-sizing: border-box;
-  padding: 12px 14px;
+  padding: 14px 16px;
   border-radius: $radius-md;
-  background-color: white;
-  box-shadow: 0 4px 12px rgb(0 0 0 / 15%);
+  box-shadow: 0 4px 12px rgb(0 0 0 / 12%);
   font-family: "Source Sans Pro", sans-serif;
   color: $black-color;
 }
 
-.iconCircle {
+.icon {
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 26px;
-  height: 26px;
-  border-radius: 50%;
   flex-shrink: 0;
+  margin-top: 1px;
 }
 
 .success {
-  .iconCircle {
-    background-color: $success-bg-color;
+  background-color: $success-bg-color;
+
+  .icon {
+    color: $success-text-color;
+  }
+
+  .actionLink {
     color: $success-text-color;
   }
 }
 
 .error {
-  .iconCircle {
-    background-color: $danger-bg-color;
+  background-color: $danger-bg-strong-color;
+
+  .icon {
+    color: $danger-color;
+  }
+
+  .actionLink {
     color: $danger-color;
   }
 }
 
 .warning {
-  .iconCircle {
-    background-color: $warning-bg-color;
+  background-color: $warning-bg-color;
+
+  .icon {
+    color: $warning-text-color;
+  }
+
+  .actionLink {
     color: $warning-text-color;
   }
 }
 
 .info {
-  .iconCircle {
-    background-color: $info-bg-color;
+  background-color: $info-bg-color;
+
+  .icon {
+    color: $info-text-color;
+  }
+
+  .actionLink {
     color: $info-text-color;
   }
 }
@@ -96,9 +113,41 @@
   line-height: 1.4;
 }
 
-.messageList {
+.title {
   margin: 0;
+  font-weight: 700;
+  color: $black-color;
+}
+
+.description {
+  margin: 2px 0 0;
+  color: $text-secondary-color;
+}
+
+.messageList {
+  margin: 2px 0 0;
   padding-left: 18px;
+  color: $text-secondary-color;
+}
+
+.actions {
+  display: flex;
+  gap: 16px;
+  margin-top: 8px;
+}
+
+.actionLink {
+  padding: 0;
+  border: none;
+  background: transparent;
+  font-family: inherit;
+  font-size: 14px;
+  font-weight: 700;
+  cursor: pointer;
+
+  &:hover {
+    text-decoration: underline;
+  }
 }
 
 .closeButton {

--- a/frontend/styles/components/shared/Toast.module.scss
+++ b/frontend/styles/components/shared/Toast.module.scss
@@ -1,0 +1,126 @@
+@import '../../Variables.module.scss';
+
+.container {
+  position: fixed;
+  z-index: $z-index-toast;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+
+  // Empty space between/around toasts shouldn't block clicks on whatever's underneath --
+  // individual toasts re-enable pointer-events on themselves below.
+  pointer-events: none;
+}
+
+.positionDesktop {
+  bottom: 24px;
+  right: 24px;
+  width: 340px;
+}
+
+.positionPhonePortrait {
+  left: 8px;
+  right: 8px;
+
+  // 80px = MobileFab's 48px height + its own 16px bottom offset + this toast's 16px clearance
+  // above it (see MobileFab.module.scss). Applied unconditionally, not just when the
+  // admin-only FAB is actually rendered -- a little extra bottom margin when it's absent is
+  // harmless, and avoids threading auth state into this provider.
+  bottom: calc(80px + env(safe-area-inset-bottom));
+}
+
+.positionPhoneLandscape {
+  left: 50%;
+  transform: translateX(-50%);
+  width: 340px;
+  bottom: calc(16px + env(safe-area-inset-bottom));
+}
+
+.toast {
+  pointer-events: auto;
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  width: 100%;
+  box-sizing: border-box;
+  padding: 12px 14px;
+  border-radius: $radius-md;
+  background-color: white;
+  box-shadow: 0 4px 12px rgb(0 0 0 / 15%);
+  font-family: "Source Sans Pro", sans-serif;
+  color: $black-color;
+}
+
+.iconCircle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.success {
+  .iconCircle {
+    background-color: $success-bg-color;
+    color: $success-text-color;
+  }
+}
+
+.error {
+  .iconCircle {
+    background-color: $danger-bg-color;
+    color: $danger-color;
+  }
+}
+
+.warning {
+  .iconCircle {
+    background-color: $warning-bg-color;
+    color: $warning-text-color;
+  }
+}
+
+.info {
+  .iconCircle {
+    background-color: $info-bg-color;
+    color: $info-text-color;
+  }
+}
+
+.body {
+  flex: 1;
+  min-width: 0;
+  font-size: 14px;
+  line-height: 1.4;
+}
+
+.messageList {
+  margin: 0;
+  padding-left: 18px;
+}
+
+.closeButton {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: $medium-grey-color;
+  cursor: pointer;
+
+  &:hover {
+    color: $black-color;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .toast {
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added toast notifications for success, error, warning, and informational messages.
  * Notifications support automatic or manual dismissal, configurable duration, multi-line messages, and persistent display.
  * Added responsive positioning, accessibility-friendly reduced-motion behavior, and a limit of three visible notifications.
  * Added consistent styling and icons for each notification type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description
- **frontend/app/components/shared/ToastProvider.tsx**: new Toast context/provider — queue capped at 3 toasts (a 4th evicts the oldest), corner-anchored positioning (desktop/tablet bottom-right, phone portrait full-width above the FAB, phone landscape centered), variant-based dismiss rules (success/info auto-dismiss after 4s, warning/error persistent until manually closed). Also fixes a hydration mismatch where the portal's `typeof document !== "undefined"` gate rendered differently on the server vs. the first client render.
- **frontend/app/components/shared/Toast.tsx**: presentational toast — variant icon, message (string or bullet list), close button.
- **frontend/styles/components/shared/Toast.module.scss**, **frontend/styles/Variables.module.scss**: variant styling built entirely from existing design tokens; added `$info-bg-color`/`$info-text-color` since no info-variant pair existed yet. Uses the previously-unused `$z-index-toast` token, which the design system had already reserved for exactly this.
- **frontend/app/ClientLayout.tsx**: mounts `ToastProvider` globally so `useToast()` is available anywhere under the `(main)` route group.

No call sites migrated yet — this is the component only. See the stacked PRs on top for the actual `alert()`/inline-error migrations.

## Testing
- [x] `yarn test:all` green (92 e2e + lint/unit/component/integration)
- [x] Manually verified in-browser: toast stacking/eviction at 4+ simultaneous toasts, variant colors/icons, desktop bottom-right positioning

## Area(s) Touched
**Product areas**
- [x] ui/ux — frontend layout/styling not tied to a specific integration

## Pre-merge Checklist
- [x] Code follows current formatting conventions and passes lint (`yarn lint`).
- [x] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
- [x] All test suites pass, both run locally and green in GitHub CI. **Do not merge if any test suite is failing.**
- [ ] A test suite was added or updated for the feature/fix in this PR. **Double-check this if you change a feature and did not update the test suites**. — no call sites migrated in this PR, so no test coverage change yet; covered in the stacked PRs on top.
- [x] Only files relevant to this change are committed — no stray or unrelated files.
- [x] If this branch has a merge conflict with master, master was merged into this branch first (not the other way around).
- [x] The rest of this PR description (Description, Testing) is filled out, not left as template placeholders.