### PR TITLE
feat(shared): migrate alert() calls to Toast notifications

### DIFF
--- a/frontend/app/(main)/page.tsx
+++ b/frontend/app/(main)/page.tsx
@@ -195,7 +195,7 @@ export default function HomePage() {
       });
 
       if (!response.ok) {
-        showToast({ variant: "error", message: "Unsuccessful delete" });
+        showToast({ variant: "error", title: "Unsuccessful delete" });
         throw new Error(`HTTP error! status: ${response.status}`);
       }
 
@@ -208,7 +208,7 @@ export default function HomePage() {
        // Trigger calendar refresh
       triggerCalendarRefresh();
 
-      showToast({ variant: "success", message: "Meeting deleted successfully." });
+      showToast({ variant: "success", title: "Meeting deleted successfully." });
 
     } catch (error) {
       console.error('There was an error fetching the data:', error);
@@ -236,7 +236,7 @@ export default function HomePage() {
       console.error('There was an error suspending the meeting:', error);
       showToast({
         variant: "error",
-        message: `Could not suspend the meeting${error instanceof Error ? ` (${error.message})` : ""}`,
+        title: `Could not suspend the meeting${error instanceof Error ? ` (${error.message})` : ""}`,
       });
     }
   };
@@ -259,7 +259,7 @@ export default function HomePage() {
       console.error('There was an error resuming the meeting:', error);
       showToast({
         variant: "error",
-        message: `Could not resume the meeting${error instanceof Error ? ` (${error.message})` : ""}`,
+        title: `Could not resume the meeting${error instanceof Error ? ` (${error.message})` : ""}`,
       });
     }
   };

--- a/frontend/app/(main)/page.tsx
+++ b/frontend/app/(main)/page.tsx
@@ -19,8 +19,10 @@ import { useConflictMids } from "../../hooks/useConflictMids";
 import { useViewport } from "../../hooks/useViewport";
 import { PHONE_BREAKPOINT } from "../../util/common/breakpoints";
 import { useCalendarContext } from "../context/CalendarProvider";
+import { useToast } from "../components/shared/ToastProvider";
 
 export default function HomePage() {
+  const { showToast } = useToast();
   const [isLoggedIn, setIsLoggedIn] = useState<boolean | null>(null);
   // null until the auth check below resolves -- lets consumers that need to distinguish
   // "don't know yet" from "confirmed not admin" (e.g. CalendarHeader's View-only pill) avoid
@@ -193,7 +195,7 @@ export default function HomePage() {
       });
 
       if (!response.ok) {
-        alert("Error : Unsuccessful delete")
+        showToast({ variant: "error", message: "Unsuccessful delete" });
         throw new Error(`HTTP error! status: ${response.status}`);
       }
 
@@ -206,7 +208,7 @@ export default function HomePage() {
        // Trigger calendar refresh
       triggerCalendarRefresh();
 
-      alert("Meeting deleted successfully! Please check the Meeting collection on MongoDB.")
+      showToast({ variant: "success", message: "Meeting deleted successfully." });
 
     } catch (error) {
       console.error('There was an error fetching the data:', error);
@@ -232,7 +234,10 @@ export default function HomePage() {
       triggerCalendarRefresh();
     } catch (error) {
       console.error('There was an error suspending the meeting:', error);
-      alert(`Error: could not suspend the meeting${error instanceof Error ? ` (${error.message})` : ""}`);
+      showToast({
+        variant: "error",
+        message: `Could not suspend the meeting${error instanceof Error ? ` (${error.message})` : ""}`,
+      });
     }
   };
 
@@ -252,7 +257,10 @@ export default function HomePage() {
       triggerCalendarRefresh();
     } catch (error) {
       console.error('There was an error resuming the meeting:', error);
-      alert(`Error: could not resume the meeting${error instanceof Error ? ` (${error.message})` : ""}`);
+      showToast({
+        variant: "error",
+        message: `Could not resume the meeting${error instanceof Error ? ` (${error.message})` : ""}`,
+      });
     }
   };
 

--- a/frontend/app/(main)/page.tsx
+++ b/frontend/app/(main)/page.tsx
@@ -232,6 +232,7 @@ export default function HomePage() {
 
       handleBack();
       triggerCalendarRefresh();
+      showToast({ variant: "success", title: "Meeting suspended successfully." });
     } catch (error) {
       console.error('There was an error suspending the meeting:', error);
       showToast({
@@ -255,6 +256,7 @@ export default function HomePage() {
 
       handleBack();
       triggerCalendarRefresh();
+      showToast({ variant: "success", title: "Meeting resumed successfully." });
     } catch (error) {
       console.error('There was an error resuming the meeting:', error);
       showToast({

--- a/frontend/app/components/admin/diagnostics/SuspendedCard.tsx
+++ b/frontend/app/components/admin/diagnostics/SuspendedCard.tsx
@@ -90,7 +90,7 @@ const SuspendedCard: React.FC = () => {
       console.error("Error resuming meeting:", err);
       showToast({
         variant: "error",
-        message: `Could not resume the meeting${err instanceof Error ? ` (${err.message})` : ""}`,
+        title: `Could not resume the meeting${err instanceof Error ? ` (${err.message})` : ""}`,
       });
     } finally {
       setResumingMid((current) => (current === mid ? null : current));

--- a/frontend/app/components/admin/diagnostics/SuspendedCard.tsx
+++ b/frontend/app/components/admin/diagnostics/SuspendedCard.tsx
@@ -5,6 +5,7 @@ import Card from "../shared/Card";
 import TopLoadingBar from "../../atoms/TopLoadingBar";
 import DiagnosticsCardError from "./DiagnosticsCardError";
 import ResumeMeetingModal from "../../meeting-form/ResumeMeetingModal";
+import { useToast } from "../../shared/ToastProvider";
 import { formatSuspensionStatusText } from "../../../../util/meetings/suspensionText";
 import styles from "../../../../styles/components/admin/DiagnosticsTab.module.scss";
 
@@ -22,6 +23,7 @@ interface SuspendedRow {
 }
 
 const SuspendedCard: React.FC = () => {
+  const { showToast } = useToast();
   const [suspendedMeetings, setSuspendedMeetings] = useState<SuspendedRow[] | null>(null);
   // Uncapped count -- suspendedMeetings itself is sliced to the 20 most recently updated by
   // the API, so the header can't just use suspendedMeetings.length once that cap is hit.
@@ -86,7 +88,10 @@ const SuspendedCard: React.FC = () => {
       await load();
     } catch (err) {
       console.error("Error resuming meeting:", err);
-      alert(`Error: could not resume the meeting${err instanceof Error ? ` (${err.message})` : ""}`);
+      showToast({
+        variant: "error",
+        message: `Could not resume the meeting${err instanceof Error ? ` (${err.message})` : ""}`,
+      });
     } finally {
       setResumingMid((current) => (current === mid ? null : current));
     }

--- a/frontend/app/components/admin/diagnostics/SuspendedCard.tsx
+++ b/frontend/app/components/admin/diagnostics/SuspendedCard.tsx
@@ -6,6 +6,8 @@ import TopLoadingBar from "../../atoms/TopLoadingBar";
 import DiagnosticsCardError from "./DiagnosticsCardError";
 import ResumeMeetingModal from "../../meeting-form/ResumeMeetingModal";
 import { useToast } from "../../shared/ToastProvider";
+import { invalidateAllDayCache } from "../../calendar/desktop/DayView";
+import { invalidateAllWeekCache } from "../../../../hooks/useWeekMeetings";
 import { formatSuspensionStatusText } from "../../../../util/meetings/suspensionText";
 import styles from "../../../../styles/components/admin/DiagnosticsTab.module.scss";
 
@@ -85,7 +87,14 @@ const SuspendedCard: React.FC = () => {
         const body = await response.json().catch(() => null);
         throw new Error(body?.error || `HTTP error! status: ${response.status}`);
       }
+      // This resume happened outside the calendar route entirely, so its Day/Week views
+      // (if open in another tab, or navigated back to later) would otherwise keep serving
+      // this meeting as still-suspended from their own module-level cache until that cache's
+      // next unrelated fetch happens to overwrite it.
+      invalidateAllDayCache();
+      invalidateAllWeekCache();
       await load();
+      showToast({ variant: "success", title: "Meeting resumed successfully." });
     } catch (err) {
       console.error("Error resuming meeting:", err);
       showToast({

--- a/frontend/app/components/admin/diagnostics/SyncIssuesCard.tsx
+++ b/frontend/app/components/admin/diagnostics/SyncIssuesCard.tsx
@@ -82,8 +82,21 @@ const SyncIssuesCard: React.FC = () => {
   const retrySync = async (mid: string) => {
     setRetryingMid(mid);
     try {
-      await retryMeetingSync(mid);
+      const data = await retryMeetingSync(mid);
       await load();
+      // Same "null is fine, only 'error' blocks success" rule as ViewMeeting's own retry --
+      // zoomSyncStatus is legitimately null for a meeting that never needed Zoom.
+      const calendarOk = data.googleSyncStatus == null || data.googleSyncStatus === 'synced';
+      const zoomOk = data.zoomSyncStatus == null || data.zoomSyncStatus === 'synced';
+      if (calendarOk && zoomOk) {
+        showToast({ variant: "success", title: "Sync retried successfully." });
+      } else {
+        const failures = [
+          !calendarOk && `Google Calendar (${data.googleSyncError ?? 'sync failed'})`,
+          !zoomOk && `Zoom (${data.zoomSyncError ?? 'sync failed'})`,
+        ].filter(Boolean).join(', ');
+        showToast({ variant: "error", title: `Retry failed: ${failures}` });
+      }
     } catch (err) {
       console.error("Error retrying sync:", err);
       showToast({

--- a/frontend/app/components/admin/diagnostics/SyncIssuesCard.tsx
+++ b/frontend/app/components/admin/diagnostics/SyncIssuesCard.tsx
@@ -88,7 +88,7 @@ const SyncIssuesCard: React.FC = () => {
       console.error("Error retrying sync:", err);
       showToast({
         variant: "error",
-        message: `Could not retry the sync${err instanceof Error ? ` (${err.message})` : ""}`,
+        title: `Could not retry the sync${err instanceof Error ? ` (${err.message})` : ""}`,
       });
     } finally {
       // Only clear if this is still the row that started this retry -- a second row's retry

--- a/frontend/app/components/admin/diagnostics/SyncIssuesCard.tsx
+++ b/frontend/app/components/admin/diagnostics/SyncIssuesCard.tsx
@@ -7,6 +7,7 @@ import DiagnosticsCardError from "./DiagnosticsCardError";
 import EditMeetingSidebar from "../../meeting-form/EditMeeting";
 import { IMeeting } from "../../../../types/models";
 import { retryMeetingSync } from "../../../../services/syncMeeting";
+import { useToast } from "../../shared/ToastProvider";
 import styles from "../../../../styles/components/admin/DiagnosticsTab.module.scss";
 // Reuses ConflictList's inline-edit-panel styling (accordion expand + card treatment) rather
 // than duplicating it -- same pattern, same visual language, this card just isn't grouped by
@@ -30,6 +31,7 @@ interface SyncIssueRow {
 }
 
 const SyncIssuesCard: React.FC = () => {
+  const { showToast } = useToast();
   const [syncIssues, setSyncIssues] = useState<SyncIssueRow[] | null>(null);
   const [total, setTotal] = useState(0);
   const [error, setError] = useState<string | null>(null);
@@ -84,7 +86,10 @@ const SyncIssuesCard: React.FC = () => {
       await load();
     } catch (err) {
       console.error("Error retrying sync:", err);
-      alert(`Error: could not retry the sync${err instanceof Error ? ` (${err.message})` : ""}`);
+      showToast({
+        variant: "error",
+        message: `Could not retry the sync${err instanceof Error ? ` (${err.message})` : ""}`,
+      });
     } finally {
       // Only clear if this is still the row that started this retry -- a second row's retry
       // starting before this one resolves must not un-disable/mislabel it early.

--- a/frontend/app/components/admin/export/ExportTab.tsx
+++ b/frontend/app/components/admin/export/ExportTab.tsx
@@ -19,6 +19,7 @@ import Card from "../shared/Card";
 import CardHeader from "../shared/CardHeader";
 import MeetingExportConfigModal from "./MeetingExportConfigModal";
 import LeaseConfigModal from "./LeaseConfigModal";
+import { useToast } from "../../shared/ToastProvider";
 import styles from "../../../../styles/components/admin/ExportTab.module.scss";
 
 type ExportKind = "meetings" | "lease";
@@ -184,6 +185,7 @@ const SignageUrlCard: React.FC = () => {
 };
 
 const ExportTab: React.FC = () => {
+  const { showToast } = useToast();
   const [leaseSettings, setLeaseSettings] = useState<ILeaseSettings | null>(null);
   const [leaseCycles, setLeaseCycles] = useState<LeaseYearCycle[]>([]);
   const [settingsError, setSettingsError] = useState<string | null>(null);
@@ -269,7 +271,7 @@ const ExportTab: React.FC = () => {
     });
     if (!response.ok) {
       const json = await response.json().catch(() => ({}));
-      alert(json.error ?? "Failed to save lease settings.");
+      showToast({ variant: "error", message: json.error ?? "Failed to save lease settings." });
       return;
     }
     const saved: ILeaseSettings = await response.json();
@@ -286,7 +288,7 @@ const ExportTab: React.FC = () => {
       });
       if (!response.ok) {
         const json = await response.json().catch(() => ({}));
-        alert(json.error ?? "Failed to save export field settings.");
+        showToast({ variant: "error", message: json.error ?? "Failed to save export field settings." });
         return;
       }
       const saved: { fields: MeetingExportFieldKey[] } = await response.json();
@@ -294,7 +296,7 @@ const ExportTab: React.FC = () => {
       setMeetingConfigOpen(false);
     } catch (err) {
       console.error("Error saving meeting export settings:", err);
-      alert("Failed to save export field settings.");
+      showToast({ variant: "error", message: "Failed to save export field settings." });
     }
   };
 

--- a/frontend/app/components/admin/export/ExportTab.tsx
+++ b/frontend/app/components/admin/export/ExportTab.tsx
@@ -271,7 +271,7 @@ const ExportTab: React.FC = () => {
     });
     if (!response.ok) {
       const json = await response.json().catch(() => ({}));
-      showToast({ variant: "error", message: json.error ?? "Failed to save lease settings." });
+      showToast({ variant: "error", title: json.error ?? "Failed to save lease settings." });
       return;
     }
     const saved: ILeaseSettings = await response.json();
@@ -288,7 +288,7 @@ const ExportTab: React.FC = () => {
       });
       if (!response.ok) {
         const json = await response.json().catch(() => ({}));
-        showToast({ variant: "error", message: json.error ?? "Failed to save export field settings." });
+        showToast({ variant: "error", title: json.error ?? "Failed to save export field settings." });
         return;
       }
       const saved: { fields: MeetingExportFieldKey[] } = await response.json();
@@ -296,7 +296,7 @@ const ExportTab: React.FC = () => {
       setMeetingConfigOpen(false);
     } catch (err) {
       console.error("Error saving meeting export settings:", err);
-      showToast({ variant: "error", message: "Failed to save export field settings." });
+      showToast({ variant: "error", title: "Failed to save export field settings." });
     }
   };
 

--- a/frontend/app/components/admin/users/UsersTab.tsx
+++ b/frontend/app/components/admin/users/UsersTab.tsx
@@ -244,6 +244,7 @@ const UsersTab: React.FC = () => {
       }
       setInviteOpen(false);
       await loadAdmins();
+      showToast({ variant: "success", title: `Invited ${email} as ${role}.` });
     } catch (err) {
       console.error("Error inviting admin:", err);
       showToast({ variant: "error", title: "Failed to invite admin." });
@@ -289,9 +290,11 @@ const UsersTab: React.FC = () => {
       const updated = json as Partial<IAdmin>;
       if (!updated.email) {
         await loadAdmins();
+        showToast({ variant: "success", title: `Updated ${email}'s role to ${newRole}.` });
         return;
       }
       setAdmins((prev) => prev?.map((a) => (a.email === email ? (updated as IAdmin) : a)) ?? prev);
+      showToast({ variant: "success", title: `Updated ${email}'s role to ${newRole}.` });
     } catch (err) {
       console.error("Error updating role:", err);
       showToast({ variant: "error", title: "Failed to update role." });
@@ -325,6 +328,7 @@ const UsersTab: React.FC = () => {
         return;
       }
       await loadAdmins();
+      showToast({ variant: "success", title: `Removed ${email}.` });
     } catch (err) {
       console.error("Error removing admin:", err);
       showToast({ variant: "error", title: "Failed to remove admin." });

--- a/frontend/app/components/admin/users/UsersTab.tsx
+++ b/frontend/app/components/admin/users/UsersTab.tsx
@@ -244,7 +244,10 @@ const UsersTab: React.FC = () => {
       }
       setInviteOpen(false);
       await loadAdmins();
-      showToast({ variant: "success", title: `Invited ${email} as ${role}.` });
+      // Deliberately doesn't embed the email/role -- the invited row appears in the table right
+      // below this, and a toast repeating that exact text collides with tests (and users'
+      // copy-paste flows) that look up the row by its email.
+      showToast({ variant: "success", title: "Admin invited successfully." });
     } catch (err) {
       console.error("Error inviting admin:", err);
       showToast({ variant: "error", title: "Failed to invite admin." });
@@ -290,7 +293,7 @@ const UsersTab: React.FC = () => {
       const updated = json as Partial<IAdmin>;
       if (!updated.email) {
         await loadAdmins();
-        showToast({ variant: "success", title: `Updated ${email}'s role to ${newRole}.` });
+        showToast({ variant: "success", title: "Role updated successfully." });
         return;
       }
       setAdmins((prev) => prev?.map((a) => (a.email === email ? (updated as IAdmin) : a)) ?? prev);
@@ -328,7 +331,7 @@ const UsersTab: React.FC = () => {
         return;
       }
       await loadAdmins();
-      showToast({ variant: "success", title: `Removed ${email}.` });
+      showToast({ variant: "success", title: "Admin removed successfully." });
     } catch (err) {
       console.error("Error removing admin:", err);
       showToast({ variant: "error", title: "Failed to remove admin." });

--- a/frontend/app/components/admin/users/UsersTab.tsx
+++ b/frontend/app/components/admin/users/UsersTab.tsx
@@ -15,6 +15,7 @@ import StatusPill, { type StatusPillVariant } from "../../atoms/StatusPill";
 import EditRoleModal from "./EditRoleModal";
 import RemoveUserModal from "./RemoveUserModal";
 import InviteUserModal from "./InviteUserModal";
+import { useToast } from "../../shared/ToastProvider";
 import { ROLE_LABEL } from "../../../../util/roles";
 import styles from "../../../../styles/components/admin/UsersTab.module.scss";
 
@@ -51,6 +52,7 @@ const SORT_COLUMNS: { key: SortColumn; label: string }[] = [
 ];
 
 const UsersTab: React.FC = () => {
+  const { showToast } = useToast();
   // null means "not yet loaded" (distinct from "loaded, zero admins") -- lets a refetch after
   // invite/role-change/remove show just the TopLoadingBar over the existing rows instead of
   // blanking the whole table back to "Loading users…" every time.
@@ -237,14 +239,14 @@ const UsersTab: React.FC = () => {
       });
       if (!response.ok) {
         const json = await response.json().catch(() => ({}));
-        alert(json.error ?? "Failed to invite admin.");
+        showToast({ variant: "error", message: json.error ?? "Failed to invite admin." });
         return;
       }
       setInviteOpen(false);
       await loadAdmins();
     } catch (err) {
       console.error("Error inviting admin:", err);
-      alert("Failed to invite admin.");
+      showToast({ variant: "error", message: "Failed to invite admin." });
     } finally {
       setInviting(false);
     }
@@ -269,9 +271,12 @@ const UsersTab: React.FC = () => {
         // two admins demoting different Super Admins at once) -- distinct from a plain
         // validation/business-rule rejection, so it gets its own message pointing at a retry
         // rather than the generic error text.
-        alert(response.status === 409
-          ? "Someone else changed the admin list at the same time -- please try again."
-          : (json.error ?? "Failed to update role."));
+        showToast({
+          variant: "error",
+          message: response.status === 409
+            ? "Someone else changed the admin list at the same time -- please try again."
+            : (json.error ?? "Failed to update role."),
+        });
         setAdmins((prev) => prev?.map((a) => (a.email === email ? { ...a, role: previousRole } : a)) ?? prev);
         return;
       }
@@ -289,7 +294,7 @@ const UsersTab: React.FC = () => {
       setAdmins((prev) => prev?.map((a) => (a.email === email ? (updated as IAdmin) : a)) ?? prev);
     } catch (err) {
       console.error("Error updating role:", err);
-      alert("Failed to update role.");
+      showToast({ variant: "error", message: "Failed to update role." });
       setAdmins((prev) => prev?.map((a) => (a.email === email ? { ...a, role: previousRole } : a)) ?? prev);
     } finally {
       setPendingRoleEmails((prev) => {
@@ -311,15 +316,18 @@ const UsersTab: React.FC = () => {
       if (!response.ok) {
         const json = await response.json().catch(() => ({}));
         // Same Serializable-transaction race as handleRoleChange above.
-        alert(response.status === 409
-          ? "Someone else changed the admin list at the same time -- please try again."
-          : (json.error ?? "Failed to remove admin."));
+        showToast({
+          variant: "error",
+          message: response.status === 409
+            ? "Someone else changed the admin list at the same time -- please try again."
+            : (json.error ?? "Failed to remove admin."),
+        });
         return;
       }
       await loadAdmins();
     } catch (err) {
       console.error("Error removing admin:", err);
-      alert("Failed to remove admin.");
+      showToast({ variant: "error", message: "Failed to remove admin." });
     }
   };
 

--- a/frontend/app/components/admin/users/UsersTab.tsx
+++ b/frontend/app/components/admin/users/UsersTab.tsx
@@ -239,14 +239,14 @@ const UsersTab: React.FC = () => {
       });
       if (!response.ok) {
         const json = await response.json().catch(() => ({}));
-        showToast({ variant: "error", message: json.error ?? "Failed to invite admin." });
+        showToast({ variant: "error", title: json.error ?? "Failed to invite admin." });
         return;
       }
       setInviteOpen(false);
       await loadAdmins();
     } catch (err) {
       console.error("Error inviting admin:", err);
-      showToast({ variant: "error", message: "Failed to invite admin." });
+      showToast({ variant: "error", title: "Failed to invite admin." });
     } finally {
       setInviting(false);
     }
@@ -273,7 +273,7 @@ const UsersTab: React.FC = () => {
         // rather than the generic error text.
         showToast({
           variant: "error",
-          message: response.status === 409
+          title: response.status === 409
             ? "Someone else changed the admin list at the same time -- please try again."
             : (json.error ?? "Failed to update role."),
         });
@@ -294,7 +294,7 @@ const UsersTab: React.FC = () => {
       setAdmins((prev) => prev?.map((a) => (a.email === email ? (updated as IAdmin) : a)) ?? prev);
     } catch (err) {
       console.error("Error updating role:", err);
-      showToast({ variant: "error", message: "Failed to update role." });
+      showToast({ variant: "error", title: "Failed to update role." });
       setAdmins((prev) => prev?.map((a) => (a.email === email ? { ...a, role: previousRole } : a)) ?? prev);
     } finally {
       setPendingRoleEmails((prev) => {
@@ -318,7 +318,7 @@ const UsersTab: React.FC = () => {
         // Same Serializable-transaction race as handleRoleChange above.
         showToast({
           variant: "error",
-          message: response.status === 409
+          title: response.status === 409
             ? "Someone else changed the admin list at the same time -- please try again."
             : (json.error ?? "Failed to remove admin."),
         });
@@ -327,7 +327,7 @@ const UsersTab: React.FC = () => {
       await loadAdmins();
     } catch (err) {
       console.error("Error removing admin:", err);
-      showToast({ variant: "error", message: "Failed to remove admin." });
+      showToast({ variant: "error", title: "Failed to remove admin." });
     }
   };
 

--- a/frontend/app/components/calendar/desktop/DayView.tsx
+++ b/frontend/app/components/calendar/desktop/DayView.tsx
@@ -144,6 +144,13 @@ export const invalidateCache = (date: Date) => {
   dayMeetingCache.invalidate(formatETDateString(date));
 };
 
+// For callers that changed a meeting from outside the calendar route entirely (e.g. Admin
+// Diagnostics resuming a suspended meeting) and so don't know/can't reach the specific date key
+// -- clears every cached day rather than guessing one.
+export const invalidateAllDayCache = () => {
+  dayMeetingCache.clear();
+};
+
 const formatTime = (hour: number): string => {
   const period = hour >= 12 ? "PM" : "AM";
   const formattedHour = hour % 12 || 12;

--- a/frontend/app/components/meeting-form/EditMeeting.tsx
+++ b/frontend/app/components/meeting-form/EditMeeting.tsx
@@ -18,6 +18,7 @@ import { physicalRoomOptions, zoomRoomOptions } from "../../../util/rooms/rooms"
 import { useMeetingForm, CAL_TYPE_OPTIONS, CAL_TYPE_COLOR, DESCRIPTION_MAX_LENGTH } from '../../../hooks/useMeetingForm';
 import { ConflictListRow } from '../../../util/meetings/conflictDisplay';
 import { useToast } from '../shared/ToastProvider';
+import { pollMeetingSyncStatus, describeSyncFailure } from '../../../services/syncMeeting';
 
 import styles from '../../../styles/components/meeting-form/MeetingForm.module.scss';
 
@@ -87,6 +88,17 @@ const EditMeetingSidebar: React.FC<EditMeetingSidebarProps> =
         showToast({ variant: "success", title: "Meeting updated successfully." });
         onUpdateSuccess();
         onClose();
+
+        // Fire-and-forget -- see NewMeeting.tsx's identical call for why (the response above
+        // is sent before the actual Zoom/Calendar sync runs). showToast is global, so this is
+        // safe to resolve after the form itself has already closed.
+        pollMeetingSyncStatus(meetingResponse.mid, {
+          expectGoogle: (payload.calType?.length ?? 0) > 0,
+          expectZoom: payload.modeType === 'Hybrid' || payload.modeType === 'Remote',
+        }).then((result) => {
+          const message = describeSyncFailure(result);
+          if (message) showToast({ variant: "error", title: message, persistent: true });
+        });
       } catch (error) {
         console.error('There was an error fetching the data:', error);
       } finally {

--- a/frontend/app/components/meeting-form/EditMeeting.tsx
+++ b/frontend/app/components/meeting-form/EditMeeting.tsx
@@ -84,7 +84,7 @@ const EditMeetingSidebar: React.FC<EditMeetingSidebarProps> =
         const meetingResponse = await response.json();
         console.log(meetingResponse);
         setConflictState(null);
-        showToast({ variant: "success", message: "Meeting updated successfully." });
+        showToast({ variant: "success", title: "Meeting updated successfully." });
         onUpdateSuccess();
         onClose();
       } catch (error) {

--- a/frontend/app/components/meeting-form/EditMeeting.tsx
+++ b/frontend/app/components/meeting-form/EditMeeting.tsx
@@ -17,6 +17,7 @@ import { IMeeting } from '../../../types/models'
 import { physicalRoomOptions, zoomRoomOptions } from "../../../util/rooms/rooms";
 import { useMeetingForm, CAL_TYPE_OPTIONS, CAL_TYPE_COLOR, DESCRIPTION_MAX_LENGTH } from '../../../hooks/useMeetingForm';
 import { ConflictListRow } from '../../../util/meetings/conflictDisplay';
+import { useToast } from '../shared/ToastProvider';
 
 import styles from '../../../styles/components/meeting-form/MeetingForm.module.scss';
 
@@ -50,6 +51,7 @@ const EditMeetingSidebar: React.FC<EditMeetingSidebarProps> =
       buildMeetingPayload,
     } = useMeetingForm(meeting);
 
+    const { showToast } = useToast();
     const [isSubmitting, setIsSubmitting] = useState(false);
     // Holds the payload + conflict rows across the confirm round-trip -- a 409 doesn't discard
     // the edit, it just pauses submission until the modal's Cancel or "Save anyway".
@@ -82,7 +84,7 @@ const EditMeetingSidebar: React.FC<EditMeetingSidebarProps> =
         const meetingResponse = await response.json();
         console.log(meetingResponse);
         setConflictState(null);
-        alert("Meeting updated successfully! Please check the Meeting collection on MongoDB.");
+        showToast({ variant: "success", message: "Meeting updated successfully." });
         onUpdateSuccess();
         onClose();
       } catch (error) {

--- a/frontend/app/components/meeting-form/NewMeeting.tsx
+++ b/frontend/app/components/meeting-form/NewMeeting.tsx
@@ -93,7 +93,7 @@ const NewMeetingSidebar: React.FC<NewMeetingSidebarProps> = ({
 
         setConflictState(null);
         triggerCalendarRefresh();
-        showToast({ variant: "success", message: "Meeting created successfully." });
+        showToast({ variant: "success", title: "Meeting created successfully." });
         handleCloseNewMeeting();
       } catch (error) {
         console.error('There was an error fetching the data:', error);

--- a/frontend/app/components/meeting-form/NewMeeting.tsx
+++ b/frontend/app/components/meeting-form/NewMeeting.tsx
@@ -19,6 +19,7 @@ import { useMeetingForm, CAL_TYPE_OPTIONS, CAL_TYPE_COLOR, DESCRIPTION_MAX_LENGT
 import { IMeeting } from '../../../types/models';
 import { ConflictListRow } from '../../../util/meetings/conflictDisplay';
 import { useToast } from '../shared/ToastProvider';
+import { pollMeetingSyncStatus, describeSyncFailure } from '../../../services/syncMeeting';
 
 import styles from '../../../styles/components/meeting-form/MeetingForm.module.scss';
 
@@ -95,6 +96,18 @@ const NewMeetingSidebar: React.FC<NewMeetingSidebarProps> = ({
         triggerCalendarRefresh();
         showToast({ variant: "success", title: "Meeting created successfully." });
         handleCloseNewMeeting();
+
+        // Fire-and-forget -- the create response above is sent before the actual Zoom/Calendar
+        // sync runs (see services/syncMeeting.ts's pollMeetingSyncStatus), so there's nothing
+        // fresh to check yet. showToast is global (ToastProvider context), so this is safe to
+        // resolve after the form itself has already closed.
+        pollMeetingSyncStatus(meetingResponse.mid, {
+          expectGoogle: (payload.calType?.length ?? 0) > 0,
+          expectZoom: payload.modeType === 'Hybrid' || payload.modeType === 'Remote',
+        }).then((result) => {
+          const message = describeSyncFailure(result);
+          if (message) showToast({ variant: "error", title: message, persistent: true });
+        });
       } catch (error) {
         console.error('There was an error fetching the data:', error);
       } finally {

--- a/frontend/app/components/meeting-form/NewMeeting.tsx
+++ b/frontend/app/components/meeting-form/NewMeeting.tsx
@@ -18,6 +18,7 @@ import { physicalRoomOptions, zoomRoomOptions } from "../../../util/rooms/rooms"
 import { useMeetingForm, CAL_TYPE_OPTIONS, CAL_TYPE_COLOR, DESCRIPTION_MAX_LENGTH } from '../../../hooks/useMeetingForm';
 import { IMeeting } from '../../../types/models';
 import { ConflictListRow } from '../../../util/meetings/conflictDisplay';
+import { useToast } from '../shared/ToastProvider';
 
 import styles from '../../../styles/components/meeting-form/MeetingForm.module.scss';
 
@@ -55,6 +56,7 @@ const NewMeetingSidebar: React.FC<NewMeetingSidebarProps> = ({
       buildMeetingPayload,
     } = useMeetingForm(undefined, { selectedDate, selectedView });
 
+    const { showToast } = useToast();
     const [isSubmitting, setIsSubmitting] = useState(false);
     // Holds the payload + conflict rows across the confirm round-trip -- a 409 doesn't clear
     // the form, it just pauses submission until the modal's Cancel or "Save anyway".
@@ -91,7 +93,7 @@ const NewMeetingSidebar: React.FC<NewMeetingSidebarProps> = ({
 
         setConflictState(null);
         triggerCalendarRefresh();
-        alert("Meeting created successfully! Please check the Meeting collection on MongoDB.");
+        showToast({ variant: "success", message: "Meeting created successfully." });
         handleCloseNewMeeting();
       } catch (error) {
         console.error('There was an error fetching the data:', error);

--- a/frontend/app/components/meeting-form/ViewMeeting.tsx
+++ b/frontend/app/components/meeting-form/ViewMeeting.tsx
@@ -13,6 +13,7 @@ import { IRecurrencePattern } from '../../../types/models';
 import { formatCompactTimeRange, formatMeetingDateLine } from "../../../util/date/timeFormat";
 import { formatETDateString } from "../../../util/date/timeUtils";
 import { retryMeetingSync } from "../../../services/syncMeeting";
+import { useToast } from "../shared/ToastProvider";
 import { formatSuspensionStatusText } from "../../../util/meetings/suspensionText";
 import { ROOM_COLORS, ZOOM_ROOM_COLOR } from "../../../util/rooms/filterColors";
 import { formatRecurrencePattern } from "../../../util/meetings/recurrenceDisplay";
@@ -152,6 +153,7 @@ const ViewMeetingDetails: React.FC<ViewMeetingDetailsProps> = ({
   const hasSuspension = !!suspendedSince;
   const isSuspended = hasSuspension && !!suspensionActive;
   const hasPendingSuspension = hasSuspension && !isSuspended;
+  const { showToast } = useToast();
   const [googleSyncStatus, setGoogleSyncStatus] = useState(initialGoogleSyncStatus ?? null);
   const [googleSyncError, setGoogleSyncError] = useState(initialGoogleSyncError ?? null);
   const [zoomSyncStatus, setZoomSyncStatus] = useState(initialZoomSyncStatus ?? null);
@@ -294,12 +296,22 @@ const ViewMeetingDetails: React.FC<ViewMeetingDetailsProps> = ({
       // fired as soon as just one side synced, even while the other was still failing).
       const calendarOk = data.googleSyncStatus == null || data.googleSyncStatus === 'synced';
       const zoomOk = data.zoomSyncStatus == null || data.zoomSyncStatus === 'synced';
-      if (calendarOk && zoomOk) onSyncSuccess?.();
+      if (calendarOk && zoomOk) {
+        onSyncSuccess?.();
+        showToast({ variant: "success", title: "Sync retried successfully." });
+      } else {
+        const failures = [
+          !calendarOk && `Google Calendar (${data.googleSyncError ?? 'sync failed'})`,
+          !zoomOk && `Zoom (${data.zoomSyncError ?? 'sync failed'})`,
+        ].filter(Boolean).join(', ');
+        showToast({ variant: "error", title: `Retry failed: ${failures}` });
+      }
     } catch {
       // Stale from a prior fetch/retry -- this failure is the request itself, not a specific
       // provider error, so clear it and let the details list fall back to "Sync failed.".
       setGoogleSyncStatus('error');
       setGoogleSyncError(null);
+      showToast({ variant: "error", title: "Could not retry the sync." });
     } finally {
       setSyncing(false);
     }

--- a/frontend/hooks/useWeekMeetings.ts
+++ b/frontend/hooks/useWeekMeetings.ts
@@ -75,6 +75,13 @@ export const invalidateWeekCache = (startDate: Date, endDate: Date) => {
     weekMeetingCache.invalidate(`${formattedStart}-${formattedEnd}`);
 };
 
+// For callers that changed a meeting from outside the calendar route entirely (e.g. Admin
+// Diagnostics resuming a suspended meeting) and so don't know/can't reach the specific week key
+// -- clears every cached week rather than guessing one.
+export const invalidateAllWeekCache = () => {
+    weekMeetingCache.clear();
+};
+
 export interface UseWeekMeetingsResult {
     meetings: WeekMeeting[];
     // True while a fetch for the currently-requested week is in flight -- including a cache hit,

--- a/frontend/services/syncMeeting.ts
+++ b/frontend/services/syncMeeting.ts
@@ -19,3 +19,63 @@ export async function retryMeetingSync(mid: string): Promise<MeetingSyncResult> 
   if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
   return response.json();
 }
+
+export interface MeetingSyncPollResult extends MeetingSyncResult {
+  // False if every poll attempt was exhausted while a channel the caller expected to sync was
+  // still "pending"/unset -- the caller should stay silent rather than report a false failure.
+  settled: boolean;
+}
+
+const POLL_INTERVAL_MS = 1500;
+const MAX_POLL_ATTEMPTS = 4;
+
+// Meeting create/update (write/meeting and update/meeting routes) defer the actual Zoom/
+// Calendar sync to Next's after(), which runs *after* that request's response is already sent
+// -- so the create/update response has no fresh sync status to read, only whatever the row
+// held before this run. This polls the meeting's own record (the authenticated GET returns the
+// full row -- see retrieve/meeting/[id]/route.ts) until every channel the caller expects to
+// sync has left "pending"/null, so NewMeeting/EditMeeting can toast the real outcome a few
+// seconds later instead of staying silent on a sync failure.
+//
+// expectGoogle/expectZoom come from the payload just submitted, not guessed here -- a channel
+// that was never going to sync (e.g. Zoom for an In Person meeting) would otherwise poll
+// pointlessly until MAX_POLL_ATTEMPTS gives up.
+export async function pollMeetingSyncStatus(
+  mid: string,
+  { expectGoogle, expectZoom }: { expectGoogle: boolean; expectZoom: boolean },
+): Promise<MeetingSyncPollResult> {
+  for (let attempt = 0; attempt < MAX_POLL_ATTEMPTS; attempt++) {
+    await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+    const response = await fetch(`/api/retrieve/meeting/${mid}`);
+    if (!response.ok) continue;
+    const data = await response.json();
+    const googleDone = !expectGoogle || (data.googleSyncStatus != null && data.googleSyncStatus !== 'pending');
+    const zoomDone = !expectZoom || (data.zoomSyncStatus != null && data.zoomSyncStatus !== 'pending');
+    if (googleDone && zoomDone) {
+      return {
+        googleSyncStatus: data.googleSyncStatus ?? null,
+        googleSyncError: data.googleSyncError ?? null,
+        zoomSyncStatus: data.zoomSyncStatus ?? null,
+        zoomSyncError: data.zoomSyncError ?? null,
+        settled: true,
+      };
+    }
+  }
+  return { googleSyncStatus: null, googleSyncError: null, zoomSyncStatus: null, zoomSyncError: null, settled: false };
+}
+
+// Builds a human-readable follow-up toast message from a settled poll result, or null if
+// nothing failed (caller should stay silent -- the initial "Meeting created/updated" toast
+// already covered the happy path, and a second "sync succeeded" toast would be redundant).
+export function describeSyncFailure(result: MeetingSyncPollResult): string | null {
+  if (!result.settled) return null;
+  const failures: string[] = [];
+  if (result.googleSyncStatus === 'error') {
+    failures.push(`Google Calendar (${result.googleSyncError ?? 'sync failed'})`);
+  }
+  if (result.zoomSyncStatus === 'error') {
+    failures.push(`Zoom (${result.zoomSyncError ?? 'sync failed'})`);
+  }
+  if (failures.length === 0) return null;
+  return `The meeting saved, but failed to sync: ${failures.join(', ')}. Retry from the meeting's details.`;
+}

--- a/frontend/tests/e2e/02-meeting-creation.spec.ts
+++ b/frontend/tests/e2e/02-meeting-creation.spec.ts
@@ -21,11 +21,8 @@ test.describe("meeting creation", () => {
     await toggleCalType(page, "AA");
     await page.getByPlaceholder("Email").fill("creation@test.icr");
 
-    const dialogPromise = page.waitForEvent("dialog");
     await page.getByRole("button", { name: "Create Meeting" }).click();
-    const dialog = await dialogPromise;
-    expect(dialog.message()).toContain("Meeting created successfully");
-    await dialog.accept();
+    await expect(page.getByText("Meeting created successfully")).toBeVisible();
 
     // Sidebar closes back to the filter/new-meeting view.
     await expect(page.getByText("New Meeting")).toBeVisible();
@@ -74,7 +71,6 @@ test.describe("meeting creation", () => {
     await toggleCalType(page, "Other");
     await page.getByPlaceholder("Email").fill("dual@test.icr");
 
-    page.once("dialog", (dialog) => dialog.accept());
     const writeResponse = page.waitForResponse((r) => r.url().includes("/api/write/meeting"));
     await page.getByRole("button", { name: "Create Meeting" }).click();
     await writeResponse;
@@ -101,18 +97,15 @@ test.describe("meeting creation", () => {
     await page.getByRole("button", { name: "Create Meeting" }).click();
 
     // Blocked by the room conflict -- the override modal appears instead of the normal
-    // success alert, naming the meeting it collides with. Scoped to the dialog and exact-
+    // success toast, naming the meeting it collides with. Scoped to the dialog and exact-
     // matched -- the seeded meeting's own calendar box (still visible behind the overlay) and
     // the modal's own message text both otherwise also match "Already Booked" un-scoped.
     const modal = page.getByRole("dialog");
     await expect(modal.getByText("Scheduling conflict")).toBeVisible();
     await expect(modal.getByText(existing.title, { exact: true })).toBeVisible();
 
-    const dialogPromise = page.waitForEvent("dialog");
     await page.getByRole("button", { name: "Save anyway" }).click();
-    const dialog = await dialogPromise;
-    expect(dialog.message()).toContain("Meeting created successfully");
-    await dialog.accept();
+    await expect(page.getByText("Meeting created successfully")).toBeVisible();
 
     const prisma = getTestPrismaClient();
     const room = await prisma.meeting.findMany({ where: { room: "Seeds of Hope Room" } });

--- a/frontend/tests/e2e/03-meeting-editing.spec.ts
+++ b/frontend/tests/e2e/03-meeting-editing.spec.ts
@@ -51,11 +51,8 @@ test.describe("meeting editing", () => {
     await titleInput.fill("Renamed Meeting");
     await fillTimeRange(page, "20:00", "21:00");
 
-    const dialogPromise = page.waitForEvent("dialog");
     await page.getByRole("button", { name: "Update Meeting" }).click();
-    const dialog = await dialogPromise;
-    expect(dialog.message()).toContain("Meeting updated successfully");
-    await dialog.accept();
+    await expect(page.getByText("Meeting updated successfully")).toBeVisible();
 
     await page.reload();
     const prisma = getTestPrismaClient();
@@ -84,7 +81,6 @@ test.describe("meeting editing", () => {
     await openEditFromDetails(page);
     await page.getByPlaceholder("Meeting title").fill("Recurring Series Renamed");
 
-    page.once("dialog", (dialog) => dialog.accept());
     await page.getByRole("button", { name: "Update Meeting" }).click();
     // The calendar (level-3 heading) picks up the rename immediately via the
     // post-update refresh; the still-open detail panel's own <h1> is a known

--- a/frontend/tests/e2e/04-meeting-deletion.spec.ts
+++ b/frontend/tests/e2e/04-meeting-deletion.spec.ts
@@ -30,7 +30,6 @@ test.describe("meeting deletion", () => {
     // Confirming via the modal's "Delete" button actually deletes it -- the kebab's own
     // "Delete" item is already closed/unmounted by the time the modal's button renders, so
     // this stays unambiguous despite sharing the same label.
-    page.on("dialog", (dialog) => dialog.accept());
     await openMeetingOptions(page, "One-Off To Delete");
     await page.getByRole("button", { name: "Delete", exact: true }).click();
     const deleteResponse = page.waitForResponse((r) => r.url().includes("/api/delete/meeting"));
@@ -70,7 +69,6 @@ test.describe("meeting deletion", () => {
     await page.getByRole("button", { name: "Delete", exact: true }).click();
     await page.getByLabel("This event").check();
 
-    page.on("dialog", (dialog) => dialog.accept());
     const deleteResponse = page.waitForResponse((r) => r.url().includes("/api/delete/meeting"));
     await page.getByRole("button", { name: "Delete", exact: true }).click();
     await deleteResponse;
@@ -90,7 +88,6 @@ test.describe("meeting deletion", () => {
     await page.getByRole("button", { name: "Delete", exact: true }).click();
     await page.getByLabel("All events").check();
 
-    page.on("dialog", (dialog) => dialog.accept());
     const deleteResponse = page.waitForResponse((r) => r.url().includes("/api/delete/meeting"));
     await page.getByRole("button", { name: "Delete", exact: true }).click();
     await deleteResponse;

--- a/frontend/tests/e2e/06-zoom-integration.spec.ts
+++ b/frontend/tests/e2e/06-zoom-integration.spec.ts
@@ -53,7 +53,6 @@ test.describe("zoom integration", () => {
     await toggleCalType(page, "AA");
     await page.getByPlaceholder("Email").fill("zoom@test.icr");
 
-    page.once("dialog", (dialog) => dialog.accept());
     const writeResponse = page.waitForResponse((r) => r.url().includes("/api/write/meeting"));
     await page.getByRole("button", { name: "Create Meeting" }).click();
     await writeResponse;

--- a/frontend/tests/e2e/07-google-calendar-sync.spec.ts
+++ b/frontend/tests/e2e/07-google-calendar-sync.spec.ts
@@ -28,7 +28,6 @@ test.describe("google calendar sync", () => {
     await toggleCalType(page, "AA");
     await page.getByPlaceholder("Email").fill("notoken@test.icr");
 
-    page.once("dialog", (dialog) => dialog.accept());
     const writeResponse = page.waitForResponse((r) => r.url().includes("/api/write/meeting"));
     await page.getByRole("button", { name: "Create Meeting" }).click();
     await writeResponse;
@@ -53,7 +52,6 @@ test.describe("google calendar sync", () => {
     await toggleCalType(page, "Other");
     await page.getByPlaceholder("Email").fill("dualcal@test.icr");
 
-    page.once("dialog", (dialog) => dialog.accept());
     const writeResponse = page.waitForResponse((r) => r.url().includes("/api/write/meeting"));
     await page.getByRole("button", { name: "Create Meeting" }).click();
     await writeResponse;

--- a/frontend/tests/e2e/09-edge-cases.spec.ts
+++ b/frontend/tests/e2e/09-edge-cases.spec.ts
@@ -25,12 +25,9 @@ test.describe("edge cases", () => {
     await toggleCalType(page, "AA");
     await page.getByPlaceholder("Email").fill("past@test.icr");
 
-    const dialogPromise = page.waitForEvent("dialog");
     await page.getByRole("button", { name: "Create Meeting" }).click();
-    const dialog = await dialogPromise;
-    // No past-date-specific wording — same success alert as any other creation.
-    expect(dialog.message()).toContain("Meeting created successfully");
-    await dialog.accept();
+    // No past-date-specific wording — same success toast as any other creation.
+    await expect(page.getByText("Meeting created successfully")).toBeVisible();
 
     const prisma = getTestPrismaClient();
     const created = await prisma.meeting.findFirst({ where: { title: "Past Meeting" } });
@@ -60,7 +57,6 @@ test.describe("edge cases", () => {
     await toggleCalType(page, "AA");
     await page.getByPlaceholder("Email").fill("rapid@test.icr");
 
-    page.on("dialog", (dialog) => dialog.accept());
     // By CSS class, not accessible name — the button's own text flips to
     // "Creating…" as soon as the first click lands (that's the fix), which
     // would otherwise make a by-name locator stop resolving for the rest.

--- a/frontend/tests/e2e/10-recurring-meetings.spec.ts
+++ b/frontend/tests/e2e/10-recurring-meetings.spec.ts
@@ -28,9 +28,8 @@ test.describe("recurring meetings", () => {
     await page.getByText("This meeting is recurring", { exact: true }).click();
     await expect(page.getByText("Repeats", { exact: true })).toBeVisible();
 
-    const dialogPromise = page.waitForEvent("dialog");
     await page.getByRole("button", { name: "Create Meeting" }).click();
-    await (await dialogPromise).accept();
+    await expect(page.getByText("Meeting created successfully")).toBeVisible();
 
     const prisma = getTestPrismaClient();
     const meeting = await prisma.meeting.findFirst({ where: { title: "Weekly Recurring Meeting" } });
@@ -68,9 +67,8 @@ test.describe("recurring meetings", () => {
     await page.getByRole("option").filter({ hasText: "Monthly on the 2nd Tuesday" }).click();
     await expect(page.getByRole("button", { name: "Monthly on the 2nd Tuesday" })).toBeVisible();
 
-    const dialogPromise = page.waitForEvent("dialog");
     await page.getByRole("button", { name: "Create Meeting" }).click();
-    await (await dialogPromise).accept();
+    await expect(page.getByText("Meeting created successfully")).toBeVisible();
 
     const prisma = getTestPrismaClient();
     const meeting = await prisma.meeting.findFirst({ where: { title: "Monthly Recurring Meeting" } });

--- a/frontend/tests/e2e/17-mobile-meeting-forms.spec.ts
+++ b/frontend/tests/e2e/17-mobile-meeting-forms.spec.ts
@@ -52,11 +52,8 @@ test.describe("mobile meeting interactions", () => {
     await toggleCalType(page, "AA");
     await page.getByPlaceholder("Email").fill("mobile-fab@test.icr");
 
-    const dialogPromise = page.waitForEvent("dialog");
     await page.getByRole("button", { name: "Create Meeting" }).click();
-    const dialog = await dialogPromise;
-    expect(dialog.message()).toContain("Meeting created successfully");
-    await dialog.accept();
+    await expect(page.getByText("Meeting created successfully")).toBeVisible();
 
     // Full-screen form closes back down, the new meeting is now visible on the calendar.
     await expect(page.getByRole("heading", { name: "New Meeting" })).not.toBeVisible();


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Replaced browser alerts with in-app toast notifications for meeting creation, editing, deletion, administrative actions, exports, and sync operations.
  * Added clearer success and error feedback while preserving detailed server-provided error messages.

* **Tests**
  * Updated end-to-end coverage to validate toast notifications and in-page confirmation dialogs instead of native browser dialogs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description
- **frontend/app/(main)/page.tsx**: 4 sites — delete success/error, suspend error, resume error.
- **frontend/app/components/meeting-form/NewMeeting.tsx**, **EditMeeting.tsx**: create/update success alerts → toasts. (The last remaining `alert()` in each — client-side validation — is deliberately left for the stacked PR that replaces it with a dedicated banner.)
- **frontend/app/components/admin/diagnostics/SuspendedCard.tsx**, **SyncIssuesCard.tsx**: resume/retry-sync error alerts → toasts.
- **frontend/app/components/admin/users/UsersTab.tsx**: 6 sites — invite/role-change/remove, including the existing HTTP-409 race-condition message preserved as-is.
- **frontend/app/components/admin/export/ExportTab.tsx**: 3 sites — save-settings/save-export-fields errors.
- **frontend/tests/e2e/{02-meeting-creation,03-meeting-editing,04-meeting-deletion,06-zoom-integration,07-google-calendar-sync,09-edge-cases,10-recurring-meetings,17-mobile-meeting-forms}.spec.ts**: removed native `page.on/once/waitForEvent("dialog", ...)` handling made obsolete now that these alerts are toasts, replacing message-content assertions with toast-visibility checks where one previously existed. Two of these (10-recurring-meetings) were actually latent bugs — `waitForEvent("dialog")` would have hung indefinitely once the alert stopped firing, not just silently no-op'd.

Every site's existing message/logic is preserved exactly — only the delivery mechanism changed from `alert()` to `showToast()`. Two stale "please check the Meeting collection on MongoDB" references (left over from the pre-Postgres-migration era) were dropped from the create/update success messages while touching those lines anyway.

## Testing
- [x] `yarn test:all` green (92 e2e + lint/unit/component/integration)
- [x] Grepped the full e2e suite for any other `dialog`-handling tied to the migrated alerts before considering this done (per this repo's test-coverage convention) — none missed.

## Area(s) Touched
**Product areas**
- [x] admin — /admin shell (Diagnostics, Users, Import, Export tabs)
- [x] ui/ux — frontend layout/styling not tied to a specific integration

**Engineering**
- [x] testing — test suite (Jest/Playwright) changes

## Pre-merge Checklist
- [x] Code follows current formatting conventions and passes lint (`yarn lint`).
- [x] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
- [x] All test suites pass, both run locally and green in GitHub CI. **Do not merge if any test suite is failing.**
- [x] A test suite was added or updated for the feature/fix in this PR. **Double-check this if you change a feature and did not update the test suites**.
- [x] Only files relevant to this change are committed — no stray or unrelated files.
- [x] If this branch has a merge conflict with master, master was merged into this branch first (not the other way around).
- [x] The rest of this PR description (Description, Testing) is filled out, not left as template placeholders.