### PR TITLE
feat(meeting-form): add live validation banner and inline field errors

### DIFF
--- a/frontend/app/(main)/page.module.scss
+++ b/frontend/app/(main)/page.module.scss
@@ -25,7 +25,13 @@
 
 .sidebarScroll {
   height: 100%;
-  overflow-y: auto;
+
+  // overflow-x explicit, not implicit -- overflow-y: auto alone computes overflow-x to auto
+  // too (CSS can't mix visible with non-visible per-axis), which silently let anything a hair
+  // wider than the sidebar (e.g. a popup or dropdown rendered inline rather than portaled)
+  // open up a horizontal scrollbar. This sidebar's width is fixed, so horizontal scroll is
+  // never wanted here.
+  overflow: hidden auto;
 }
 
 // Wraps the full <-> compact cross-fade (see CalendarSidebarShell).

--- a/frontend/app/components/atoms/TextField.tsx
+++ b/frontend/app/components/atoms/TextField.tsx
@@ -11,6 +11,16 @@ interface TextFieldProps {
   // Scales font-size to ~80% for narrow embedding contexts (the 280px Main Calendar
   // sidebar) -- set via inline style below, so a CSS override can't win over it.
   compact?: boolean;
+  // Rendered below the field once the caller decides it's earned display (e.g. only after
+  // the field has been focused and blurred) -- this component doesn't gate visibility
+  // itself, it just renders whatever's passed.
+  error?: string;
+  // Composed with this component's own internal focus/blur handling (the underline
+  // animation), not overwritten by it -- named explicitly here rather than left to flow
+  // through a `...props` spread, since spread order would otherwise let a caller-supplied
+  // onBlur silently replace toggleFocus instead of running alongside it.
+  onFocus?: () => void;
+  onBlur?: () => void;
   [key: string]: unknown; // Allow for additional props
 }
 
@@ -21,12 +31,22 @@ const TextField: React.FC<TextFieldProps> = ({
   label,
   multiline = false,
   compact = false,
+  error,
+  onFocus,
+  onBlur,
   ...props
 }) => {
   const [underlineOnFocus, setUnderlineOnFocus] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
-  const toggleFocus = () => setUnderlineOnFocus((prev) => !prev);
+  const handleFocus = () => {
+    setUnderlineOnFocus(true);
+    onFocus?.();
+  };
+  const handleBlur = () => {
+    setUnderlineOnFocus(false);
+    onBlur?.();
+  };
 
   // Determine font size based on label presence -- "" (passed for description fields
   // that intentionally render no label) must count as unlabeled, same as undefined/null.
@@ -46,41 +66,44 @@ const TextField: React.FC<TextFieldProps> = ({
   }, [multiline, value]);
 
   return (
-    <div className={styles.textfieldcontainer}>
-      {label && (
-        <label
-          className={styles.textfieldlabel}
-          style={{ fontSize: labelFontSize }}
-        >
-          {typeof label === "string" ? <span>{label}</span> : label}
-        </label>
-      )}
-      {multiline ? (
-        <textarea
-          ref={textareaRef}
-          rows={1}
-          value={value}
-          onFocus={toggleFocus}
-          onBlur={toggleFocus}
-          onChange={(e) => onChange(e.target.value)}
-          className={inputClassName}
-          placeholder={input}
-          style={{ fontSize }}
-          {...props}
-        />
-      ) : (
-        <input
-          type="text"
-          value={value}
-          onFocus={toggleFocus}
-          onBlur={toggleFocus}
-          onChange={(e) => onChange(e.target.value)}
-          className={inputClassName}
-          placeholder={input}
-          style={{ fontSize }}
-          {...props}
-        />
-      )}
+    <div className={styles.textfieldwrapper}>
+      <div className={`${styles.textfieldcontainer} ${error ? styles.textfieldContainerError : ''}`}>
+        {label && (
+          <label
+            className={styles.textfieldlabel}
+            style={{ fontSize: labelFontSize }}
+          >
+            {typeof label === "string" ? <span>{label}</span> : label}
+          </label>
+        )}
+        {multiline ? (
+          <textarea
+            ref={textareaRef}
+            rows={1}
+            value={value}
+            onFocus={handleFocus}
+            onBlur={handleBlur}
+            onChange={(e) => onChange(e.target.value)}
+            className={inputClassName}
+            placeholder={input}
+            style={{ fontSize }}
+            {...props}
+          />
+        ) : (
+          <input
+            type="text"
+            value={value}
+            onFocus={handleFocus}
+            onBlur={handleBlur}
+            onChange={(e) => onChange(e.target.value)}
+            className={inputClassName}
+            placeholder={input}
+            style={{ fontSize }}
+            {...props}
+          />
+        )}
+      </div>
+      {error && <span className={styles.textfieldErrorText}>{error}</span>}
     </div>
   );
 };

--- a/frontend/app/components/meeting-form/EditMeeting.tsx
+++ b/frontend/app/components/meeting-form/EditMeeting.tsx
@@ -10,6 +10,7 @@ import LabeledCheckbox from '../atoms/CheckBox';
 import RecurringMeetingForm from './RecurringMeeting';
 import ZoomHostField from './ZoomHostField';
 import ConflictOverrideModal from './ConflictOverrideModal';
+import FormValidationBanner from './FormValidationBanner';
 import CloseIcon from '@mui/icons-material/Close';
 import IconButton from '@mui/material/IconButton';
 
@@ -50,6 +51,10 @@ const EditMeetingSidebar: React.FC<EditMeetingSidebarProps> =
       handleCalTypeToggle,
       getValidationErrors,
       buildMeetingPayload,
+      setSubmitAttempted,
+      liveValidationErrors,
+      markFieldTouched,
+      getFieldError,
     } = useMeetingForm(meeting);
 
     const { showToast } = useToast();
@@ -112,9 +117,9 @@ const EditMeetingSidebar: React.FC<EditMeetingSidebarProps> =
       // actually prevents a second in-flight request.
       if (isSubmitting) return;
 
+      setSubmitAttempted(true);
       const validationErrors = getValidationErrors();
       if (validationErrors.length > 0) {
-        alert(validationErrors.join('\n'));
         return;
       }
 
@@ -132,11 +137,14 @@ const EditMeetingSidebar: React.FC<EditMeetingSidebarProps> =
             <CloseIcon sx={{ color: 'black' }} />
           </IconButton>
         </div>
+        <FormValidationBanner errors={liveValidationErrors} />
         <MeetingForm
           meetingTitleTextField={<TextField
             input="Meeting title"
             value={inputMeetingTitleValue}
             onChange={setMeetingTitleValue}
+            onBlur={() => markFieldTouched("title")}
+            error={getFieldError("title")}
             compact={compact}
           />}
           modeTypeButtons={<ModeTypeButtons
@@ -229,6 +237,8 @@ const EditMeetingSidebar: React.FC<EditMeetingSidebarProps> =
             label={<img src="svg/mail-icon.svg" alt="Mail Icon" />}
             value={inputEmailValue}
             onChange={setEmailValue}
+            onBlur={() => markFieldTouched("email")}
+            error={getFieldError("email")}
             compact={compact}
           />}
           descriptionTextField={<TextField
@@ -236,6 +246,8 @@ const EditMeetingSidebar: React.FC<EditMeetingSidebarProps> =
             label=""
             value={inputDescriptionValue}
             onChange={setDescriptionValue}
+            onBlur={() => markFieldTouched("description")}
+            error={getFieldError("description")}
             multiline
             maxLength={DESCRIPTION_MAX_LENGTH}
             compact={compact}

--- a/frontend/app/components/meeting-form/FormValidationBanner.tsx
+++ b/frontend/app/components/meeting-form/FormValidationBanner.tsx
@@ -46,7 +46,7 @@ const FormValidationBanner: React.FC<FormValidationBannerProps> = ({ errors }) =
       containerRef.current.scrollTop = Math.max(0, containerRef.current.scrollTop - lastHeightRef.current);
     }
     wasVisibleRef.current = visible;
-  }, [visible]);
+  }, [visible, errors]);
 
   if (!visible) return null;
 

--- a/frontend/app/components/meeting-form/FormValidationBanner.tsx
+++ b/frontend/app/components/meeting-form/FormValidationBanner.tsx
@@ -1,0 +1,74 @@
+import React, { useLayoutEffect, useRef } from "react";
+import ErrorOutlineIcon from "@mui/icons-material/ErrorOutline";
+import type { MeetingFormFieldError } from "../../../hooks/useMeetingForm";
+import styles from "../../../styles/components/meeting-form/FormValidationBanner.module.scss";
+
+interface FormValidationBannerProps {
+  errors: MeetingFormFieldError[];
+}
+
+// Walks up from the banner to find the actual scrolling ancestor -- neither NewMeeting nor
+// EditMeeting owns that container directly (it's CalendarSidebarShell's .sidebarScroll on
+// desktop, MobileFullScreenSheet's .fullScreen on mobile), and matching by computed overflow
+// rather than by class name keeps this working if either of those containers is restyled.
+function findScrollableAncestor(el: HTMLElement | null): HTMLElement | null {
+  let node = el?.parentElement ?? null;
+  while (node && node !== document.body) {
+    const style = window.getComputedStyle(node);
+    if (/(auto|scroll)/.test(style.overflowY) && node.scrollHeight > node.clientHeight) {
+      return node;
+    }
+    node = node.parentElement;
+  }
+  return null;
+}
+
+const FormValidationBanner: React.FC<FormValidationBannerProps> = ({ errors }) => {
+  const bannerRef = useRef<HTMLDivElement>(null);
+  const containerRef = useRef<HTMLElement | null>(null);
+  const lastHeightRef = useRef(0);
+  const wasVisibleRef = useRef(false);
+
+  const visible = errors.length > 0;
+
+  useLayoutEffect(() => {
+    if (visible) {
+      if (bannerRef.current) {
+        containerRef.current = containerRef.current ?? findScrollableAncestor(bannerRef.current);
+        lastHeightRef.current = bannerRef.current.offsetHeight;
+      }
+      if (!wasVisibleRef.current) {
+        containerRef.current?.scrollTo({ top: 0, behavior: "smooth" });
+      }
+    } else if (wasVisibleRef.current && containerRef.current) {
+      // The banner just left the flow above the form -- without this, the container's
+      // remaining content jumps up by exactly the height that used to be reserved for it.
+      containerRef.current.scrollTop = Math.max(0, containerRef.current.scrollTop - lastHeightRef.current);
+    }
+    wasVisibleRef.current = visible;
+  }, [visible]);
+
+  if (!visible) return null;
+
+  const fieldCount = new Set(errors.flatMap((error) => error.fields)).size;
+
+  return (
+    <div className={styles.banner} ref={bannerRef} role="alert">
+      <span className={styles.iconCircle}>
+        <ErrorOutlineIcon fontSize="small" />
+      </span>
+      <div className={styles.body}>
+        <p className={styles.title}>
+          Fix {fieldCount} {fieldCount === 1 ? "field" : "fields"} before saving
+        </p>
+        <ul className={styles.messageList}>
+          {errors.map((error, index) => (
+            <li key={index}>{error.message}</li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+};
+
+export default FormValidationBanner;

--- a/frontend/app/components/meeting-form/NewMeeting.tsx
+++ b/frontend/app/components/meeting-form/NewMeeting.tsx
@@ -10,6 +10,7 @@ import LabeledCheckbox from '../atoms/CheckBox';
 import RecurringMeetingForm from './RecurringMeeting';
 import ZoomHostField from './ZoomHostField';
 import ConflictOverrideModal from './ConflictOverrideModal';
+import FormValidationBanner from './FormValidationBanner';
 import CloseIcon from '@mui/icons-material/Close';
 import IconButton from '@mui/material/IconButton';
 
@@ -55,6 +56,10 @@ const NewMeetingSidebar: React.FC<NewMeetingSidebarProps> = ({
       resetForm,
       getValidationErrors,
       buildMeetingPayload,
+      setSubmitAttempted,
+      liveValidationErrors,
+      markFieldTouched,
+      getFieldError,
     } = useMeetingForm(undefined, { selectedDate, selectedView });
 
     const { showToast } = useToast();
@@ -121,9 +126,9 @@ const NewMeetingSidebar: React.FC<NewMeetingSidebarProps> = ({
       // prevents a second in-flight request.
       if (isSubmitting) return;
 
+      setSubmitAttempted(true);
       const validationErrors = getValidationErrors();
       if (validationErrors.length > 0) {
-        alert(validationErrors.join('\n'));
         return;
       }
 
@@ -141,11 +146,14 @@ const NewMeetingSidebar: React.FC<NewMeetingSidebarProps> = ({
             <CloseIcon sx={{ color: 'black' }} />
           </IconButton>
         </div>
+        <FormValidationBanner errors={liveValidationErrors} />
         <MeetingForm
           meetingTitleTextField={<TextField
             input="Meeting title"
             value={inputMeetingTitleValue}
             onChange={setMeetingTitleValue}
+            onBlur={() => markFieldTouched("title")}
+            error={getFieldError("title")}
             compact
           />}
           modeTypeButtons={
@@ -234,6 +242,8 @@ const NewMeetingSidebar: React.FC<NewMeetingSidebarProps> = ({
             label={<img src="svg/mail-icon.svg" alt="Mail Icon" />}
             value={inputEmailValue}
             onChange={setEmailValue}
+            onBlur={() => markFieldTouched("email")}
+            error={getFieldError("email")}
             compact
           />}
           descriptionTextField={<TextField
@@ -241,6 +251,8 @@ const NewMeetingSidebar: React.FC<NewMeetingSidebarProps> = ({
             label=""
             value={inputDescriptionValue}
             onChange={setDescriptionValue}
+            onBlur={() => markFieldTouched("description")}
+            error={getFieldError("description")}
             multiline
             maxLength={DESCRIPTION_MAX_LENGTH}
             compact

--- a/frontend/hooks/useMeetingForm.ts
+++ b/frontend/hooks/useMeetingForm.ts
@@ -18,6 +18,17 @@ export const CAL_TYPE_OPTIONS = ["AA", "Al-Anon", "Other"];
 export const CAL_TYPE_COLOR = "#CC3366";
 export { DESCRIPTION_MAX_LENGTH };
 
+// Field keys a validation error can be attributed to -- lets FormValidationBanner report a
+// live count of distinct fields needing fixing, not just a count of error messages (a single
+// message can cover two fields, e.g. the Hybrid room/zoomRoom rule below).
+export type MeetingFormField =
+  | "title" | "date" | "time" | "email" | "calTypes" | "description" | "room" | "zoomRoom" | "recurrence";
+
+export interface MeetingFormFieldError {
+  fields: MeetingFormField[];
+  message: string;
+}
+
 const isValidEmail = (email: string) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
 
 // "MM/DD/YYYY" -> "YYYY-MM-DD" via string rearrangement, no Date round-trip — avoids the
@@ -144,6 +155,18 @@ export function useMeetingForm(initialMeeting?: IMeeting, defaultContext?: Meeti
     const [recurrencePattern, setRecurrencePattern] = useState<IRecurrencePattern | null>(
         initialMeeting?.recurrencePattern ?? null
     );
+    // Flips true on the first failed submit -- before that, FormValidationBanner stays hidden
+    // even if fields are technically incomplete (nobody wants to see errors before they've
+    // tried to save). Once true, liveValidationErrors below re-derives on every render, so the
+    // banner's "Fix N fields" count updates live as each field is corrected.
+    const [submitAttempted, setSubmitAttempted] = useState(false);
+    // Which fields the user has focused into and back out of at least once -- an inline
+    // per-field error only renders for a field in this set, so a field the user hasn't
+    // reached yet doesn't show red before they've had a chance to fill it in.
+    const [touchedFields, setTouchedFields] = useState<Set<MeetingFormField>>(new Set());
+    const markFieldTouched = useCallback((field: MeetingFormField) => {
+        setTouchedFields((prev) => (prev.has(field) ? prev : new Set(prev).add(field)));
+    }, []);
 
     // Must be stable: RecurringMeeting.tsx's effect depends on this callback, and an
     // unstable reference here caused an infinite render loop.
@@ -190,37 +213,42 @@ export function useMeetingForm(initialMeeting?: IMeeting, defaultContext?: Meeti
         setZoomHost("");
         setIsRecurring(false);
         setRecurrencePattern(null);
+        setSubmitAttempted(false);
+        setTouchedFields(new Set());
     };
 
-    const getValidationErrors = (): string[] => {
-        const errors: string[] = [];
+    const getValidationErrors = (): MeetingFormFieldError[] => {
+        const errors: MeetingFormFieldError[] = [];
 
-        if (!title.trim()) errors.push("Meeting title is required.");
-        if (!date) errors.push("Date is required.");
+        if (!title.trim()) errors.push({ fields: ["title"], message: "Meeting title is required." });
+        if (!date) errors.push({ fields: ["date"], message: "Date is required." });
 
         const [startTime, endTime] = time?.split(' - ') || [];
-        if (!startTime || !endTime) errors.push("Start and end time are required.");
+        if (!startTime || !endTime) errors.push({ fields: ["time"], message: "Start and end time are required." });
 
         if (!email.trim()) {
-            errors.push("Email is required.");
+            errors.push({ fields: ["email"], message: "Email is required." });
         } else if (!isValidEmail(email)) {
-            errors.push("Email must be a valid email address.");
+            errors.push({ fields: ["email"], message: "Email must be a valid email address." });
         }
 
-        if (calTypes.length === 0) errors.push("At least one calendar type is required.");
+        if (calTypes.length === 0) errors.push({ fields: ["calTypes"], message: "At least one calendar type is required." });
 
         if (description.length > DESCRIPTION_MAX_LENGTH) {
-            errors.push(`Description must be ${DESCRIPTION_MAX_LENGTH} characters or fewer (Zoom's limit) — currently ${description.length}.`);
+            errors.push({
+                fields: ["description"],
+                message: `Description must be ${DESCRIPTION_MAX_LENGTH} characters or fewer (Zoom's limit) — currently ${description.length}.`,
+            });
         }
 
         if (mode === "Hybrid" && (!room || !zoomRoom)) {
-            errors.push("Hybrid meetings require both a physical room and a Zoom room.");
+            errors.push({ fields: ["room", "zoomRoom"], message: "Hybrid meetings require both a physical room and a Zoom room." });
         } else if (mode === "In Person" && !room) {
-            errors.push("In Person meetings require a physical room.");
+            errors.push({ fields: ["room"], message: "In Person meetings require a physical room." });
         }
 
         if (isRecurring && recurrencePattern === null) {
-            errors.push("Recurrence details are required for recurring meetings.");
+            errors.push({ fields: ["recurrence"], message: "Recurrence details are required for recurring meetings." });
         }
 
         return errors;
@@ -275,6 +303,19 @@ export function useMeetingForm(initialMeeting?: IMeeting, defaultContext?: Meeti
         return payload;
     };
 
+    // Recomputed every render rather than memoized -- the form has a handful of fields, so
+    // re-running getValidationErrors() on each render is cheap, and memoizing would just
+    // mean listing every field it reads as a dependency array.
+    const liveValidationErrors = submitAttempted ? getValidationErrors() : [];
+
+    // Independent of submitAttempted -- a field can show its own inline error the moment
+    // it's been touched, even before any submit attempt (e.g. blurring an empty title on
+    // the very first pass through the form).
+    const getFieldError = (field: MeetingFormField): string | undefined => {
+        if (!touchedFields.has(field)) return undefined;
+        return getValidationErrors().find((error) => error.fields.includes(field))?.message;
+    };
+
     return {
         title, setTitle,
         mode, setMode,
@@ -295,5 +336,9 @@ export function useMeetingForm(initialMeeting?: IMeeting, defaultContext?: Meeti
         resetForm,
         getValidationErrors,
         buildMeetingPayload,
+        submitAttempted, setSubmitAttempted,
+        liveValidationErrors,
+        markFieldTouched,
+        getFieldError,
     };
 }

--- a/frontend/styles/components/atoms/MobileFullScreenSheet.module.scss
+++ b/frontend/styles/components/atoms/MobileFullScreenSheet.module.scss
@@ -5,7 +5,10 @@
     inset: 0;
     z-index: $z-index-modal;
     background-color: #fff;
-    overflow-y: auto;
+
+    // See page.module.scss's .sidebarScroll for why overflow-x is explicit, not left to the
+    // overflow-y: auto/visible-x default.
+    overflow: hidden auto;
     padding-top: env(safe-area-inset-top);
     padding-bottom: env(safe-area-inset-bottom);
 }

--- a/frontend/styles/components/atoms/TextField.module.scss
+++ b/frontend/styles/components/atoms/TextField.module.scss
@@ -1,5 +1,11 @@
 @import '../../Variables.module.scss';
 
+.textfieldwrapper {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+}
+
 .textfieldcontainer {
     display: flex;
     align-items: center;
@@ -14,6 +20,21 @@
     &:focus-within {
         border-color: $brand-pink-color;
     }
+}
+
+.textfieldContainerError {
+    border-color: $danger-color;
+
+    &:focus-within {
+        border-color: $danger-color;
+    }
+}
+
+.textfieldErrorText {
+    margin-top: 4px;
+    font-family: 'Source Sans Pro', sans-serif;
+    font-size: 12px;
+    color: $danger-color;
 }
 
 .textfieldinput {

--- a/frontend/styles/components/meeting-form/FormValidationBanner.module.scss
+++ b/frontend/styles/components/meeting-form/FormValidationBanner.module.scss
@@ -1,0 +1,46 @@
+@import '../../Variables.module.scss';
+
+.banner {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  width: 100%;
+  box-sizing: border-box;
+  padding: 12px 16px;
+  margin-bottom: 16px;
+  border-radius: $radius-md;
+  background-color: $danger-bg-color;
+  font-family: "Source Sans Pro", sans-serif;
+}
+
+.iconCircle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  background-color: white;
+  color: $danger-color;
+  flex-shrink: 0;
+}
+
+.body {
+  flex: 1;
+  min-width: 0;
+}
+
+.title {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 600;
+  color: $black-color;
+}
+
+.messageList {
+  margin: 4px 0 0;
+  padding-left: 18px;
+  font-size: 13px;
+  line-height: 1.5;
+  color: #444;
+}

--- a/frontend/tests/e2e/02-meeting-creation.spec.ts
+++ b/frontend/tests/e2e/02-meeting-creation.spec.ts
@@ -29,7 +29,7 @@ test.describe("meeting creation", () => {
     await expect(page.getByText("Full Flow Meeting")).toBeVisible();
   });
 
-  test("2.3 missing title blocks submission with a validation alert", async ({ adminPage }) => {
+  test("2.3 missing title blocks submission with a validation banner", async ({ adminPage }) => {
     const { page } = adminPage;
     await page.goto("/");
     await page.getByText("New Meeting").click();
@@ -41,20 +41,17 @@ test.describe("meeting creation", () => {
     await toggleCalType(page, "AA");
     await page.getByPlaceholder("Email").fill("noname@test.icr");
 
-    // This alert() fires synchronously inside the click handler (validation runs
-    // before any `await`), so it must be dismissed by a listener that's already
-    // registered when the dialog opens — waitForEvent()'s await-after-click would
-    // deadlock, since the click itself can't resolve until the dialog closes.
-    let dialogMessage = "";
-    page.once("dialog", (dialog) => {
-      dialogMessage = dialog.message();
-      dialog.accept();
-    });
     await page.getByRole("button", { name: "Create Meeting" }).click();
-    expect(dialogMessage).toContain("Meeting title is required");
+    await expect(page.getByText("Fix 1 field before saving")).toBeVisible();
+    await expect(page.getByText("Meeting title is required.")).toBeVisible();
 
     // Form is still open — nothing was submitted.
     await expect(page.getByRole("heading", { name: "New Meeting" })).toBeVisible();
+
+    // The banner's live count decrements as the field is fixed, then disappears once
+    // every validation rule is satisfied.
+    await page.getByPlaceholder("Meeting title").fill("Now Has A Title");
+    await expect(page.getByText("Fix 1 field before saving")).toHaveCount(0);
   });
 
   test("2.4 checking multiple Meeting Types saves both categories", async ({ adminPage }) => {


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added inline meeting-form validation with field-specific error messages and a summary banner.
  * Validation updates as fields are corrected and replaces browser alert messages.
  * Text fields now support error states and focus/blur interactions.

* **Bug Fixes**
  * Prevented unwanted horizontal scrolling in sidebars and full-screen sheets.
  * Improved validation feedback during form submission.

* **Tests**
  * Updated meeting creation coverage for the inline validation experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description
- **frontend/hooks/useMeetingForm.ts**: refactored `getValidationErrors()` from a flat `string[]` to field-tagged `{fields, message}[]` (a `MeetingFormField` union), and added `submitAttempted`/`touchedFields` state so the banner and inline errors can each independently derive when to show.
- **frontend/app/components/meeting-form/FormValidationBanner.tsx**: new full-width banner replacing the last 2 `alert(validationErrors.join('\n'))` calls in NewMeeting/EditMeeting — shows a live "Fix N fields before saving" count (N = distinct fields, not message count) that decrements as fields are corrected and disappears once valid. Scrolls the form to top on first appearance; compensates the scroll container's `scrollTop` on dismissal so the form doesn't visibly jump when the banner's height leaves the flow.
- **frontend/app/components/atoms/TextField.tsx**: added `error`/`onFocus`/`onBlur` props, pulled out of the generic `...props` spread explicitly (spread order would otherwise let a caller's `onBlur` silently replace the component's own focus-underline handling instead of composing with it). Renders inline error text below the field.
- Wired into **NewMeeting.tsx**/**EditMeeting.tsx**: title/email/description show an inline error once the user has focused into and back out of that field while it's still invalid.
- **frontend/app/(main)/page.module.scss**, **frontend/styles/components/atoms/MobileFullScreenSheet.module.scss**: fixed the meeting-form sidebar/mobile sheet silently allowing horizontal scroll — `overflow-y: auto` alone computes `overflow-x` to `auto` too per the CSS spec, so anything a hair wider than the container (e.g. an inline, non-portaled popup) opened a horizontal scrollbar. Both now set `overflow-x: hidden` explicitly.
- **frontend/tests/e2e/02-meeting-creation.spec.ts**: rewrote test 2.3 to assert the banner (live count + message, then disappearance after fixing the field) instead of the removed native dialog.

## Testing
- [x] `yarn test:all` green (92 e2e + lint/unit/component/integration)
- [x] `yarn lint:css` explicitly (new `.scss` files touched)
- [x] Manually verified in-browser: banner renders with correct live field count and messages, auto-scrolls the form to top on first appearance

## Area(s) Touched
**Product areas**
- [x] ui/ux — frontend layout/styling not tied to a specific integration

**Engineering**
- [x] testing — test suite (Jest/Playwright) changes

## Pre-merge Checklist
- [x] Code follows current formatting conventions and passes lint (`yarn lint`).
- [x] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
- [x] All test suites pass, both run locally and green in GitHub CI. **Do not merge if any test suite is failing.**
- [x] A test suite was added or updated for the feature/fix in this PR. **Double-check this if you change a feature and did not update the test suites**.
- [x] Only files relevant to this change are committed — no stray or unrelated files.
- [x] If this branch has a merge conflict with master, master was merged into this branch first (not the other way around).
- [x] The rest of this PR description (Description, Testing) is filled out, not left as template placeholders.