### PR TITLE
feat(admin): convert ad-hoc inline error/info divs to Toast

### DIFF
--- a/frontend/app/components/admin/AdminShell.tsx
+++ b/frontend/app/components/admin/AdminShell.tsx
@@ -42,7 +42,7 @@ const AdminShell: React.FC<AdminShellProps> = ({ role, email }) => {
     if (showResponsiveBanner) {
       showToast({
         variant: "info",
-        message: "Admin works best on a larger screen. Some panels may be cramped here.",
+        title: "Admin works best on a larger screen. Some panels may be cramped here.",
         persistent: true,
       });
     }

--- a/frontend/app/components/admin/AdminShell.tsx
+++ b/frontend/app/components/admin/AdminShell.tsx
@@ -1,14 +1,13 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import type { Role } from "@prisma/client";
 import LockIcon from "@mui/icons-material/Lock";
-import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
-import CloseIcon from "@mui/icons-material/Close";
 import DiagnosticsTab from "./diagnostics/DiagnosticsTab";
 import UsersTab from "./users/UsersTab";
 import ExportTab from "./export/ExportTab";
 import { useViewport } from "../../../hooks/useViewport";
+import { useToast } from "../shared/ToastProvider";
 import styles from "../../../styles/components/admin/AdminShell.module.scss";
 
 interface AdminShellProps {
@@ -28,13 +27,27 @@ const AdminShell: React.FC<AdminShellProps> = ({ role, email }) => {
   const isSuperAdmin = role === "SUPER_ADMIN";
 
   const [activeTab, setActiveTab] = useState<TabKey>("diagnostics");
-  const [bannerDismissed, setBannerDismissed] = useState(false);
   const viewport = useViewport();
+  const { showToast } = useToast();
 
   // Admin is a low-frequency, high-consequence, information-dense surface -- worth a heads-up
   // below desktop width rather than a redesign, unlike the calendar's dedicated mobile views.
-  // null viewport (not yet measured) intentionally renders no banner, not a default-shown one.
-  const showResponsiveBanner = viewport?.device !== "desktop" && viewport !== null && !bannerDismissed;
+  // null viewport (not yet measured) intentionally shows no toast, not a default-shown one.
+  const showResponsiveBanner = viewport?.device !== "desktop" && viewport !== null;
+
+  // Fires once per transition into the narrow range, not on every render while narrow --
+  // the effect dependency only re-runs on an actual value change. Persistent, so it stays
+  // until the user closes it via the toast's own dismiss button.
+  useEffect(() => {
+    if (showResponsiveBanner) {
+      showToast({
+        variant: "info",
+        message: "Admin works best on a larger screen. Some panels may be cramped here.",
+        persistent: true,
+      });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [showResponsiveBanner]);
 
   // Derived, not synced via effect: falls back to Diagnostics for render whenever the
   // stored activeTab is super-admin-only and the role no longer qualifies (e.g. a
@@ -45,21 +58,6 @@ const AdminShell: React.FC<AdminShellProps> = ({ role, email }) => {
   return (
     <div className={styles.container}>
       <h1 className={styles.title}>Admin</h1>
-      {showResponsiveBanner && (
-        <div className={styles.responsiveBanner}>
-          <InfoOutlinedIcon fontSize="small" />
-          <span className={styles.responsiveBannerText}>
-            Admin works best on a larger screen. Some panels may be cramped here.
-          </span>
-          <button
-            className={styles.responsiveBannerDismiss}
-            aria-label="Dismiss"
-            onClick={() => setBannerDismissed(true)}
-          >
-            <CloseIcon fontSize="small" />
-          </button>
-        </div>
-      )}
       <div className={styles.tabRow}>
         {allTabs.map((tab) => {
           const locked = tab.superAdminOnly && !isSuperAdmin;

--- a/frontend/app/components/admin/export/ExportTab.tsx
+++ b/frontend/app/components/admin/export/ExportTab.tsx
@@ -215,7 +215,7 @@ const ExportTab: React.FC = () => {
     } catch (err) {
       if (isCancelled()) return;
       console.error("Error loading lease settings:", err);
-      showToast({ variant: "error", message: "Failed to load lease settings.", persistent: true });
+      showToast({ variant: "error", title: "Failed to load lease settings.", persistent: true });
     }
   };
 
@@ -230,7 +230,7 @@ const ExportTab: React.FC = () => {
     } catch (err) {
       if (isCancelled()) return;
       console.error("Error loading meeting export settings:", err);
-      showToast({ variant: "error", message: "Failed to load export field settings.", persistent: true });
+      showToast({ variant: "error", title: "Failed to load export field settings.", persistent: true });
     }
   };
 
@@ -262,7 +262,7 @@ const ExportTab: React.FC = () => {
       console.error(`Error exporting ${kind}:`, err);
       showToast({
         variant: "error",
-        message: err instanceof Error ? err.message : "Export failed.",
+        title: err instanceof Error ? err.message : "Export failed.",
         persistent: true,
       });
     } finally {

--- a/frontend/app/components/admin/export/ExportTab.tsx
+++ b/frontend/app/components/admin/export/ExportTab.tsx
@@ -196,11 +196,12 @@ const ExportTab: React.FC = () => {
   const [meetingExportTotal, setMeetingExportTotal] = useState(0);
   const [meetingConfigOpen, setMeetingConfigOpen] = useState(false);
 
-  const loadLeaseSettings = async () => {
+  const loadLeaseSettings = async (isCancelled: () => boolean) => {
     try {
       const response = await fetch("/api/retrieve/lease-settings");
       if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
       const json: { settings: ILeaseSettings; cycles: LeaseYearCycle[] } = await response.json();
+      if (isCancelled()) return;
       setLeaseSettings(json.settings);
       // fetch/JSON.parse hands back ISO strings for Date fields despite the LeaseYearCycle type,
       // so callers comparing against `new Date(...)` values (LeaseConfigModal's cycle picker) need real Dates here.
@@ -212,19 +213,22 @@ const ExportTab: React.FC = () => {
         })),
       );
     } catch (err) {
+      if (isCancelled()) return;
       console.error("Error loading lease settings:", err);
       showToast({ variant: "error", message: "Failed to load lease settings.", persistent: true });
     }
   };
 
-  const loadMeetingExportSettings = async () => {
+  const loadMeetingExportSettings = async (isCancelled: () => boolean) => {
     try {
       const response = await fetch("/api/retrieve/meeting-export-settings");
       if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
       const json: { fields: MeetingExportFieldKey[]; total: number } = await response.json();
+      if (isCancelled()) return;
       setMeetingExportFields(json.fields);
       setMeetingExportTotal(json.total);
     } catch (err) {
+      if (isCancelled()) return;
       console.error("Error loading meeting export settings:", err);
       showToast({ variant: "error", message: "Failed to load export field settings.", persistent: true });
     }
@@ -234,8 +238,13 @@ const ExportTab: React.FC = () => {
     // Async fetch-then-set; the lint rule can't see the setState calls sit after an
     // await, so this is a false positive for the standard "load on mount" pattern.
     /* eslint-disable react-hooks/set-state-in-effect */
-    loadLeaseSettings();
-    loadMeetingExportSettings();
+    let cancelled = false;
+    const isCancelled = () => cancelled;
+    loadLeaseSettings(isCancelled);
+    loadMeetingExportSettings(isCancelled);
+    return () => {
+      cancelled = true;
+    };
     /* eslint-enable react-hooks/set-state-in-effect */
   }, []);
 

--- a/frontend/app/components/admin/export/ExportTab.tsx
+++ b/frontend/app/components/admin/export/ExportTab.tsx
@@ -188,15 +188,12 @@ const ExportTab: React.FC = () => {
   const { showToast } = useToast();
   const [leaseSettings, setLeaseSettings] = useState<ILeaseSettings | null>(null);
   const [leaseCycles, setLeaseCycles] = useState<LeaseYearCycle[]>([]);
-  const [settingsError, setSettingsError] = useState<string | null>(null);
   const [configOpen, setConfigOpen] = useState(false);
   const [ratesOpen, setRatesOpen] = useState(false);
   const [downloading, setDownloading] = useState<ExportKind | null>(null);
   const [downloaded, setDownloaded] = useState<ExportKind | null>(null);
-  const [exportError, setExportError] = useState<string | null>(null);
   const [meetingExportFields, setMeetingExportFields] = useState<MeetingExportFieldKey[] | null>(null);
   const [meetingExportTotal, setMeetingExportTotal] = useState(0);
-  const [meetingSettingsError, setMeetingSettingsError] = useState<string | null>(null);
   const [meetingConfigOpen, setMeetingConfigOpen] = useState(false);
 
   const loadLeaseSettings = async () => {
@@ -214,10 +211,9 @@ const ExportTab: React.FC = () => {
           endDate: new Date(cycle.endDate),
         })),
       );
-      setSettingsError(null);
     } catch (err) {
       console.error("Error loading lease settings:", err);
-      setSettingsError("Failed to load lease settings.");
+      showToast({ variant: "error", message: "Failed to load lease settings.", persistent: true });
     }
   };
 
@@ -228,10 +224,9 @@ const ExportTab: React.FC = () => {
       const json: { fields: MeetingExportFieldKey[]; total: number } = await response.json();
       setMeetingExportFields(json.fields);
       setMeetingExportTotal(json.total);
-      setMeetingSettingsError(null);
     } catch (err) {
       console.error("Error loading meeting export settings:", err);
-      setMeetingSettingsError("Failed to load export field settings.");
+      showToast({ variant: "error", message: "Failed to load export field settings.", persistent: true });
     }
   };
 
@@ -246,7 +241,6 @@ const ExportTab: React.FC = () => {
 
   const handleExport = async (kind: ExportKind) => {
     setDownloading(kind);
-    setExportError(null);
     try {
       if (kind === "meetings") {
         await downloadExport("/api/export/meetings", `ithaca-recovery-meetings-${todayISO()}.xlsx`);
@@ -257,7 +251,11 @@ const ExportTab: React.FC = () => {
       setTimeout(() => setDownloaded((curr) => (curr === kind ? null : curr)), 1800);
     } catch (err) {
       console.error(`Error exporting ${kind}:`, err);
-      setExportError(err instanceof Error ? err.message : "Export failed.");
+      showToast({
+        variant: "error",
+        message: err instanceof Error ? err.message : "Export failed.",
+        persistent: true,
+      });
     } finally {
       setDownloading(null);
     }
@@ -313,10 +311,6 @@ const ExportTab: React.FC = () => {
 
   return (
     <div className={styles.container}>
-      {exportError && <div className={styles.errorBanner}>{exportError}</div>}
-      {settingsError && <div className={styles.errorBanner}>{settingsError}</div>}
-      {meetingSettingsError && <div className={styles.errorBanner}>{meetingSettingsError}</div>}
-
       <div className={styles.grid}>
         <Card className={styles.exportCard}>
           <CardHeader

--- a/frontend/app/components/admin/users/UsersTab.tsx
+++ b/frontend/app/components/admin/users/UsersTab.tsx
@@ -363,7 +363,7 @@ const UsersTab: React.FC = () => {
           </div>
         </div>
         {admins === null && !error && <div className={styles.emptyState}>Loading users…</div>}
-        {error && <div className={styles.emptyState}>{error}</div>}
+        {error && <div className={styles.errorState}>{error}</div>}
         {admins !== null && !error && (
           <div className={styles.tableWrapper}>
             <table className={styles.table}>

--- a/frontend/styles/components/admin/AdminShell.module.scss
+++ b/frontend/styles/components/admin/AdminShell.module.scss
@@ -13,35 +13,6 @@
   }
 }
 
-.responsiveBanner {
-  display: flex;
-  align-items: flex-start;
-  gap: 8px;
-  background: $warning-bg-color;
-  color: $warning-text-color;
-  border-radius: 8px;
-  padding: 10px 12px;
-  font-size: 13px;
-  line-height: 1.4;
-  margin-bottom: 20px;
-}
-
-.responsiveBannerText {
-  flex: 1;
-}
-
-.responsiveBannerDismiss {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
-  background: none;
-  border: none;
-  padding: 0;
-  cursor: pointer;
-  color: inherit;
-}
-
 .title {
   font-size: 28px;
   font-weight: 600;

--- a/frontend/styles/components/admin/ExportTab.module.scss
+++ b/frontend/styles/components/admin/ExportTab.module.scss
@@ -49,15 +49,6 @@
   font-size: 14px;
 }
 
-.errorBanner {
-  background: #FBE1E7;
-  color: $brand-pink-color;
-  border: 1.5px solid $brand-pink-color;
-  border-radius: 8px;
-  padding: 10px 16px;
-  font-size: 14px;
-}
-
 .cardDesc {
   font-size: 14px;
   color: #555;

--- a/frontend/styles/components/admin/UsersTab.module.scss
+++ b/frontend/styles/components/admin/UsersTab.module.scss
@@ -271,6 +271,11 @@
   font-size: 14px;
 }
 
+.errorState {
+  color: $danger-color;
+  font-size: 14px;
+}
+
 .legendAnchor {
   position: relative;
   display: inline-flex;


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a persistent notification when the admin interface is viewed at a non-desktop size.
  * Export-related failures and configuration errors now appear as persistent notifications, including available error details.

* **Bug Fixes**
  * Improved the visual styling of error messages in the admin users section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description
- **frontend/app/components/admin/export/ExportTab.tsx**: the three independent `.errorBanner` divs (lease-settings load failure, meeting-export-settings load failure, export-download failure) become persistent error toasts. They previously used `$brand-pink-color` instead of the semantically-correct `$danger-color`; none of the three local error-state variables were read anywhere besides their own render, so they're removed outright rather than mirrored alongside the toast.
- **frontend/app/components/admin/users/UsersTab.tsx**: the load-error message reused `.emptyState`'s neutral styling (a real styling bug — no error coloring at all). Gets its own `.errorState` class using `$danger-color`.
- **frontend/app/components/admin/AdminShell.tsx**: the hand-rolled dismissible "works best on a larger screen" notice becomes a persistent info toast fired from an effect (guarded so it only re-fires on an actual transition into the narrow-viewport condition, not on every render). Drops the bespoke banner markup, icon, and dismiss-button styling in favor of the shared component — the lowest-priority item in this whole stack, done last specifically as a dogfooding check that `persistent: true` toasts work for a real non-transient case.
- Left alone (documented as intentional, not missed): `DiagnosticsCardError` and its 5 callers (inline card-body replacement with its own Retry affordance — a different UI need from a toast), and `SyncIssuesCard`'s single-row `fetchError` (scoped to one expanded edit panel, same category).

## Testing
- [x] `yarn test:all` green (92 e2e + lint/unit/component/integration)
- [x] Grepped the e2e suite for any test asserting on the removed banner/dismiss-button UI or the old error-message text before removing it — none found.

## Area(s) Touched
**Product areas**
- [x] admin — /admin shell (Diagnostics, Users, Import, Export tabs)
- [x] ui/ux — frontend layout/styling not tied to a specific integration

## Pre-merge Checklist
- [x] Code follows current formatting conventions and passes lint (`yarn lint`).
- [x] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
- [x] All test suites pass, both run locally and green in GitHub CI. **Do not merge if any test suite is failing.**
- [x] A test suite was added or updated for the feature/fix in this PR. **Double-check this if you change a feature and did not update the test suites**. — no existing test coverage touched the removed UI (confirmed by grep), so nothing needed updating.
- [x] Only files relevant to this change are committed — no stray or unrelated files.
- [x] If this branch has a merge conflict with master, master was merged into this branch first (not the other way around).
- [x] The rest of this PR description (Description, Testing) is filled out, not left as template placeholders.