### PR TITLE
fix(calendar): show the sync-error badge on meeting blocks for admins

### DIFF
--- a/frontend/app/(main)/page.tsx
+++ b/frontend/app/(main)/page.tsx
@@ -16,6 +16,7 @@ import EditMeetingSidebar from "../components/meeting-form/EditMeeting";
 import { convertUTCToET } from "../../util/date/timeUtils";
 import { IMeeting } from "../../types/models";
 import { useConflictMids } from "../../hooks/useConflictMids";
+import { useSyncErrorMids } from "../../hooks/useSyncErrorMids";
 import { useViewport } from "../../hooks/useViewport";
 import { PHONE_BREAKPOINT } from "../../util/common/breakpoints";
 import { useCalendarContext } from "../context/CalendarProvider";
@@ -33,6 +34,11 @@ export default function HomePage() {
   // signed in) to avoid every non-admin viewer firing a denied request on mount and every
   // 30s refresh (see useConflictMids' `enabled` param).
   const { mids: conflictMids, counts: conflictCounts } = useConflictMids(refreshTrigger, isAdmin);
+  // Same admin gate/refresh cadence as conflictMids above (see useSyncErrorMids) -- backs the
+  // calendar block's sync-error badge, previously always false for every viewer (including
+  // admins) since googleSyncStatus/zoomSyncStatus are deliberately excluded from the public
+  // meeting payload the Day/Week views otherwise read from (see util/meetings/publicMeeting.ts).
+  const syncErrorMids = useSyncErrorMids(refreshTrigger, isAdmin);
 
   const triggerCalendarRefresh = useCallback(() => {
     setRefreshTrigger(prev => prev + 1);
@@ -430,6 +436,7 @@ export default function HomePage() {
             refreshTrigger={refreshTrigger}
             scrollLocked={isViewMeetingOpen}
             conflictMids={conflictMids}
+            syncErrorMids={syncErrorMids}
           />
         ) : isPhone ? (
           <DayPortraitView
@@ -444,6 +451,7 @@ export default function HomePage() {
             refreshTrigger={refreshTrigger}
             scrollLocked={isViewMeetingOpen}
             conflictMids={conflictMids}
+            syncErrorMids={syncErrorMids}
             isAdmin={isAdmin}
           />
         ) : (
@@ -468,6 +476,7 @@ export default function HomePage() {
                 refreshTrigger={refreshTrigger}
                 scrollLocked={isViewMeetingOpen}
                 conflictMids={conflictMids}
+                syncErrorMids={syncErrorMids}
               />
             ) : (
               <WeekView
@@ -483,6 +492,7 @@ export default function HomePage() {
                 refreshTrigger={refreshTrigger}
                 scrollLocked={isViewMeetingOpen}
                 conflictMids={conflictMids}
+                syncErrorMids={syncErrorMids}
               />
             )}
           </React.Fragment>

--- a/frontend/app/api/admin/sync-error-mids/route.ts
+++ b/frontend/app/api/admin/sync-error-mids/route.ts
@@ -1,0 +1,27 @@
+import { Role } from "@prisma/client";
+import { NextResponse } from "next/server";
+import { requireRole } from "../../../../services/auth";
+import { prisma } from "../../../../lib/prisma";
+
+// Admin-only: which meetings currently have a Google Calendar or Zoom sync error -- backs the
+// Day/Week calendar's sync-error badge (see BoxText's syncError prop). Mirrors
+// /api/admin/conflict-mids exactly (same admin gate, same mids-by-lookup shape) rather than
+// folding this into the public day/week retrieve routes (util/meetings/publicMeeting.ts's
+// allowlist) -- googleSyncStatus/zoomSyncStatus are deliberately excluded from PublicMeeting
+// (see that file's comment, BUG-022) since ViewMeeting's admin-only status band must not leak
+// them to an unauthenticated viewer. The calendar block's badge needs the same admin gate, just
+// enforced here instead, so a public/non-admin viewer's calendar never renders it either.
+export const GET = async () => {
+  const auth = await requireRole(Role.ADMIN);
+  if (auth instanceof Response) return auth;
+
+  const meetings = await prisma.meeting.findMany({
+    where: {
+      deletedAt: null,
+      OR: [{ googleSyncStatus: "error" }, { zoomSyncStatus: "error" }],
+    },
+    select: { mid: true },
+  });
+
+  return NextResponse.json({ mids: meetings.map((m) => m.mid) });
+};

--- a/frontend/app/components/calendar/desktop/DailyViewRow.tsx
+++ b/frontend/app/components/calendar/desktop/DailyViewRow.tsx
@@ -14,7 +14,6 @@ interface Meeting {
   displayEndTime?: string; // true time, for the label
   tags?: string[];
   id: string;
-  syncError?: boolean;
   positionIndex?: number; // Lane index among overlapping meetings in this room, assigned by layoutOverlappingMeetings
   totalOverlapping?: number; // Lane count among overlapping meetings in this room
   isOverflowIndicator?: boolean; // "+N more" pseudo-entry standing in for meetings past the 2 shown lanes
@@ -41,6 +40,8 @@ interface DailyViewRowProps {
   setLastClickedDate?: (date: Date) => void;
   // Admin-only (see hooks/useConflictMids) -- mids with an unresolved conflict.
   conflictMids?: Set<string>;
+  // Admin-only (see hooks/useSyncErrorMids) -- mids with a Google Calendar/Zoom sync error.
+  syncErrorMids?: Set<string>;
   // Landscape-mode overrides, all optional -- DayLandscapeView passes every one of these
   // together to run a much smaller, dynamically-sized subcompact grid; no other caller sets
   // any of them, so the defaults below reproduce desktop DayView's fixed 155px-hour /
@@ -74,6 +75,7 @@ const DailyViewRow: React.FC<DailyViewRowProps> = ({
   columnDate,
   setLastClickedDate,
   conflictMids,
+  syncErrorMids,
   hourWidth = DEFAULT_HOUR_WIDTH,
   rowHeight = DEFAULT_ROW_HEIGHT,
   startHour = 0,
@@ -180,7 +182,7 @@ const DailyViewRow: React.FC<DailyViewRowProps> = ({
           time={compactTime}
           tags={meeting.tags}
           meetingId={meeting.id}
-          syncError={meeting.syncError}
+          syncError={syncErrorMids?.has(meeting.id)}
           hasConflict={conflictMids?.has(meeting.id)}
           selected={isSelected}
           fillHeight={uniformHeight || (isStacked && !isSelected)}
@@ -286,6 +288,7 @@ const DailyViewRow: React.FC<DailyViewRowProps> = ({
         isOpen={overlapModalMeetings !== null}
         meetings={overlapModalMeetings ?? []}
         conflictMids={conflictMids}
+        syncErrorMids={syncErrorMids}
         onClose={() => setOverlapModalMeetings(null)}
         onSelectMeeting={(meetingId) => {
           pendingModalAnchorRef.current = true;

--- a/frontend/app/components/calendar/desktop/DayView.tsx
+++ b/frontend/app/components/calendar/desktop/DayView.tsx
@@ -9,9 +9,7 @@ import { createCache } from "../../../../util/common/simpleCache";
 import { defaultRooms } from "../../../../util/rooms/rooms";
 import { layoutOverlappingMeetings, OverlapMeeting } from "../../../../util/meetings/meetingOverlapLayout";
 
-interface Meeting extends OverlapMeeting {
-  syncError?: boolean;
-}
+type Meeting = OverlapMeeting;
 
 type Room = {
   name: string;
@@ -97,7 +95,6 @@ export const fetchMeetingsByDay = async (date: Date): Promise<Room[]> => {
           displayEndTime: etTimeFmt.format(new Date(meeting.trueEndDateTime)),
           date: formattedDate,
           tags: [...meeting.calType, meeting.modeType],
-          syncError: meeting.googleSyncStatus === 'error' || meeting.zoomSyncStatus === 'error',
         };
 
         // A Hybrid meeting occupies both its physical room and its Zoom room; In Person
@@ -178,6 +175,8 @@ interface DayViewProps {
   // room/zoomRoom/zoomHost conflict, for the card's conflict badge. Omitted entirely by
   // /signage's public kiosk render, which defaults to no badges ever showing.
   conflictMids?: Set<string>;
+  // Admin-only (see hooks/useSyncErrorMids) -- mids with a Google Calendar/Zoom sync error.
+  syncErrorMids?: Set<string>;
 }
 
 const DayView: React.FC<DayViewProps> = ({
@@ -192,6 +191,7 @@ const DayView: React.FC<DayViewProps> = ({
   refreshTrigger = 0,
   scrollLocked = false,
   conflictMids,
+  syncErrorMids,
 }) => {
   const [currentTimePosition, setCurrentTimePosition] = useState(0);
   const [meetings, setMeetings] = useState<Room[]>([]);
@@ -340,6 +340,7 @@ const DayView: React.FC<DayViewProps> = ({
                     columnDate={selectedDate}
                     setLastClickedDate={setLastClickedDate}
                     conflictMids={conflictMids}
+                    syncErrorMids={syncErrorMids}
                   />
                 </div>
                 {timeSlots.map((_, colIndex) => (

--- a/frontend/app/components/calendar/desktop/WeekView.tsx
+++ b/frontend/app/components/calendar/desktop/WeekView.tsx
@@ -45,6 +45,8 @@ interface WeekViewProps {
     // Admin-only (see hooks/useConflictMids) -- mids with an unresolved conflict. Omitted
     // entirely by /signage's public kiosk render, which defaults to no badges ever showing.
     conflictMids?: Set<string>;
+    // Admin-only (see hooks/useSyncErrorMids) -- mids with a Google Calendar/Zoom sync error.
+    syncErrorMids?: Set<string>;
 }
 
 const WeekView: React.FC<WeekViewProps> = ({
@@ -60,6 +62,7 @@ const WeekView: React.FC<WeekViewProps> = ({
     refreshTrigger = 0,
     scrollLocked = false,
     conflictMids,
+    syncErrorMids,
 }) => {
     const [currentTimePosition, setCurrentTimePosition] = useState(0);
     const [weekStartDate, setWeekStartDate] = useState<Date>(() => getFirstDayOfWeek(selectedDate));
@@ -222,6 +225,7 @@ const WeekView: React.FC<WeekViewProps> = ({
                                     columnDate={day}
                                     setLastClickedDate={setLastClickedDate}
                                     conflictMids={conflictMids}
+                                    syncErrorMids={syncErrorMids}
                                 />
 
                                 {/* Current time indicator - only show for current day */}

--- a/frontend/app/components/calendar/mobile/DayLandscapeSwitcher.tsx
+++ b/frontend/app/components/calendar/mobile/DayLandscapeSwitcher.tsx
@@ -16,6 +16,7 @@ interface DayLandscapeSwitcherProps {
   refreshTrigger?: number;
   scrollLocked?: boolean;
   conflictMids?: Set<string>;
+  syncErrorMids?: Set<string>;
 }
 
 // Landscape phone's entry point: DayLandscapeView is the default (all rooms, one day, per the

--- a/frontend/app/components/calendar/mobile/DayLandscapeView.tsx
+++ b/frontend/app/components/calendar/mobile/DayLandscapeView.tsx
@@ -13,9 +13,7 @@ import { useElementSize } from "../../../../hooks/useElementSize";
 import { useCalendarContext } from "../../../context/CalendarProvider";
 import TopLoadingBar from "../../atoms/TopLoadingBar";
 
-interface Meeting extends OverlapMeeting {
-  syncError?: boolean;
-}
+type Meeting = OverlapMeeting;
 
 type Room = {
   name: string;
@@ -111,6 +109,7 @@ interface DayLandscapeViewProps {
   refreshTrigger?: number;
   scrollLocked?: boolean;
   conflictMids?: Set<string>;
+  syncErrorMids?: Set<string>;
 }
 
 // Landscape phone's default view (see mobile/MultiDayLandscapeView for the alternate):
@@ -138,6 +137,7 @@ const DayLandscapeView: React.FC<DayLandscapeViewProps> = ({
   refreshTrigger = 0,
   scrollLocked = false,
   conflictMids,
+  syncErrorMids,
 }) => {
   const { changeSelectedDate, transitionDirection, transitionAlreadyAnimatedByCaller, setNavHidden } =
     useCalendarContext();
@@ -429,6 +429,7 @@ const DayLandscapeView: React.FC<DayLandscapeViewProps> = ({
                     columnDate={date}
                     setLastClickedDate={setLastClickedDate}
                     conflictMids={conflictMids}
+                    syncErrorMids={syncErrorMids}
                     hourWidth={hourWidth}
                     rowHeight={rowHeight}
                     startHour={START_HOUR}

--- a/frontend/app/components/calendar/mobile/DayPortraitView.tsx
+++ b/frontend/app/components/calendar/mobile/DayPortraitView.tsx
@@ -14,9 +14,7 @@ import { useCalendarContext } from "../../../context/CalendarProvider";
 import TopLoadingBar from "../../atoms/TopLoadingBar";
 import styles from "../../../../styles/components/calendar/mobile/DayPortraitView.module.scss";
 
-interface Meeting extends OverlapMeeting {
-  syncError?: boolean;
-}
+type Meeting = OverlapMeeting;
 
 // Mobile shows up to 3 overlapping meetings side by side before folding into a "+N"
 // indicator, vs. desktop WeekView's default of 2 (see util/meetingOverlapLayout.ts).
@@ -54,6 +52,7 @@ interface DayPortraitViewProps {
   refreshTrigger?: number;
   scrollLocked?: boolean;
   conflictMids?: Set<string>;
+  syncErrorMids?: Set<string>;
   isAdmin: boolean | null;
 }
 
@@ -78,6 +77,7 @@ const DayPortraitView: React.FC<DayPortraitViewProps> = ({
   refreshTrigger = 0,
   scrollLocked = false,
   conflictMids,
+  syncErrorMids,
   isAdmin,
 }) => {
   const { changeSelectedDate, transitionDirection, transitionAlreadyAnimatedByCaller } =
@@ -294,6 +294,7 @@ const DayPortraitView: React.FC<DayPortraitViewProps> = ({
             columnDate={date}
             setLastClickedDate={setLastClickedDate}
             conflictMids={conflictMids}
+            syncErrorMids={syncErrorMids}
             hourHeight={MOBILE_HOUR_HEIGHT}
             hideTags
           />

--- a/frontend/app/components/calendar/mobile/MultiDayLandscapeView.tsx
+++ b/frontend/app/components/calendar/mobile/MultiDayLandscapeView.tsx
@@ -12,9 +12,7 @@ import { useElementWidth } from "../../../../hooks/useElementWidth";
 import { useScrollNavHide } from "../../../../hooks/useScrollNavHide";
 import TopLoadingBar from "../../atoms/TopLoadingBar";
 
-interface Meeting extends OverlapMeeting {
-  syncError?: boolean;
-}
+type Meeting = OverlapMeeting;
 
 // A day column needs at least this much width to stay legible at the compact tier (room +
 // title, per BoxText's tier table) -- the day count below is derived from how many of these
@@ -61,6 +59,7 @@ interface MultiDayLandscapeViewProps {
   refreshTrigger?: number;
   scrollLocked?: boolean;
   conflictMids?: Set<string>;
+  syncErrorMids?: Set<string>;
 }
 
 // Landscape phone's generalized week: a "page" of `days` consecutive dates, `days` itself
@@ -80,6 +79,7 @@ const MultiDayLandscapeView: React.FC<MultiDayLandscapeViewProps> = ({
   refreshTrigger = 0,
   scrollLocked = false,
   conflictMids,
+  syncErrorMids,
 }) => {
   // Two different refs: scrollAreaRef is the vertical-scroll container (unaffected by the
   // time column's width); stripWrapperRef measures only the space actually left for day
@@ -286,6 +286,7 @@ const MultiDayLandscapeView: React.FC<MultiDayLandscapeViewProps> = ({
           columnDate={date}
           setLastClickedDate={setLastClickedDate}
           conflictMids={conflictMids}
+          syncErrorMids={syncErrorMids}
           hourHeight={MULTIDAY_HOUR_HEIGHT}
           hideTags
           tier="compact"

--- a/frontend/app/components/calendar/shared/DayColumn.tsx
+++ b/frontend/app/components/calendar/shared/DayColumn.tsx
@@ -17,7 +17,6 @@ interface Meeting {
     room?: string; // Added room property
     zoomRoom?: string | null;
     primaryColor?: string; // Added to support different colored meetings
-    syncError?: boolean;
     positionIndex?: number; // For handling overlapping meetings
     totalOverlapping?: number; // For handling overlapping meetings
     isOverflowIndicator?: boolean; // "+N more" pseudo-entry, rendered as a small pill instead of a meeting card
@@ -47,6 +46,8 @@ interface DayColumnProps {
     setLastClickedDate?: (date: Date) => void;
     // Admin-only (see hooks/useConflictMids) -- mids with an unresolved conflict.
     conflictMids?: Set<string>;
+    // Admin-only (see hooks/useSyncErrorMids) -- mids with a Google Calendar/Zoom sync error.
+    syncErrorMids?: Set<string>;
     // Desktop's default: 120px/hour, matching .timeSlot's 120px row height in both
     // DayView and WeekView. Mobile passes 60 (half height, to fit more of the day on
     // screen -- see DayPortraitView, whose own .timeColumn/.timeSlot heights must be
@@ -80,6 +81,7 @@ const DayColumn: React.FC<DayColumnProps> = ({
     columnDate,
     setLastClickedDate,
     conflictMids,
+    syncErrorMids,
     hourHeight = DEFAULT_HOUR_HEIGHT,
     hideTags = false,
     tier,
@@ -188,7 +190,7 @@ const DayColumn: React.FC<DayColumnProps> = ({
                             ? formatZoomRoomLabel(meeting.zoomRoom!)
                             : undefined
                     }
-                    syncError={meeting.syncError}
+                    syncError={syncErrorMids?.has(meeting.id)}
                     hasConflict={conflictMids?.has(meeting.id)}
                     fillHeight
                     hideTags={hideTags}
@@ -296,6 +298,7 @@ const DayColumn: React.FC<DayColumnProps> = ({
                 isOpen={overlapModalMeetings !== null}
                 meetings={overlapModalMeetings ?? []}
                 conflictMids={conflictMids}
+                syncErrorMids={syncErrorMids}
                 onClose={() => setOverlapModalMeetings(null)}
                 onSelectMeeting={(meetingId) => {
                     pendingModalAnchorRef.current = true;

--- a/frontend/app/components/calendar/shared/OverlapMeetingsModal.tsx
+++ b/frontend/app/components/calendar/shared/OverlapMeetingsModal.tsx
@@ -16,7 +16,6 @@ interface OverlapMeeting {
     zoomRoom?: string | null;
     tags?: string[];
     primaryColor?: string;
-    syncError?: boolean;
 }
 
 interface OverlapMeetingsModalProps {
@@ -26,6 +25,9 @@ interface OverlapMeetingsModalProps {
     // BoxText's corner badge reads from; kept as the live Set (not baked into each meeting at
     // click time) so a conflict that appears/resolves while the modal is open stays accurate.
     conflictMids?: Set<string>;
+    // Admin-only (see hooks/useSyncErrorMids) -- mids with a Google Calendar/Zoom sync error.
+    // Same live-Set treatment as conflictMids above.
+    syncErrorMids?: Set<string>;
     onClose: () => void;
     onSelectMeeting: (meetingId: string) => void;
 }
@@ -34,6 +36,7 @@ const OverlapMeetingsModal: React.FC<OverlapMeetingsModalProps> = ({
     isOpen,
     meetings,
     conflictMids,
+    syncErrorMids,
     onClose,
     onSelectMeeting,
 }) => {
@@ -74,6 +77,7 @@ const OverlapMeetingsModal: React.FC<OverlapMeetingsModalProps> = ({
                     {meetings.map(meeting => {
                         const locationLabel = meeting.room || meeting.zoomRoom || '';
                         const hasConflict = conflictMids?.has(meeting.id);
+                        const hasSyncError = syncErrorMids?.has(meeting.id);
                         return (
                             <div
                                 key={meeting.id}
@@ -84,7 +88,7 @@ const OverlapMeetingsModal: React.FC<OverlapMeetingsModalProps> = ({
                                 }}
                                 onClick={() => onSelectMeeting(meeting.id)}
                             >
-                                {meeting.syncError && (
+                                {hasSyncError && (
                                     <span role="img" aria-label="Sync failed" title="Sync failed" className={styles.syncError}>
                                         <img src="/svg/sync-error-icon.svg" alt="" />
                                     </span>

--- a/frontend/hooks/useSyncErrorMids.ts
+++ b/frontend/hooks/useSyncErrorMids.ts
@@ -1,0 +1,35 @@
+import { useEffect, useState } from "react";
+
+// Admin-only sync-error-badge data for the Day/Week calendar (see app/api/admin/sync-error-mids).
+// Mirrors useConflictMids.ts exactly -- the endpoint enforces admin-only via requireRole, so a
+// public/non-admin viewer's fetch 401s and this just resolves to an empty set, no error
+// surfaced. `enabled` (default true) lets a caller that already knows the viewer isn't an admin
+// skip the fetch entirely; also accepts null (the caller's own admin check hasn't resolved yet)
+// and treats it the same as false.
+export function useSyncErrorMids(refreshTrigger: number, enabled: boolean | null = true): Set<string> {
+  const [mids, setMids] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    if (!enabled) {
+      setMids(new Set());
+      return;
+    }
+
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch("/api/admin/sync-error-mids");
+        if (!res.ok) return;
+        const data = await res.json();
+        if (!cancelled) setMids(new Set<string>(data.mids ?? []));
+      } catch (err) {
+        console.error("Error fetching sync-error mids:", err);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [refreshTrigger, enabled]);
+
+  return mids;
+}

--- a/frontend/hooks/useSyncErrorMids.ts
+++ b/frontend/hooks/useSyncErrorMids.ts
@@ -19,10 +19,16 @@ export function useSyncErrorMids(refreshTrigger: number, enabled: boolean | null
     (async () => {
       try {
         const res = await fetch("/api/admin/sync-error-mids");
-        if (!res.ok) return;
+        if (!res.ok) {
+          // A mid-session role change or expired session (401/403) after a prior successful
+          // fetch shouldn't leave stale admin-only sync-error mids rendered.
+          if (!cancelled) setMids(new Set());
+          return;
+        }
         const data = await res.json();
         if (!cancelled) setMids(new Set<string>(data.mids ?? []));
       } catch (err) {
+        if (!cancelled) setMids(new Set());
         console.error("Error fetching sync-error mids:", err);
       }
     })();

--- a/frontend/hooks/useWeekMeetings.ts
+++ b/frontend/hooks/useWeekMeetings.ts
@@ -4,9 +4,7 @@ import { createCache } from "../util/common/simpleCache";
 import { IMeeting } from "../types/models";
 import { OverlapMeeting } from "../util/meetings/meetingOverlapLayout";
 
-export interface WeekMeeting extends OverlapMeeting {
-    syncError?: boolean;
-}
+export type WeekMeeting = OverlapMeeting;
 
 // Module-level, shared cache -- extracted out of WeekView.tsx so the mobile day view
 // (DayPortraitView.tsx) hits the exact same cache for the same week's data instead of a
@@ -43,7 +41,6 @@ export const mapRawMeetingsToWeekMeetings = (data: (IMeeting & { date: string })
             tags: [...meeting.calType, meeting.modeType],
             room: meeting.room,
             zoomRoom: meeting.zoomRoom,
-            syncError: meeting.googleSyncStatus === 'error' || meeting.zoomSyncStatus === 'error',
         };
     });
 

--- a/frontend/tests/integration/sync-error-mids-route.test.ts
+++ b/frontend/tests/integration/sync-error-mids-route.test.ts
@@ -1,0 +1,71 @@
+import { randomUUID } from "crypto";
+import type { Meeting } from "@prisma/client";
+
+jest.mock("../../services/auth", () => ({
+  requireRole: jest.fn(),
+}));
+
+import { requireRole } from "../../services/auth";
+import { getTestPrismaClient, disconnectTestPrismaClient } from "../factories/db";
+import { buildMeetingData as buildBaseMeetingData } from "../factories/meeting";
+import { GET } from "../../app/api/admin/sync-error-mids/route";
+
+const mockedRequireRole = requireRole as jest.Mock;
+
+function buildMeetingData(overrides: Partial<Meeting> = {}) {
+  return buildBaseMeetingData({
+    title: "Sync Error Mids Meeting",
+    modeType: "Hybrid",
+    zoomRoom: "Serenity Room - Zoom",
+    ...overrides,
+  });
+}
+
+afterAll(async () => {
+  await disconnectTestPrismaClient();
+});
+
+beforeEach(() => {
+  mockedRequireRole.mockResolvedValue({ user: { role: "ADMIN" }, accessToken: "fake-token" });
+});
+
+test("rejects a non-admin request without touching the database", async () => {
+  mockedRequireRole.mockResolvedValue(
+    new Response(JSON.stringify({ error: "Unauthorized" }), { status: 401 }),
+  );
+
+  const response = await GET();
+  expect(response.status).toBe(401);
+});
+
+test("returns the mids of meetings with a Google Calendar or Zoom sync error", async () => {
+  const prisma = getTestPrismaClient();
+
+  const midGoogleError = `m-${randomUUID()}`;
+  const midZoomError = `m-${randomUUID()}`;
+  const midSynced = `m-${randomUUID()}`;
+  const midPending = `m-${randomUUID()}`;
+
+  await prisma.meeting.create({
+    data: buildMeetingData({ mid: midGoogleError, googleSyncStatus: "error", zoomSyncStatus: "synced" }),
+  });
+  await prisma.meeting.create({
+    data: buildMeetingData({ mid: midZoomError, googleSyncStatus: "synced", zoomSyncStatus: "error" }),
+  });
+  // Neither channel in an error state -- must not show up as a false positive.
+  await prisma.meeting.create({
+    data: buildMeetingData({ mid: midSynced, googleSyncStatus: "synced", zoomSyncStatus: "synced" }),
+  });
+  // Still working through sync ("pending"/unset) -- not yet an error, must not show up either.
+  await prisma.meeting.create({
+    data: buildMeetingData({ mid: midPending, googleSyncStatus: "pending", zoomSyncStatus: null }),
+  });
+
+  const response = await GET();
+  expect(response.status).toBe(200);
+  const body = await response.json();
+
+  expect(body.mids).toEqual(expect.arrayContaining([midGoogleError, midZoomError]));
+  expect(body.mids).not.toContain(midSynced);
+  expect(body.mids).not.toContain(midPending);
+});

--- a/frontend/tests/integration/sync-error-mids-route.test.ts
+++ b/frontend/tests/integration/sync-error-mids-route.test.ts
@@ -45,6 +45,7 @@ test("returns the mids of meetings with a Google Calendar or Zoom sync error", a
   const midZoomError = `m-${randomUUID()}`;
   const midSynced = `m-${randomUUID()}`;
   const midPending = `m-${randomUUID()}`;
+  const midDeleted = `m-${randomUUID()}`;
 
   await prisma.meeting.create({
     data: buildMeetingData({ mid: midGoogleError, googleSyncStatus: "error", zoomSyncStatus: "synced" }),
@@ -60,6 +61,11 @@ test("returns the mids of meetings with a Google Calendar or Zoom sync error", a
   await prisma.meeting.create({
     data: buildMeetingData({ mid: midPending, googleSyncStatus: "pending", zoomSyncStatus: null }),
   });
+  // A genuine sync error, but soft-deleted -- must still respect the route's `deletedAt: null`
+  // filter, same as every other meeting-list endpoint.
+  await prisma.meeting.create({
+    data: buildMeetingData({ mid: midDeleted, googleSyncStatus: "error", deletedAt: new Date() }),
+  });
 
   const response = await GET();
   expect(response.status).toBe(200);
@@ -68,4 +74,5 @@ test("returns the mids of meetings with a Google Calendar or Zoom sync error", a
   expect(body.mids).toEqual(expect.arrayContaining([midGoogleError, midZoomError]));
   expect(body.mids).not.toContain(midSynced);
   expect(body.mids).not.toContain(midPending);
+  expect(body.mids).not.toContain(midDeleted);
 });


### PR DESCRIPTION
Resolves #<!-- none -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Calendar views now identify meetings with Google Calendar or Zoom synchronization errors.
  * Sync-error indicators are consistently displayed across desktop, mobile, daily, weekly, and overlapping-meeting views.
  * Administrators can retrieve meetings affected by synchronization errors.

* **Bug Fixes**
  * Sync-error information now refreshes with calendar updates and is restricted to authorized administrators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description
- **app/api/admin/sync-error-mids/route.ts** (new): admin-gated endpoint returning the mids of meetings with a `googleSyncStatus`/`zoomSyncStatus` of `"error"`. Mirrors `app/api/admin/conflict-mids/route.ts` exactly.
- **hooks/useSyncErrorMids.ts** (new): fetches that endpoint, gated the same way `useConflictMids` is (admin-only, 30s refresh cadence).
- **app/(main)/page.tsx** and every Day/Week calendar view (`DayView`, `WeekView`, `DayPortraitView`, `DayLandscapeSwitcher`, `DayLandscapeView`, `MultiDayLandscapeView`, `DailyViewRow`, `DayColumn`, `OverlapMeetingsModal`): thread a `syncErrorMids` Set down to `BoxText`'s `syncError` prop, replacing a `meeting.syncError` field that was always `false`.
- **hooks/useWeekMeetings.ts**, **app/components/calendar/desktop/DayView.tsx**: removed the dead `syncError` computation — it read `googleSyncStatus`/`zoomSyncStatus` off data shaped by `PublicMeeting`, which deliberately excludes those two fields (see `util/meetings/publicMeeting.ts`'s comment, BUG-022), so the field was always `false` regardless of a meeting's real sync state.
- **tests/integration/sync-error-mids-route.test.ts** (new): mirrors `conflict-mids-route.test.ts`'s coverage.

**Root cause:** the calendar block's sync-error badge has been silently broken for every viewer, including admins, since `PublicMeeting` was introduced — the Day/Week/mobile views all read from that public-shaped payload, so `meeting.googleSyncStatus`/`zoomSyncStatus` were never actually present in the response. The conflict badge next to it never had this problem because it was already wired through a dedicated admin-gated endpoint instead of the public payload; this PR gives the sync-error badge the same treatment.

## Testing
- [x] `yarn test:all` — lint, unit, component, integration, e2e all green
- [x] New integration test (`sync-error-mids-route.test.ts`) covers both the 401-for-non-admin path and correct mid filtering (error vs synced vs pending)
- [x] Manually verified as Super Admin in a local dev server: a meeting with a real `zoomSyncStatus: "error"` now shows the red sync-error icon on its calendar block

## Area(s) Touched
**Product areas**
- [x] admin — /admin shell (Diagnostics, Users, Import, Export tabs)
- [x] ui/ux — frontend layout/styling not tied to a specific integration

**Integrations**
- [x] google-calendar — Google Calendar sync
- [x] zoom-api — Zoom meeting/host sync

**Engineering**
- [x] testing — test suite (Jest/Playwright) changes

## Pre-merge Checklist
- [x] Code follows current formatting conventions and passes lint (`yarn lint`).
- [x] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
- [x] All test suites pass, both run locally and green in GitHub CI. **Do not merge if any test suite is failing.**
- [x] A test suite was added or updated for the feature/fix in this PR.
- [x] Only files relevant to this change are committed — no stray or unrelated files.
- [ ] If this branch has a merge conflict with master, master was merged into this branch first (not the other way around).
- [x] The rest of this PR description (Description, Testing) is filled out, not left as template placeholders.