### PR TITLE
fix(test): wrap ViewMeeting component tests in ToastProvider

### DIFF
--- a/frontend/tests/component/ViewMeeting.test.tsx
+++ b/frontend/tests/component/ViewMeeting.test.tsx
@@ -1,6 +1,16 @@
 import React from "react";
 import { render, screen, waitFor, within, fireEvent } from "@testing-library/react";
 import ViewMeetingDetails from "../../app/components/meeting-form/ViewMeeting";
+import { ToastProvider } from "../../app/components/shared/ToastProvider";
+
+// ViewMeeting's "Retry sync" button reads useToast() -- which throws outside a ToastProvider --
+// so every render here needs one in the tree, not just the ones that click Retry.
+const renderViewMeeting = (props: React.ComponentProps<typeof ViewMeetingDetails>) =>
+  render(
+    <ToastProvider>
+      <ViewMeetingDetails {...props} />
+    </ToastProvider>
+  );
 
 beforeEach(() => {
   global.fetch = jest.fn().mockResolvedValue({
@@ -40,20 +50,20 @@ const makeAnchorEl = (): HTMLElement => {
 
 describe("ViewMeeting", () => {
   it("desktop: renders nothing without an anchorEl", async () => {
-    render(<ViewMeetingDetails {...baseProps} anchorEl={null} isPhone={false} />);
+    renderViewMeeting({ ...baseProps, anchorEl: null, isPhone: false });
     // useZoomHostPool's fetch effect still resolves post-render; wait for it to settle
     // (inside act) rather than asserting synchronously and leaving it unflushed.
     await waitFor(() => expect(screen.queryByText("Serenity Group")).not.toBeInTheDocument());
   });
 
   it("desktop: renders the meeting title once an anchorEl is present, outside any dialog role", async () => {
-    render(<ViewMeetingDetails {...baseProps} anchorEl={makeAnchorEl()} isPhone={false} />);
+    renderViewMeeting({ ...baseProps, anchorEl: makeAnchorEl(), isPhone: false });
     expect(await screen.findByText("Serenity Group")).toBeInTheDocument();
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
   });
 
   it("mobile: renders inside a bottom sheet even with no anchorEl", async () => {
-    render(<ViewMeetingDetails {...baseProps} anchorEl={null} isPhone />);
+    renderViewMeeting({ ...baseProps, anchorEl: null, isPhone: true });
     const dialog = await screen.findByRole("dialog", { name: "Serenity Group" });
     expect(dialog).toBeInTheDocument();
     // ViewMeeting's own <h1> title, distinct from BottomSheet's visually-hidden duplicate
@@ -62,12 +72,12 @@ describe("ViewMeeting", () => {
   });
 
   it("mobile: shows the same Edit/Delete kebab menu for an admin", async () => {
-    render(<ViewMeetingDetails {...baseProps} anchorEl={null} isPhone isAdmin />);
+    renderViewMeeting({ ...baseProps, anchorEl: null, isPhone: true, isAdmin: true });
     expect(await screen.findByRole("button", { name: "Meeting options" })).toBeInTheDocument();
   });
 
   it("prefixes the mode label with its mode icon", async () => {
-    render(<ViewMeetingDetails {...baseProps} anchorEl={makeAnchorEl()} isPhone={false} />);
+    renderViewMeeting({ ...baseProps, anchorEl: makeAnchorEl(), isPhone: false });
     const label = await screen.findByText("In Person");
     expect(label.querySelector("img")).toHaveAttribute("src", "/svg/location-icon.svg");
   });
@@ -85,14 +95,14 @@ describe("ViewMeeting", () => {
     };
 
     it("shows the sync-failure and conflict blocks for an admin", async () => {
-      render(<ViewMeetingDetails {...withProblems} isAdmin anchorEl={makeAnchorEl()} isPhone={false} />);
+      renderViewMeeting({ ...withProblems, isAdmin: true, anchorEl: makeAnchorEl(), isPhone: false });
       expect(await screen.findByText("Failed to sync")).toBeInTheDocument();
       expect(screen.getByText(/Conflicts with 2 other meetings/)).toBeInTheDocument();
       expect(screen.getByRole("button", { name: "Retry sync" })).toBeInTheDocument();
     });
 
     it("hides the entire status band for a non-admin/public viewer", async () => {
-      render(<ViewMeetingDetails {...withProblems} isAdmin={false} anchorEl={makeAnchorEl()} isPhone={false} />);
+      renderViewMeeting({ ...withProblems, isAdmin: false, anchorEl: makeAnchorEl(), isPhone: false });
       await screen.findByText("Serenity Group");
       expect(screen.queryByText("Failed to sync")).not.toBeInTheDocument();
       expect(screen.queryByText(/Conflicts with/)).not.toBeInTheDocument();
@@ -100,7 +110,7 @@ describe("ViewMeeting", () => {
     });
 
     it("hides the status band while the auth check is still pending (isAdmin === null)", async () => {
-      render(<ViewMeetingDetails {...withProblems} isAdmin={null} anchorEl={makeAnchorEl()} isPhone={false} />);
+      renderViewMeeting({ ...withProblems, isAdmin: null, anchorEl: makeAnchorEl(), isPhone: false });
       await screen.findByText("Serenity Group");
       expect(screen.queryByText("Failed to sync")).not.toBeInTheDocument();
       expect(screen.queryByText(/Conflicts with/)).not.toBeInTheDocument();
@@ -108,7 +118,7 @@ describe("ViewMeeting", () => {
     });
 
     it("toggles the per-channel error details on the info button", async () => {
-      render(<ViewMeetingDetails {...withProblems} isAdmin anchorEl={makeAnchorEl()} isPhone={false} />);
+      renderViewMeeting({ ...withProblems, isAdmin: true, anchorEl: makeAnchorEl(), isPhone: false });
       const toggle = await screen.findByRole("button", { name: "Show sync error details" });
       expect(screen.queryByText(/Insufficient permissions/)).not.toBeInTheDocument();
 


### PR DESCRIPTION
Resolves #<!-- none -->

@coderabbitai summary

## Description
- **tests/component/ViewMeeting.test.tsx**: `ViewMeeting.tsx`'s "Retry sync" button now calls `useToast()` (merged in via #353's toast migration), which throws when no `ToastProvider` is in the tree. This test file renders `ViewMeetingDetails` directly with no provider, so all 9 tests in the file started failing the moment #353 merged. Added a `renderViewMeeting()` helper that wraps every render in `ToastProvider`, replacing the 9 direct `render(<ViewMeetingDetails .../>)` calls.

**Why this wasn't caught before merge:** `.github/workflows/test.yml`'s `Test` workflow only runs `lint`, `unit`, `integration`, and `e2e` — there's no `component` job, so `yarn test:component` (part of local `yarn test:all`) never actually runs in CI. Flagging this as a gap worth a follow-up, but keeping this PR scoped to just the regression fix.

## Testing
- [x] `yarn jest --config config/jest.component.config.ts ViewMeeting.test.tsx` — 9/9 pass (was 9/9 failing before this fix)
- [x] `yarn test:component` — full suite, 16/16 suites, 79/79 tests pass
- [x] `yarn lint` — 0 errors
- [x] `npx tsc --noEmit` — clean

## Area(s) Touched
**Engineering**
- [x] testing — test suite (Jest/Playwright) changes

## Pre-merge Checklist
- [x] Code follows current formatting conventions and passes lint (`yarn lint`).
- [x] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
- [x] All test suites pass, both run locally and green in GitHub CI. **Do not merge if any test suite is failing.**
- [x] A test suite was added or updated for the feature/fix in this PR.
- [x] Only files relevant to this change are committed — no stray or unrelated files.
- [x] If this branch has a merge conflict with master, master was merged into this branch first (not the other way around).
- [x] The rest of this PR description (Description, Testing) is filled out, not left as template placeholders.