### PR TITLE
fix(signage): rescale on first direct navigation, not just after a view switch

### DIFF
--- a/frontend/app/(signage)/signage/page.tsx
+++ b/frontend/app/(signage)/signage/page.tsx
@@ -2,7 +2,7 @@
 
 export const dynamic = "force-dynamic";
 
-import { Suspense, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { Suspense, useEffect, useLayoutEffect, useMemo, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import Logo from "../../components/atoms/Logo";
 import CalendarNavbar from "../../components/calendar/desktop/CalendarNavbar";
@@ -51,33 +51,36 @@ function SignageContent() {
   const [selectedDate, setSelectedDate] = useState(new Date());
   const [refreshTrigger, setRefreshTrigger] = useState(0);
 
-  const contentRef = useRef<HTMLDivElement>(null);
+  // A callback ref (stored in state), not a plain useRef -- a plain ref's populated value
+  // isn't reactive, so on first mount (viewport still null, page renders null) the element
+  // stays permanently absent from this effect's closure with no re-run ever triggered once it
+  // actually attaches. Storing it in state makes attachment itself a dependency change.
+  const [contentEl, setContentEl] = useState<HTMLDivElement | null>(null);
   const [scale, setScale] = useState(1);
 
   // Scale the whole page (header + calendar) together as one unit.
-  // Day's timeline runs horizontally, so it scales to fit height. 
+  // Day's timeline runs horizontally, so it scales to fit height.
   // Week's timeline runs downward, so it scales to fit width.
   useLayoutEffect(() => {
-    const el = contentRef.current;
-    if (!el) return;
+    if (!contentEl) return;
 
     const recalcScale = () => {
       if (view === "Day") {
-        if (el.scrollHeight > 0) setScale(window.innerHeight / el.scrollHeight);
-      } else if (el.scrollWidth > 0) {
-        setScale(window.innerWidth / el.scrollWidth);
+        if (contentEl.scrollHeight > 0) setScale(window.innerHeight / contentEl.scrollHeight);
+      } else if (contentEl.scrollWidth > 0) {
+        setScale(window.innerWidth / contentEl.scrollWidth);
       }
     };
 
     recalcScale();
     const observer = new ResizeObserver(recalcScale);
-    observer.observe(el);
+    observer.observe(contentEl);
     window.addEventListener("resize", recalcScale);
     return () => {
       observer.disconnect();
       window.removeEventListener("resize", recalcScale);
     };
-  }, [view, filters]);
+  }, [view, filters, contentEl]);
 
   useEffect(() => {
     const id = setInterval(() => setRefreshTrigger(prev => prev + 1), REFRESH_INTERVAL_MS);
@@ -116,7 +119,7 @@ function SignageContent() {
   return (
     <div style={{ height: "100vh", overflow: view === "Day" ? "hidden" : "auto" }}>
       <div
-        ref={contentRef}
+        ref={setContentEl}
         style={{
           transform: `scale(${scale})`,
           transformOrigin: "top left",

--- a/frontend/tests/e2e/13-digital-signage.spec.ts
+++ b/frontend/tests/e2e/13-digital-signage.spec.ts
@@ -32,4 +32,22 @@ test.describe("digital signage", () => {
     await expect(page.getByText("Serenity Signage Meeting")).toBeVisible();
     await expect(page.getByText("Unity Signage Meeting")).toHaveCount(0);
   });
+
+  // Regression test for #348: the auto-fit scale calculation used to be gated on a plain
+  // useRef, which isn't reactive -- on a fresh direct navigation (not a click-through from an
+  // already-scaled state) the effect fired before the content div ever mounted and never
+  // re-ran, leaving the page stuck at scale(1) until something else (a view switch) happened
+  // to force a re-run. Deliberately does a fresh page.goto (not reusing a warmed-up page) to
+  // match the bug's actual repro path.
+  test("13.6 /signage rescales to fit the viewport on first direct navigation, without a view switch", async ({ page }) => {
+    await seedMeeting({ title: "Direct Nav Signage Meeting" });
+    await page.goto("/signage");
+    await expect(page.getByText("Direct Nav Signage Meeting")).toBeVisible();
+
+    const contentDiv = page.locator('div[style*="transform"]').first();
+    const transform = await contentDiv.evaluate((el) => window.getComputedStyle(el).transform);
+    // scale(1) resolves to the identity matrix -- if the auto-fit calculation never ran, this
+    // is exactly what a fresh, unscaled render would still show.
+    expect(transform).not.toBe("matrix(1, 0, 0, 1, 0, 0)");
+  });
 });


### PR DESCRIPTION
Resolves #348

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed digital signage auto-scaling when opening the signage page directly.
  - Ensured signage content fits the available view immediately without requiring a view switch or filter change.

- **Tests**
  - Added end-to-end coverage verifying that meetings render and initial signage scaling is applied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description
- **frontend/app/(signage)/signage/page.tsx**: the auto-fit scale calculation was a `useLayoutEffect` keyed on `[view, filters]`, reading a plain `useRef`. A ref's populated value isn't reactive — on a fresh direct navigation to `/signage` (`useViewport()` starts null, the page renders `null` on the first commit, so the content div never mounts on that first pass) the effect fired once against a `null` ref and exited immediately, then never re-ran once the element actually attached, since nothing in `[view, filters]` had changed. The page stayed stuck at `scale(1)` until something else in that dependency array (switching Day/Week) happened to force a re-run. Switched `contentRef` from a plain `useRef` to a callback ref stored in state (`useState<HTMLDivElement | null>`), so attachment itself is now a dependency the effect reacts to. Matches the issue's own suggested fix direction.

## Testing
- [x] `yarn test:all` passes locally (lint, lint:css, unit, component, integration, e2e all green).
- [x] Added `13.6` to `tests/e2e/13-digital-signage.spec.ts` — navigates directly to `/signage` (fresh `page.goto`, matching the actual repro path, not a click-through from an already-scaled state) and asserts the content's computed `transform` isn't the identity matrix (`scale(1)`). Verified it actually catches the regression: temporarily reverted to the old plain-`useRef` version and confirmed the test fails, then restored the fix and confirmed it passes.

## Area(s) Touched
**Product areas**
- [ ] auth — sign-in, sessions, NextAuth, role-based access
- [ ] admin — /admin shell (Diagnostics, Users, Import, Export tabs)
- [ ] docs — /docs Resources page (rendering, navigation, search)
- [x] ui/ux — frontend layout/styling not tied to a specific integration

**Integrations**
- [ ] google-calendar — Google Calendar sync
- [ ] zoom-api — Zoom meeting/host sync

**Engineering**
- [ ] security — auth hardening, data exposure, dependency/security scanning
- [x] testing — test suite (Jest/Playwright) changes
- [ ] github-actions — workflows, Dependabot config, other .github/ CI tooling
- [ ] cleanup — refactor or dead-code removal, no behavior change
- [ ] documentation — docs/ or README changes only

## Pre-merge Checklist
- [x] Code follows current formatting conventions and passes lint (`yarn lint`).
- [x] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
- [x] All test suites pass, both run locally and green in GitHub CI. **Do not merge if any test suite is failing.**
- [x] A test suite was added or updated for the feature/fix in this PR — see Testing above.
- [x] Only files relevant to this change are committed — no stray or unrelated files.
- [x] If this branch has a merge conflict with master, master was merged into this branch first (not the other way around).
- [x] The rest of this PR description (Description, Testing) is filled out, not left as template placeholders.