### PR TITLE
fix(calendar): scale the view-toggle icon and 'View only' pill with the header row

### DIFF
--- a/frontend/app/components/calendar/shared/CalendarHeader.tsx
+++ b/frontend/app/components/calendar/shared/CalendarHeader.tsx
@@ -65,7 +65,7 @@ const CalendarHeader: React.FC<CalendarHeaderProps> = ({ selectedDate, selectedV
   );
 
   return (
-    <>
+    <div className={styles.headerWrapper}>
       <div className={styles.navbarContainer}>
         {heading}
         {children}
@@ -76,7 +76,7 @@ const CalendarHeader: React.FC<CalendarHeaderProps> = ({ selectedDate, selectedV
           <span>View only - sign in as Admin to manage meetings</span>
         </div>
       )}
-    </>
+    </div>
   );
 };
 

--- a/frontend/styles/components/calendar/desktop/CalendarNavbar.module.scss
+++ b/frontend/styles/components/calendar/desktop/CalendarNavbar.module.scss
@@ -1,17 +1,17 @@
 @import '../../../Variables.module.scss';
 
-.navbarContainer {
-  display: flex;
-  align-items: center;
-  gap: 24px;
-  font-family: 'Source Sans Pro', sans-serif;
-  align-self: stretch;
-
-  // Lets .navbarHeading/.navbarControls query *this row's* actual available
-  // width below, rather than the viewport's -- the sidebar (CalendarSidebarShell) eats an
-  // arbitrary chunk of viewport width first, so a viewport-based breakpoint doesn't know
-  // how much room this row really has and can fire too late (still 36px when the date text
-  // is already crowding the Day/Today/arrow controls) or too early.
+// Establishes the container-query boundary that .navbarContainer's and .viewOnlyPill's own
+// clamp(...cqi...) rules below all query against -- both need to live *inside* this wrapper
+// (not just .navbarContainer) so cqi/cqw units resolve for either of them. cqi units only
+// resolve against the nearest ancestor with container-type set; .viewOnlyPill used to be a
+// sibling of .navbarContainer instead of a descendant of this wrapper (see CalendarHeader.tsx),
+// so it structurally couldn't participate in this scaling at all -- it needed moving inside,
+// not just a different unit.
+.headerWrapper {
+  // Queries *this row's* actual available width, rather than the viewport's -- the sidebar
+  // (CalendarSidebarShell) eats an arbitrary chunk of viewport width first, so a viewport-based
+  // breakpoint doesn't know how much room this row really has and can fire too late (still 36px
+  // when the date text is already crowding the Day/Today/arrow controls) or too early.
   container-type: inline-size;
   container-name: calendar-navbar;
 
@@ -25,6 +25,24 @@
   position: relative;
   z-index: 50;
 
+  // Mobile's CalendarHeader runs edge-to-edge (see DayPortraitView.module.scss / page
+  // .module.scss's phone-width padding: 0), unlike desktop CalendarNavbar which sits inside
+  // .primaryCalendar's 10px inset -- without its own padding here the heading/pill would sit
+  // flush against the screen edges. Living here (not just on .navbarContainer) means
+  // .viewOnlyPill now inherits this inset automatically as a fellow descendant, instead of
+  // needing its own separate margin-left hack to fake the same offset.
+  @media (width <= $breakpoint-phone) {
+    padding: 12px 14px 6px;
+  }
+}
+
+.navbarContainer {
+  display: flex;
+  align-items: center;
+  gap: 24px;
+  font-family: 'Source Sans Pro', sans-serif;
+  align-self: stretch;
+
   img {
     cursor: pointer;
   }
@@ -33,14 +51,6 @@
     margin: 0;
     padding: 0;
     box-sizing: border-box;
-  }
-
-  // Mobile's CalendarHeader runs edge-to-edge (see DayPortraitView.module.scss / page
-  // .module.scss's phone-width padding: 0), unlike desktop CalendarNavbar which sits inside
-  // .primaryCalendar's 10px inset -- without its own padding here the heading/pill would sit
-  // flush against the screen edges.
-  @media (width <= $breakpoint-phone) {
-    padding: 12px 14px 6px;
   }
 }
 
@@ -180,36 +190,34 @@
 }
 
 .viewOptionIcon {
-  width: 22px;
-  height: 22px;
+  // Same clamp(min, Xcqi, max) treatment as .dateToggle img above, at the same 2.67cqi rate --
+  // was left as a hardcoded 22px while the button chrome around it already scaled, so it stayed
+  // a fixed size while everything around it shrank.
+  width: clamp(11px, 2.67cqi, 22px);
+  height: clamp(11px, 2.67cqi, 22px);
 }
 
 // "View only" footer pill -- shown beneath the main nav row for anyone not signed in as
 // Admin (mirrors AppNavbar's .navLocked lock-icon treatment, but in brand-pink to read as
-// an informational notice rather than a disabled control).
+// an informational notice rather than a disabled control). Scales continuously via the same
+// cqi units as the rest of the row now that it's a descendant of .headerWrapper (see
+// CalendarHeader.tsx) -- previously a single hardcoded step-down at the phone breakpoint,
+// which snapped instead of shrinking smoothly alongside its surroundings.
 .viewOnlyPill {
   display: inline-flex;
   align-items: center;
   gap: 6px;
   width: fit-content;
   margin-top: 8px;
-  padding: 6px 14px;
+  padding: clamp(3px, 1.33cqi, 6px) clamp(7px, 2cqi, 14px);
   border-radius: 999px;
   background: rgb(204 51 102 / 8%);
   color: $brand-pink-color;
-  font-size: 14px;
+  font-size: clamp(11px, 2.67cqi, 14px);
   font-weight: 600;
-
-  // Smaller to match the tighter mobile heading, and shifted right by .navbarContainer's own
-  // phone-only 14px horizontal padding above -- this pill is a sibling of .navbarContainer,
-  // not a descendant (see CalendarHeader.tsx), so it doesn't inherit that padding on its own.
-  @media (width <= $breakpoint-phone) {
-    margin-left: 14px;
-    font-size: 12px;
-  }
 }
 
 .viewOnlyIcon {
-  width: 14px;
-  height: 14px;
+  width: clamp(7px, 2.67cqi, 14px);
+  height: clamp(7px, 2.67cqi, 14px);
 }

--- a/frontend/tests/e2e/05-calendar-display.spec.ts
+++ b/frontend/tests/e2e/05-calendar-display.spec.ts
@@ -70,4 +70,34 @@ test.describe("calendar display", () => {
     await expect(page.getByText("Morning Meeting")).toBeVisible();
     await expect(page.getByText("Evening Meeting")).toBeVisible();
   });
+
+  // Regression test for #350: the view-toggle icon and the unauthenticated "View only" pill
+  // stayed a fixed pixel size while the rest of the header row scaled continuously with its
+  // own container width (container queries, not viewport-based breakpoints). The pill in
+  // particular couldn't scale at all -- it rendered as a DOM sibling of the container-query
+  // root, not a descendant, so cqi units had no ancestor to resolve against. Both widths stay
+  // above the tablet breakpoint (768px, see hooks/useViewport.ts) so the desktop shell -- and
+  // this container-query row -- stays mounted at both sizes; only the row's own available
+  // width (viewport minus the sidebar) changes.
+  test("calendar header: view-toggle icon and 'View only' pill scale continuously with the header row's own width", async ({ page }) => {
+    await page.goto("/");
+    const viewToggleIcon = page.locator('img[src*="view-timeline-icon.svg"]');
+    const pillText = page.getByText("View only - sign in as Admin to manage meetings");
+    const pillIcon = page.locator('img[src="/svg/lock-icon.svg"]');
+
+    await page.setViewportSize({ width: 1400, height: 900 });
+    await expect(viewToggleIcon).toBeVisible();
+    const wideIconWidth = await viewToggleIcon.evaluate((el) => el.getBoundingClientRect().width);
+    const widePillFontSize = parseFloat(await pillText.evaluate((el) => window.getComputedStyle(el).fontSize));
+    const widePillIconWidth = await pillIcon.evaluate((el) => el.getBoundingClientRect().width);
+
+    await page.setViewportSize({ width: 820, height: 900 });
+    const narrowIconWidth = await viewToggleIcon.evaluate((el) => el.getBoundingClientRect().width);
+    const narrowPillFontSize = parseFloat(await pillText.evaluate((el) => window.getComputedStyle(el).fontSize));
+    const narrowPillIconWidth = await pillIcon.evaluate((el) => el.getBoundingClientRect().width);
+
+    expect(narrowIconWidth).toBeLessThan(wideIconWidth);
+    expect(narrowPillFontSize).toBeLessThan(widePillFontSize);
+    expect(narrowPillIconWidth).toBeLessThan(widePillIconWidth);
+  });
 });


### PR DESCRIPTION
Resolves #350

@coderabbitai summary

## Description
Two distinct root causes, per the issue's own breakdown:

- **`.viewOptionIcon`** (`styles/components/calendar/desktop/CalendarNavbar.module.scss`) was hardcoded at `22px` while the dropdown button chrome around it already scaled via `clamp(...cqi...)`. Gave it the same `clamp(min, Ncqi, max)` treatment already used by `.dateToggle img` a few lines up — simple, low-risk, matches the issue's suggested fix exactly.
- **The "View only" pill** (`app/components/calendar/shared/CalendarHeader.tsx`) couldn't scale at all, regardless of what CSS unit was used — it rendered as a DOM **sibling** of `.navbarContainer` (the container-query root), not a descendant, and `cqi`/`cqw` units only resolve against the nearest ancestor with `container-type` set. Structural fix: moved `container-type: inline-size` off `.navbarContainer` onto a new wrapping `.headerWrapper` that contains **both** `.navbarContainer` and the pill, so both now share the same container-query context. The pill's sizing (padding, font-size, icon) was then switched from a single hardcoded phone-breakpoint step-down to continuous `clamp(...cqi...)` scaling, consistent with the rest of the row. As a side effect, the pill now inherits `.headerWrapper`'s phone-only padding automatically instead of needing its own separate `margin-left` hack to fake the same inset.

## Testing
- [x] `yarn test:all` passes locally (lint, lint:css, unit, component, integration, e2e all green) — `.scss` was touched, so `lint:css` was run explicitly per project convention, not just as part of `test:all`.
- [x] Added a new test to `tests/e2e/05-calendar-display.spec.ts` — measures the view-toggle icon's rendered width and the "View only" pill's font-size/icon width at two viewport widths (both above the tablet breakpoint, so the desktop shell stays mounted at both) and asserts both shrink at the narrower width. Verified it actually catches the regression: temporarily reverted the SCSS/TSX changes and confirmed the test fails (icon width `22 === 22`, no scaling), then restored the fix and confirmed it passes.

## Area(s) Touched
**Product areas**
- [ ] auth — sign-in, sessions, NextAuth, role-based access
- [ ] admin — /admin shell (Diagnostics, Users, Import, Export tabs)
- [ ] docs — /docs Resources page (rendering, navigation, search)
- [x] ui/ux — frontend layout/styling not tied to a specific integration

**Integrations**
- [ ] google-calendar — Google Calendar sync
- [ ] zoom-api — Zoom meeting/host sync

**Engineering**
- [ ] security — auth hardening, data exposure, dependency/security scanning
- [x] testing — test suite (Jest/Playwright) changes
- [ ] github-actions — workflows, Dependabot config, other .github/ CI tooling
- [ ] cleanup — refactor or dead-code removal, no behavior change
- [ ] documentation — docs/ or README changes only

## Pre-merge Checklist
- [x] Code follows current formatting conventions and passes lint (`yarn lint`).
- [x] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
- [x] All test suites pass, both run locally and green in GitHub CI. **Do not merge if any test suite is failing.**
- [x] A test suite was added or updated for the feature/fix in this PR — see Testing above.
- [x] Only files relevant to this change are committed — no stray or unrelated files.
- [x] If this branch has a merge conflict with master, master was merged into this branch first (not the other way around).
- [x] The rest of this PR description (Description, Testing) is filled out, not left as template placeholders.