### PR TITLE
feat(admin): split digital signage into its own Signage tab

### DIFF
--- a/docs/01-user-guide/how-to/export-data.md
+++ b/docs/01-user-guide/how-to/export-data.md
@@ -52,7 +52,3 @@ meeting itself is set up:
 "The meeting's own hours" means that one meeting's start-to-end duration, not a sum across its
 whole recurrence — a weekly 1-hour meeting is still just "1 hour" for this calculation, not "1
 hour × however many weeks are in the lease."
-
-## Generate a signage URL
-
-See [Use Digital Signage](use-digital-signage.md).

--- a/docs/01-user-guide/how-to/use-digital-signage.md
+++ b/docs/01-user-guide/how-to/use-digital-signage.md
@@ -13,5 +13,5 @@ requiring a phone or computer.
 
 Which rooms, calendars, and modes the signage page shows can be pre-configured via URL query
 parameters. Generate one from
-**Admin → Export → Generate Signage URL**, pick the filters you want baked in, and use the
+**Admin → Signage**, pick the filters you want baked in, and use the
 resulting link on whatever device drives the display board.

--- a/docs/01-user-guide/reference/quick-reference-card.md
+++ b/docs/01-user-guide/reference/quick-reference-card.md
@@ -32,6 +32,10 @@
 1. Click meeting → click **⋮** → **"Suspend"** (or **"Reactivate"** if already suspended)
 2. Suspending hides it from the live calendar without deleting it — all data is preserved
 
+**Generate a signage URL** *(Admin → Signage)*
+1. Pick locations, calendars, and modes to include
+2. Copy the generated link into the display board's device
+
 **Export data** *(Admin → Export, Super Admin only)*
 1. "Export Meetings" → full XLSX backup
 2. "Export Lease CSV" → PandaDoc Bulk Send, once per year in early July

--- a/docs/01-user-guide/reference/roles-and-permissions.md
+++ b/docs/01-user-guide/reference/roles-and-permissions.md
@@ -5,8 +5,8 @@ Three roles, each a superset of the one before it.
 | Role | Can do |
 |---|---|
 | **User** (no sign-in and basic users) | View the calendar and `/signage`.|
-| **Admin** | Everything a User can, plus: create, edit, delete, suspend, and resume meetings; retry a failed sync; view the Diagnostics tab. |
-| **Super Admin** | Everything an Admin can, plus: invite/remove admins and change their roles (Users tab); use the Export tab (meetings backup, lease CSV, signage URL generator, lease/export settings). |
+| **Admin** | Everything a User can, plus: create, edit, delete, suspend, and resume meetings; retry a failed sync; view the Diagnostics tab; use the Signage tab (signage URL generator). |
+| **Super Admin** | Everything an Admin can, plus: invite/remove admins and change their roles (Users tab); use the Export tab (meetings backup, lease CSV, lease/export settings). |
 
 ## How you get a role
 

--- a/docs/03-development/project-structure.md
+++ b/docs/03-development/project-structure.md
@@ -62,7 +62,7 @@ app/
 │   ├── atoms/                   # Primitive UI elements, shared across every domain
 │   ├── calendar/                # desktop/, mobile/, shared/ — see Component Hierarchy below
 │   ├── meeting-form/            # New/Edit/View meeting, recurrence, Zoom host field, suspend/resume
-│   ├── admin/                   # AdminShell + diagnostics/, export/, users/, shared/ subfolders
+│   ├── admin/                   # AdminShell + diagnostics/, signage/, users/, export/, shared/ subfolders
 │   ├── docs/                    # Renders the in-app /docs Resources page
 │   ├── navbar/                  # App-wide top nav (desktop + mobile variants)
 │   └── shared/                  # Cross-domain components (Toast/ToastProvider, FilterGroup)
@@ -76,7 +76,7 @@ app/
 | Route | Purpose |
 |---|---|
 | `/` | Home — calendar (Day/Week, responsive mobile layouts) |
-| `/admin` | Admin shell: Diagnostics, Users, Export tabs |
+| `/admin` | Admin shell: Diagnostics, Signage, Users, Export tabs |
 | `/docs` | In-app documentation (Resources page), Pagefind-searchable |
 | `/login` | Sign-in |
 | `/signage` | Read-only kiosk calendar for the physical display board |
@@ -108,8 +108,9 @@ We group components by what they do (domain/feature) rather than how they compos
   `MeetingCountsCard`, `ConflictsCard`/`ConflictList`, `SuspendedCard`, `SyncIssuesCard`,
   `DiagnosticsCardError`) — each card fetches its own `/api/admin/diagnostics/*` endpoint
   independently (see [API Reference §Diagnostics](api-reference.md#diagnostics))
-- `export/` — `ExportTab`, `LeaseConfigModal`, `MeetingExportConfigModal`
+- `signage/` — `SignageTab` (builds a filtered `/signage` URL to hand to the display device)
 - `users/` — `UsersTab`, `InviteUserModal`, `EditRoleModal`, `RemoveUserModal`
+- `export/` — `ExportTab`, `LeaseConfigModal`, `MeetingExportConfigModal`
 - `shared/` — `Card`, `CardHeader` (used across every admin tab)
 
 **`docs/`** — `DocsShell`, `DocsArticle`, `DocsTocList`, `DocsIcons` — renders `/docs` from this

--- a/frontend/app/components/admin/AdminShell.tsx
+++ b/frontend/app/components/admin/AdminShell.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useState } from "react";
 import type { Role } from "@prisma/client";
 import LockIcon from "@mui/icons-material/Lock";
 import DiagnosticsTab from "./diagnostics/DiagnosticsTab";
+import SignageTab from "./signage/SignageTab";
 import UsersTab from "./users/UsersTab";
 import ExportTab from "./export/ExportTab";
 import { useViewport } from "../../../hooks/useViewport";
@@ -15,10 +16,11 @@ interface AdminShellProps {
   email: string;
 }
 
-type TabKey = "diagnostics" | "users" | "export";
+type TabKey = "diagnostics" | "signage" | "users" | "export";
 
 const allTabs: { key: TabKey; label: string; superAdminOnly: boolean }[] = [
   { key: "diagnostics", label: "Diagnostics", superAdminOnly: false },
+  { key: "signage", label: "Signage", superAdminOnly: false },
   { key: "users", label: "Users", superAdminOnly: true },
   { key: "export", label: "Export", superAdminOnly: true },
 ];
@@ -79,6 +81,7 @@ const AdminShell: React.FC<AdminShellProps> = ({ role, email }) => {
       </div>
       <div className={styles.tabContent}>
         {effectiveTab === "diagnostics" && <DiagnosticsTab email={email} role={role} />}
+        {effectiveTab === "signage" && <SignageTab />}
         {effectiveTab === "users" && isSuperAdmin && <UsersTab />}
         {effectiveTab === "export" && isSuperAdmin && <ExportTab />}
       </div>

--- a/frontend/app/components/admin/export/ExportTab.tsx
+++ b/frontend/app/components/admin/export/ExportTab.tsx
@@ -1,20 +1,11 @@
 "use client";
 
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useState } from "react";
 import BackupIcon from "@mui/icons-material/Backup";
 import DescriptionIcon from "@mui/icons-material/Description";
-import TvIcon from "@mui/icons-material/Tv";
-import {
-  SIGNAGE_CAL_TYPES,
-  SIGNAGE_MODE_TYPES,
-  SIGNAGE_ROOM_SLUGS,
-  SIGNAGE_ZOOM_SLUGS,
-} from "../../../../util/filters/signageFilters";
-import { ROOM_COLORS, ZOOM_ROOM_COLOR, CATEGORY_COLOR } from "../../../../util/rooms/filterColors";
 import type { ILeaseSettings } from "../../../../types/models";
 import { ALL_MEETING_EXPORT_FIELD_KEYS, type MeetingExportFieldKey } from "../../../../util/meetings/meetingExportFields";
 import type { LeaseYearCycle } from "../../../../util/lease/leaseYearCycles";
-import FilterGroup, { FilterGroupItem } from "../../shared/FilterGroup";
 import Card from "../shared/Card";
 import CardHeader from "../shared/CardHeader";
 import MeetingExportConfigModal from "./MeetingExportConfigModal";
@@ -23,33 +14,6 @@ import { useToast } from "../../shared/ToastProvider";
 import styles from "../../../../styles/components/admin/ExportTab.module.scss";
 
 type ExportKind = "meetings" | "lease";
-
-const LOCATION_ROOMS = Object.keys(SIGNAGE_ROOM_SLUGS);
-const ZOOM_ROOMS = Object.keys(SIGNAGE_ZOOM_SLUGS);
-
-const LOCATION_ITEMS: FilterGroupItem[] = LOCATION_ROOMS.map((name) => ({
-  key: name,
-  label: name,
-  color: ROOM_COLORS[name],
-}));
-const ZOOM_ITEMS: FilterGroupItem[] = ZOOM_ROOMS.map((name) => ({
-  key: name,
-  label: name,
-  color: ZOOM_ROOM_COLOR,
-}));
-const CAL_TYPE_ITEMS: FilterGroupItem[] = SIGNAGE_CAL_TYPES.map((name) => ({
-  key: name,
-  label: name,
-  color: CATEGORY_COLOR,
-}));
-const MODE_ITEMS: FilterGroupItem[] = SIGNAGE_MODE_TYPES.map((name) => ({
-  key: name,
-  label: name,
-  color: CATEGORY_COLOR,
-}));
-
-const allChecked = (names: string[]): Record<string, boolean> =>
-  Object.fromEntries(names.map((name) => [name, true]));
 
 const todayISO = () =>
   new Intl.DateTimeFormat("en-CA", { timeZone: "America/New_York" }).format(new Date());
@@ -77,112 +41,6 @@ async function downloadExport(url: string, fallbackFilename: string) {
   document.body.removeChild(link);
   URL.revokeObjectURL(blobUrl);
 }
-
-const SignageUrlCard: React.FC = () => {
-  const [checkedRooms, setCheckedRooms] = useState<Record<string, boolean>>(() =>
-    allChecked([...LOCATION_ROOMS, ...ZOOM_ROOMS]));
-  const [checkedTypes, setCheckedTypes] = useState<Record<string, boolean>>(() => allChecked(SIGNAGE_CAL_TYPES));
-  const [checkedModes, setCheckedModes] = useState<Record<string, boolean>>(() => allChecked(SIGNAGE_MODE_TYPES));
-  const [view, setView] = useState<"day" | "week">("day");
-  const [origin, setOrigin] = useState("");
-  const [copied, setCopied] = useState(false);
-
-  // Effect (not a lazy useState initializer) deliberately: this component is SSR'd, where
-  // `window` doesn't exist, so origin must resolve post-hydration to avoid a mismatch.
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    setOrigin(window.location.origin);
-  }, []);
-
-  const { generatedUrl, isFullyOpen } = useMemo(() => {
-    const buildParam = (
-      allNames: string[],
-      checked: Record<string, boolean>,
-      slugs: Record<string, string> = {},
-    ): string | null => {
-      const on = allNames.filter((name) => checked[name]);
-      if (on.length === allNames.length) return null;
-      return on.map((name) => slugs[name] ?? name).join(",");
-    };
-
-    const roomsParam = buildParam(LOCATION_ROOMS, checkedRooms, SIGNAGE_ROOM_SLUGS);
-    const zoomParam = buildParam(ZOOM_ROOMS, checkedRooms, SIGNAGE_ZOOM_SLUGS);
-    const typesParam = buildParam(SIGNAGE_CAL_TYPES, checkedTypes);
-    const modesParam = buildParam(SIGNAGE_MODE_TYPES, checkedModes);
-
-    const params = new URLSearchParams();
-    if (roomsParam !== null) params.set("rooms", roomsParam);
-    if (zoomParam !== null) params.set("zoom", zoomParam);
-    if (typesParam !== null) params.set("types", typesParam);
-    if (modesParam !== null) params.set("modes", modesParam);
-    params.set("view", view);
-
-    return {
-      generatedUrl: `${origin}/signage?${params.toString()}`,
-      isFullyOpen: roomsParam === null && zoomParam === null && typesParam === null && modesParam === null,
-    };
-  }, [checkedRooms, checkedTypes, checkedModes, view, origin]);
-
-  const handleCopy = async () => {
-    try {
-      await navigator.clipboard.writeText(generatedUrl);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 1800);
-    } catch (err) {
-      console.error("Error copying signage link:", err);
-    }
-  };
-
-  const toggleRoom = (key: string, value: boolean) => setCheckedRooms((prev) => ({ ...prev, [key]: value }));
-  const toggleType = (key: string, value: boolean) => setCheckedTypes((prev) => ({ ...prev, [key]: value }));
-  const toggleMode = (key: string, value: boolean) => setCheckedModes((prev) => ({ ...prev, [key]: value }));
-
-  return (
-    <Card>
-      <CardHeader icon={<TvIcon />} title="Generate Signage URL" />
-      <div className={styles.cardDesc}>
-        Build a filtered link for digital signage display. Pick which locations, calendars, and
-        meeting modes it should show, then copy the link into the signage device.
-      </div>
-
-      <div className={styles.filterGrid}>
-        <FilterGroup title="LOCATION" items={LOCATION_ITEMS} checked={checkedRooms} onToggle={toggleRoom} />
-        <FilterGroup title="ZOOM ROOMS" items={ZOOM_ITEMS} checked={checkedRooms} onToggle={toggleRoom} />
-        <FilterGroup title="CALENDAR" items={CAL_TYPE_ITEMS} checked={checkedTypes} onToggle={toggleType} />
-        <FilterGroup title="MODE" items={MODE_ITEMS} checked={checkedModes} onToggle={toggleMode} />
-      </div>
-
-      <div className={styles.sectionLabel}>Display view</div>
-      <div className={styles.viewToggle}>
-        <button
-          className={`${styles.viewButton} ${view === "day" ? styles.viewButtonActive : ""}`}
-          onClick={() => setView("day")}
-        >
-          Daily
-        </button>
-        <button
-          className={`${styles.viewButton} ${view === "week" ? styles.viewButtonActive : ""}`}
-          onClick={() => setView("week")}
-        >
-          Weekly
-        </button>
-      </div>
-
-      <div className={styles.sectionLabel}>Generated link</div>
-      <div className={styles.linkRow}>
-        <input readOnly className={styles.linkField} value={generatedUrl} onFocus={(e) => e.target.select()} />
-        <button className={styles.copyButton} onClick={handleCopy}>
-          {copied ? "Copied ✓" : "Copy Link"}
-        </button>
-      </div>
-      <div className={styles.linkCaption}>
-        {isFullyOpen
-          ? "Everything is checked, so this link shows all locations, calendars, and modes — the same as leaving filters off."
-          : "Only the checked locations, calendars, and modes will show on this link."}
-      </div>
-    </Card>
-  );
-};
 
 const ExportTab: React.FC = () => {
   const { showToast } = useToast();
@@ -397,8 +255,6 @@ const ExportTab: React.FC = () => {
           </div>
         </Card>
       </div>
-
-      <SignageUrlCard />
 
       {configOpen && leaseSettings && (
         <LeaseConfigModal

--- a/frontend/app/components/admin/signage/SignageTab.tsx
+++ b/frontend/app/components/admin/signage/SignageTab.tsx
@@ -1,0 +1,152 @@
+"use client";
+
+import React, { useEffect, useMemo, useState } from "react";
+import TvIcon from "@mui/icons-material/Tv";
+import {
+  SIGNAGE_CAL_TYPES,
+  SIGNAGE_MODE_TYPES,
+  SIGNAGE_ROOM_SLUGS,
+  SIGNAGE_ZOOM_SLUGS,
+} from "../../../../util/filters/signageFilters";
+import { ROOM_COLORS, ZOOM_ROOM_COLOR, CATEGORY_COLOR } from "../../../../util/rooms/filterColors";
+import FilterGroup, { FilterGroupItem } from "../../shared/FilterGroup";
+import Card from "../shared/Card";
+import CardHeader from "../shared/CardHeader";
+import styles from "../../../../styles/components/admin/SignageTab.module.scss";
+
+const LOCATION_ROOMS = Object.keys(SIGNAGE_ROOM_SLUGS);
+const ZOOM_ROOMS = Object.keys(SIGNAGE_ZOOM_SLUGS);
+
+const LOCATION_ITEMS: FilterGroupItem[] = LOCATION_ROOMS.map((name) => ({
+  key: name,
+  label: name,
+  color: ROOM_COLORS[name],
+}));
+const ZOOM_ITEMS: FilterGroupItem[] = ZOOM_ROOMS.map((name) => ({
+  key: name,
+  label: name,
+  color: ZOOM_ROOM_COLOR,
+}));
+const CAL_TYPE_ITEMS: FilterGroupItem[] = SIGNAGE_CAL_TYPES.map((name) => ({
+  key: name,
+  label: name,
+  color: CATEGORY_COLOR,
+}));
+const MODE_ITEMS: FilterGroupItem[] = SIGNAGE_MODE_TYPES.map((name) => ({
+  key: name,
+  label: name,
+  color: CATEGORY_COLOR,
+}));
+
+const allChecked = (names: string[]): Record<string, boolean> =>
+  Object.fromEntries(names.map((name) => [name, true]));
+
+const SignageTab: React.FC = () => {
+  const [checkedRooms, setCheckedRooms] = useState<Record<string, boolean>>(() =>
+    allChecked([...LOCATION_ROOMS, ...ZOOM_ROOMS]));
+  const [checkedTypes, setCheckedTypes] = useState<Record<string, boolean>>(() => allChecked(SIGNAGE_CAL_TYPES));
+  const [checkedModes, setCheckedModes] = useState<Record<string, boolean>>(() => allChecked(SIGNAGE_MODE_TYPES));
+  const [view, setView] = useState<"day" | "week">("day");
+  const [origin, setOrigin] = useState("");
+  const [copied, setCopied] = useState(false);
+
+  // Effect (not a lazy useState initializer) deliberately: this component is SSR'd, where
+  // `window` doesn't exist, so origin must resolve post-hydration to avoid a mismatch.
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setOrigin(window.location.origin);
+  }, []);
+
+  const { generatedUrl, isFullyOpen } = useMemo(() => {
+    const buildParam = (
+      allNames: string[],
+      checked: Record<string, boolean>,
+      slugs: Record<string, string> = {},
+    ): string | null => {
+      const on = allNames.filter((name) => checked[name]);
+      if (on.length === allNames.length) return null;
+      return on.map((name) => slugs[name] ?? name).join(",");
+    };
+
+    const roomsParam = buildParam(LOCATION_ROOMS, checkedRooms, SIGNAGE_ROOM_SLUGS);
+    const zoomParam = buildParam(ZOOM_ROOMS, checkedRooms, SIGNAGE_ZOOM_SLUGS);
+    const typesParam = buildParam(SIGNAGE_CAL_TYPES, checkedTypes);
+    const modesParam = buildParam(SIGNAGE_MODE_TYPES, checkedModes);
+
+    const params = new URLSearchParams();
+    if (roomsParam !== null) params.set("rooms", roomsParam);
+    if (zoomParam !== null) params.set("zoom", zoomParam);
+    if (typesParam !== null) params.set("types", typesParam);
+    if (modesParam !== null) params.set("modes", modesParam);
+    params.set("view", view);
+
+    return {
+      generatedUrl: `${origin}/signage?${params.toString()}`,
+      isFullyOpen: roomsParam === null && zoomParam === null && typesParam === null && modesParam === null,
+    };
+  }, [checkedRooms, checkedTypes, checkedModes, view, origin]);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(generatedUrl);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1800);
+    } catch (err) {
+      console.error("Error copying signage link:", err);
+    }
+  };
+
+  const toggleRoom = (key: string, value: boolean) => setCheckedRooms((prev) => ({ ...prev, [key]: value }));
+  const toggleType = (key: string, value: boolean) => setCheckedTypes((prev) => ({ ...prev, [key]: value }));
+  const toggleMode = (key: string, value: boolean) => setCheckedModes((prev) => ({ ...prev, [key]: value }));
+
+  return (
+    <div className={styles.container}>
+      <Card>
+        <CardHeader icon={<TvIcon />} title="Generate Signage URL" />
+        <div className={styles.cardDesc}>
+          Build a filtered link for digital signage display. Pick which locations, calendars, and
+          meeting modes it should show, then copy the link into the signage device.
+        </div>
+
+        <div className={styles.filterGrid}>
+          <FilterGroup title="LOCATION" items={LOCATION_ITEMS} checked={checkedRooms} onToggle={toggleRoom} />
+          <FilterGroup title="ZOOM ROOMS" items={ZOOM_ITEMS} checked={checkedRooms} onToggle={toggleRoom} />
+          <FilterGroup title="CALENDAR" items={CAL_TYPE_ITEMS} checked={checkedTypes} onToggle={toggleType} />
+          <FilterGroup title="MODE" items={MODE_ITEMS} checked={checkedModes} onToggle={toggleMode} />
+        </div>
+
+        <div className={styles.sectionLabel}>Display view</div>
+        <div className={styles.viewToggle}>
+          <button
+            className={`${styles.viewButton} ${view === "day" ? styles.viewButtonActive : ""}`}
+            onClick={() => setView("day")}
+          >
+            Daily
+          </button>
+          <button
+            className={`${styles.viewButton} ${view === "week" ? styles.viewButtonActive : ""}`}
+            onClick={() => setView("week")}
+          >
+            Weekly
+          </button>
+        </div>
+
+        <div className={styles.sectionLabel}>Generated link</div>
+        <div className={styles.linkRow}>
+          <input readOnly className={styles.linkField} value={generatedUrl} onFocus={(e) => e.target.select()} />
+          <button className={styles.copyButton} onClick={handleCopy}>
+            {copied ? "Copied ✓" : "Copy Link"}
+          </button>
+        </div>
+        <div className={styles.linkCaption}>
+          {isFullyOpen
+            ? "Everything is checked, so this link shows all locations, calendars, and modes — the same as leaving filters off."
+            : "Only the checked locations, calendars, and modes will show on this link."}
+        </div>
+      </Card>
+    </div>
+  );
+};
+
+export default SignageTab;

--- a/frontend/styles/components/admin/ExportTab.module.scss
+++ b/frontend/styles/components/admin/ExportTab.module.scss
@@ -512,94 +512,9 @@
   }
 }
 
-// Generate Signage URL card
-
-.filterGrid {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 20px 40px;
-  margin-bottom: 20px;
-
-  @media (width <= 560px) {
-    grid-template-columns: 1fr;
-  }
-}
-
-// Spacing between two caption-variant FilterGroups stacked in one .filterGrid column --
+// Spacing between two caption-variant FilterGroups stacked in one filter-grid column --
 // FilterGroup's own .groupSpaced margin is tied to the bigger "title" heading variant, which
 // we don't want here.
 .stackedGroup {
   margin-top: 20px;
-}
-
-.viewToggle {
-  display: inline-flex;
-  gap: 8px;
-  margin-bottom: 20px;
-}
-
-.viewButton {
-  background: #fff;
-  border: 1.5px solid #E5E5E5;
-  border-radius: 8px;
-  color: $black-color;
-  font-family: inherit;
-  font-size: 14px;
-  padding: 8px 18px;
-  cursor: pointer;
-}
-
-.viewButtonActive {
-  background: $brand-pink-color;
-  border-color: $brand-pink-color;
-  color: #fff;
-  font-weight: 600;
-}
-
-.linkRow {
-  display: flex;
-  gap: 12px;
-  margin-bottom: 8px;
-
-  @media (width <= $breakpoint-phone) {
-    flex-direction: column;
-  }
-}
-
-.linkField {
-  flex: 1;
-
-  // Without this, a flex item's default min-width: auto refuses to shrink below its content's
-  // intrinsic width -- a long signage URL would push .linkField (and the row) wider than the
-  // card instead of actually using the flex: 1 space it's been given.
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  font-family: monospace;
-  font-size: 13px;
-  color: $black-color;
-  background: $grey-lightest-color;
-  border: 1.5px solid #E5E5E5;
-  border-radius: 6px;
-  padding: 8px 12px;
-  box-sizing: border-box;
-}
-
-.copyButton {
-  background: $brand-pink-color;
-  color: #fff;
-  border: none;
-  border-radius: 8px;
-  padding: 8px 20px;
-  font-family: inherit;
-  font-size: 14px;
-  font-weight: 600;
-  cursor: pointer;
-  white-space: nowrap;
-}
-
-.linkCaption {
-  font-size: 13px;
-  color: $medium-grey-color;
 }

--- a/frontend/styles/components/admin/SignageTab.module.scss
+++ b/frontend/styles/components/admin/SignageTab.module.scss
@@ -1,0 +1,111 @@
+@import '../../Variables.module.scss';
+
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.cardDesc {
+  font-size: 14px;
+  color: #555;
+  margin-bottom: 14px;
+}
+
+.sectionLabel {
+  font-size: 16px;
+  font-weight: 600;
+  color: $medium-grey-color;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+  margin: 20px 0 12px;
+
+  &:first-of-type {
+    margin-top: 0;
+  }
+}
+
+.filterGrid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 20px 40px;
+  margin-bottom: 20px;
+
+  @media (width <= 560px) {
+    grid-template-columns: 1fr;
+  }
+}
+
+.viewToggle {
+  display: inline-flex;
+  gap: 8px;
+  margin-bottom: 20px;
+}
+
+.viewButton {
+  background: #fff;
+  border: 1.5px solid #E5E5E5;
+  border-radius: 8px;
+  color: $black-color;
+  font-family: inherit;
+  font-size: 14px;
+  padding: 8px 18px;
+  cursor: pointer;
+}
+
+.viewButtonActive {
+  background: $brand-pink-color;
+  border-color: $brand-pink-color;
+  color: #fff;
+  font-weight: 600;
+}
+
+.linkRow {
+  display: flex;
+  gap: 12px;
+  margin-bottom: 8px;
+
+  @media (width <= $breakpoint-phone) {
+    flex-direction: column;
+  }
+}
+
+.linkField {
+  flex: 1;
+
+  // Without this, a flex item's default min-width: auto refuses to shrink below its content's
+  // intrinsic width -- a long signage URL would push .linkField (and the row) wider than the
+  // card instead of actually using the flex: 1 space it's been given.
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: monospace;
+  font-size: 13px;
+  color: $black-color;
+  background: $grey-lightest-color;
+  border: 1.5px solid #E5E5E5;
+  border-radius: 6px;
+  padding: 8px 12px;
+  box-sizing: border-box;
+}
+
+.copyButton {
+  background: $brand-pink-color;
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  padding: 8px 20px;
+  font-family: inherit;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.linkCaption {
+  font-size: 13px;
+  color: $medium-grey-color;
+}

--- a/frontend/tests/e2e/01-authentication.spec.ts
+++ b/frontend/tests/e2e/01-authentication.spec.ts
@@ -160,10 +160,11 @@ test("1.7 Sign Out clears the session and reverts to the signed-out view", async
   await expect(page.getByRole("link", { name: "Sign In" })).toBeVisible();
 });
 
-test("1.8 ADMIN (non-super) sees Diagnostics unlocked but Users/Export locked", async ({ adminPage }) => {
+test("1.8 ADMIN (non-super) sees Diagnostics/Signage unlocked but Users/Export locked", async ({ adminPage }) => {
   const { page } = adminPage;
   await page.goto("/admin");
   await expect(page.getByTestId("admin-tab-diagnostics")).toBeEnabled();
+  await expect(page.getByTestId("admin-tab-signage")).toBeEnabled();
   await expect(page.getByTestId("admin-tab-users")).toBeDisabled();
   await expect(page.getByTestId("admin-tab-export")).toBeDisabled();
   // Tooltip text is CSS hover-only (visible on :hover/:focus-within) — assert it's
@@ -171,10 +172,10 @@ test("1.8 ADMIN (non-super) sees Diagnostics unlocked but Users/Export locked", 
   await expect(page.getByText("Requires super admin").first()).toBeAttached();
 });
 
-test("1.9 SUPER_ADMIN sees all three admin tabs unlocked", async ({ superAdminPage }) => {
+test("1.9 SUPER_ADMIN sees all four admin tabs unlocked", async ({ superAdminPage }) => {
   const { page } = superAdminPage;
   await page.goto("/admin");
-  for (const key of ["diagnostics", "users", "export"]) {
+  for (const key of ["diagnostics", "signage", "users", "export"]) {
     await expect(page.getByTestId(`admin-tab-${key}`)).toBeEnabled();
   }
 });

--- a/frontend/tests/e2e/11-admin-panel.spec.ts
+++ b/frontend/tests/e2e/11-admin-panel.spec.ts
@@ -7,10 +7,10 @@ import { Role } from "@prisma/client";
 // Manual script §11 (Admin Panel — Roles & Tabs).
 
 test.describe("admin panel", () => {
-  test("11.2 SUPER_ADMIN sees all three tabs accessible", async ({ superAdminPage }) => {
+  test("11.2 SUPER_ADMIN sees all four tabs accessible", async ({ superAdminPage }) => {
     const { page } = superAdminPage;
     await page.goto("/admin");
-    for (const key of ["diagnostics", "users", "export"]) {
+    for (const key of ["diagnostics", "signage", "users", "export"]) {
       await expect(page.getByTestId(`admin-tab-${key}`)).toBeEnabled();
     }
     await expect(page.getByTestId("admin-tab-import")).toHaveCount(0);
@@ -95,6 +95,14 @@ test.describe("admin panel", () => {
 
     await page.getByRole("button", { name: "Edit Role" }).click();
     await expect(page.getByText("Can't change the last Super Admin's role.")).toBeVisible();
+  });
+
+  test("11.8b the Signage tab shows the signage URL generator, unlocked for a non-super Admin", async ({ adminPage }) => {
+    const { page } = adminPage;
+    await page.goto("/admin");
+    await page.getByTestId("admin-tab-signage").click();
+    await expect(page.getByText("Generate Signage URL")).toBeVisible();
+    await expect(page.getByRole("button", { name: "Copy Link" })).toBeVisible();
   });
 
   test("11.9 exporting meetings downloads a real file", async ({ superAdminPage }) => {

--- a/frontend/util/rooms/filterColors.ts
+++ b/frontend/util/rooms/filterColors.ts
@@ -1,6 +1,6 @@
 // Shared physical-room / zoom-room / category color coding used by both the calendar
-// sidebar filter (MeetingsFilter) and the Export tab's signage filter (SignageUrlCard) —
-// keyed by the same full room names used in util/signageFilters.ts, so a color change
+// sidebar filter (MeetingsFilter) and the Signage tab's URL-generator filter (SignageTab) —
+// keyed by the same full room names used in util/filters/signageFilters.ts, so a color change
 // only has to happen in one place. Mirrored (manually -- Sass vars aren't importable into
 // TS) in styles/Variables.module.scss's $room-*-color variables, for any SCSS that needs
 // to reference the same palette directly.


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated Admin → Signage tab for creating shareable display URLs.
  * Configure locations, rooms, calendar types, meeting modes, and day/week views.
  * Copy generated signage links directly from the admin interface.

* **Changes**
  * Signage URL generation moved from Admin → Export to Admin → Signage.
  * Updated role access and quick-reference guidance for the new workflow.

* **Tests**
  * Expanded coverage for signage access, permissions, URL generation, and link copying.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description
- **frontend/app/components/admin/signage/SignageTab.tsx** (new): the signage-URL generator, extracted verbatim from `ExportTab`'s embedded `SignageUrlCard` into its own tab component.
- **frontend/styles/components/admin/SignageTab.module.scss** (new): signage-only style classes moved out of `ExportTab.module.scss`.
- **frontend/app/components/admin/export/ExportTab.tsx**: `SignageUrlCard` and its signage-specific imports/constants removed; Export tab now only covers the two export cards.
- **frontend/styles/components/admin/ExportTab.module.scss**: signage-only classes removed; `.cardDesc`/`.sectionLabel`/`.stackedGroup` kept since they're still shared with `LeaseConfigModal`/`MeetingExportConfigModal`.
- **frontend/app/components/admin/AdminShell.tsx**: adds a `signage` tab gated `superAdminOnly: false` (Admin-level, like Diagnostics — not Super-Admin-only like the Export tab it came from). New tab order: Diagnostics → Signage → Users → Export.
- **frontend/util/rooms/filterColors.ts**: fixed a stale comment referencing the removed `SignageUrlCard` and the wrong `signageFilters.ts` path.
- **tests/e2e/01-authentication.spec.ts, tests/e2e/11-admin-panel.spec.ts**: updated tab-list assertions for the new 4-tab layout and Admin-level Signage gating; added a new test asserting the Signage tab renders its URL generator for a non-super Admin.
- **docs/**: updated `use-digital-signage.md`, `export-data.md`, `quick-reference-card.md`, `roles-and-permissions.md`, `project-structure.md` to reflect the new tab location/gating.

## Testing
- [x] `yarn lint` — 0 errors (pre-existing warnings only, unrelated to this change)
- [x] `yarn lint:css` — clean
- [x] `yarn tsc --noEmit` — clean
- [x] `yarn test:all` — all green: 132 unit, 79 component, 71 integration, 94 e2e (includes the new/updated Signage tab tests)
- [x] Searched test suites for stale wording tied to the old Export-tab-embedded signage behavior (`SignageUrlCard`, "Generate Signage URL" under Export, "all three tabs") — none found outside the files updated in this PR.

## Area(s) Touched
**Product areas**
- [x] admin — /admin shell (Diagnostics, Users, Import, Export tabs)
- [x] docs — /docs Resources page (rendering, navigation, search)
- [x] ui/ux — frontend layout/styling not tied to a specific integration

**Integrations**

**Engineering**
- [x] testing — test suite (Jest/Playwright) changes
- [x] cleanup — refactor or dead-code removal, no behavior change

## Pre-merge Checklist
- [x] Code follows current formatting conventions and passes lint (`yarn lint`).
- [x] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
- [x] All test suites pass, both run locally and green in GitHub CI. **Do not merge if any test suite is failing.**
- [x] A test suite was added or updated for the feature/fix in this PR. **Double-check this if you change a feature and did not update the test suites**.
- [x] Only files relevant to this change are committed — no stray or unrelated files.
- [x] If this branch has a merge conflict with master, master was merged into this branch first (not the other way around).
- [x] The rest of this PR description (Description, Testing) is filled out, not left as template placeholders.