### PR TITLE
docs(development): add a CI/CD workflows reference

### DIFF
--- a/docs/01-user-guide/how-to/export-data.md
+++ b/docs/01-user-guide/how-to/export-data.md
@@ -40,9 +40,8 @@ Each meeting's "Rent Charge" in the CSV depends on its room's configured rate/un
 meeting itself is set up:
 
 - **A `/hr`-rate room:** `4 × the meeting's own hours × the hourly rate`. E.g. a 1-hour meeting in
-  a $15/hr room charges $60/month. The `4` is a flat, deliberately round weeks-per-month — it's
-  not recalculated per month, so the charge stays the same $60 every month regardless of how many
-  times that specific weekday actually falls in a given month.
+  a $15/hr room charges $60/month. The `4` is a flat, not recalculated per month,
+  so the charge stays the same $60 every month.
 - **A `/month`-rate room:** just that flat monthly rate, regardless of the meeting's actual
   duration.
 - **Remote meetings (no physical room):** billed at the flat rate configured for the "Zoom Only"

--- a/docs/01-user-guide/how-to/export-data.md
+++ b/docs/01-user-guide/how-to/export-data.md
@@ -40,7 +40,7 @@ Each meeting's "Rent Charge" in the CSV depends on its room's configured rate/un
 meeting itself is set up:
 
 - **A `/hr`-rate room:** `4 × the meeting's own hours × the hourly rate`. E.g. a 1-hour meeting in
-  a $15/hr room charges $60/month. The `4` is a flat, not recalculated per month,
+  a $15/hr room charges $60/month. The `4` is a fixed multiplier, not recalculated per month,
   so the charge stays the same $60 every month.
 - **A `/month`-rate room:** just that flat monthly rate, regardless of the meeting's actual
   duration.

--- a/docs/03-development/README.md
+++ b/docs/03-development/README.md
@@ -18,6 +18,9 @@ For developers (current or future H4I teams) writing code against this app. Orga
 - **How does testing work? How do I run the suite?** [Testing](testing/README.md).
   Before a release, see [Manual Test Script](testing/manual-test-script-template.md)
   for what automation can't cover.
+- **What runs automatically on a push/PR? How do dependency bumps, release versioning, and
+  labeling work?** [CI/CD](ci-cd.md) — every GitHub Actions workflow in the repo, and how they
+  fit together.
 
 > [!NOTE]
 > Adding a new page under `docs/`? It also needs an entry in the hand-curated `MANIFEST` array in

--- a/docs/03-development/ci-cd.md
+++ b/docs/03-development/ci-cd.md
@@ -1,0 +1,118 @@
+# CI/CD
+
+What runs automatically in this repo, and why. For the actual test *tiers* (what `unit`/
+`component`/`integration`/`e2e` each cover), see [Testing](testing/README.md) — this doc is about
+the GitHub Actions workflows themselves and how they fit together. For the human side (review,
+merge, deploy, rollback), see
+[Deployment and Rollback](../02-handoff/deployment-and-rollback.md).
+
+All workflows live in [`.github/workflows/`](https://github.com/cornellh4i/ithaca-recovery/tree/master/.github/workflows).
+
+> [!NOTE]
+> There's no separate "CD" workflow in this repo. Deploys are Vercel's own git integration
+> reacting to a push to `master` — not a GitHub Actions job. See
+> [Deployment and Rollback §2](../02-handoff/deployment-and-rollback.md#2-deploy-to-production).
+
+## Test suite — `test.yml`
+
+Runs on every push/PR to `main`/`master` as separate jobs (`doc-freshness`, `lint`, `unit`,
+`component`, `integration`, `e2e`), so a slow or flaky e2e run doesn't hold up the fast unit-test
+signal. Full breakdown of what each job actually tests: [Testing §CI](testing/README.md#ci).
+
+`CHECKPOINT_DISABLE: "1"` is set repo-wide in this workflow's `env` — Prisma CLI otherwise pings
+`checkpoint.prisma.io` after every command and can hang a job if that ping stalls.
+
+## Commit and PR title linting — `commitlint.yml`, `pr-title-lint.yml`
+
+Both enforce [Conventional Commits](https://www.conventionalcommits.org/) formatting
+(`type(scope): subject`, e.g. `fix(calendar): position the current-time line in ET`) — rules
+configured in `frontend/config/commitlint.config.mjs` (extends
+`@commitlint/config-conventional`).
+
+- `commitlint.yml` lints every commit on a PR individually
+  (`commitlint --from <base sha> --to <head sha>`), so a non-conventional commit fails even if
+  it's later squashed into a conventional PR title.
+- `pr-title-lint.yml` lints the PR title itself, using
+  [`amannn/action-semantic-pull-request`](https://github.com/amannn/action-semantic-pull-request).
+  This matters beyond style: a squash-merge inherits the PR title as the merge commit's message,
+  so a non-conventional title still lands in `master`'s history even when every individual commit
+  was compliant.
+
+## Automated code review — CodeRabbit
+
+Not a GitHub Actions workflow — a separate GitHub App, configured via
+[`.coderabbit.yaml`](https://github.com/cornellh4i/ithaca-recovery/blob/master/.coderabbit.yaml)
+at the repo root. Auto-reviews every PR with inline comments and a summary, except PRs opened by
+`dependabot[bot]` (already gated by CI + the auto-merge policy below — a review there is just
+noise). It also suggests a Conventional-Commits-compliant title on open, mirroring the same rules
+`commitlint.yml`/`pr-title-lint.yml` enforce.
+
+> [!NOTE]
+> Auto-review only fires for PRs based on the repo's default branch. A PR stacked on top of
+> another PR (base branch isn't `master`) needs a manual `@coderabbitai review` comment on that PR
+> to trigger one.
+
+## Security scanning — `codeql.yml`
+
+[CodeQL](https://codeql.github.com/) static analysis on every push/PR to `main`/`master`, plus a
+weekly scheduled run (Sundays 01:30 UTC) to catch anything a new advisory flags in code that
+hasn't changed recently. Currently scans `javascript-typescript` only. Findings post to the repo's
+**Security → Code scanning alerts** tab, not as PR check failures.
+
+## Dependency updates — `dependabot.yml`, `dependabot-auto-merge.yml`
+
+[`dependabot.yml`](https://github.com/cornellh4i/ithaca-recovery/blob/master/.github/dependabot.yml)
+opens weekly update PRs for two ecosystems, grouped differently on purpose:
+
+- **`frontend/` npm packages** — patch and minor bumps are grouped into one `safe-updates` PR;
+  major bumps stay individual. `dependabot-auto-merge.yml` watches for the `safe-updates` group
+  specifically and runs `gh pr merge --auto --squash` on it — that still waits on every required
+  status check (§Branch protection below), it just removes the need for a human to click merge on
+  routine bumps.
+- **GitHub Actions versions** (`.github/workflows/*`) — never auto-merged, regardless of semver
+  level. Action version bumps don't reliably follow semver for breaking changes (an
+  `actions/checkout` major once broke fork-PR checkout under `pull_request_target` despite looking
+  like a routine bump), so every one of these gets a human read of the diff.
+
+## Scheduled maintenance bots — `calver-bump.yml`, `bump-node-version.yml`
+
+Both run on the same monthly schedule (1st of the month, 09:00 UTC) plus `workflow_dispatch` for a
+manual run, and both open a PR rather than pushing directly:
+
+- **`calver-bump.yml`** — bumps `frontend/package.json`'s CalVer version (`YYYY.M.0`) when the
+  year/month has changed since the last recorded version. Patch resets to `0` at the start of each
+  month; a same-month re-release needs a manual patch bump.
+- **`bump-node-version.yml`** — checks Node's current Active LTS against the version pinned in
+  `frontend/.nvmrc`, and if it's moved on, updates `.nvmrc`, `package.json`'s `engines.node`, and
+  `test.yml`'s `node-version` together in one PR. The PR body is a deliberate reminder to confirm
+  [Vercel's supported Node.js runtime versions](https://vercel.com/docs/functions/runtimes/node-js/node-js-versions)
+  include the new major before merging — Vercel has lagged behind a fresh LTS release before.
+
+## Labels — `label-from-checklist.yml`, `sync-labels.yml`
+
+- **`label-from-checklist.yml`** — re-derives a PR/issue's `scope:`/`type:`/`priority:` labels
+  from whichever checkboxes are checked in its body, every time the body is edited (not just on
+  open), so unchecking a box removes the label too. Only ever touches the labels it manages —
+  never `status:`, `good first issue`, or anything applied by hand.
+- **`sync-labels.yml`** — keeps the repo's `type:`/`scope:`/`priority:`/`status:` labels
+  themselves in sync with
+  [`.github/labels.yml`](https://github.com/cornellh4i/ithaca-recovery/blob/master/.github/labels.yml),
+  triggered whenever that file changes on `master` (plus manual `workflow_dispatch`). Runs with
+  `skip-delete: true` since `labels.yml` only owns those prefixed labels, not GitHub's or
+  Dependabot's defaults (`bug`, `enhancement`, `dependencies`, ...).
+
+## Branch protection
+
+`master` requires a passing run of `title-lint`, `commitlint`, `lint`, `unit`, `integration`, and
+`e2e`, plus one approving review, before a PR can merge (repo Admins can bypass this — see
+[Deployment and Rollback §1](../02-handoff/deployment-and-rollback.md#1-review-and-test-before-merge)
+for the human-facing version of this rule). `component`, `doc-freshness`, and `CodeQL` all run on
+every PR but aren't part of that required set yet.
+
+## Where to go next
+
+- [Testing](testing/README.md) — what each test tier actually covers, and what's still manual
+- [Deployment and Rollback](../02-handoff/deployment-and-rollback.md) — the merge → deploy →
+  rollback path once CI is green
+- `frontend/config/commitlint.config.mjs` — the Conventional Commits rules `commitlint.yml`
+  enforces

--- a/docs/03-development/ci-cd.md
+++ b/docs/03-development/ci-cd.md
@@ -15,12 +15,14 @@ All workflows live in [`.github/workflows/`](https://github.com/cornellh4i/ithac
 
 ## Test suite — `test.yml`
 
-Runs on every push/PR to `main`/`master` as separate jobs (`doc-freshness`, `lint`, `unit`,
-`component`, `integration`, `e2e`), so a slow or flaky e2e run doesn't hold up the fast unit-test
-signal. Full breakdown of what each job actually tests: [Testing §CI](testing/README.md#ci).
+Runs on pushes to `main`/`master` and on every pull request (targeting any base branch), as
+separate jobs (`doc-freshness`, `lint`, `unit`, `component`, `integration`, `e2e`), so a slow or
+flaky e2e run doesn't hold up the fast unit-test signal. Full breakdown of what each job actually
+tests: [Testing §CI](testing/README.md#ci).
 
-`CHECKPOINT_DISABLE: "1"` is set repo-wide in this workflow's `env` — Prisma CLI otherwise pings
-`checkpoint.prisma.io` after every command and can hang a job if that ping stalls.
+`CHECKPOINT_DISABLE: "1"` is set at the workflow level in `test.yml`'s `env`, so every job in this
+workflow (not other workflows) skips it — Prisma CLI otherwise pings `checkpoint.prisma.io` after
+every command and can hang a job if that ping stalls.
 
 ## Commit and PR title linting — `commitlint.yml`, `pr-title-lint.yml`
 
@@ -42,21 +44,22 @@ configured in `frontend/config/commitlint.config.mjs` (extends
 
 Not a GitHub Actions workflow — a separate GitHub App, configured via
 [`.coderabbit.yaml`](https://github.com/cornellh4i/ithaca-recovery/blob/master/.coderabbit.yaml)
-at the repo root. Auto-reviews every PR with inline comments and a summary, except PRs opened by
-`dependabot[bot]` (already gated by CI + the auto-merge policy below — a review there is just
-noise). It also suggests a Conventional-Commits-compliant title on open, mirroring the same rules
+at the repo root. Auto-reviews PRs based on the repo's default branch (`master`) with inline
+comments and a summary, except PRs opened by `dependabot[bot]` (already gated by CI + the
+auto-merge policy below — a review there is just noise). It also suggests a
+Conventional-Commits-compliant title on open, mirroring the same rules
 `commitlint.yml`/`pr-title-lint.yml` enforce.
 
 > [!NOTE]
-> Auto-review only fires for PRs based on the repo's default branch. A PR stacked on top of
-> another PR (base branch isn't `master`) needs a manual `@coderabbitai review` comment on that PR
-> to trigger one.
+> A PR stacked on top of another PR (base branch isn't `master`) needs a manual
+> `@coderabbitai review` comment on that PR to trigger one.
 
 ## Security scanning — `codeql.yml`
 
-[CodeQL](https://codeql.github.com/) static analysis on every push/PR to `main`/`master`, plus a
-weekly scheduled run (Sundays 01:30 UTC) to catch anything a new advisory flags in code that
-hasn't changed recently. Currently scans `javascript-typescript` only. Findings post to the repo's
+[CodeQL](https://codeql.github.com/) static analysis on pushes to `main`/`master` and on every
+pull request (targeting any base branch), plus a weekly scheduled run (Sundays 01:30 UTC) to
+catch anything a new advisory flags in code that hasn't changed recently. Currently scans
+`javascript-typescript` only. Findings post to the repo's
 **Security → Code scanning alerts** tab, not as PR check failures.
 
 ## Dependency updates — `dependabot.yml`, `dependabot-auto-merge.yml`

--- a/docs/03-development/testing/README.md
+++ b/docs/03-development/testing/README.md
@@ -119,6 +119,9 @@ required set yet. See [Deployment and Rollback](../../02-handoff/deployment-and-
 for the full picture, including why CI passing and a production deploy happening aren't the same
 guarantee.
 
+`test.yml` is one of several workflows in `.github/workflows/` — commit/PR-title linting,
+CodeQL, dependency-update automation, and more. See [CI/CD](../ci-cd.md) for the full set.
+
 ## What's still manual
 
 `tests/e2e/` only runs Chromium, and none of the automated tiers touch real Zoom/Google

--- a/frontend/build-scripts/generate-docs-content.mjs
+++ b/frontend/build-scripts/generate-docs-content.mjs
@@ -62,6 +62,7 @@ const MANIFEST = [
   { group: "Development", relPath: "03-development/api-reference.md" },
   { group: "Development", relPath: "03-development/environment-variables.md" },
   { group: "Development", relPath: "03-development/integration-guides.md" },
+  { group: "Development", relPath: "03-development/ci-cd.md" },
   { group: "Development", relPath: "03-development/testing/README.md" },
   { group: "Development", relPath: "03-development/testing/manual-test-script-template.md" },
 ];


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive CI/CD guide covering automated testing, reviews, security scanning, dependency updates, releases, and deployments.
  * Linked the CI/CD guide from the development and testing documentation.
  * Included the new guide in the published documentation.
  * Simplified the `/hr` lease-rate example to clarify that the multiplier is fixed and monthly charges remain constant.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description
- **docs/03-development/ci-cd.md** (new): developer-facing reference for every workflow in `.github/workflows/` (test suite, commit/PR-title linting, CodeQL, dependency updates + auto-merge, scheduled CalVer/Node-LTS bump bots, label sync) plus CodeRabbit (a GitHub App, not a workflow) and the branch-protection required-check list. Cross-links to `testing/README.md` (test tier detail) and `02-handoff/deployment-and-rollback.md` (the human review/merge/deploy process) rather than duplicating either.
- **docs/03-development/README.md**: added an index bullet pointing to the new doc.
- **docs/03-development/testing/README.md**: added a short pointer from its existing "## CI" section to the new doc, for the workflows outside `test.yml`.
- **frontend/build-scripts/generate-docs-content.mjs**: registered `03-development/ci-cd.md` in the `MANIFEST` array so it's picked up by the in-app `/docs` page.
- **docs/01-user-guide/how-to/export-data.md**: re-applied a small wording trim to the "How the rate is calculated" section that was stashed and orphaned after PR #364's squash-merge — unrelated to the CI/CD doc, just piggybacked here since both are docs-only changes.

## Testing
- [x] `yarn lint` — 0 errors (pre-existing warnings only, unrelated to this change)
- [x] `.github/scripts/check-doc-versions.sh` — passes (Node/Next version mentions still in sync)
- [x] `node build-scripts/generate-docs-content.mjs` — regenerates cleanly, picks up the new manifest entry (35 docs/ files)
- [x] Every factual claim in `ci-cd.md` (cron schedules, job names, required-check list, dependabot grouping, CodeRabbit config) cross-checked directly against the actual `.github/workflows/*.yml`, `.github/dependabot.yml`, and `.coderabbit.yaml` source files, and every internal markdown link/anchor verified to resolve.
- This is a docs-only change (plus one `.mjs` manifest array edit) — no application behavior changed, so the full `yarn test:all` suite doesn't apply here beyond the lint pass above.

## Area(s) Touched
**Product areas**
- [x] docs — /docs Resources page (rendering, navigation, search)

**Engineering**
- [x] documentation — docs/ or README changes only

## Pre-merge Checklist
- [x] Code follows current formatting conventions and passes lint (`yarn lint`).
- [x] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
- [x] All test suites pass, both run locally and green in GitHub CI. **Do not merge if any test suite is failing.**
- [ ] A test suite was added or updated for the feature/fix in this PR. **Double-check this if you change a feature and did not update the test suites**. — N/A, docs-only change, no test-observable behavior.
- [x] Only files relevant to this change are committed — no stray or unrelated files.
- [x] If this branch has a merge conflict with master, master was merged into this branch first (not the other way around).
- [x] The rest of this PR description (Description, Testing) is filled out, not left as template placeholders.