### PR TITLE
fix(calendar): render the zoom-room-mismatch badge in Day view

### DIFF
--- a/frontend/app/components/calendar/desktop/DailyViewRow.tsx
+++ b/frontend/app/components/calendar/desktop/DailyViewRow.tsx
@@ -2,8 +2,12 @@ import React, { useState, useRef, useEffect } from 'react';
 import BoxText from '../../atoms/BoxText';
 import OverlapMeetingsModal from '../shared/OverlapMeetingsModal';
 import styles from '../../../../styles/components/calendar/desktop/DailyViewRow.module.scss';
+import { isZoomRoomMismatched } from '../../../../util/rooms/rooms';
 import { formatCompactTimeRange } from '../../../../util/date/timeFormat';
 import { formatETDateString } from '../../../../util/date/timeUtils';
+
+// Drops the " - Zoom" suffix for a more compact badge label -- same helper as DayColumn.tsx
+const formatZoomRoomLabel = (zoomRoom: string) => zoomRoom.replace(/ - Zoom$/, '');
 
 // Meeting Interface
 interface Meeting {
@@ -14,6 +18,8 @@ interface Meeting {
   displayEndTime?: string; // true time, for the label
   tags?: string[];
   id: string;
+  room?: string; // Physical room -- compared against zoomRoom for the mismatch badge
+  zoomRoom?: string | null;
   positionIndex?: number; // Lane index among overlapping meetings in this room, assigned by layoutOverlappingMeetings
   totalOverlapping?: number; // Lane count among overlapping meetings in this room
   isOverflowIndicator?: boolean; // "+N more" pseudo-entry standing in for meetings past the 2 shown lanes
@@ -182,6 +188,11 @@ const DailyViewRow: React.FC<DailyViewRowProps> = ({
           time={compactTime}
           tags={meeting.tags}
           meetingId={meeting.id}
+          zoomTag={
+            meeting.room && isZoomRoomMismatched(meeting.room, meeting.zoomRoom)
+              ? formatZoomRoomLabel(meeting.zoomRoom!)
+              : undefined
+          }
           syncError={syncErrorMids?.has(meeting.id)}
           hasConflict={conflictMids?.has(meeting.id)}
           selected={isSelected}

--- a/frontend/app/components/calendar/desktop/DayView.tsx
+++ b/frontend/app/components/calendar/desktop/DayView.tsx
@@ -95,6 +95,7 @@ export const fetchMeetingsByDay = async (date: Date): Promise<Room[]> => {
           displayEndTime: etTimeFmt.format(new Date(meeting.trueEndDateTime)),
           date: formattedDate,
           tags: [...meeting.calType, meeting.modeType],
+          zoomRoom: meeting.zoomRoom,
         };
 
         // A Hybrid meeting occupies both its physical room and its Zoom room; In Person
@@ -112,8 +113,11 @@ export const fetchMeetingsByDay = async (date: Date): Promise<Room[]> => {
           }
           // Own copy per room bucket -- a Hybrid meeting appears in both its physical
           // room and Zoom room rows, and each row lays out overlap independently, so
-          // they can't share one `room` field value.
-          groupedRooms[roomName].push({ ...meetingEntry, room: roomName });
+          // they can't share one card object. `room` stays the meeting's actual physical
+          // room in *both* copies (not the bucket's own roomName) -- isZoomRoomMismatched
+          // compares physical room to zoomRoom, and that pairing doesn't change depending
+          // on which row happens to be rendering the card.
+          groupedRooms[roomName].push({ ...meetingEntry, room: meeting.room });
         });
       });
 

--- a/frontend/tests/e2e/06-zoom-integration.spec.ts
+++ b/frontend/tests/e2e/06-zoom-integration.spec.ts
@@ -34,10 +34,15 @@ test.describe("zoom integration", () => {
       zoomRoom: "Unity Room - Zoom",
     });
     await page.goto("/");
-    // The zoomTag mismatch badge (util/rooms.ts isZoomRoomMismatched) is rendered by
-    // DayColumn only — DayView's BoxText usage doesn't pass a zoomTag at all.
-    await selectView(page, "Week");
+    // The zoomTag mismatch badge (util/rooms.ts isZoomRoomMismatched) renders in both
+    // Day view (DailyViewRow) and Week view (DayColumn) -- Day view used to silently
+    // drop it (DayView.tsx never carried zoomRoom through its room/zoomRoom-bucketing,
+    // and DailyViewRow never passed a zoomTag prop at all), so check both here rather
+    // than only the view that happened to already work.
     await toggleFilter(page, "Serenity Room");
+    await expect(page.getByTitle("Zoom room: Unity Room")).toBeVisible();
+
+    await selectView(page, "Week");
     await expect(page.getByTitle("Zoom room: Unity Room")).toBeVisible();
   });
 


### PR DESCRIPTION
Resolves #372

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added compact labels to meeting cards when the physical room and Zoom room do not match.
  * Zoom-room information is now preserved when viewing meetings across calendar room groupings.

* **Bug Fixes**
  * Improved room information accuracy for duplicated meetings in Day and Week calendar views.

* **Tests**
  * Expanded integration coverage to verify Zoom-room mismatch indicators in both Day and Week views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description
- **`frontend/app/components/calendar/desktop/DayView.tsx`**: the per-meeting entry built for each room bucket never carried `zoomRoom`, and the bucketing loop overwrote `room` with the bucket's own room name for every copy — so even with `zoomRoom` added, the Zoom-room-bucket copy would compare a Zoom room name against itself instead of the physical room. Now `zoomRoom` is included, and `room` stays the meeting's actual physical room in every bucket copy.
- **`frontend/app/components/calendar/desktop/DailyViewRow.tsx`**: never computed or passed a `zoomTag` prop to `BoxText` at all (unlike `DayColumn.tsx`, Week view's equivalent, which already does this). Added the `room`/`zoomRoom` fields to its `Meeting` interface, imported `isZoomRoomMismatched`, and passed a computed `zoomTag` prop, mirroring `DayColumn.tsx`'s existing pattern.
- **`frontend/tests/e2e/06-zoom-integration.spec.ts`**: extended test 6.11 to assert the mismatch badge in both Day view (previously untested — this is exactly why the bug went unnoticed) and Week view, and updated a stale comment that documented the old broken behavior as expected.

Found incidentally while capturing a screenshot for an unrelated docs page; the Zoom-room-mismatch badge (video icon + Zoom room name, shown when a Hybrid meeting's Zoom room doesn't match its physical room's default pairing) worked correctly in Week view but silently never rendered in Day view, the default calendar view.

## Testing
- [x] `npx playwright test --config config/playwright.config.ts -g "6.11"` — passes, asserts the badge in both Day and Week view
- [x] Manually reproduced in the browser: created a Hybrid meeting with Room = Serenity Room, Zoom Room = Unity Room - Zoom, confirmed the badge now renders in Day view (previously did not)
- [x] `npx tsc --noEmit` — no new type errors
- [x] Full `yarn test:all` — 132 unit + 79 component + 75 integration + 95 e2e, all passing
- [x] Searched the test suites for any pre-existing test asserting the old (broken) Day-view behavior — none found; the only related tests are Week-view-only and unaffected (see PR conversation for detail)

## Area(s) Touched
**Product areas**
- [x] ui/ux — frontend layout/styling not tied to a specific integration

**Integrations**
- [x] zoom-api — Zoom meeting/host sync

**Engineering**
- [x] testing — test suite (Jest/Playwright) changes

## Pre-merge Checklist
- [x] Code follows current formatting conventions and passes lint (`yarn lint`).
- [x] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
- [x] All test suites pass, both run locally and green in GitHub CI. **Do not merge if any test suite is failing.**
- [x] A test suite was added or updated for the feature/fix in this PR. **Double-check this if you change a feature and did not update the test suites**.
- [x] Only files relevant to this change are committed — no stray or unrelated files.
- [ ] If this branch has a merge conflict with master, master was merged into this branch first (not the other way around).
- [x] The rest of this PR description (Description, Testing) is filled out, not left as template placeholders.