### PR TITLE
fix(calendar): make CalendarNavbar's selectedView a controlled prop

### DIFF
--- a/frontend/app/(main)/page.tsx
+++ b/frontend/app/(main)/page.tsx
@@ -460,6 +460,7 @@ export default function HomePage() {
             <CalendarNavbar
               selectedDate={selectedDate}
               onDateChange={changeSelectedDate}
+              selectedView={selectedView}
               onViewChange={setSelectedView}
               isAdmin={isAdmin}
               transitionDirection={transitionDirection}

--- a/frontend/app/(signage)/signage/page.tsx
+++ b/frontend/app/(signage)/signage/page.tsx
@@ -45,8 +45,9 @@ function SignageContent() {
     () => parseSignageFilters(searchParams),
     [searchParams]
   );
-  // Seeded once from the URL; CalendarNavbar can still change it locally (e.g. if
-  // the kiosk is touch-enabled), since it's the same navbar the interactive app uses.
+  // Seeded once from the URL; passed to CalendarNavbar as its controlled selectedView (see that
+  // component's own comment), so a touch-enabled kiosk's dropdown still works via onViewChange
+  // -- it's the same navbar the interactive app uses, just no longer owning this state itself.
   const [view, setView] = useState<'Day' | 'Week'>(() => parseSignageView(searchParams));
 
   const [selectedDate, setSelectedDate] = useState(new Date());
@@ -154,6 +155,7 @@ function SignageContent() {
         <CalendarNavbar
           selectedDate={selectedDate}
           onDateChange={changeSelectedDate}
+          selectedView={view}
           onViewChange={(v) => setView(v === "Week" ? "Week" : "Day")}
           transitionDirection={transitionDirection}
         />

--- a/frontend/app/components/calendar/desktop/CalendarNavbar.tsx
+++ b/frontend/app/components/calendar/desktop/CalendarNavbar.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import Dropdown from '../../atoms/Dropdown';
 import CalendarHeader from '../shared/CalendarHeader';
 import styles from "../../../../styles/components/calendar/desktop/CalendarNavbar.module.scss";
@@ -38,10 +38,21 @@ export const computeHeadingTransitionKey = (selectedView: string, selectedDate: 
 type CalendarNavbarProps = {
     selectedDate: Date;
     onDateChange: (date : Date) => void;
+    // Controlled -- CalendarNavbar previously owned this as local state (useState('Day')),
+    // which desynced from whichever caller-owned selectedView actually decides which content
+    // (DayView vs. WeekView) renders below it: page.tsx keeps its own selectedView in
+    // CalendarContext (only ever updated via this same onViewChange, but re-initialized to
+    // "Day" on every CalendarNavbar remount -- e.g. a viewport resize crossing the desktop/
+    // mobile breakpoint round-trip), and /signage seeds its own view from a URL param that
+    // CalendarNavbar's old local state had no way to see at all (?view=week rendered WeekView
+    // while the navbar still believed it was in Day view -- wrong heading text, wrong arrow
+    // step, and, once the heading gained a per-view axis, a wrong slide direction too). Now the
+    // single source of truth lives with whichever parent actually decides what to render.
+    selectedView: string;
     onViewChange: (view: string) => void;
     // Optional: signage (a public kiosk with no sign-in concept at all) renders this without
-    // ever resolving a real admin status, CalendarHeader treats the resulting null the same as 
-    // "not yet known" and skips the View-only pill either way, whereas the main calendar always 
+    // ever resolving a real admin status, CalendarHeader treats the resulting null the same as
+    // "not yet known" and skips the View-only pill either way, whereas the main calendar always
     // supplies its resolved (or still-loading) boolean | null.
     isAdmin?: boolean | null;
     // Which way CalendarHeader's heading slides on a date/view change (see CalendarProvider's
@@ -54,22 +65,20 @@ type CalendarNavbarProps = {
 const CalendarNavbar: React.FC<CalendarNavbarProps> = ({
     selectedDate,
     onDateChange,
+    selectedView,
     onViewChange,
     isAdmin = null,
     transitionDirection = 'forward',
 }) => {
-    const [selectedView, setSelectedView] = useState('Day');
-
     const handleViewChange = (value: string) => {
-      setSelectedView(value);
       onViewChange(value); // Call the external function
       onDateChange(new Date());
     };
   
-    // Jumps to today's date within whatever view is currently active -- must not touch
-    // selectedView (previously forced this to "Day" without telling the parent via
-    // onViewChange, desyncing CalendarHeader's date-range label and shiftSelectedDate's own
-    // day-vs-week step from whatever view was actually still rendered underneath).
+    // Jumps to today's date within whatever view is currently active. selectedView is now the
+    // caller's own controlled prop (see its own comment), so there's no local state here that
+    // could silently reset it -- this used to matter when it was still local state, forced to
+    // "Day" without telling the parent via onViewChange.
     const handleToday = () => {
       onDateChange(new Date());
     };

--- a/frontend/tests/component/CalendarNavbar.test.tsx
+++ b/frontend/tests/component/CalendarNavbar.test.tsx
@@ -4,26 +4,36 @@ import CalendarNavbar, { computeHeadingTransitionKey } from "../../app/component
 import { formatETDateString, addDaysToETDateString } from "../../util/date/timeUtils";
 import { getFirstDayOfWeek } from "../../util/date/weekDates";
 
-// Wraps CalendarNavbar with the controlled selectedDate state a real parent would own, so
-// clicking Today/arrows and re-rendering with the updated date exercises the same loop the
-// real app does, not just the callback's argument in isolation. Renders selectedDate as text
-// (ET date string) so the test can assert on it without reaching into CalendarNavbar's
-// internals.
+// Wraps CalendarNavbar with the controlled selectedDate/selectedView state a real parent would
+// own, so clicking Today/arrows/the view dropdown and re-rendering with the updated values
+// exercises the same loop the real app does, not just the callback's argument in isolation.
+// selectedView in particular: CalendarNavbar no longer owns this as local state (see its own
+// comment on why), so a harness that ignored onViewChange would silently pass no matter what
+// the component did with it.
 const Harness: React.FC = () => {
   const [selectedDate, setSelectedDate] = useState(new Date());
+  const [selectedView, setSelectedView] = useState('Day');
   return (
     <>
       <div data-testid="selected-date">{formatETDateString(selectedDate)}</div>
-      <CalendarNavbar selectedDate={selectedDate} onDateChange={setSelectedDate} onViewChange={() => {}} />
+      <CalendarNavbar
+        selectedDate={selectedDate}
+        onDateChange={setSelectedDate}
+        selectedView={selectedView}
+        onViewChange={setSelectedView}
+      />
     </>
   );
 };
 
-// Regression test for a bug where clicking "Today" force-set the view dropdown's internal
-// selectedView to "Day" without telling the parent (onViewChange was never called) -- this
-// desynced shiftSelectedDate's own day-vs-week step from whatever view (e.g. Week) was
-// actually still rendered, so the arrows silently started moving a Week view by a single day
-// instead of by a week after Today was clicked.
+// Regression test for a bug where clicking "Today" used to force-reset the view dropdown's
+// (then-local) selectedView to "Day" without telling the parent (onViewChange was never
+// called) -- this desynced shiftSelectedDate's own day-vs-week step from whatever view (e.g.
+// Week) was actually still rendered, so the arrows silently started moving a Week view by a
+// single day instead of by a week after Today was clicked. selectedView is now a controlled
+// prop (see CalendarNavbar's own comment) which makes this class of bug structurally harder to
+// reintroduce, but the test still guards handleToday's actual contract: it must never call
+// onViewChange.
 test("clicking Today while in Week view keeps arrow navigation stepping by week, not by day", () => {
   render(<Harness />);
 
@@ -62,4 +72,38 @@ test("heading transition key stays the same for a different day within the same 
   const sunday = new Date("2026-08-16T12:00:00-04:00");
   const wednesday = new Date("2026-08-19T12:00:00-04:00");
   expect(computeHeadingTransitionKey("Week", sunday)).toBe(computeHeadingTransitionKey("Week", wednesday));
+});
+
+// Regression test for CalendarNavbar previously always initializing its own local selectedView
+// to "Day" (useState('Day')) regardless of what a caller wanted rendered underneath it --
+// /signage?view=week seeded WeekView from the URL but the navbar still believed it was in Day
+// view, so the dropdown/heading showed Day-formatted text and the arrows stepped by 1 day
+// instead of 7. Mounts directly in Week view (no interaction first, unlike the Today test
+// above) to prove the controlled prop is respected from the very first render, not just after
+// the dropdown is clicked.
+test("mounting directly in Week view renders week controls and steps by week, not by day", () => {
+  const WeekHarness: React.FC = () => {
+    const [selectedDate, setSelectedDate] = useState(new Date("2026-08-19T12:00:00-04:00")); // a Wednesday
+    return (
+      <>
+        <div data-testid="selected-date">{formatETDateString(selectedDate)}</div>
+        <CalendarNavbar
+          selectedDate={selectedDate}
+          onDateChange={setSelectedDate}
+          selectedView="Week"
+          onViewChange={() => {}}
+        />
+      </>
+    );
+  };
+  render(<WeekHarness />);
+
+  expect(screen.getByRole("button", { name: "Week" })).toBeInTheDocument();
+
+  const start = screen.getByTestId("selected-date").textContent as string;
+  fireEvent.click(screen.getByAltText("Right Arrow"));
+  const afterOneClick = screen.getByTestId("selected-date").textContent;
+
+  expect(afterOneClick).toBe(addDaysToETDateString(start, 7));
+  expect(afterOneClick).not.toBe(addDaysToETDateString(start, 1));
 });

--- a/frontend/tests/e2e/13-digital-signage.spec.ts
+++ b/frontend/tests/e2e/13-digital-signage.spec.ts
@@ -33,6 +33,20 @@ test.describe("digital signage", () => {
     await expect(page.getByText("Unity Signage Meeting")).toHaveCount(0);
   });
 
+  // Regression test: CalendarNavbar used to own selectedView as its own local state, always
+  // initialized to "Day" regardless of what a caller wanted rendered -- /signage?view=week
+  // seeded WeekView from this URL param, but the navbar still believed it was in Day view (its
+  // own dropdown/heading showed Day-formatted text, and its arrows stepped by 1 day instead of
+  // 7). selectedView is now a controlled prop threaded from this page's own `view` state.
+  test("13.7 /signage?view=week renders the week view and the navbar agrees", async ({ page }) => {
+    await seedMeeting({ title: "Week View Signage Meeting" });
+    await page.goto("/signage?view=week");
+    await expect(page.getByText("Week View Signage Meeting")).toBeVisible();
+    // The navbar's own view dropdown must read "Week", not the "Day" it would show if it were
+    // still tracking view as disconnected local state defaulting to "Day".
+    await expect(page.getByRole("button", { name: "Week" })).toBeVisible();
+  });
+
   // Regression test for #348: the auto-fit scale calculation used to be gated on a plain
   // useRef, which isn't reactive -- on a fresh direct navigation (not a click-through from an
   // already-scaled state) the effect fired before the content div ever mounted and never


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Calendar navigation now consistently reflects the selected Day, Week, or Month view.
  * Starting directly in Week view displays the correct controls and advances by seven days when navigating.

* **Tests**
  * Added regression coverage for calendar view selection and navigation.
  * Added signage coverage to verify URL-selected Week view is displayed correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description
- **app/components/calendar/desktop/CalendarNavbar.tsx**: `selectedView` was owned as local state (`useState('Day')`), disconnected from whichever parent actually decides what content renders below it. Now a required controlled prop.
- **app/(main)/page.tsx**: passes its own `selectedView` (already tracked in `CalendarContext`) into `CalendarNavbar` explicitly.
- **app/(signage)/signage/page.tsx**: passes its own `view` state (already seeded from the `?view=` URL param) into `CalendarNavbar` explicitly — this is the concrete bug this PR fixes: `/signage?view=week` rendered `WeekView` while the navbar still believed it was in Day view (wrong heading text, wrong arrow step — 1 day instead of 7 — and, since #371 gave the heading a per-view slide axis, a wrong slide direction too).
- **tests/component/CalendarNavbar.test.tsx**: harness now owns `selectedView` itself (required now that the component is controlled); new test mounts directly in Week view with no prior interaction, to prove the prop is respected from the first render.
- **tests/e2e/13-digital-signage.spec.ts**: new test covering the real `/signage?view=week` repro path end-to-end.

Found during a code-review pass on #371 (this PR is stacked on #375) — not filed as its own GitHub issue, so no `Resolves #` line.

## Testing
- `yarn test:all` (lint, lint:css, unit, component, integration, e2e) — all green: 132 unit / 82 component / 75 integration / 96 e2e passing, 0 lint errors.
- New regression tests as described above; both verified to actually fail against the pre-fix code and pass against the fix.

## Area(s) Touched
**Product areas**
- [x] ui/ux — frontend layout/styling not tied to a specific integration

## Pre-merge Checklist
- [x] Code follows current formatting conventions and passes lint (`yarn lint`).
- [x] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
- [x] All test suites pass, both run locally and green in GitHub CI. **Do not merge if any test suite is failing.**
- [x] A test suite was added or updated for the feature/fix in this PR.
- [x] Only files relevant to this change are committed — no stray or unrelated files.
- [x] If this branch has a merge conflict with master, master was merged into this branch first (not the other way around). *(no conflict — stacked on #375, which is up to date with master)*
- [x] The rest of this PR description (Description, Testing) is filled out, not left as template placeholders.