### PR TITLE
chore(stylelint): enforce scss/load-partial-extension: never

### DIFF
--- a/frontend/app/(auth)/login/page.module.scss
+++ b/frontend/app/(auth)/login/page.module.scss
@@ -1,4 +1,4 @@
-@import '../../../styles/Variables.module.scss';
+@import '../../../styles/Variables.module';
 
 .page {
     min-height: 100vh;

--- a/frontend/app/(main)/page.module.scss
+++ b/frontend/app/(main)/page.module.scss
@@ -1,4 +1,4 @@
-@import '../../styles/Variables.module.scss';
+@import '../../styles/Variables.module';
 
 .container {
   display: flex;

--- a/frontend/config/stylelint.config.mjs
+++ b/frontend/config/stylelint.config.mjs
@@ -1,7 +1,7 @@
 const stylelintConfig = {
   extends: ["stylelint-config-standard-scss"],
   rules: {
-    "scss/load-partial-extension": null,
+    "scss/load-partial-extension": "never",
     // CSS Modules classes are accessed as JS properties (styles.emptyState),
     // so camelCase is the codebase-wide convention -- not kebab-case.
     "selector-class-pattern": null,

--- a/frontend/styles/components/admin/AdminShell.module.scss
+++ b/frontend/styles/components/admin/AdminShell.module.scss
@@ -1,4 +1,4 @@
-@import '../../Variables.module.scss';
+@import '../../Variables.module';
 
 .container {
   width: 100%;

--- a/frontend/styles/components/admin/Card.module.scss
+++ b/frontend/styles/components/admin/Card.module.scss
@@ -1,4 +1,4 @@
-@import '../../Variables.module.scss';
+@import '../../Variables.module';
 
 .card {
   background: #fff;

--- a/frontend/styles/components/admin/CardHeader.module.scss
+++ b/frontend/styles/components/admin/CardHeader.module.scss
@@ -1,4 +1,4 @@
-@import '../../Variables.module.scss';
+@import '../../Variables.module';
 
 .cardHeader {
   display: flex;

--- a/frontend/styles/components/admin/ConflictList.module.scss
+++ b/frontend/styles/components/admin/ConflictList.module.scss
@@ -1,4 +1,4 @@
-@import '../../Variables.module.scss';
+@import '../../Variables.module';
 
 .emptyState {
   color: $medium-grey-color;

--- a/frontend/styles/components/admin/DiagnosticsTab.module.scss
+++ b/frontend/styles/components/admin/DiagnosticsTab.module.scss
@@ -1,4 +1,4 @@
-@import '../../Variables.module.scss';
+@import '../../Variables.module';
 
 .container {
   display: flex;

--- a/frontend/styles/components/admin/ExportTab.module.scss
+++ b/frontend/styles/components/admin/ExportTab.module.scss
@@ -1,4 +1,4 @@
-@import '../../Variables.module.scss';
+@import '../../Variables.module';
 
 .container {
   display: flex;

--- a/frontend/styles/components/admin/SignageTab.module.scss
+++ b/frontend/styles/components/admin/SignageTab.module.scss
@@ -1,4 +1,4 @@
-@import '../../Variables.module.scss';
+@import '../../Variables.module';
 
 .container {
   display: flex;

--- a/frontend/styles/components/admin/UserModals.module.scss
+++ b/frontend/styles/components/admin/UserModals.module.scss
@@ -1,4 +1,4 @@
-@import '../../Variables.module.scss';
+@import '../../Variables.module';
 
 .modalOverlay {
   position: fixed;

--- a/frontend/styles/components/admin/UsersTab.module.scss
+++ b/frontend/styles/components/admin/UsersTab.module.scss
@@ -1,4 +1,4 @@
-@import '../../Variables.module.scss';
+@import '../../Variables.module';
 
 .container {
   display: flex;

--- a/frontend/styles/components/atoms/BoxText.module.scss
+++ b/frontend/styles/components/atoms/BoxText.module.scss
@@ -1,5 +1,5 @@
 @import 'https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600&display=swap';
-@import '../../Variables.module.scss';
+@import '../../Variables.module';
 
 .box {
   box-sizing: border-box;

--- a/frontend/styles/components/atoms/CheckButton.module.scss
+++ b/frontend/styles/components/atoms/CheckButton.module.scss
@@ -1,4 +1,4 @@
-@import '../../Variables.module.scss';
+@import '../../Variables.module';
 
 .checkButton {
     width: 32px;

--- a/frontend/styles/components/atoms/Checkbox.module.scss
+++ b/frontend/styles/components/atoms/Checkbox.module.scss
@@ -1,4 +1,4 @@
-@import '../../Variables.module.scss';
+@import '../../Variables.module';
 
 .checkbox {
     display: flex;

--- a/frontend/styles/components/atoms/DatePicker.module.scss
+++ b/frontend/styles/components/atoms/DatePicker.module.scss
@@ -1,4 +1,4 @@
-@import '../../Variables.module.scss';
+@import '../../Variables.module';
 
 .date-picker-wrapper {
   display: flex;

--- a/frontend/styles/components/atoms/Dropdown.module.scss
+++ b/frontend/styles/components/atoms/Dropdown.module.scss
@@ -1,4 +1,4 @@
-@import '../../Variables.module.scss';
+@import '../../Variables.module';
 
 .dropdown {
     position: relative;

--- a/frontend/styles/components/atoms/GoogleSignInButton.module.scss
+++ b/frontend/styles/components/atoms/GoogleSignInButton.module.scss
@@ -1,4 +1,4 @@
-@import '../../Variables.module.scss';
+@import '../../Variables.module';
 
 .googleButton {
     width: 100%;

--- a/frontend/styles/components/atoms/IconButton.module.scss
+++ b/frontend/styles/components/atoms/IconButton.module.scss
@@ -1,4 +1,4 @@
-@import '../../Variables.module.scss';
+@import '../../Variables.module';
 
 .iconButton {
     padding: 0;

--- a/frontend/styles/components/atoms/MiniCalendar.module.scss
+++ b/frontend/styles/components/atoms/MiniCalendar.module.scss
@@ -1,5 +1,5 @@
 @use 'sass:color';
-@import '../../Variables.module.scss';
+@import '../../Variables.module';
 
 // Main container
 .container {

--- a/frontend/styles/components/atoms/MobileFullScreenSheet.module.scss
+++ b/frontend/styles/components/atoms/MobileFullScreenSheet.module.scss
@@ -1,4 +1,4 @@
-@import '../../Variables.module.scss';
+@import '../../Variables.module';
 
 .fullScreen {
     position: fixed;

--- a/frontend/styles/components/atoms/ModeTypeButtons.module.scss
+++ b/frontend/styles/components/atoms/ModeTypeButtons.module.scss
@@ -1,4 +1,4 @@
-@import '../../Variables.module.scss';
+@import '../../Variables.module';
 
 // Connected segmented control (was three loosely-spaced text buttons) -- reads clearly at any
 // container width, and a solid fill on the selected state keeps it visible regardless of what

--- a/frontend/styles/components/atoms/RadioGroup.module.scss
+++ b/frontend/styles/components/atoms/RadioGroup.module.scss
@@ -1,4 +1,4 @@
-@import '../../Variables.module.scss';
+@import '../../Variables.module';
 
 .radioGroupContainer {
     display: flex;

--- a/frontend/styles/components/atoms/SpinnerInput.module.scss
+++ b/frontend/styles/components/atoms/SpinnerInput.module.scss
@@ -1,5 +1,5 @@
 @import 'https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600&display=swap';
-@import '../../Variables.module.scss';
+@import '../../Variables.module';
 
 .spinnerInputContainer {
     display: flex;

--- a/frontend/styles/components/atoms/StatCounter.module.scss
+++ b/frontend/styles/components/atoms/StatCounter.module.scss
@@ -1,4 +1,4 @@
-@import '../../Variables.module.scss';
+@import '../../Variables.module';
 
 .block {
   display: flex;

--- a/frontend/styles/components/atoms/StatusPill.module.scss
+++ b/frontend/styles/components/atoms/StatusPill.module.scss
@@ -1,4 +1,4 @@
-@import '../../Variables.module.scss';
+@import '../../Variables.module';
 
 .pill {
   display: inline-block;

--- a/frontend/styles/components/atoms/TextButton.module.scss
+++ b/frontend/styles/components/atoms/TextButton.module.scss
@@ -1,4 +1,4 @@
-@import '../../Variables.module.scss';
+@import '../../Variables.module';
 
 .meetingContainer {
   display: flex;

--- a/frontend/styles/components/atoms/TextField.module.scss
+++ b/frontend/styles/components/atoms/TextField.module.scss
@@ -1,4 +1,4 @@
-@import '../../Variables.module.scss';
+@import '../../Variables.module';
 
 .textfieldwrapper {
     display: flex;

--- a/frontend/styles/components/atoms/TimePicker.module.scss
+++ b/frontend/styles/components/atoms/TimePicker.module.scss
@@ -1,5 +1,5 @@
 @import 'https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600&display=swap';
-@import '../../Variables.module.scss';
+@import '../../Variables.module';
 
 .time-picker-wrapper {
   display: flex;

--- a/frontend/styles/components/atoms/Tooltip.module.scss
+++ b/frontend/styles/components/atoms/Tooltip.module.scss
@@ -1,4 +1,4 @@
-@import '../../Variables.module.scss';
+@import '../../Variables.module';
 
 .wrapper {
     position: relative;

--- a/frontend/styles/components/atoms/TopLoadingBar.module.scss
+++ b/frontend/styles/components/atoms/TopLoadingBar.module.scss
@@ -1,4 +1,4 @@
-@import '../../Variables.module.scss';
+@import '../../Variables.module';
 
 .track {
   position: absolute;

--- a/frontend/styles/components/calendar/desktop/CalendarNavbar.module.scss
+++ b/frontend/styles/components/calendar/desktop/CalendarNavbar.module.scss
@@ -1,4 +1,4 @@
-@import '../../../Variables.module.scss';
+@import '../../../Variables.module';
 
 // Establishes the container-query boundary that .navbarContainer's and .viewOnlyPill's own
 // clamp(...cqi...) rules below all query against -- both need to live *inside* this wrapper

--- a/frontend/styles/components/calendar/desktop/CompactCalendarSidebar.module.scss
+++ b/frontend/styles/components/calendar/desktop/CompactCalendarSidebar.module.scss
@@ -1,4 +1,4 @@
-@import '../../../Variables.module.scss';
+@import '../../../Variables.module';
 
 .rail {
   display: flex;

--- a/frontend/styles/components/calendar/desktop/DailyViewRow.module.scss
+++ b/frontend/styles/components/calendar/desktop/DailyViewRow.module.scss
@@ -1,4 +1,4 @@
-@import '../../../Variables.module.scss';
+@import '../../../Variables.module';
 
 .meetingWrapper {
   position: absolute;

--- a/frontend/styles/components/calendar/desktop/DayView.module.scss
+++ b/frontend/styles/components/calendar/desktop/DayView.module.scss
@@ -1,5 +1,5 @@
 @import 'https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600&display=swap';
-@import '../../../Variables.module.scss';
+@import '../../../Variables.module';
 
 .outerContainer {
   display: flex;

--- a/frontend/styles/components/calendar/desktop/WeekView.module.scss
+++ b/frontend/styles/components/calendar/desktop/WeekView.module.scss
@@ -1,5 +1,5 @@
 @import 'https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600&display=swap';
-@import '../../../Variables.module.scss';
+@import '../../../Variables.module';
 
 .outerContainer {
   display: flex;

--- a/frontend/styles/components/calendar/mobile/DayLandscapeView.module.scss
+++ b/frontend/styles/components/calendar/mobile/DayLandscapeView.module.scss
@@ -1,4 +1,4 @@
-@import '../../../Variables.module.scss';
+@import '../../../Variables.module';
 
 .outerContainer {
   flex: 1 1 auto;

--- a/frontend/styles/components/calendar/mobile/DayPortraitView.module.scss
+++ b/frontend/styles/components/calendar/mobile/DayPortraitView.module.scss
@@ -1,4 +1,4 @@
-@import '../../../Variables.module.scss';
+@import '../../../Variables.module';
 
 .container {
     display: flex;

--- a/frontend/styles/components/calendar/mobile/MobileFab.module.scss
+++ b/frontend/styles/components/calendar/mobile/MobileFab.module.scss
@@ -1,4 +1,4 @@
-@import '../../../Variables.module.scss';
+@import '../../../Variables.module';
 
 .fabWrapper {
     position: fixed;

--- a/frontend/styles/components/calendar/mobile/MultiDayLandscapeView.module.scss
+++ b/frontend/styles/components/calendar/mobile/MultiDayLandscapeView.module.scss
@@ -1,4 +1,4 @@
-@import '../../../Variables.module.scss';
+@import '../../../Variables.module';
 
 .outerContainer {
   flex: 1 1 auto;

--- a/frontend/styles/components/calendar/shared/DayColumn.module.scss
+++ b/frontend/styles/components/calendar/shared/DayColumn.module.scss
@@ -1,4 +1,4 @@
-@import '../../../Variables.module.scss';
+@import '../../../Variables.module';
 
 .columnWrapper {
   display: flex;

--- a/frontend/styles/components/calendar/shared/OverlapMeetingsModal.module.scss
+++ b/frontend/styles/components/calendar/shared/OverlapMeetingsModal.module.scss
@@ -1,5 +1,5 @@
 @import 'https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600&display=swap';
-@import '../../../Variables.module.scss';
+@import '../../../Variables.module';
 
 .modalOverlay {
   position: fixed;

--- a/frontend/styles/components/docs/DocsShell.module.scss
+++ b/frontend/styles/components/docs/DocsShell.module.scss
@@ -1,4 +1,4 @@
-@import '../../Variables.module.scss';
+@import '../../Variables.module';
 
 .page {
   display: flex;

--- a/frontend/styles/components/meeting-form/ConflictOverrideModal.module.scss
+++ b/frontend/styles/components/meeting-form/ConflictOverrideModal.module.scss
@@ -1,4 +1,4 @@
-@import '../../Variables.module.scss';
+@import '../../Variables.module';
 
 .modalOverlay {
   position: fixed;

--- a/frontend/styles/components/meeting-form/DeleteMeetingModal.module.scss
+++ b/frontend/styles/components/meeting-form/DeleteMeetingModal.module.scss
@@ -1,4 +1,4 @@
-@import '../../Variables.module.scss';
+@import '../../Variables.module';
 
 .modalOverlay {
   position: fixed;

--- a/frontend/styles/components/meeting-form/DeleteRecurringModal.module.scss
+++ b/frontend/styles/components/meeting-form/DeleteRecurringModal.module.scss
@@ -1,5 +1,5 @@
 @import 'https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600&display=swap';
-@import '../../Variables.module.scss';
+@import '../../Variables.module';
 
 .modalOverlay {
   position: fixed;

--- a/frontend/styles/components/meeting-form/FormValidationBanner.module.scss
+++ b/frontend/styles/components/meeting-form/FormValidationBanner.module.scss
@@ -1,4 +1,4 @@
-@import '../../Variables.module.scss';
+@import '../../Variables.module';
 
 .banner {
   display: flex;

--- a/frontend/styles/components/meeting-form/MeetingForm.module.scss
+++ b/frontend/styles/components/meeting-form/MeetingForm.module.scss
@@ -1,5 +1,5 @@
 @import 'https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600&display=swap';
-@import '../../Variables.module.scss';
+@import '../../Variables.module';
 
 .newMeetingSidebar {
   background-color: #fff;

--- a/frontend/styles/components/meeting-form/RecurringMeeting.module.scss
+++ b/frontend/styles/components/meeting-form/RecurringMeeting.module.scss
@@ -1,5 +1,5 @@
 @import 'https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600&display=swap';
-@import '../../Variables.module.scss';
+@import '../../Variables.module';
 
 .container {
   color: var(--black, $black-color);

--- a/frontend/styles/components/meeting-form/ResumeMeetingModal.module.scss
+++ b/frontend/styles/components/meeting-form/ResumeMeetingModal.module.scss
@@ -1,4 +1,4 @@
-@import '../../Variables.module.scss';
+@import '../../Variables.module';
 
 .modalOverlay {
   position: fixed;

--- a/frontend/styles/components/meeting-form/SuspendMeetingModal.module.scss
+++ b/frontend/styles/components/meeting-form/SuspendMeetingModal.module.scss
@@ -1,4 +1,4 @@
-@import '../../Variables.module.scss';
+@import '../../Variables.module';
 
 .modalOverlay {
   position: fixed;

--- a/frontend/styles/components/meeting-form/ViewMeeting.module.scss
+++ b/frontend/styles/components/meeting-form/ViewMeeting.module.scss
@@ -1,4 +1,4 @@
-@import '../../Variables.module.scss';
+@import '../../Variables.module';
 @import 'https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600&display=swap';
 
 // Wraps the visual card below; carries only the portal's fixed positioning so the card's

--- a/frontend/styles/components/meeting-form/ZoomHostField.module.scss
+++ b/frontend/styles/components/meeting-form/ZoomHostField.module.scss
@@ -1,4 +1,4 @@
-@import '../../Variables.module.scss';
+@import '../../Variables.module';
 
 .zoomHostField {
     width: 100%;

--- a/frontend/styles/components/navigation/AccessDeniedCard.module.scss
+++ b/frontend/styles/components/navigation/AccessDeniedCard.module.scss
@@ -1,4 +1,4 @@
-@import '../../Variables.module.scss';
+@import '../../Variables.module';
 
 .card {
     background-color: $white-color;

--- a/frontend/styles/components/navigation/AppNavigation.module.scss
+++ b/frontend/styles/components/navigation/AppNavigation.module.scss
@@ -1,5 +1,5 @@
 @use 'sass:color';
-@import '../../Variables.module.scss';
+@import '../../Variables.module';
 
 .navbar {
     width: 100%;

--- a/frontend/styles/components/navigation/LoginCard.module.scss
+++ b/frontend/styles/components/navigation/LoginCard.module.scss
@@ -1,4 +1,4 @@
-@import '../../Variables.module.scss';
+@import '../../Variables.module';
 
 .card {
     background-color: #fff;

--- a/frontend/styles/components/navigation/MobileLoginSheet.module.scss
+++ b/frontend/styles/components/navigation/MobileLoginSheet.module.scss
@@ -1,4 +1,4 @@
-@import '../../Variables.module.scss';
+@import '../../Variables.module';
 
 .header {
     display: flex;

--- a/frontend/styles/components/navigation/SignInDifferentAccountButton.module.scss
+++ b/frontend/styles/components/navigation/SignInDifferentAccountButton.module.scss
@@ -1,4 +1,4 @@
-@import '../../Variables.module.scss';
+@import '../../Variables.module';
 
 .button {
     width: 100%;

--- a/frontend/styles/components/shared/FilterGroup.module.scss
+++ b/frontend/styles/components/shared/FilterGroup.module.scss
@@ -1,4 +1,4 @@
-@import '../../Variables.module.scss';
+@import '../../Variables.module';
 
 .group {
   display: flex;

--- a/frontend/styles/components/shared/Toast.module.scss
+++ b/frontend/styles/components/shared/Toast.module.scss
@@ -1,4 +1,4 @@
-@import '../../Variables.module.scss';
+@import '../../Variables.module';
 
 .container {
   position: fixed;


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized Sass stylesheet imports across the application.
  * Existing visual styling and behavior remain unchanged.

* **Chores**
  * Updated style validation to enforce extensionless Sass partial imports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description
- **config/stylelint.config.mjs**: `scss/load-partial-extension` was set to `null` (fully disabled), which let SCSS partial imports drift between `../../Variables.module` and `../../Variables.module.scss` across the codebase with nothing enforcing either direction. CodeRabbit flagged this inconsistency on PR #381 with two contradictory suggestions (remove the extension vs. add it) — both technically "false positives" against the disabled rule, but pointing at a real underlying gap. Set to `"never"` (disallow the extension) to match the majority existing convention.
- Ran `stylelint --fix`, which mechanically stripped the `.scss` extension from 59 `@import` lines across `styles/`. No functional change — Sass resolves partial imports identically either way.

## Testing
- [x] `yarn lint:css` — 0 violations after the fix (was 59 before).
- [x] Full `yarn test:all` green: lint, lint:css, 132/132 unit, 84/84 component, 75/75 integration, 98/98 e2e.

## Area(s) Touched
**Product areas**
- [ ] auth — sign-in, sessions, NextAuth, role-based access
- [ ] admin — /admin shell (Diagnostics, Users, Import, Export tabs)
- [ ] docs — /docs Resources page (rendering, navigation, search)
- [x] ui/ux — frontend layout/styling not tied to a specific integration

**Integrations**
- [ ] google-calendar — Google Calendar sync
- [ ] zoom-api — Zoom meeting/host sync

**Engineering**
- [ ] security — auth hardening, data exposure, dependency/security scanning
- [ ] testing — test suite (Jest/Playwright) changes
- [ ] github-actions — workflows, Dependabot config, other .github/ CI tooling
- [x] cleanup — refactor or dead-code removal, no behavior change
- [ ] documentation — docs/ or README changes only

## Pre-merge Checklist
- [x] Code follows current formatting conventions and passes lint (`yarn lint`).
- [x] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
- [x] All test suites pass, both run locally and green in GitHub CI. **Do not merge if any test suite is failing.**
- [ ] A test suite was added or updated for the feature/fix in this PR.
- [x] Only files relevant to this change are committed — no stray or unrelated files.
- [x] If this branch has a merge conflict with master, master was merged into this branch first (not the other way around).
- [x] The rest of this PR description (Description, Testing) is filled out, not left as template placeholders.