### PR TITLE
fix(day-view): reveal 12am hour cell past sticky room column

### DIFF
--- a/frontend/app/components/calendar/desktop/DayView.module.scss
+++ b/frontend/app/components/calendar/desktop/DayView.module.scss
@@ -105,6 +105,17 @@
   overflow: auto;
   scroll-snap-type: x mandatory;
 
+  // .headerRow/.timeLabel (the only scroll-snap-align targets) sit 180px + .scrollContainer's
+  // own 30px margin-left into the document, past .roomContainer's sticky 180px column. Without
+  // this, mandatory snap's only valid resting point is scrollLeft: 210 -- the 30px margin gap
+  // ends up hidden behind .roomContainer (harmless, it's blank), but the first hour column also
+  // lands at the exact same viewport x as .roomContainer and paints underneath it (z-index 20
+  // beats the grid's z-index 1), and scrolling further left to clear it is impossible since
+  // mandatory snap won't rest anywhere before 210. Matching .roomContainer's 180px width here
+  // shifts the valid resting point to scrollLeft: 30, which lands the first hour column flush
+  // against .roomContainer's right edge instead of underneath it.
+  scroll-padding-left: 180px;
+
   // Hide scrollbar for Chrome, Safari and Opera
   &::-webkit-scrollbar {
     display: none;


### PR DESCRIPTION
Resolves #349

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved horizontal scrolling in the calendar day view.
  * Ensured scroll snapping aligns correctly with the sticky room column.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description
- **`app/components/calendar/desktop/DayView.module.scss`**: added `scroll-padding-left: 180px` to `.viewContainer`. Mandatory scroll-snap's only valid resting point was `scrollLeft: 210` (`.roomContainer`'s 180px sticky column + `.scrollContainer`'s 30px `margin-left`), which put the 12am–1am hour column at the exact same viewport x as the sticky room-label column, painted underneath it (`.roomContainer`'s `z-index: 20` beats the grid's `z-index: 1`). Scrolling further left to clear it was impossible since mandatory snap wouldn't rest anywhere before 210. Matching `.roomContainer`'s 180px width as `scroll-padding-left` shifts the valid resting point to `scrollLeft: 30`, landing the first hour column flush against the room column's right edge instead of underneath it.

## Testing
- Confirmed live against the dev server (`yarn dev`, `/signage?view=day`): forced `viewContainer.scrollLeft = 0`, let mandatory snap settle, and verified via `getBoundingClientRect()` that the "12 AM" header/grid cell now starts exactly where `.roomContainer` ends (no overlap) — previously snap forced `scrollLeft` back to 210 and the cell was hidden underneath the sticky column.
- `yarn lint:css` passed standalone.
- Full `yarn test:all` (lint, stylelint, unit, component, integration, e2e) passed: 132/132 unit, 129/129 component, 75/75 integration, 98/98 e2e, 0 lint errors.
- Searched existing suites for coverage tied to this behavior (`scroll-padding`, `scrollLeft`, `12am`/`12 AM`, scroll-snap) — the only matches are `DayLandscapeView.test.tsx`/`MultiDayLandscapeView.test.tsx`, which cover the unrelated *mobile* landscape views. No existing desktop-DayView test asserts the old (broken) scroll behavior. This is a real-browser CSS scroll-snap layout bug that JSDOM (used by the unit/component suites) doesn't compute — Jest-side coverage wouldn't actually exercise it, so no new test was added here; a Playwright e2e case asserting the resolved `scrollLeft`/cell visibility would be the right follow-up if this area sees more work.

## Area(s) Touched
**Product areas**
- [ ] auth — sign-in, sessions, NextAuth, role-based access
- [ ] admin — /admin shell (Diagnostics, Users, Import, Export tabs)
- [ ] docs — /docs Resources page (rendering, navigation, search)
- [x] ui/ux — frontend layout/styling not tied to a specific integration

**Integrations**
- [ ] google-calendar — Google Calendar sync
- [ ] zoom-api — Zoom meeting/host sync

**Engineering**
- [ ] security — auth hardening, data exposure, dependency/security scanning
- [ ] testing — test suite (Jest/Playwright) changes
- [ ] github-actions — workflows, Dependabot config, other .github/ CI tooling
- [ ] cleanup — refactor or dead-code removal, no behavior change
- [ ] documentation — docs/ or README changes only

## Pre-merge Checklist
- [x] Code follows current formatting conventions and passes lint (`yarn lint`).
- [x] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
- [x] All test suites pass, both run locally and green in GitHub CI. **Do not merge if any test suite is failing.**
- [ ] A test suite was added or updated for the feature/fix in this PR. **Double-check this if you change a feature and did not update the test suites**. (Searched — see Testing section; no existing test covered the old behavior, and JSDOM can't exercise real scroll-snap layout, so no new test was added.)
- [x] Only files relevant to this change are committed — no stray or unrelated files.
- [x] If this branch has a merge conflict with master, master was merged into this branch first (not the other way around).
- [x] The rest of this PR description (Description, Testing) is filled out, not left as template placeholders.
