### PR TITLE
fix(docs): derive TOC label and heading slug from plain heading text

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,9 +2,9 @@
 
 Welcome to the documentation hub for the **Ithaca Recovery Management System**. For ease of navigation,
 this hub has been organized by its audience:
-- [User Guide](#user-guide-01-user-guide) for everyday users of the system;
-- [Handoff](#handoff-02-handoff) for the ICR leadership and this application maintainer; and
-- [Development](#development-03-development) for developer teams writing code for this app.
+- [User Guide](#user-guide) for everyday users of the system;
+- [Handoff](#handoff) for the ICR leadership and this application maintainer; and
+- [Development](#development) for developer teams writing code for this app.
 
 ## [User Guide](01-user-guide/)
 

--- a/frontend/util/docs/parseMarkdown.ts
+++ b/frontend/util/docs/parseMarkdown.ts
@@ -1,4 +1,4 @@
-import { marked, Renderer, type Tokens } from "marked";
+import { marked, Renderer, Lexer, Parser, TextRenderer, type Tokens } from "marked";
 
 export interface TocItem {
   level: number;
@@ -11,6 +11,15 @@ export function slugify(text: string): string {
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/(^-|-$)/g, "");
+}
+
+// Strips markdown syntax down to its rendered text (e.g. "[User Guide](url)" -> "User Guide"),
+// via marked's own TextRenderer -- reused for both the slug and the TOC label below, so a
+// heading written as a markdown link doesn't leave "[User Guide](url)"-style raw syntax in the
+// slug or in DocsTocList's sidebar (which renders TocItem.text as plain text, not HTML).
+const textRenderer = new TextRenderer();
+function headingPlainText(raw: string): string {
+  return Parser.parseInline(Lexer.lexInline(raw), { renderer: textRenderer });
 }
 
 const CALLOUT_LABELS: Record<string, string> = {
@@ -73,11 +82,12 @@ export function parseMarkdown(markdown: string): { html: string; toc: TocItem[] 
     // Repeated heading text (e.g. two "Overview" sections in one doc) would otherwise collide on
     // both the rendered element's id and the TOC's own slug -- a fragment link then always jumps
     // to the first match, and DocsTocList's `key={item.slug}` would collide too.
-    const baseSlug = slugify(text) || "section";
+    const plainText = headingPlainText(text);
+    const baseSlug = slugify(plainText) || "section";
     const count = slugCounts.get(baseSlug) ?? 0;
     slugCounts.set(baseSlug, count + 1);
     const slug = count === 0 ? baseSlug : `${baseSlug}-${count}`;
-    if (depth <= 2) toc.push({ level: depth, text, slug });
+    if (depth <= 2) toc.push({ level: depth, text: plainText, slug });
     // parseInline renders inline markdown within the heading (several docs headings wrap
     // route paths in backticks, e.g. `### `POST /api/write/meeting``) -- the raw token text
     // alone would leave those backticks showing instead of styled <code>.

--- a/frontend/util/docs/parseMarkdown.ts
+++ b/frontend/util/docs/parseMarkdown.ts
@@ -1,4 +1,4 @@
-import { marked, Renderer, Lexer, Parser, TextRenderer, type Tokens } from "marked";
+import { marked, Renderer, Parser, type Tokens } from "marked";
 
 export interface TocItem {
   level: number;
@@ -14,12 +14,14 @@ export function slugify(text: string): string {
 }
 
 // Strips markdown syntax down to its rendered text (e.g. "[User Guide](url)" -> "User Guide"),
-// via marked's own TextRenderer -- reused for both the slug and the TOC label below, so a
+// via marked's own Parser.textRenderer -- reused for both the slug and the TOC label below, so a
 // heading written as a markdown link doesn't leave "[User Guide](url)"-style raw syntax in the
-// slug or in DocsTocList's sidebar (which renders TocItem.text as plain text, not HTML).
-const textRenderer = new TextRenderer();
-function headingPlainText(raw: string): string {
-  return Parser.parseInline(Lexer.lexInline(raw), { renderer: textRenderer });
+// slug or in DocsTocList's sidebar (which renders TocItem.text as plain text, not HTML). Takes the
+// heading token's already-lexed `tokens` (not the raw source string) to avoid re-lexing the same
+// text a renderer.heading call already has tokens for.
+const plainTextParser = new Parser();
+function headingPlainText(tokens: Tokens.Heading["tokens"]): string {
+  return plainTextParser.parseInline(tokens, plainTextParser.textRenderer);
 }
 
 const CALLOUT_LABELS: Record<string, string> = {
@@ -78,11 +80,11 @@ export function parseMarkdown(markdown: string): { html: string; toc: TocItem[] 
     const bodyHtml = marked.parser(marked.lexer(body), { renderer });
     return `<div class="callout callout-${kind.toLowerCase()}"><p class="calloutLabel">${calloutIconSvg(kind)}${CALLOUT_LABELS[kind]}</p>${bodyHtml}</div>\n`;
   };
-  renderer.heading = ({ text, depth }: Tokens.Heading) => {
+  renderer.heading = ({ text, depth, tokens }: Tokens.Heading) => {
     // Repeated heading text (e.g. two "Overview" sections in one doc) would otherwise collide on
     // both the rendered element's id and the TOC's own slug -- a fragment link then always jumps
     // to the first match, and DocsTocList's `key={item.slug}` would collide too.
-    const plainText = headingPlainText(text);
+    const plainText = headingPlainText(tokens);
     const baseSlug = slugify(plainText) || "section";
     const count = slugCounts.get(baseSlug) ?? 0;
     slugCounts.set(baseSlug, count + 1);


### PR DESCRIPTION
Resolves #388

@coderabbitai summary

## Description
- **`frontend/util/docs/parseMarkdown.ts`**: `renderer.heading`'s TOC entry and heading-id slug were both derived from the raw markdown source text of the heading, not its rendered plain text. For a heading written as a markdown link (e.g. `docs/README.md`'s `## [User Guide](/docs/01-user-guide)`), this meant the "ON THIS PAGE" sidebar showed literal `[User Guide](/docs/01-user-guide)` text (since `DocsTocList` renders `TocItem.text` as plain React text, not HTML), and the heading's `id` slugified down to an ugly `user-guide-01-user-guide`. Added a `headingPlainText()` helper that renders a heading's already-lexed inline tokens through `marked`'s own `Parser.textRenderer` (which strips markdown syntax down to plain rendered text) and uses that for both the TOC label and the slug — so the slug now matches the same clean formatting the TOC displays (`user-guide`), and the sidebar shows "User Guide" instead of raw syntax.
- **`docs/README.md`**: updated its own intro-section anchor links (`#user-guide-01-user-guide` → `#user-guide`, `#handoff-02-handoff` → `#handoff`, `#development-03-development` → `#development`) to match the new clean slug format — these were hardcoded to the old ugly slugs and would have silently broken otherwise.

## Testing
- Confirmed live against the dev server (`yarn dev`, `/docs`): "ON THIS PAGE" sidebar now shows "User Guide" / "Handoff" / "Development" instead of raw `[Label](url)` syntax, and the intro paragraph's `#user-guide` link correctly scrolls to/highlights the right heading.
- A review pass caught a real issue before this was pushed further: the initial version called `Parser.parseInline(tokens, { renderer: textRenderer })` (static method, options-object form), which type-checks incorrectly (`tsc` `TS2740` — a bare `TextRenderer` doesn't structurally satisfy the full `Renderer` type the options object expects). This was invisible to `yarn test:all` (no `tsc`/`next build` step in that chain) but would have broken the actual Vercel build. Fixed by using `Parser`'s own instance `.textRenderer` and its instance `parseInline(tokens, renderer)` method, which is explicitly typed to accept either a `Renderer` or a `TextRenderer`. Re-verified with `npx tsc --noEmit -p .` — clean, 0 errors.
- Also fixed on review: the initial version re-lexed the raw heading text a second time via `Lexer.lexInline()`; now reuses the heading token's own already-lexed `tokens` array instead (marked's block tokenizer already inline-lexes it once for `renderer.heading`).
- `yarn lint` clean (0 errors, 31 pre-existing warnings unrelated to this change).
- Full `yarn test:all` (lint, stylelint, unit, component, integration, e2e) passed twice — once before the review-driven fixes and again after: 132/132 unit, 129/129 component, 75/75 integration, 98/98 e2e.
- No existing test suite covers `parseMarkdown`/TOC/slug generation (searched — none found), so no existing test asserted the old (broken) behavior.

## Area(s) Touched
**Product areas**
- [ ] auth — sign-in, sessions, NextAuth, role-based access
- [ ] admin — /admin shell (Diagnostics, Users, Import, Export tabs)
- [x] docs — /docs Resources page (rendering, navigation, search)
- [ ] ui/ux — frontend layout/styling not tied to a specific integration

**Integrations**
- [ ] google-calendar — Google Calendar sync
- [ ] zoom-api — Zoom meeting/host sync

**Engineering**
- [ ] security — auth hardening, data exposure, dependency/security scanning
- [ ] testing — test suite (Jest/Playwright) changes
- [ ] github-actions — workflows, Dependabot config, other .github/ CI tooling
- [ ] cleanup — refactor or dead-code removal, no behavior change
- [ ] documentation — docs/ or README changes only

## Pre-merge Checklist
- [x] Code follows current formatting conventions and passes lint (`yarn lint`).
- [x] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
- [x] All test suites pass, both run locally and green in GitHub CI. **Do not merge if any test suite is failing.**
- [ ] A test suite was added or updated for the feature/fix in this PR. **Double-check this if you change a feature and did not update the test suites**. (Searched — no existing test covers `parseMarkdown`'s TOC/slug generation; none was added here either. Worth a follow-up unit test on `parseMarkdown()` if this file sees more work.)
- [x] Only files relevant to this change are committed — no stray or unrelated files.
- [x] If this branch has a merge conflict with master, master was merged into this branch first (not the other way around).
- [x] The rest of this PR description (Description, Testing) is filled out, not left as template placeholders.
