### PR TITLE
ci(github-actions): add typecheck to test:all and CI

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -23,7 +23,7 @@ jobs:
       # individual PRs for manual review + CI green -- those are the ones most likely to
       # carry breaking changes this repo's CI doesn't always catch.
       # Auto-merge still doesn't bypass required status checks -- it just lets the PR merge
-      # itself once lint/unit/integration/e2e all pass.
+      # itself once lint/typecheck/unit/component/integration/e2e all pass.
       - name: Enable auto-merge for patch/minor updates
         if: steps.metadata.outputs.dependency-group == 'safe-updates'
         run: gh pr merge --auto --squash "$PR_URL"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,6 +51,20 @@ jobs:
       - run: yarn lint
       - run: yarn lint:css
 
+  typecheck:
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: yarn
+          cache-dependency-path: frontend/yarn.lock
+      - run: yarn install --frozen-lockfile
+      - run: yarn typecheck
+
   unit:
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -116,11 +116,12 @@ architecture and per-service setup (Postgres, Google OAuth, Google Calendar, Zoo
 ```bash
 yarn lint                # ESLint (part of test:all below)
 yarn lint:css             # stylelint — separate from yarn lint (part of test:all below)
+yarn typecheck           # tsc --noEmit — full cross-file type-checking (part of test:all below)
 yarn test:unit           # pure functions, seconds, no setup
 yarn test:component      # individual components in isolation, seconds, no setup
 yarn test:integration    # route handlers against an embedded Postgres instance
 yarn test:e2e            # full Playwright E2E suite (needs `yarn playwright install --with-deps chromium` once)
-yarn test:all            # lint + unit + component + integration + e2e, in that order
+yarn test:all            # lint + lint:css + typecheck + unit + component + integration + e2e, in that order
 ```
 
 See [`docs/03-development/testing/README.md`](docs/03-development/testing/README.md) for how the suite and CI work.

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Documentation lives in [`docs/`](docs/), organized by audience — see [`docs/RE
 
 Everything under [`.github/`](.github/) runs automatically on push/PR to `master` or on a schedule.
 
-* [`workflows/test.yml`](.github/workflows/test.yml) — lint, unit, component, integration, Playwright e2e (see [Running Tests](#running-tests) below), and a `doc-freshness` job that fails if README.md / `docs/03-development/project-structure.md` cite a Node or Next.js major version that no longer matches `frontend/package.json` (via [`.github/scripts/check-doc-versions.sh`](.github/scripts/check-doc-versions.sh))
+* [`workflows/test.yml`](.github/workflows/test.yml) — lint, typecheck, unit, component, integration, Playwright e2e (see [Running Tests](#running-tests) below), and a `doc-freshness` job that fails if README.md / `docs/03-development/project-structure.md` cite a Node or Next.js major version that no longer matches `frontend/package.json` (via [`.github/scripts/check-doc-versions.sh`](.github/scripts/check-doc-versions.sh))
 * [`workflows/codeql.yml`](.github/workflows/codeql.yml) — CodeQL static analysis for security vulnerabilities, on every PR plus a weekly scheduled scan
 * [`workflows/bump-node-version.yml`](.github/workflows/bump-node-version.yml) — monthly check for a new Node.js Active LTS release; opens a PR bumping `.nvmrc`/`package.json`/`test.yml` if one exists (Vercel's supported versions still need a manual check before merging)
 * [`workflows/calver-bump.yml`](.github/workflows/calver-bump.yml) — monthly CalVer bump (see [Versioning](#versioning)); opens a PR resetting `PATCH` to `0` on the 1st of each month

--- a/docs/02-handoff/deployment-and-rollback.md
+++ b/docs/02-handoff/deployment-and-rollback.md
@@ -16,18 +16,18 @@ it becomes part of the live app. Before one can be merged, two things are requir
 
 - **A second person has to approve it.** Whoever wrote the change can't approve their own pull
   request — that's not allowed.
-- **A set of automated checks has to pass** — code style, and three tiers of automated tests
-  (unit, integration, and full click-through tests of the actual app). See
-  [Testing](../03-development/testing/README.md) for what each covers.
+- **A set of automated checks has to pass** — code style, a type-check pass, and four tiers of
+  automated tests (unit, component-level, integration, and full click-through tests of the actual
+  app). See [Testing](../03-development/testing/README.md) for what each covers.
 
 GitHub itself blocks the merge until both are satisfied.
 
 **Two caveats:**
 
-- A few secondary checks (a component-level test tier, a documentation-freshness check, and a
-  security scan) run automatically but aren't required to pass before merging. Thus, it's
-  possible, though not typical, for one of those specifically to be failing at merge time. The
-  core tests mentioned above are always required.
+- A couple of secondary checks (a documentation-freshness check and a security scan) run
+  automatically but aren't required to pass before merging. Thus, it's possible, though not
+  typical, for one of those specifically to be failing at merge time. The core tests mentioned
+  above are always required.
 - A small number of people with Admin-level access on the repository can skip the
   review/check requirement entirely if needed. This is a standard GitHub capability reserved for
   exceptional cases, and is not part of the normal day-to-day process.

--- a/docs/03-development/ci-cd.md
+++ b/docs/03-development/ci-cd.md
@@ -16,9 +16,9 @@ All workflows live in [`.github/workflows/`](https://github.com/cornellh4i/ithac
 ## Test suite — `test.yml`
 
 Runs on pushes to `main`/`master` and on every pull request (targeting any base branch), as
-separate jobs (`doc-freshness`, `lint`, `unit`, `component`, `integration`, `e2e`), so a slow or
-flaky e2e run doesn't hold up the fast unit-test signal. Full breakdown of what each job actually
-tests: [Testing §CI](testing/README.md#ci).
+separate jobs (`doc-freshness`, `lint`, `typecheck`, `unit`, `component`, `integration`, `e2e`), so
+a slow or flaky e2e run doesn't hold up the fast unit-test signal. Full breakdown of what each job
+actually tests: [Testing §CI](testing/README.md#ci).
 
 `CHECKPOINT_DISABLE: "1"` is set at the workflow level in `test.yml`'s `env`, so every job in this
 workflow (not other workflows) skips it — Prisma CLI otherwise pings `checkpoint.prisma.io` after
@@ -106,11 +106,12 @@ manual run, and both open a PR rather than pushing directly:
 
 ## Branch protection
 
-`master` requires a passing run of `title-lint`, `commitlint`, `lint`, `unit`, `integration`, and
-`e2e`, plus one approving review, before a PR can merge (repo Admins can bypass this — see
+`master` requires a passing run of `title-lint`, `commitlint`, `lint`, `typecheck`, `unit`,
+`component`, `integration`, and `e2e`, plus one approving review, before a PR can merge (repo
+Admins can bypass this — see
 [Deployment and Rollback §1](../02-handoff/deployment-and-rollback.md#1-review-and-test-before-merge)
-for the human-facing version of this rule). `component`, `doc-freshness`, and `CodeQL` all run on
-every PR but aren't part of that required set yet.
+for the human-facing version of this rule). `doc-freshness` and `CodeQL` run on every PR but aren't
+part of that required set.
 
 ## Where to go next
 

--- a/docs/03-development/local-setup.md
+++ b/docs/03-development/local-setup.md
@@ -89,9 +89,9 @@ Either make a small edit (e.g. add a one line comment), or work on a small issue
 [*good first issue*s](https://github.com/cornellh4i/ithaca-recovery/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22).
 
 1. Make an edit.
-2. `yarn test:all` — runs lint, lint:css, unit, component, integration, and e2e in sequence
-   (`lint:css` covers any `.scss` file you touched too, no separate step needed). This is the same
-   set of tiers CI runs (see [Testing](testing/README.md)).
+2. `yarn test:all` — runs lint, lint:css, typecheck, unit, component, integration, and e2e in
+   sequence (`lint:css` covers any `.scss` file you touched too, no separate step needed). This is
+   the same set of tiers CI runs (see [Testing](testing/README.md)).
 3. `git diff` to see your change, then `git checkout -- <file>` to revert it if it was just practice.
 
 ## Where to go next

--- a/docs/03-development/local-setup.md
+++ b/docs/03-development/local-setup.md
@@ -73,13 +73,14 @@ that already has a working `GOOGLE_CLIENT_ID`/`_SECRET` and an admin account you
 ```bash
 yarn lint               # ESLint, seconds
 yarn lint:css           # stylelint, seconds — separate from `yarn lint`, .scss files only
+yarn typecheck          # tsc --noEmit, seconds — full cross-file type-checking
 yarn test:unit          # seconds, no setup beyond what you already have
 yarn test:component     # seconds, no setup
 yarn test:integration   # spins up its own embedded Postgres instance — separate from your Neon dev DB
 yarn test:e2e           # needs `yarn playwright install --with-deps chromium` once
 ```
 
-All six should pass on a clean clone with no further setup — the test suites don't use your
+All seven should pass on a clean clone with no further setup — the test suites don't use your
 `.env`'s `DATABASE_URL` at all (`integration`/`e2e` spin up their own embedded Postgres instances).
 If something fails here before you've changed any code, flag and investigate immediately.
 

--- a/docs/03-development/project-structure.md
+++ b/docs/03-development/project-structure.md
@@ -274,9 +274,10 @@ yarn build             # rebuild docs snapshot + search index, prisma generate, 
 yarn start             # Start production server
 yarn lint              # Run ESLint
 yarn lint:css          # Run stylelint (separate from yarn lint — only runs on .scss files)
+yarn typecheck         # tsc --noEmit — full cross-file type-checking
 yarn test:unit         # Jest — pure functions
 yarn test:component    # Jest + React Testing Library — components in isolation
 yarn test:integration  # Jest — route handlers against an embedded Postgres instance
 yarn test:e2e          # Playwright — full browser E2E (needs `yarn playwright install --with-deps chromium` once)
-yarn test:all          # lint && lint:css && test:unit && test:component && test:integration && test:e2e
+yarn test:all          # lint && lint:css && typecheck && test:unit && test:component && test:integration && test:e2e
 ```

--- a/docs/03-development/testing/README.md
+++ b/docs/03-development/testing/README.md
@@ -92,11 +92,12 @@ for the specifics.
 ```bash
 yarn lint                # ESLint
 yarn lint:css            # stylelint — .scss files only, not part of plain `yarn lint`
+yarn typecheck           # tsc --noEmit — full cross-file type-checking, ESLint alone doesn't do this
 yarn test:unit           # seconds, no setup
 yarn test:component      # seconds, no setup
 yarn test:integration    # spins up an embedded Postgres instance
 yarn test:e2e            # spawns a real `next dev` server + Chromium
-yarn test:all            # lint && lint:css && test:unit && test:component && test:integration && test:e2e
+yarn test:all            # lint && lint:css && typecheck && test:unit && test:component && test:integration && test:e2e
 ```
 
 `test:e2e` needs Playwright's browser binaries installed once: `yarn playwright install --with-deps chromium`.
@@ -104,20 +105,20 @@ yarn test:all            # lint && lint:css && test:unit && test:component && te
 ## CI
 
 [`.github/workflows/test.yml`](https://github.com/cornellh4i/ithaca-recovery/blob/master/.github/workflows/test.yml) runs on every push/PR to
-`main`/`master`, as separate jobs: `lint` (ESLint + stylelint), `unit`, `component`, `integration`,
-`e2e`, plus `doc-freshness` (fails if the README/docs cite a stale Node/Next version) — a slow or
-flaky e2e run shouldn't hold up the fast unit-test signal on a PR.
+`main`/`master`, as separate jobs: `lint` (ESLint + stylelint), `typecheck` (`tsc --noEmit`), `unit`,
+`component`, `integration`, `e2e`, plus `doc-freshness` (fails if the README/docs cite a stale
+Node/Next version) — a slow or flaky e2e run shouldn't hold up the fast unit-test signal on a PR.
 The `e2e` job deliberately has no Google/Zoom secrets configured, per the fail-soft design above,
 so it never makes a real external call. On failure it uploads Playwright's trace files
 (`test-results/`) as a downloadable artifact for debugging a CI-only failure.
 
 Note that CI and the Vercel deployment are independent systems — a red `test.yml` run doesn't
 itself block a Vercel deploy. Separately, `master` **is** protected: merging requires a passing
-run of `title-lint`, `commitlint`, `lint`, `unit`, `integration`, and `e2e`, plus one approving
-review (repo Admins can bypass this) — `component` and `doc-freshness` run but aren't part of that
-required set yet. See [Deployment and Rollback](../../02-handoff/deployment-and-rollback.md) §1-2
-for the full picture, including why CI passing and a production deploy happening aren't the same
-guarantee.
+run of `title-lint`, `commitlint`, `lint`, `typecheck`, `unit`, `component`, `integration`, and
+`e2e`, plus one approving review (repo Admins can bypass this) — `doc-freshness` runs but isn't
+part of that required set. See [Deployment and Rollback](../../02-handoff/deployment-and-rollback.md)
+§1-2 for the full picture, including why CI passing and a production deploy happening aren't the
+same guarantee.
 
 `test.yml` is one of several workflows in `.github/workflows/` — commit/PR-title linting,
 CodeQL, dependency-update automation, and more. See [CI/CD](../ci-cd.md) for the full set.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,11 +12,12 @@
     "lint:css:fix": "stylelint --config config/stylelint.config.mjs \"{styles,app}/**/*.scss\" --fix",
     "commitlint": "commitlint --config config/commitlint.config.mjs",
     "postinstall": "prisma generate",
+    "typecheck": "tsc --noEmit -p .",
     "test:unit": "jest --config config/jest.config.ts",
     "test:component": "jest --config config/jest.component.config.ts",
     "test:integration": "jest --config config/jest.integration.config.ts",
     "test:e2e": "playwright test --config config/playwright.config.ts",
-    "test:all": "yarn lint && yarn lint:css && yarn test:unit && yarn test:component && yarn test:integration && yarn test:e2e"
+    "test:all": "yarn lint && yarn lint:css && yarn typecheck && yarn test:unit && yarn test:component && yarn test:integration && yarn test:e2e"
   },
   "dependencies": {
     "@emotion/react": "^11.14.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,7 @@
     "lint:css:fix": "stylelint --config config/stylelint.config.mjs \"{styles,app}/**/*.scss\" --fix",
     "commitlint": "commitlint --config config/commitlint.config.mjs",
     "postinstall": "prisma generate",
-    "typecheck": "tsc --noEmit -p .",
+    "typecheck": "node build-scripts/generate-docs-content.mjs && next typegen && tsc --noEmit -p .",
     "test:unit": "jest --config config/jest.config.ts",
     "test:component": "jest --config config/jest.component.config.ts",
     "test:integration": "jest --config config/jest.integration.config.ts",


### PR DESCRIPTION
Resolves #391

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated TypeScript type checking to the validation workflow.
  * Updated the full test command to include type checking before test suites.
  * Added type-check status as a required quality gate alongside component tests.

* **Documentation**
  * Updated setup, testing, CI/CD, deployment, and project guidance to reflect the expanded validation process.
  * Clarified which automated checks are required before changes can be merged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description
- **frontend/package.json**: add `typecheck` script (`tsc --noEmit -p .`), folded into `test:all` right after `lint:css` so a type error fails fast, before the slower Jest/Playwright tiers.
- **.github/workflows/test.yml**: add a `typecheck` job, mirroring the `lint` job's shape (checkout, setup-node, `yarn install --frozen-lockfile`, `yarn typecheck`).
- **docs**: update README.md, docs/03-development/{testing/README,ci-cd,project-structure,local-setup}.md, docs/02-handoff/deployment-and-rollback.md, and the dependabot-auto-merge.yml comment to mention `typecheck` and reflect `component` now being a required check.
- Repo ruleset `1403679`'s `required_status_checks` already updated live (out-of-band, via `gh api`) to include `typecheck` and `component` — done ahead of this PR merging so the checks actually gate merge once this job exists on `master`.

## Testing
- [x] `yarn typecheck` passes clean on the current tree.
- [x] Introduced a throwaway type error (`const x: number = "not a number"` in Icon.tsx) and confirmed both `yarn typecheck` and `yarn test:all` fail on it — `test:all` stops at the `typecheck` step, before reaching `test:unit`. Reverted before committing.
- [x] Confirmed via `gh api repos/cornellh4i/ithaca-recovery/rules/branches/master` that `typecheck` and `component` are now listed in `required_status_checks`.

## Area(s) Touched
**Product areas**
- [ ] auth — sign-in, sessions, NextAuth, role-based access
- [ ] admin — /admin shell (Diagnostics, Users, Import, Export tabs)
- [ ] docs — /docs Resources page (rendering, navigation, search)
- [ ] ui/ux — frontend layout/styling not tied to a specific integration

**Integrations**
- [ ] google-calendar — Google Calendar sync
- [ ] zoom-api — Zoom meeting/host sync

**Engineering**
- [ ] security — auth hardening, data exposure, dependency/security scanning
- [x] testing — test suite (Jest/Playwright) changes
- [x] github-actions — workflows, Dependabot config, other .github/ CI tooling
- [ ] cleanup — refactor or dead-code removal, no behavior change
- [x] documentation — docs/ or README changes only

## Pre-merge Checklist
- [x] Code follows current formatting conventions and passes lint (`yarn lint`).
- [x] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
- [ ] All test suites pass, both run locally and green in GitHub CI. **Do not merge if any test suite is failing.**
- [x] A test suite was added or updated for the feature/fix in this PR — N/A, this PR *is* the check (`typecheck` itself); verified manually per Testing above.
- [x] Only files relevant to this change are committed — no stray or unrelated files.
- [x] If this branch has a merge conflict with master, master was merged into this branch first (not the other way around).
- [x] The rest of this PR description (Description, Testing) is filled out, not left as template placeholders.