### PR TITLE
chore(github-actions): set persist-credentials: false on test.yml checkout steps

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,6 +42,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@v7
         with:
           node-version: 24
@@ -57,6 +59,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@v7
         with:
           node-version: 24
@@ -69,6 +73,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@v7
         with:
           node-version: 24
@@ -81,6 +87,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@v7
         with:
           node-version: 24
@@ -94,6 +102,8 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@v7
         with:
           node-version: 24
@@ -116,6 +126,8 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@v7
         with:
           node-version: 24


### PR DESCRIPTION
Resolves #393

@coderabbitai summary

## Description
- **.github/workflows/test.yml**: added `persist-credentials: false` to the `actions/checkout@v7` step in `lint`, `typecheck`, `unit`, `component`, `integration`, and `e2e` — none of these jobs push or authenticate back to GitHub, so there's no reason to retain repo credentials in the local git config past checkout. Matches what `doc-freshness` already does. Flagged by CodeRabbit on PR #392's `typecheck` job; confirmed the same gap existed on the other five pre-existing jobs.

## Testing
- [x] `git grep -c "persist-credentials: false" .github/workflows/test.yml` → 7 (one per job: doc-freshness + the 6 added here)
- [ ] CI green on this PR (no job relies on persisted credentials)

## Area(s) Touched
**Engineering**
- [x] security — auth hardening, data exposure, dependency/security scanning
- [x] github-actions — workflows, Dependabot config, other .github/ CI tooling

## Pre-merge Checklist
- [x] Code follows current formatting conventions and passes lint (`yarn lint`).
- [x] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
- [ ] All test suites pass, both run locally and green in GitHub CI. **Do not merge if any test suite is failing.**
- [x] A test suite was added or updated for the feature/fix in this PR. **Double-check this if you change a feature and did not update the test suites**. (N/A — CI config change, no app code touched)
- [x] Only files relevant to this change are committed — no stray or unrelated files.
- [x] If this branch has a merge conflict with master, master was merged into this branch first (not the other way around).
- [x] The rest of this PR description (Description, Testing) is filled out, not left as template placeholders.