### PR TITLE
fix(meeting-form): adopt shared accessible modal primitive

### DIFF
--- a/frontend/app/components/meeting-form/ConflictOverrideModal.tsx
+++ b/frontend/app/components/meeting-form/ConflictOverrideModal.tsx
@@ -1,5 +1,6 @@
-import React, { useEffect, useRef } from 'react';
+import React from 'react';
 import Icon from '../ui/displays/Icon';
+import Modal from '../ui/overlays/Modal';
 import styles from './ConflictOverrideModal.module.scss';
 import { fieldLabel, formatOverlapSummary, formatMeetingSchedule, ConflictListRow } from '../../../util/meetings/conflictDisplay';
 
@@ -22,74 +23,53 @@ const ConflictOverrideModal: React.FC<ConflictOverrideModalProps> = ({
   onCancel,
   onConfirm,
   isConfirming = false,
-}) => {
-  // "Go back" (the non-destructive default) gets initial focus, mirroring BottomSheet.tsx's own
-  // focus-on-open/restore-on-close pattern -- without this, focus stays on the form's now-
-  // re-enabled submit button underneath, and Enter/Space could resubmit it while this is up.
-  const cancelButtonRef = useRef<HTMLButtonElement>(null);
+}) => (
+  <Modal
+    isOpen={isOpen}
+    onClose={onCancel}
+    overlayClassName={styles.modalOverlay}
+    contentClassName={styles.modalContent}
+    labelledBy="conflict-override-title"
+    preventClose={isConfirming}
+  >
+    <div className={styles.header}>
+      <span className={styles.iconCircle}>
+        <Icon name="warning-circle" size={20} />
+      </span>
+      <h2 id="conflict-override-title" className={styles.title}>Scheduling conflict</h2>
+    </div>
 
-  useEffect(() => {
-    if (!isOpen) return;
+    <p className={styles.message}>
+      This meeting&apos;s room, Zoom room, or Zoom host is already booked at this time. You can save
+      anyway, or go back and change the room, Zoom room, Zoom host, or schedule.
+    </p>
 
-    const previouslyFocused = document.activeElement as HTMLElement | null;
-    cancelButtonRef.current?.focus();
-
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") onCancel();
-    };
-    document.addEventListener("keydown", handleKeyDown);
-
-    return () => {
-      document.removeEventListener("keydown", handleKeyDown);
-      previouslyFocused?.focus();
-    };
-  }, [isOpen, onCancel]);
-
-  if (!isOpen) return null;
-
-  return (
-    <div className={styles.modalOverlay}>
-      <div className={styles.modalContent} role="dialog" aria-modal="true" aria-labelledby="conflict-override-title">
-        <div className={styles.header}>
-          <span className={styles.iconCircle}>
-            <Icon name="warning-circle" size={20} />
-          </span>
-          <h2 id="conflict-override-title" className={styles.title}>Scheduling conflict</h2>
-        </div>
-
-        <p className={styles.message}>
-          This meeting&apos;s room, Zoom room, or Zoom host is already booked at this time. You can save
-          anyway, or go back and change the room, Zoom room, Zoom host, or schedule.
-        </p>
-
-        <div className={styles.conflictList}>
-          {conflicts.map((conflict, i) => (
-            <div key={`${conflict.field}-${conflict.value}-${i}`} className={styles.conflictGroup}>
-              <div className={styles.conflictMeta}>
-                {fieldLabel(conflict.field)}: <span className={styles.conflictValue}>{conflict.value}</span>
-              </div>
-              <div className={styles.overlapSummary}>{formatOverlapSummary(conflict.overlap, conflict.meetings)}</div>
-              {conflict.meetings.map((meeting) => (
-                <div key={meeting.mid} className={styles.conflictEntry}>
-                  <span className={styles.meetingTitle}>{meeting.title}</span>
-                  <div className={styles.meetingSchedule}>{formatMeetingSchedule(meeting)}</div>
-                </div>
-              ))}
+    <div className={styles.conflictList}>
+      {conflicts.map((conflict, i) => (
+        <div key={`${conflict.field}-${conflict.value}-${i}`} className={styles.conflictGroup}>
+          <div className={styles.conflictMeta}>
+            {fieldLabel(conflict.field)}: <span className={styles.conflictValue}>{conflict.value}</span>
+          </div>
+          <div className={styles.overlapSummary}>{formatOverlapSummary(conflict.overlap, conflict.meetings)}</div>
+          {conflict.meetings.map((meeting) => (
+            <div key={meeting.mid} className={styles.conflictEntry}>
+              <span className={styles.meetingTitle}>{meeting.title}</span>
+              <div className={styles.meetingSchedule}>{formatMeetingSchedule(meeting)}</div>
             </div>
           ))}
         </div>
-
-        <div className={styles.buttonContainer}>
-          <button ref={cancelButtonRef} className={styles.cancelButton} onClick={onCancel} disabled={isConfirming}>
-            Go back
-          </button>
-          <button className={styles.overrideButton} onClick={onConfirm} disabled={isConfirming}>
-            {isConfirming ? "Saving…" : "Save anyway"}
-          </button>
-        </div>
-      </div>
+      ))}
     </div>
-  );
-};
+
+    <div className={styles.buttonContainer}>
+      <button className={styles.cancelButton} onClick={onCancel} disabled={isConfirming}>
+        Go back
+      </button>
+      <button className={styles.overrideButton} onClick={onConfirm} disabled={isConfirming}>
+        {isConfirming ? "Saving…" : "Save anyway"}
+      </button>
+    </div>
+  </Modal>
+);
 
 export default ConflictOverrideModal;

--- a/frontend/app/components/meeting-form/DeleteMeetingModal.module.scss
+++ b/frontend/app/components/meeting-form/DeleteMeetingModal.module.scss
@@ -10,7 +10,13 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  z-index: 1000;
+
+  // Must beat ViewMeeting's own .popupAnchor (z-index: 2000) -- this modal is rendered inside
+  // ViewMeeting as a sibling of the popup card, but Modal's own createPortal moves it straight
+  // to document.body, escaping .popupAnchor's already-portaled stacking context rather than
+  // inheriting it. A lower value here means ViewMeeting's popup renders on top and intercepts
+  // clicks meant for this modal's buttons.
+  z-index: 2001;
 }
 
 .modalContent {

--- a/frontend/app/components/meeting-form/DeleteMeetingModal.tsx
+++ b/frontend/app/components/meeting-form/DeleteMeetingModal.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import Icon from '../ui/displays/Icon';
+import Modal from '../ui/overlays/Modal';
 import styles from './DeleteMeetingModal.module.scss';
 
 interface DeleteMeetingModalProps {
@@ -21,46 +22,46 @@ const DeleteMeetingModal: React.FC<DeleteMeetingModalProps> = ({
   onCancel,
   onConfirm,
   onSuspendInstead,
-}) => {
-  if (!isOpen) return null;
-
-  return (
-    <div className={styles.modalOverlay}>
-      <div className={styles.modalContent}>
-        <div className={styles.header}>
-          <span className={styles.iconCircle}>
-            <Icon name="delete" size={20} />
-          </span>
-          <h2 className={styles.title}>Delete this meeting?</h2>
-        </div>
-
-        <p className={styles.message}>
-          <strong>{title}</strong> ({timeRangeText}) will be permanently removed from the
-          calendar starting <strong className={styles.effectiveDate}>{effectiveDateText}</strong>.
-          This can&apos;t be undone.
-        </p>
-
-        {onSuspendInstead && (
-          <div className={styles.suspendNudge}>
-            <Icon name="warning-circle" size={16} className={styles.nudgeIcon} />
-            <span>
-              Not sure? <strong>Suspend</strong> instead — the meeting is paused and hidden from the
-              calendar, but can be viewed from the admin dashboard and reactivated. <strong>Delete</strong> is
-              permanent.
-            </span>
-          </div>
-        )}
-
-        <div className={styles.buttonContainer}>
-          <button className={styles.cancelButton} onClick={onCancel}>Cancel</button>
-          {onSuspendInstead && (
-            <button className={styles.suspendButton} onClick={onSuspendInstead}>Suspend</button>
-          )}
-          <button className={styles.deleteButton} onClick={onConfirm}>Delete</button>
-        </div>
-      </div>
+}) => (
+  <Modal
+    isOpen={isOpen}
+    onClose={onCancel}
+    overlayClassName={styles.modalOverlay}
+    contentClassName={styles.modalContent}
+    labelledBy="delete-meeting-title"
+  >
+    <div className={styles.header}>
+      <span className={styles.iconCircle}>
+        <Icon name="delete" size={20} />
+      </span>
+      <h2 id="delete-meeting-title" className={styles.title}>Delete this meeting?</h2>
     </div>
-  );
-};
+
+    <p className={styles.message}>
+      <strong>{title}</strong> ({timeRangeText}) will be permanently removed from the
+      calendar starting <strong className={styles.effectiveDate}>{effectiveDateText}</strong>.
+      This can&apos;t be undone.
+    </p>
+
+    {onSuspendInstead && (
+      <div className={styles.suspendNudge}>
+        <Icon name="warning-circle" size={16} className={styles.nudgeIcon} />
+        <span>
+          Not sure? <strong>Suspend</strong> instead — the meeting is paused and hidden from the
+          calendar, but can be viewed from the admin dashboard and reactivated. <strong>Delete</strong> is
+          permanent.
+        </span>
+      </div>
+    )}
+
+    <div className={styles.buttonContainer}>
+      <button className={styles.cancelButton} onClick={onCancel}>Cancel</button>
+      {onSuspendInstead && (
+        <button className={styles.suspendButton} onClick={onSuspendInstead}>Suspend</button>
+      )}
+      <button className={styles.deleteButton} onClick={onConfirm}>Delete</button>
+    </div>
+  </Modal>
+);
 
 export default DeleteMeetingModal;

--- a/frontend/app/components/meeting-form/DeleteRecurringModal.module.scss
+++ b/frontend/app/components/meeting-form/DeleteRecurringModal.module.scss
@@ -11,7 +11,13 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  z-index: 1000;
+
+  // Must beat ViewMeeting's own .popupAnchor (z-index: 2000) -- this modal is rendered inside
+  // ViewMeeting as a sibling of the popup card, but Modal's own createPortal moves it straight
+  // to document.body, escaping .popupAnchor's already-portaled stacking context rather than
+  // inheriting it. A lower value here means ViewMeeting's popup renders on top and intercepts
+  // clicks meant for this modal's buttons.
+  z-index: 2001;
 }
 
 .modalContent {

--- a/frontend/app/components/meeting-form/DeleteRecurringModal.tsx
+++ b/frontend/app/components/meeting-form/DeleteRecurringModal.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import Icon from '../ui/displays/Icon';
+import Modal from '../ui/overlays/Modal';
 import styles from './DeleteRecurringModal.module.scss';
 
 interface DeleteRecurringModalProps {
@@ -22,8 +23,6 @@ const DeleteRecurringModal: React.FC<DeleteRecurringModalProps> = ({
 }) => {
   const [selectedOption, setSelectedOption] = useState<'this' | 'thisAndFollowing' | 'all'>('this');
 
-  if (!isOpen) return null;
-
   const handleOptionSelect = (option: 'this' | 'thisAndFollowing' | 'all') => {
     setSelectedOption(option);
   };
@@ -32,98 +31,102 @@ const DeleteRecurringModal: React.FC<DeleteRecurringModalProps> = ({
     onDelete(selectedOption);
     onClose();
   };
-  
+
   return (
-    <div className={styles.modalOverlay}>
-      <div className={styles.modalContent}>
-        <div className={styles.header}>
-          <span className={styles.iconCircle}>
-            <Icon name="delete" size={20} />
-          </span>
-          <h2 className={styles.modalTitle}>Delete recurring event</h2>
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      overlayClassName={styles.modalOverlay}
+      contentClassName={styles.modalContent}
+      labelledBy="delete-recurring-title"
+    >
+      <div className={styles.header}>
+        <span className={styles.iconCircle}>
+          <Icon name="delete" size={20} />
+        </span>
+        <h2 id="delete-recurring-title" className={styles.modalTitle}>Delete recurring event</h2>
+      </div>
+
+      <p className={styles.message}>
+        {selectedOption === 'this' ? (
+          <>
+            Only the occurrence of <strong>{title}</strong> on{' '}
+            <strong className={styles.effectiveDate}>{effectiveDateText}</strong> will be
+            permanently removed from the calendar.
+          </>
+        ) : selectedOption === 'thisAndFollowing' ? (
+          <>
+            <strong>{title}</strong> will be permanently removed from the calendar starting{' '}
+            <strong className={styles.effectiveDate}>{effectiveDateText}</strong>, including
+            every occurrence after it.
+          </>
+        ) : (
+          <>
+            <strong>{title}</strong> will be permanently removed from the calendar entirely —
+            every occurrence, including ones before{' '}
+            <strong className={styles.effectiveDate}>{effectiveDateText}</strong>.
+          </>
+        )}{' '}
+        This action can&apos;t be undone.
+      </p>
+
+      <div className={styles.optionsContainer}>
+        <div className={styles.optionItem}>
+          <input
+            type="radio"
+            id="this-event"
+            name="delete-option"
+            checked={selectedOption === 'this'}
+            onChange={() => handleOptionSelect('this')}
+            className={styles.radioInput}
+          />
+          <label htmlFor="this-event" className={styles.radioLabel}>This event</label>
         </div>
 
-        <p className={styles.message}>
-          {selectedOption === 'this' ? (
-            <>
-              Only the occurrence of <strong>{title}</strong> on{' '}
-              <strong className={styles.effectiveDate}>{effectiveDateText}</strong> will be
-              permanently removed from the calendar.
-            </>
-          ) : selectedOption === 'thisAndFollowing' ? (
-            <>
-              <strong>{title}</strong> will be permanently removed from the calendar starting{' '}
-              <strong className={styles.effectiveDate}>{effectiveDateText}</strong>, including
-              every occurrence after it.
-            </>
-          ) : (
-            <>
-              <strong>{title}</strong> will be permanently removed from the calendar entirely —
-              every occurrence, including ones before{' '}
-              <strong className={styles.effectiveDate}>{effectiveDateText}</strong>.
-            </>
-          )}{' '}
-          This action can&apos;t be undone.
-        </p>
-
-        <div className={styles.optionsContainer}>
-          <div className={styles.optionItem}>
-            <input
-              type="radio"
-              id="this-event"
-              name="delete-option"
-              checked={selectedOption === 'this'}
-              onChange={() => handleOptionSelect('this')}
-              className={styles.radioInput}
-            />
-            <label htmlFor="this-event" className={styles.radioLabel}>This event</label>
-          </div>
-
-          <div className={styles.optionItem}>
-            <input
-              type="radio"
-              id="this-and-following"
-              name="delete-option"
-              checked={selectedOption === 'thisAndFollowing'}
-              onChange={() => handleOptionSelect('thisAndFollowing')}
-              className={styles.radioInput}
-            />
-            <label htmlFor="this-and-following" className={styles.radioLabel}>This and following events</label>
-          </div>
-
-          <div className={styles.optionItem}>
-            <input
-              type="radio"
-              id="all-events"
-              name="delete-option"
-              checked={selectedOption === 'all'}
-              onChange={() => handleOptionSelect('all')}
-              className={styles.radioInput}
-            />
-            <label htmlFor="all-events" className={styles.radioLabel}>All events</label>
-          </div>
+        <div className={styles.optionItem}>
+          <input
+            type="radio"
+            id="this-and-following"
+            name="delete-option"
+            checked={selectedOption === 'thisAndFollowing'}
+            onChange={() => handleOptionSelect('thisAndFollowing')}
+            className={styles.radioInput}
+          />
+          <label htmlFor="this-and-following" className={styles.radioLabel}>This and following events</label>
         </div>
 
-        {onSuspendInstead && (
-          <div className={styles.suspendNudge}>
-            <Icon name="warning-circle" size={16} className={styles.nudgeIcon} />
-            <span>
-              Not sure? <strong>Suspend</strong> instead — the meeting is paused and hidden from the
-              calendar, but can be viewed from the admin dashboard and reactivated. <strong>Delete</strong> is
-              permanent.
-            </span>
-          </div>
-        )}
-
-        <div className={styles.buttonContainer}>
-          <button className={styles.cancelButton} onClick={onClose}>Cancel</button>
-          {onSuspendInstead && (
-            <button className={styles.suspendButton} onClick={onSuspendInstead}>Suspend</button>
-          )}
-          <button className={styles.deleteButton} onClick={handleDelete}>Delete</button>
+        <div className={styles.optionItem}>
+          <input
+            type="radio"
+            id="all-events"
+            name="delete-option"
+            checked={selectedOption === 'all'}
+            onChange={() => handleOptionSelect('all')}
+            className={styles.radioInput}
+          />
+          <label htmlFor="all-events" className={styles.radioLabel}>All events</label>
         </div>
       </div>
-    </div>
+
+      {onSuspendInstead && (
+        <div className={styles.suspendNudge}>
+          <Icon name="warning-circle" size={16} className={styles.nudgeIcon} />
+          <span>
+            Not sure? <strong>Suspend</strong> instead — the meeting is paused and hidden from the
+            calendar, but can be viewed from the admin dashboard and reactivated. <strong>Delete</strong> is
+            permanent.
+          </span>
+        </div>
+      )}
+
+      <div className={styles.buttonContainer}>
+        <button className={styles.cancelButton} onClick={onClose}>Cancel</button>
+        {onSuspendInstead && (
+          <button className={styles.suspendButton} onClick={onSuspendInstead}>Suspend</button>
+        )}
+        <button className={styles.deleteButton} onClick={handleDelete}>Delete</button>
+      </div>
+    </Modal>
   );
 };
 

--- a/frontend/app/components/meeting-form/ResumeMeetingModal.module.scss
+++ b/frontend/app/components/meeting-form/ResumeMeetingModal.module.scss
@@ -10,7 +10,13 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  z-index: 1000;
+
+  // Must beat ViewMeeting's own .popupAnchor (z-index: 2000) -- this modal is rendered inside
+  // ViewMeeting as a sibling of the popup card, but Modal's own createPortal moves it straight
+  // to document.body, escaping .popupAnchor's already-portaled stacking context rather than
+  // inheriting it. A lower value here means ViewMeeting's popup renders on top and intercepts
+  // clicks meant for this modal's buttons.
+  z-index: 2001;
 }
 
 .modalContent {

--- a/frontend/app/components/meeting-form/ResumeMeetingModal.tsx
+++ b/frontend/app/components/meeting-form/ResumeMeetingModal.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import styles from './ResumeMeetingModal.module.scss';
 import DatePicker from '../ui/pickers/DatePicker';
 import Icon from '../ui/displays/Icon';
+import Modal from '../ui/overlays/Modal';
 import { formatETDateString, parseMMDDYYYY } from '../../../util/date/timeUtils';
 
 interface ResumeMeetingModalProps {
@@ -37,8 +38,6 @@ const ResumeMeetingModal: React.FC<ResumeMeetingModalProps> = ({
   // DatePicker's own value/onChange contract is MM/DD/YYYY (see DatePicker.tsx's doc comment).
   const [resumeDate, setResumeDate] = useState('');
 
-  if (!isOpen) return null;
-
   const todayStr = formatETDateString(new Date());
   const sinceStr = suspendedSince ? formatETDateString(new Date(suspendedSince)) : null;
   const minStr = sinceStr && sinceStr > todayStr ? sinceStr : todayStr;
@@ -53,13 +52,21 @@ const ResumeMeetingModal: React.FC<ResumeMeetingModalProps> = ({
   };
 
   return (
-    <div className={styles.modalOverlay} data-testid="resume-meeting-modal">
-      <div className={styles.modalContent}>
+    <Modal
+      isOpen={isOpen}
+      onClose={onCancel}
+      overlayClassName={styles.modalOverlay}
+      contentClassName={styles.modalContent}
+      labelledBy="resume-meeting-title"
+    >
+      {/* data-testid lives on this inner wrapper, not Modal's own content div, since Modal
+          doesn't accept passthrough props -- see tests/e2e/14-meeting-suspension.spec.ts. */}
+      <div data-testid="resume-meeting-modal">
         <div className={styles.header}>
           <span className={styles.iconCircle}>
             <Icon name="resume" size={20} />
           </span>
-          <h2 className={styles.title}>{isActive ? 'Resume this meeting?' : 'Cancel scheduled suspension?'}</h2>
+          <h2 id="resume-meeting-title" className={styles.title}>{isActive ? 'Resume this meeting?' : 'Cancel scheduled suspension?'}</h2>
         </div>
 
         <p className={styles.message}>
@@ -120,7 +127,7 @@ const ResumeMeetingModal: React.FC<ResumeMeetingModalProps> = ({
           </button>
         </div>
       </div>
-    </div>
+    </Modal>
   );
 };
 

--- a/frontend/app/components/meeting-form/SuspendMeetingModal.module.scss
+++ b/frontend/app/components/meeting-form/SuspendMeetingModal.module.scss
@@ -10,7 +10,13 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  z-index: 1000;
+
+  // Must beat ViewMeeting's own .popupAnchor (z-index: 2000) -- this modal is rendered inside
+  // ViewMeeting as a sibling of the popup card, but Modal's own createPortal moves it straight
+  // to document.body, escaping .popupAnchor's already-portaled stacking context rather than
+  // inheriting it. A lower value here means ViewMeeting's popup renders on top and intercepts
+  // clicks meant for this modal's buttons.
+  z-index: 2001;
 }
 
 .modalContent {

--- a/frontend/app/components/meeting-form/SuspendMeetingModal.tsx
+++ b/frontend/app/components/meeting-form/SuspendMeetingModal.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import styles from './SuspendMeetingModal.module.scss';
 import DatePicker from '../ui/pickers/DatePicker';
 import Icon from '../ui/displays/Icon';
+import Modal from '../ui/overlays/Modal';
 import { formatETDateString, parseMMDDYYYY } from '../../../util/date/timeUtils';
 
 interface SuspendMeetingModalProps {
@@ -34,8 +35,6 @@ const SuspendMeetingModal: React.FC<SuspendMeetingModalProps> = ({
   // DatePicker's own value/onChange contract is MM/DD/YYYY (see DatePicker.tsx's doc comment).
   const [resumeDate, setResumeDate] = useState('');
 
-  if (!isOpen) return null;
-
   const minStr = formatETDateString(new Date(effectiveDate));
   const pickedDate = parseMMDDYYYY(resumeDate);
   const pickedStr = pickedDate ? formatETDateString(pickedDate) : null;
@@ -47,70 +46,74 @@ const SuspendMeetingModal: React.FC<SuspendMeetingModalProps> = ({
   };
 
   return (
-    <div className={styles.modalOverlay}>
-      <div className={styles.modalContent}>
-        <div className={styles.header}>
-          <span className={styles.iconCircle}>
-            <Icon name="pause" size={20} />
-          </span>
-          <h2 className={styles.title}>Suspend this meeting?</h2>
-        </div>
+    <Modal
+      isOpen={isOpen}
+      onClose={onCancel}
+      overlayClassName={styles.modalOverlay}
+      contentClassName={styles.modalContent}
+      labelledBy="suspend-meeting-title"
+    >
+      <div className={styles.header}>
+        <span className={styles.iconCircle}>
+          <Icon name="pause" size={20} />
+        </span>
+        <h2 id="suspend-meeting-title" className={styles.title}>Suspend this meeting?</h2>
+      </div>
 
-        <p className={styles.message}>
-          <strong>{title}</strong> will be paused and hidden from the calendar starting{' '}
-          <strong className={styles.effectiveDate}>{effectiveDateText}</strong>, until reactivated.
-          It can still be viewed and reactivated from the admin dashboard.
+      <p className={styles.message}>
+        <strong>{title}</strong> will be paused and hidden from the calendar starting{' '}
+        <strong className={styles.effectiveDate}>{effectiveDateText}</strong>, until reactivated.
+        It can still be viewed and reactivated from the admin dashboard.
+      </p>
+
+      {pastOccurrenceDateText && (
+        <p className={styles.pastNotice}>
+          {pastOccurrenceDateText} already happened, so suspending starts today instead.
         </p>
+      )}
 
-        {pastOccurrenceDateText && (
-          <p className={styles.pastNotice}>
-            {pastOccurrenceDateText} already happened, so suspending starts today instead.
-          </p>
-        )}
-
-        <div className={styles.resumeOptions}>
-          <label className={styles.radioRow}>
+      <div className={styles.resumeOptions}>
+        <label className={styles.radioRow}>
+          <input
+            type="radio"
+            name="resumeOption"
+            checked={resumeOption === 'indefinite'}
+            onChange={() => setResumeOption('indefinite')}
+          />
+          Indefinitely
+        </label>
+        <div className={styles.radioRow}>
+          <label className={styles.radioLabel}>
             <input
               type="radio"
               name="resumeOption"
-              checked={resumeOption === 'indefinite'}
-              onChange={() => setResumeOption('indefinite')}
+              checked={resumeOption === 'until'}
+              onChange={() => setResumeOption('until')}
             />
-            Indefinitely
+            <span className={styles.untilLabel}>Until</span>
           </label>
-          <div className={styles.radioRow}>
-            <label className={styles.radioLabel}>
-              <input
-                type="radio"
-                name="resumeOption"
-                checked={resumeOption === 'until'}
-                onChange={() => setResumeOption('until')}
-              />
-              <span className={styles.untilLabel}>Until</span>
-            </label>
-            {resumeOption === 'until' && (
-              <span className={styles.untilDatePicker}>
-                <DatePicker label="" value={resumeDate} onChange={setResumeDate} underlineOnFocus={false} compact />
-              </span>
-            )}
-          </div>
-          {resumeOption === 'until' && resumeDate && !isUntilDateValid && (
-            <p className={styles.dateError}>Must be after {effectiveDateText}.</p>
+          {resumeOption === 'until' && (
+            <span className={styles.untilDatePicker}>
+              <DatePicker label="" value={resumeDate} onChange={setResumeDate} underlineOnFocus={false} compact />
+            </span>
           )}
         </div>
-
-        <div className={styles.buttonContainer}>
-          <button className={styles.cancelButton} onClick={onCancel}>Cancel</button>
-          <button
-            className={styles.suspendButton}
-            onClick={handleConfirm}
-            disabled={resumeOption === 'until' && !isUntilDateValid}
-          >
-            Suspend
-          </button>
-        </div>
+        {resumeOption === 'until' && resumeDate && !isUntilDateValid && (
+          <p className={styles.dateError}>Must be after {effectiveDateText}.</p>
+        )}
       </div>
-    </div>
+
+      <div className={styles.buttonContainer}>
+        <button className={styles.cancelButton} onClick={onCancel}>Cancel</button>
+        <button
+          className={styles.suspendButton}
+          onClick={handleConfirm}
+          disabled={resumeOption === 'until' && !isUntilDateValid}
+        >
+          Suspend
+        </button>
+      </div>
+    </Modal>
   );
 };
 

--- a/frontend/app/components/meeting-form/ViewMeeting.tsx
+++ b/frontend/app/components/meeting-form/ViewMeeting.tsx
@@ -250,6 +250,13 @@ const ViewMeetingDetails: React.FC<ViewMeetingDetailsProps> = ({
       // to document.body, so it's a DOM sibling of this popup, not a descendant -- without this
       // check, clicking a day on it reads as an outside click and closes the whole thing.
       if ((target as Element).closest?.('[data-datepicker-popup]')) return;
+      // Same escape hatch for the Delete/DeleteRecurring/Suspend/Resume modals below (see
+      // `modals`) -- they render via the shared Modal primitive, which portals to document.body
+      // in the same way, so a click on any of their buttons is also a DOM sibling of this popup,
+      // not a descendant. Without this, e.g. clicking DeleteMeetingModal's "Delete" button
+      // registers as an outside click and unmounts this whole popup (and the modal with it)
+      // before the button's own onClick can fire.
+      if ((target as Element).closest?.('[data-modal-popup]')) return;
       onBack();
     };
 

--- a/frontend/app/components/ui/overlays/Modal.tsx
+++ b/frontend/app/components/ui/overlays/Modal.tsx
@@ -107,6 +107,12 @@ const Modal: React.FC<ModalProps> = ({
   return createPortal(
     <div
       className={overlayClassName}
+      // Host components that portal themselves (e.g. ViewMeeting) may run their own
+      // outside-click-closes-me listener keyed off DOM containment. Once this modal is *also*
+      // portaled to document.body, it's a sibling of such a host, not a descendant, so a click
+      // anywhere in here would misread as "outside" without this hook -- mirrors the existing
+      // [data-datepicker-popup] / [data-user-menu-popup] escape-hatch convention.
+      data-modal-popup="true"
       onMouseDown={(event) => {
         if (event.target === event.currentTarget && !preventClose) onClose();
       }}

--- a/frontend/tests/component/ConflictOverrideModal.test.tsx
+++ b/frontend/tests/component/ConflictOverrideModal.test.tsx
@@ -36,16 +36,42 @@ describe("ConflictOverrideModal", () => {
   });
 
   it("lists the conflicting meetings by field and title when open", () => {
-    const { container } = render(
-      <ConflictOverrideModal isOpen conflicts={conflicts} onCancel={jest.fn()} onConfirm={jest.fn()} />,
-    );
+    render(<ConflictOverrideModal isOpen conflicts={conflicts} onCancel={jest.fn()} onConfirm={jest.fn()} />);
     expect(screen.getByText("Scheduling conflict")).toBeInTheDocument();
-    // "Room:" and its value render as separate text/element siblings within .conflictMeta, so
-    // check the container's full text rather than an exact single-node match.
-    expect(container.textContent).toContain("Room:");
+    // "Room:" and its value render as separate text/element siblings within .conflictMeta, and
+    // ConflictOverrideModal now renders via Modal's createPortal (to document.body, not RTL's
+    // own container div), so check the dialog's own text rather than an exact single-node match
+    // or the render() container.
+    expect(screen.getByRole("dialog").textContent).toContain("Room:");
     expect(screen.getByText("Fellowship Room")).toBeInTheDocument();
     expect(screen.getByText("New Meeting")).toBeInTheDocument();
     expect(screen.getByText("Busy Meeting")).toBeInTheDocument();
+  });
+
+  it("renders accessible dialog semantics", () => {
+    render(<ConflictOverrideModal isOpen conflicts={conflicts} onCancel={jest.fn()} onConfirm={jest.fn()} />);
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toHaveAttribute("aria-modal", "true");
+    expect(dialog).toHaveAccessibleName("Scheduling conflict");
+  });
+
+  it("focuses Go back (the non-destructive default) on open", () => {
+    render(<ConflictOverrideModal isOpen conflicts={conflicts} onCancel={jest.fn()} onConfirm={jest.fn()} />);
+    expect(screen.getByRole("button", { name: "Go back" })).toHaveFocus();
+  });
+
+  it("calls onCancel on Escape", () => {
+    const onCancel = jest.fn();
+    render(<ConflictOverrideModal isOpen conflicts={conflicts} onCancel={onCancel} onConfirm={jest.fn()} />);
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call onCancel on Escape while confirming", () => {
+    const onCancel = jest.fn();
+    render(<ConflictOverrideModal isOpen conflicts={conflicts} onCancel={onCancel} onConfirm={jest.fn()} isConfirming />);
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onCancel).not.toHaveBeenCalled();
   });
 
   it("calls onCancel when Go back is clicked", () => {

--- a/frontend/tests/component/DeleteMeetingModal.test.tsx
+++ b/frontend/tests/component/DeleteMeetingModal.test.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import DeleteMeetingModal from "../../app/components/meeting-form/DeleteMeetingModal";
+
+const baseProps = {
+  title: "Weekly Standup",
+  timeRangeText: "9:00 - 9:30 AM",
+  effectiveDateText: "Aug 15, 2026",
+  onCancel: jest.fn(),
+  onConfirm: jest.fn(),
+};
+
+describe("DeleteMeetingModal", () => {
+  it("renders nothing when closed", () => {
+    render(<DeleteMeetingModal isOpen={false} {...baseProps} />);
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("renders accessible dialog semantics and focuses Cancel on open", () => {
+    render(<DeleteMeetingModal isOpen {...baseProps} />);
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toHaveAttribute("aria-modal", "true");
+    expect(dialog).toHaveAccessibleName("Delete this meeting?");
+    expect(screen.getByRole("button", { name: "Cancel" })).toHaveFocus();
+  });
+
+  it("calls onCancel on Escape", () => {
+    const onCancel = jest.fn();
+    render(<DeleteMeetingModal isOpen {...baseProps} onCancel={onCancel} />);
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onConfirm when Delete is clicked", () => {
+    const onConfirm = jest.fn();
+    render(<DeleteMeetingModal isOpen {...baseProps} onConfirm={onConfirm} />);
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/tests/component/DeleteRecurringModal.test.tsx
+++ b/frontend/tests/component/DeleteRecurringModal.test.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import DeleteRecurringModal from "../../app/components/meeting-form/DeleteRecurringModal";
+
+const baseProps = {
+  title: "Weekly Standup",
+  effectiveDateText: "Aug 15, 2026",
+  onClose: jest.fn(),
+  onDelete: jest.fn(),
+};
+
+describe("DeleteRecurringModal", () => {
+  it("renders nothing when closed", () => {
+    render(<DeleteRecurringModal isOpen={false} {...baseProps} />);
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("renders accessible dialog semantics and focuses the first radio option on open", () => {
+    render(<DeleteRecurringModal isOpen {...baseProps} />);
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toHaveAttribute("aria-modal", "true");
+    expect(dialog).toHaveAccessibleName("Delete recurring event");
+    // First focusable in DOM order is the "This event" radio (the options precede the button
+    // row) -- non-destructive, so this is still a safe initial-focus target.
+    expect(screen.getByLabelText("This event")).toHaveFocus();
+  });
+
+  it("calls onClose on Escape", () => {
+    const onClose = jest.fn();
+    render(<DeleteRecurringModal isOpen {...baseProps} onClose={onClose} />);
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onDelete with the selected option, then closes", () => {
+    const onDelete = jest.fn();
+    const onClose = jest.fn();
+    render(<DeleteRecurringModal isOpen {...baseProps} onDelete={onDelete} onClose={onClose} />);
+    fireEvent.click(screen.getByLabelText("All events"));
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+    expect(onDelete).toHaveBeenCalledWith("all");
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/tests/component/Modal.test.tsx
+++ b/frontend/tests/component/Modal.test.tsx
@@ -1,0 +1,107 @@
+import React, { useState } from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import Modal from "../../app/components/ui/overlays/Modal";
+
+const Dialog: React.FC<{ isOpen: boolean; onClose: () => void; preventClose?: boolean }> = ({
+  isOpen,
+  onClose,
+  preventClose,
+}) => (
+  <Modal isOpen={isOpen} onClose={onClose} labelledBy="dialog-title" preventClose={preventClose}>
+    <h2 id="dialog-title">Dialog title</h2>
+    <button>First</button>
+    <button>Last</button>
+  </Modal>
+);
+
+// Wraps Dialog with a real trigger button so open/close is driven by user interaction --
+// needed to exercise Modal's focus-restoration-to-previously-focused-element behavior, which
+// only makes sense relative to a real "what was focused before this opened" starting point.
+const Harness: React.FC<{ preventClose?: boolean }> = ({ preventClose }) => {
+  const [isOpen, setIsOpen] = useState(false);
+  return (
+    <div>
+      <button onClick={() => setIsOpen(true)}>Open dialog</button>
+      <Dialog isOpen={isOpen} onClose={() => setIsOpen(false)} preventClose={preventClose} />
+    </div>
+  );
+};
+
+describe("Modal", () => {
+  it("renders nothing when closed", () => {
+    render(<Dialog isOpen={false} onClose={jest.fn()} />);
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("renders dialog semantics when open", () => {
+    render(<Dialog isOpen onClose={jest.fn()} />);
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toHaveAttribute("aria-modal", "true");
+    expect(dialog).toHaveAccessibleName("Dialog title");
+  });
+
+  it("falls back to ariaLabel when no labelledBy element exists", () => {
+    render(
+      <Modal isOpen onClose={jest.fn()} ariaLabel="Fallback label">
+        <button>Only button</button>
+      </Modal>,
+    );
+    expect(screen.getByRole("dialog")).toHaveAccessibleName("Fallback label");
+  });
+
+  it("moves focus to the first focusable element on open", () => {
+    render(<Dialog isOpen onClose={jest.fn()} />);
+    expect(screen.getByRole("button", { name: "First" })).toHaveFocus();
+  });
+
+  it("traps Tab/Shift+Tab at the dialog's edges", () => {
+    render(<Dialog isOpen onClose={jest.fn()} />);
+    const first = screen.getByRole("button", { name: "First" });
+    const last = screen.getByRole("button", { name: "Last" });
+
+    last.focus();
+    fireEvent.keyDown(document, { key: "Tab" });
+    expect(first).toHaveFocus();
+
+    fireEvent.keyDown(document, { key: "Tab", shiftKey: true });
+    expect(last).toHaveFocus();
+  });
+
+  it("calls onClose on Escape", () => {
+    const onClose = jest.fn();
+    render(<Dialog isOpen onClose={onClose} />);
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not close on Escape or overlay click when preventClose is set", () => {
+    const onClose = jest.fn();
+    const { container } = render(<Dialog isOpen onClose={onClose} preventClose />);
+    fireEvent.keyDown(document, { key: "Escape" });
+    fireEvent.mouseDown(container.ownerDocument.body.querySelector("div")!);
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("calls onClose on a genuine overlay backdrop click, not a click inside the content", () => {
+    const onClose = jest.fn();
+    render(<Dialog isOpen onClose={onClose} />);
+    fireEvent.mouseDown(screen.getByRole("dialog")); // click inside content -- should not close
+    expect(onClose).not.toHaveBeenCalled();
+
+    const overlay = screen.getByRole("dialog").parentElement!;
+    fireEvent.mouseDown(overlay, { target: overlay });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("restores focus to the element that was focused before opening", () => {
+    render(<Harness />);
+    const trigger = screen.getByRole("button", { name: "Open dialog" });
+    trigger.focus();
+    fireEvent.click(trigger);
+
+    expect(screen.getByRole("button", { name: "First" })).toHaveFocus();
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    expect(trigger).toHaveFocus();
+  });
+});

--- a/frontend/tests/component/Modal.test.tsx
+++ b/frontend/tests/component/Modal.test.tsx
@@ -76,9 +76,10 @@ describe("Modal", () => {
 
   it("does not close on Escape or overlay click when preventClose is set", () => {
     const onClose = jest.fn();
-    const { container } = render(<Dialog isOpen onClose={onClose} preventClose />);
+    render(<Dialog isOpen onClose={onClose} preventClose />);
     fireEvent.keyDown(document, { key: "Escape" });
-    fireEvent.mouseDown(container.ownerDocument.body.querySelector("div")!);
+    const overlay = screen.getByRole("dialog").parentElement!;
+    fireEvent.mouseDown(overlay, { target: overlay });
     expect(onClose).not.toHaveBeenCalled();
   });
 

--- a/frontend/tests/component/ResumeMeetingModal.test.tsx
+++ b/frontend/tests/component/ResumeMeetingModal.test.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import ResumeMeetingModal from "../../app/components/meeting-form/ResumeMeetingModal";
+
+const baseProps = {
+  title: "Weekly Standup",
+  onCancel: jest.fn(),
+  onConfirm: jest.fn(),
+};
+
+describe("ResumeMeetingModal", () => {
+  it("renders nothing when closed", () => {
+    render(<ResumeMeetingModal isOpen={false} {...baseProps} />);
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("renders accessible dialog semantics, keeps its e2e testid, and focuses the first radio option on open", () => {
+    render(<ResumeMeetingModal isOpen {...baseProps} />);
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toHaveAttribute("aria-modal", "true");
+    expect(dialog).toHaveAccessibleName("Resume this meeting?");
+    // tests/e2e/14-meeting-suspension.spec.ts scopes locators off this testid.
+    expect(screen.getByTestId("resume-meeting-modal")).toBeInTheDocument();
+    // First focusable in DOM order is the "Immediately (today)" radio (options precede the
+    // button row) -- non-destructive, so this is still a safe initial-focus target.
+    expect(screen.getByRole("radio", { name: "Immediately (today)" })).toHaveFocus();
+  });
+
+  it("calls onCancel on Escape", () => {
+    const onCancel = jest.fn();
+    render(<ResumeMeetingModal isOpen {...baseProps} onCancel={onCancel} />);
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onConfirm(null) for immediate resume", () => {
+    const onConfirm = jest.fn();
+    render(<ResumeMeetingModal isOpen {...baseProps} onConfirm={onConfirm} />);
+    fireEvent.click(screen.getByRole("button", { name: "Resume", exact: true }));
+    expect(onConfirm).toHaveBeenCalledWith(null);
+  });
+});

--- a/frontend/tests/component/SuspendMeetingModal.test.tsx
+++ b/frontend/tests/component/SuspendMeetingModal.test.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import SuspendMeetingModal from "../../app/components/meeting-form/SuspendMeetingModal";
+
+const baseProps = {
+  title: "Weekly Standup",
+  effectiveDateText: "Aug 15, 2026",
+  effectiveDate: "2026-08-15T00:00:00.000Z",
+  onCancel: jest.fn(),
+  onConfirm: jest.fn(),
+};
+
+describe("SuspendMeetingModal", () => {
+  it("renders nothing when closed", () => {
+    render(<SuspendMeetingModal isOpen={false} {...baseProps} />);
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("renders accessible dialog semantics and focuses the first radio option on open", () => {
+    render(<SuspendMeetingModal isOpen {...baseProps} />);
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toHaveAttribute("aria-modal", "true");
+    expect(dialog).toHaveAccessibleName("Suspend this meeting?");
+    // First focusable in DOM order is the "Indefinitely" radio (options precede the button
+    // row) -- non-destructive, so this is still a safe initial-focus target.
+    expect(screen.getByRole("radio", { name: "Indefinitely" })).toHaveFocus();
+  });
+
+  it("calls onCancel on Escape", () => {
+    const onCancel = jest.fn();
+    render(<SuspendMeetingModal isOpen {...baseProps} onCancel={onCancel} />);
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onConfirm(null) for an indefinite suspension", () => {
+    const onConfirm = jest.fn();
+    render(<SuspendMeetingModal isOpen {...baseProps} onConfirm={onConfirm} />);
+    fireEvent.click(screen.getByRole("button", { name: "Suspend" }));
+    expect(onConfirm).toHaveBeenCalledWith(null);
+  });
+});


### PR DESCRIPTION
Part of #385

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Accessibility**
  - Improved meeting dialogs with consistent focus management, keyboard navigation, Escape handling, and accessible labeling.
- **Bug Fixes**
  - Prevented meeting popups from closing unexpectedly when interacting with delete, suspend, or resume dialogs.
  - Improved dialog stacking so modals appear correctly above meeting popups.
- **Tests**
  - Expanded coverage for dialog rendering, focus behavior, keyboard interactions, backdrop clicks, and meeting actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description
- **`app/components/meeting-form/{DeleteMeetingModal,DeleteRecurringModal,ResumeMeetingModal,SuspendMeetingModal,ConflictOverrideModal}.tsx`**: switched from hand-rolled overlay markup to the existing shared `Modal` primitive (`app/components/ui/overlays/Modal.tsx`, already used by `EditRoleModal`/`InviteUserModal`/`RemoveUserModal`) — gains `role="dialog"`/`aria-modal`, initial focus, Tab/Shift+Tab focus trapping, Escape dismissal, and focus restoration for free. `ConflictOverrideModal` also gets `preventClose={isConfirming}`, closing a gap where Escape could still cancel mid-save even though both its buttons were already disabled for that case.
- **`app/components/ui/overlays/Modal.tsx`**: portaled overlay div now carries `data-modal-popup="true"`.
- **`app/components/meeting-form/ViewMeeting.tsx`**: its outside-click-closes-the-popup listener now exempts `[data-modal-popup]`, mirroring the existing `[data-datepicker-popup]` escape hatch already in the same file.
- **`app/components/meeting-form/{DeleteMeetingModal,DeleteRecurringModal,ResumeMeetingModal,SuspendMeetingModal}.module.scss`**: bumped `.modalOverlay` z-index from 1000 to 2001.

**Why the last two bullets:** converting these four modals to `Modal`'s own `createPortal`-to-`document.body` surfaced two real bugs, since they're rendered from inside `ViewMeeting`'s own already-portaled popup and stop being DOM descendants of it once portaled a second time:
1. Their z-index (1000) lost to `ViewMeeting`'s own `.popupAnchor` (2000) once no longer nested inside it, so the popup rendered on top and intercepted clicks meant for Delete/Suspend/Resume buttons.
2. `ViewMeeting`'s outside-click listener misread any click inside these modals as "outside" (no longer a DOM descendant of `popupRef`), closing/unmounting the whole popup before the click's own handler could fire.

Both were caught by a full `yarn test:all` run (not assumed) and fixed before this PR; the underlying `04-meeting-deletion.spec.ts`/`14-meeting-suspension.spec.ts` e2e specs now pass and directly guard both fixes going forward.

## Testing
- [x] `yarn test:all` (lint, lint:css, typecheck, unit, component, integration, e2e) — full run, all green: 132 unit / 158 component / 75 integration / 98 e2e.
- New `tests/component/Modal.test.tsx` covers the primitive's own mechanics (dialog semantics, initial focus, Tab/Shift+Tab trap, Escape, overlay-click, focus restoration) once; each converted modal gets a lighter test (`tests/component/{DeleteMeetingModal,DeleteRecurringModal,ResumeMeetingModal,SuspendMeetingModal}.test.tsx`, `ConflictOverrideModal.test.tsx` extended) covering dialog semantics + Escape + initial focus for that specific modal, not re-proving the full trap/restoration mechanics 5 more times.
- Searched `tests/e2e`/`tests/integration`/`tests/component` for assertions tied to the old (pre-`Modal`) behavior of these 5 modals before merging — none found; the only pre-existing test needing a fix was `tests/component/ConflictOverrideModal.test.tsx`'s use of `container.textContent`, updated to query `screen`/`getByRole("dialog")` since the modal now portals outside the RTL render container.

## Area(s) Touched
**Product areas**
- [ ] auth — sign-in, sessions, NextAuth, role-based access
- [ ] admin — /admin shell (Diagnostics, Users, Import, Export tabs)
- [ ] docs — /docs Resources page (rendering, navigation, search)
- [x] ui/ux — frontend layout/styling not tied to a specific integration

**Integrations**
- [ ] google-calendar — Google Calendar sync
- [ ] zoom-api — Zoom meeting/host sync

**Engineering**
- [ ] security — auth hardening, data exposure, dependency/security scanning
- [x] testing — test suite (Jest/Playwright) changes
- [ ] github-actions — workflows, Dependabot config, other .github/ CI tooling
- [ ] cleanup — refactor or dead-code removal, no behavior change
- [ ] documentation — docs/ or README changes only

## Pre-merge Checklist
- [x] Code follows current formatting conventions and passes lint (`yarn lint`).
- [x] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
- [x] All test suites pass, both run locally and green in GitHub CI. **Do not merge if any test suite is failing.**
- [x] A test suite was added or updated for the feature/fix in this PR. **Double-check this if you change a feature and did not update the test suites**.
- [x] Only files relevant to this change are committed — no stray or unrelated files.
- [ ] If this branch has a merge conflict with master, master was merged into this branch first (not the other way around).
- [x] The rest of this PR description (Description, Testing) is filled out, not left as template placeholders.
