### PR TITLE
refactor(calendar,admin): adopt shared accessible modal primitive

### DIFF
--- a/docs/03-development/project-structure.md
+++ b/docs/03-development/project-structure.md
@@ -95,6 +95,13 @@ We group components by what they do (domain/feature) rather than how they compos
 - `pickers/` — `DatePicker`, `TimePicker`
 - `displays/` — `BoxText`, `Icon`, `Logo`, `StatCounter`, `StatusPill`, `TagList`, `TopLoadingBar`
 
+`Modal` is the shared accessible dialog primitive — dialog semantics (`role="dialog"`,
+`aria-modal`), initial focus, Tab/Shift+Tab focus trapping, Escape dismissal, focus restoration,
+and portal-to-`document.body`. Every confirm/dialog-style modal in the app (delete/suspend/resume
+confirmations, conflict overrides, export configuration, the calendar's overlapping-meetings
+picker, admin user management) is built on it rather than hand-rolling overlay markup; new
+dialog-style modals should do the same.
+
 `Icon` is the name-based entry point (e.g. `<Icon name="warning" />`) for the app's icon set —
 most render as `@mui/icons-material` glyphs tinted via `currentColor` from ambient CSS; a couple
 of brand logos with no MUI equivalent (Google, Zoom) stay as local `public/svg/` assets.

--- a/frontend/app/components/admin/export/LeaseConfigModal.tsx
+++ b/frontend/app/components/admin/export/LeaseConfigModal.tsx
@@ -3,6 +3,7 @@
 import React, { useState } from "react";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import CheckCircleIcon from "@mui/icons-material/CheckCircle";
+import Modal from "../../ui/overlays/Modal";
 import type { ILeaseSettings, IRoomRate } from "../../../../types/models";
 import type { LeaseYearCycle } from "../../../../util/lease/leaseYearCycles";
 import styles from "./ExportTab.module.scss";
@@ -92,9 +93,15 @@ const LeaseConfigModal: React.FC<LeaseConfigModalProps> = ({ initial, cycles, on
   const templateSummary = draft.emailTemplate.split("\n")[0]?.slice(0, 60) || "No message set";
 
   return (
-    <div className={styles.modalOverlay} onClick={onCancel}>
-      <div className={styles.modal} onClick={(e) => e.stopPropagation()}>
-        <h3 className={styles.modalTitle}>Configure PandaDocs lease export</h3>
+    <Modal
+      isOpen
+      onClose={onCancel}
+      overlayClassName={styles.modalOverlay}
+      contentClassName={styles.modal}
+      labelledBy="lease-config-title"
+      preventClose={saving}
+    >
+        <h3 id="lease-config-title" className={styles.modalTitle}>Configure PandaDocs lease export</h3>
         <p className={styles.modalIntro}>
           These settings control the lease period, rates, rental agent contact, and email wording used when
           generating the export. Per-meeting details (group name, contact email, schedule) always come from the
@@ -256,8 +263,7 @@ const LeaseConfigModal: React.FC<LeaseConfigModalProps> = ({ initial, cycles, on
             {saving ? "Saving…" : "Save"}
           </button>
         </div>
-      </div>
-    </div>
+    </Modal>
   );
 };
 

--- a/frontend/app/components/admin/export/MeetingExportConfigModal.tsx
+++ b/frontend/app/components/admin/export/MeetingExportConfigModal.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState } from "react";
 import FilterGroup, { FilterGroupItem } from "../../shared/FilterGroup";
+import Modal from "../../ui/overlays/Modal";
 import { MEETING_EXPORT_FIELD_GROUPS, type MeetingExportFieldKey } from "../../../../util/meetings/meetingExportFields";
 import styles from "./ExportTab.module.scss";
 
@@ -47,31 +48,35 @@ const MeetingExportConfigModal: React.FC<MeetingExportConfigModalProps> = ({ ini
   };
 
   return (
-    <div className={styles.modalOverlay} onClick={onCancel}>
-      <div className={styles.modal} onClick={(e) => e.stopPropagation()}>
-        <h3 className={styles.modalTitle}>Configure meeting export</h3>
-        <p className={styles.modalIntro}>
-          Meeting ID and Meeting Name are always included. Pick which other fields the export should have.
-        </p>
+    <Modal
+      isOpen
+      onClose={onCancel}
+      overlayClassName={styles.modalOverlay}
+      contentClassName={styles.modal}
+      labelledBy="export-config-title"
+    >
+      <h3 id="export-config-title" className={styles.modalTitle}>Configure meeting export</h3>
+      <p className={styles.modalIntro}>
+        Meeting ID and Meeting Name are always included. Pick which other fields the export should have.
+      </p>
 
-        <div className={styles.filterGrid}>
-          <FilterGroup title="MEETING" items={MEETING_FIELDS} checked={checked} onToggle={toggle} />
-          <div>
-            <FilterGroup title="SCHEDULE" items={SCHEDULE_FIELDS} checked={checked} onToggle={toggle} />
-            <div className={styles.stackedGroup}>
-              <FilterGroup title="CONTACT" items={CONTACT_FIELDS} checked={checked} onToggle={toggle} />
-            </div>
+      <div className={styles.filterGrid}>
+        <FilterGroup title="MEETING" items={MEETING_FIELDS} checked={checked} onToggle={toggle} />
+        <div>
+          <FilterGroup title="SCHEDULE" items={SCHEDULE_FIELDS} checked={checked} onToggle={toggle} />
+          <div className={styles.stackedGroup}>
+            <FilterGroup title="CONTACT" items={CONTACT_FIELDS} checked={checked} onToggle={toggle} />
           </div>
         </div>
-
-        <div className={styles.modalActions}>
-          <button className={styles.cancelButton} onClick={onCancel}>Cancel</button>
-          <button className={styles.saveButton} onClick={handleSave} disabled={saving}>
-            {saving ? "Saving…" : "Save"}
-          </button>
-        </div>
       </div>
-    </div>
+
+      <div className={styles.modalActions}>
+        <button className={styles.cancelButton} onClick={onCancel}>Cancel</button>
+        <button className={styles.saveButton} onClick={handleSave} disabled={saving}>
+          {saving ? "Saving…" : "Save"}
+        </button>
+      </div>
+    </Modal>
   );
 };
 

--- a/frontend/app/components/calendar/shared/OverlapMeetingsModal.tsx
+++ b/frontend/app/components/calendar/shared/OverlapMeetingsModal.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import { createPortal } from 'react-dom';
 import styles from './OverlapMeetingsModal.module.scss';
 import { formatCompactTimeRange } from '../../../../util/date/timeFormat';
 import { toPastelColor } from '../../../../util/common/color';
 import Icon from '../../ui/displays/Icon';
 import TagList from '../../ui/displays/TagList';
+import Modal from '../../ui/overlays/Modal';
 
 interface OverlapMeeting {
     id: string;
@@ -41,8 +41,6 @@ const OverlapMeetingsModal: React.FC<OverlapMeetingsModalProps> = ({
     onClose,
     onSelectMeeting,
 }) => {
-    if (!isOpen) return null;
-
     // Full range across every meeting shown (true, unclipped times where available) --
     // e.g. "9 - 11 AM" for meetings spanning 9-10, 9:30-10:30, and 10-11.
     const timeRangeLabel = meetings.reduce<{ start: string; end: string } | null>((range, meeting) => {
@@ -55,17 +53,22 @@ const OverlapMeetingsModal: React.FC<OverlapMeetingsModalProps> = ({
         };
     }, null);
 
-    // Portaled to document.body -- both Day and Week view render this from deep inside
-    // absolutely-positioned, z-indexed ancestors (e.g. DayView's .gridMeetingRow), each
-    // of which forms its own stacking context. Left in place, this modal's z-index would
-    // only be compared *within* that ancestor's context, so a sibling with a higher
-    // z-index at the parent level (e.g. the sticky room-label column) would still paint
-    // over it despite `position: fixed` and z-index: 1000 here.
-    return createPortal(
-        <div className={styles.modalOverlay} onClick={(e) => e.stopPropagation()}>
-            <div className={styles.modalContent}>
+    return (
+        // Both Day and Week view render this from deep inside absolutely-positioned, z-indexed
+        // ancestors (e.g. DayView's .gridMeetingRow) that are also each their own clickable cell
+        // -- Modal itself portals to document.body (see its own doc comment for why), which
+        // sidesteps the z-index-only-compared-within-ancestor-context problem this used to note,
+        // but a click anywhere in here still bubbles through the *React* tree (not the DOM tree)
+        // up to that cell's own click-to-create-a-meeting handler unless stopped here.
+        <Modal
+            isOpen={isOpen}
+            onClose={onClose}
+            overlayClassName={styles.modalOverlay}
+            labelledBy="overlap-meetings-title"
+        >
+            <div className={styles.modalContent} onClick={(e) => e.stopPropagation()}>
                 <div className={styles.header}>
-                    <h2 className={styles.modalTitle}>
+                    <h2 id="overlap-meetings-title" className={styles.modalTitle}>
                         {meetings.length} Meeting{meetings.length === 1 ? '' : 's'}
                         {timeRangeLabel && ` (${formatCompactTimeRange(timeRangeLabel.start, timeRangeLabel.end)})`}
                     </h2>
@@ -129,8 +132,7 @@ const OverlapMeetingsModal: React.FC<OverlapMeetingsModalProps> = ({
                     })}
                 </div>
             </div>
-        </div>,
-        document.body,
+        </Modal>
     );
 };
 

--- a/frontend/tests/component/LeaseConfigModal.test.tsx
+++ b/frontend/tests/component/LeaseConfigModal.test.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import LeaseConfigModal from "../../app/components/admin/export/LeaseConfigModal";
+import type { ILeaseSettings } from "../../types/models";
+import type { LeaseYearCycle } from "../../util/lease/leaseYearCycles";
+
+const initial: ILeaseSettings = {
+  leaseStartDate: new Date("2026-07-01"),
+  leaseEndDate: new Date("2027-06-30"),
+  rooms: [{ room: "Serenity Room", rate: 20, unit: "hr" }],
+  agentFirstName: "Jane",
+  agentLastName: "Doe",
+  agentTitle: "Rental Agent",
+  agentEmail: "jane@example.com",
+  agentPhone: "555-0100",
+  agentStreetAddress: "1 Main St",
+  agentCity: "Ithaca",
+  agentState: "NY",
+  agentZip: "14850",
+  emailTemplate: "Hello {group}",
+};
+
+const cycles: LeaseYearCycle[] = [
+  { startDate: new Date("2026-07-01"), endDate: new Date("2027-06-30"), label: "Jul 1, 2026 – Jun 30, 2027", status: "current" },
+];
+
+describe("LeaseConfigModal", () => {
+  it("renders accessible dialog semantics", () => {
+    render(<LeaseConfigModal initial={initial} cycles={cycles} onCancel={jest.fn()} onSave={jest.fn()} />);
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toHaveAttribute("aria-modal", "true");
+    expect(dialog).toHaveAccessibleName("Configure PandaDocs lease export");
+  });
+
+  it("calls onCancel on Escape", () => {
+    const onCancel = jest.fn();
+    render(<LeaseConfigModal initial={initial} cycles={cycles} onCancel={onCancel} onSave={jest.fn()} />);
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onCancel on Cancel click", () => {
+    const onCancel = jest.fn();
+    render(<LeaseConfigModal initial={initial} cycles={cycles} onCancel={onCancel} onSave={jest.fn()} />);
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onSave with the current draft when Save is clicked", () => {
+    const onSave = jest.fn().mockResolvedValue(undefined);
+    render(<LeaseConfigModal initial={initial} cycles={cycles} onCancel={jest.fn()} onSave={onSave} />);
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    expect(onSave).toHaveBeenCalledWith(initial);
+  });
+});

--- a/frontend/tests/component/MeetingExportConfigModal.test.tsx
+++ b/frontend/tests/component/MeetingExportConfigModal.test.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import MeetingExportConfigModal from "../../app/components/admin/export/MeetingExportConfigModal";
+import { ALL_MEETING_EXPORT_FIELD_KEYS } from "../../util/meetings/meetingExportFields";
+
+describe("MeetingExportConfigModal", () => {
+  it("renders accessible dialog semantics", () => {
+    render(<MeetingExportConfigModal initialFields={ALL_MEETING_EXPORT_FIELD_KEYS} onCancel={jest.fn()} onSave={jest.fn()} />);
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toHaveAttribute("aria-modal", "true");
+    expect(dialog).toHaveAccessibleName("Configure meeting export");
+  });
+
+  it("calls onCancel on Escape", () => {
+    const onCancel = jest.fn();
+    render(<MeetingExportConfigModal initialFields={ALL_MEETING_EXPORT_FIELD_KEYS} onCancel={onCancel} onSave={jest.fn()} />);
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onCancel on Cancel click", () => {
+    const onCancel = jest.fn();
+    render(<MeetingExportConfigModal initialFields={ALL_MEETING_EXPORT_FIELD_KEYS} onCancel={onCancel} onSave={jest.fn()} />);
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onSave with the checked fields when Save is clicked", async () => {
+    const onSave = jest.fn().mockResolvedValue(undefined);
+    render(<MeetingExportConfigModal initialFields={ALL_MEETING_EXPORT_FIELD_KEYS} onCancel={jest.fn()} onSave={onSave} />);
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    expect(onSave).toHaveBeenCalledWith(expect.arrayContaining(ALL_MEETING_EXPORT_FIELD_KEYS));
+  });
+});

--- a/frontend/tests/component/OverlapMeetingsModal.test.tsx
+++ b/frontend/tests/component/OverlapMeetingsModal.test.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import OverlapMeetingsModal from "../../app/components/calendar/shared/OverlapMeetingsModal";
+
+const meetings = [
+  { id: "m1", title: "Morning AA", startTime: "09:00", endTime: "10:00", room: "Serenity Room" },
+  { id: "m2", title: "Morning Al-Anon", startTime: "09:30", endTime: "10:30", room: "Unity Room" },
+];
+
+describe("OverlapMeetingsModal", () => {
+  it("renders nothing when closed", () => {
+    render(<OverlapMeetingsModal isOpen={false} meetings={meetings} onClose={jest.fn()} onSelectMeeting={jest.fn()} />);
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("renders accessible dialog semantics naming the meeting count", () => {
+    render(<OverlapMeetingsModal isOpen meetings={meetings} onClose={jest.fn()} onSelectMeeting={jest.fn()} />);
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toHaveAttribute("aria-modal", "true");
+    expect(dialog).toHaveAccessibleName(/2 Meetings/);
+    expect(screen.getByText("Morning AA")).toBeInTheDocument();
+    expect(screen.getByText("Morning Al-Anon")).toBeInTheDocument();
+  });
+
+  it("calls onClose on Escape and on the Close button", () => {
+    const onClose = jest.fn();
+    render(<OverlapMeetingsModal isOpen meetings={meetings} onClose={onClose} onSelectMeeting={jest.fn()} />);
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledTimes(1);
+    fireEvent.click(screen.getByRole("button", { name: "Close" }));
+    expect(onClose).toHaveBeenCalledTimes(2);
+  });
+
+  it("calls onSelectMeeting when a meeting row is clicked, without also closing via bubbling", () => {
+    const onSelectMeeting = jest.fn();
+    const onClose = jest.fn();
+    render(<OverlapMeetingsModal isOpen meetings={meetings} onClose={onClose} onSelectMeeting={onSelectMeeting} />);
+    fireEvent.click(screen.getByText("Morning AA"));
+    expect(onSelectMeeting).toHaveBeenCalledWith("m1");
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/tests/e2e/17-mobile-meeting-forms.spec.ts
+++ b/frontend/tests/e2e/17-mobile-meeting-forms.spec.ts
@@ -92,10 +92,10 @@ test.describe("mobile meeting interactions", () => {
 
     await page.getByRole("button", { name: /more meetings at this time/ }).click();
 
-    // OverlapMeetingsModal has no role="dialog" and no drag grabber (unlike BottomSheet) --
-    // confirms it stayed a plain centered modal rather than getting swept into the bottom-
-    // sheet treatment.
-    const modal = page.locator('[class*="modalContent"]');
+    // OverlapMeetingsModal renders via the shared Modal primitive (role="dialog") but has no
+    // drag grabber (unlike BottomSheet) -- confirms it stayed a plain centered modal rather
+    // than getting swept into the bottom-sheet treatment.
+    const modal = page.getByRole("dialog");
     await expect(modal).toBeVisible();
     await expect(modal.locator('[class*="grabber"]')).toHaveCount(0);
   });


### PR DESCRIPTION
Resolves #385

@coderabbitai summary

## Description
- **`app/components/calendar/shared/OverlapMeetingsModal.tsx`**: switched from its own hand-rolled `createPortal` to the shared `Modal` primitive (see the base PR of this stack). Keeps its existing click-bubbling shield (it's rendered as a sibling of a clickable calendar day-cell in the *React tree*, not just the DOM tree, so a click on a meeting row would otherwise also fire the cell's own click-to-create-a-meeting handler) by moving `onClick={(e) => e.stopPropagation()}` onto its own inner content wrapper instead of `Modal`'s overlay div. Also gains click-outside-to-close for the first time — previously nothing happened on a backdrop click at all.
- **`app/components/admin/export/{MeetingExportConfigModal,LeaseConfigModal}.tsx`**: same swap. Both already had matching overlay-click-to-close/inner-stopPropagation behavior, so converting them is behavior-preserving; `LeaseConfigModal` additionally gets `preventClose={saving}`, matching its own already-disabled Cancel/Save buttons during a save. `LeaseConfigModal` wasn't named in #385/#358 but is the third hand-rolled modal in `admin/export/`, identical in shape to `MeetingExportConfigModal` — converted alongside it for consistency rather than left as the odd one out.
- **`tests/e2e/17-mobile-meeting-forms.spec.ts`**: updated a now-stale comment/assertion ("OverlapMeetingsModal has no role=dialog") to match the new behavior, and strengthened the locator to `getByRole("dialog")`.
- **`docs/03-development/project-structure.md`**: documents `Modal` as the shared accessible dialog primitive that new confirm/dialog-style modals should use.

## Testing
- [x] `yarn test:all` (lint, lint:css, typecheck, unit, component, integration, e2e) — full run, all green: 132 unit / 170 component / 75 integration / 98 e2e.
- New `tests/component/{OverlapMeetingsModal,MeetingExportConfigModal,LeaseConfigModal}.test.tsx` cover dialog semantics + Escape + initial focus for each; `OverlapMeetingsModal`'s also covers the click-bubbling shield (row click doesn't also close the modal) and Escape/Close-button dismissal.
- Searched `tests/e2e`/`tests/integration`/`tests/component` for assertions tied to the old (pre-`Modal`) behavior of these 3 modals before merging — none found needing a fix beyond the `17-mobile-meeting-forms.spec.ts` comment update above.
- Verified this stacked layer introduces no repeat of the base PR's two regressions (z-index/outside-click) — `OverlapMeetingsModal`'s host (calendar day cells) and `MeetingExportConfigModal`/`LeaseConfigModal`'s host (`ExportTab`) were both checked directly and confirmed to have no competing outside-click-to-close listener.

## Area(s) Touched
**Product areas**
- [x] admin — /admin shell (Diagnostics, Users, Import, Export tabs)
- [ ] docs — /docs Resources page (rendering, navigation, search)
- [x] ui/ux — frontend layout/styling not tied to a specific integration

**Integrations**
- [ ] google-calendar — Google Calendar sync
- [ ] zoom-api — Zoom meeting/host sync

**Engineering**
- [ ] security — auth hardening, data exposure, dependency/security scanning
- [x] testing — test suite (Jest/Playwright) changes
- [ ] github-actions — workflows, Dependabot config, other .github/ CI tooling
- [ ] cleanup — refactor or dead-code removal, no behavior change
- [x] documentation — docs/ or README changes only

## Pre-merge Checklist
- [x] Code follows current formatting conventions and passes lint (`yarn lint`).
- [x] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
- [x] All test suites pass, both run locally and green in GitHub CI. **Do not merge if any test suite is failing.**
- [x] A test suite was added or updated for the feature/fix in this PR. **Double-check this if you change a feature and did not update the test suites**.
- [x] Only files relevant to this change are committed — no stray or unrelated files.
- [ ] If this branch has a merge conflict with master, master was merged into this branch first (not the other way around).
- [x] The rest of this PR description (Description, Testing) is filled out, not left as template placeholders.
