### PR TITLE
fix(admin): standardize admin route error responses and validation

### DIFF
--- a/docs/03-development/api-reference.md
+++ b/docs/03-development/api-reference.md
@@ -174,6 +174,7 @@ Zoom sync runs the same mode-gated, resolve-before-publish way as `POST /api/wri
 ```
 
 **Response:** `200 OK` — created `IAdmin` object
+**Error:** `400 Bad Request` — request body fails schema validation (issues listed in the response); `409 Conflict` — an admin with this email already exists
 
 ---
 
@@ -205,7 +206,7 @@ Zoom sync runs the same mode-gated, resolve-before-publish way as `POST /api/wri
 ```
 
 **Response:** `200 OK` — updated `IAdmin`
-**Error:** `400 Bad Request` if it would leave zero Super Admins, `404 Not Found`
+**Error:** `400 Bad Request` — request body fails schema validation, or it would leave zero Super Admins; `404 Not Found`; `409 Conflict` — a concurrent change conflicted with this update, retry
 
 ---
 
@@ -218,7 +219,7 @@ Zoom sync runs the same mode-gated, resolve-before-publish way as `POST /api/wri
 ```
 
 **Response:** `200 OK` — deleted `IAdmin` object
-**Error:** `400 Bad Request` if it would leave zero Super Admins, `404 Not Found`
+**Error:** `400 Bad Request` — it would leave zero Super Admins; `404 Not Found`; `409 Conflict` — a concurrent change conflicted with this removal, retry
 
 ---
 

--- a/docs/03-development/api-reference.md
+++ b/docs/03-development/api-reference.md
@@ -174,7 +174,7 @@ Zoom sync runs the same mode-gated, resolve-before-publish way as `POST /api/wri
 ```
 
 **Response:** `200 OK` — created `IAdmin` object
-**Error:** `400 Bad Request` — request body fails schema validation (issues listed in the response); `409 Conflict` — an admin with this email already exists
+**Error:** `400 Bad Request` — request body fails schema validation (issues listed in the response) or is malformed JSON; `409 Conflict` — an admin with this email already exists; `500 Internal Server Error`
 
 ---
 
@@ -186,7 +186,7 @@ Zoom sync runs the same mode-gated, resolve-before-publish way as `POST /api/wri
 | `email` | string | Admin email address |
 
 **Response:** `200 OK` — `IAdmin`
-**Error:** `404 Not Found`
+**Error:** `404 Not Found`; `500 Internal Server Error`
 
 ---
 
@@ -194,6 +194,7 @@ Zoom sync runs the same mode-gated, resolve-before-publish way as `POST /api/wri
 **Requires:** `SUPER_ADMIN`. Retrieve all admins (backs the Users tab on `/admin`).
 
 **Response:** `200 OK` — `IAdmin[]`
+**Error:** `500 Internal Server Error`
 
 ---
 
@@ -206,7 +207,7 @@ Zoom sync runs the same mode-gated, resolve-before-publish way as `POST /api/wri
 ```
 
 **Response:** `200 OK` — updated `IAdmin`
-**Error:** `400 Bad Request` — request body fails schema validation, or it would leave zero Super Admins; `404 Not Found`; `409 Conflict` — a concurrent change conflicted with this update, retry
+**Error:** `400 Bad Request` — request body fails schema validation, is malformed JSON, or it would leave zero Super Admins; `404 Not Found`; `409 Conflict` — a concurrent change conflicted with this update, retry; `500 Internal Server Error`
 
 ---
 
@@ -219,7 +220,7 @@ Zoom sync runs the same mode-gated, resolve-before-publish way as `POST /api/wri
 ```
 
 **Response:** `200 OK` — deleted `IAdmin` object
-**Error:** `400 Bad Request` — it would leave zero Super Admins; `404 Not Found`; `409 Conflict` — a concurrent change conflicted with this removal, retry
+**Error:** `400 Bad Request` — it would leave zero Super Admins; `404 Not Found`; `409 Conflict` — a concurrent change conflicted with this removal, retry; `500 Internal Server Error`
 
 ---
 

--- a/frontend/app/api/delete/admin/route.ts
+++ b/frontend/app/api/delete/admin/route.ts
@@ -17,13 +17,13 @@ export const DELETE = async (request: Request) => {
     const deleteUser = await prisma.$transaction(async (tx) => {
       const target = await tx.admin.findUnique({ where: { email } });
       if (!target) {
-        throw new Response(JSON.stringify({ error: "Admin not found" }), { status: 404 });
+        throw NextResponse.json({ error: "Admin not found" }, { status: 404 });
       }
 
       if (target.role === Role.SUPER_ADMIN) {
         const superAdminCount = await tx.admin.count({ where: { role: Role.SUPER_ADMIN } });
         if (superAdminCount <= 1) {
-          throw new Response(JSON.stringify({ error: "Cannot remove the last remaining Super Admin" }), { status: 400 });
+          throw NextResponse.json({ error: "Cannot remove the last remaining Super Admin" }, { status: 400 });
         }
       }
 
@@ -37,12 +37,7 @@ export const DELETE = async (request: Request) => {
     if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2034") {
       return NextResponse.json({ error: "Another change conflicted with this removal -- please retry." }, { status: 409 });
     }
-    console.error("Admin not found: ", error);
-    return new Response(JSON.stringify({ error: "Internal Server Error" }), {
-      status: 500,
-      headers: {
-        'Content-Type': 'application/json',
-      },
-    });
+    console.error(error);
+    return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
   }
 }

--- a/frontend/app/api/retrieve/admin/route.ts
+++ b/frontend/app/api/retrieve/admin/route.ts
@@ -1,6 +1,6 @@
 import { IAdmin } from "../../../../types/models";
 import { Role } from '@prisma/client';
-import { NextRequest } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { requireRole } from "../../../../services/auth";
 import { prisma } from "../../../../lib/prisma";
 
@@ -22,28 +22,14 @@ const getAdminByEmail = async (request: NextRequest) => {
       },
     });
     if (!user) {
-      return new Response(JSON.stringify({ error: `Admin not found` }), {
-        status: 404,
-        headers: {
-          'Content-Type': 'application/json',
-        },
-      });
+      return NextResponse.json({ error: "Admin not found" }, { status: 404 });
     }
 
-    return new Response(JSON.stringify(user), {
-      status: 200,
-      headers: {
-        'Content-Type': 'application/json',
-      },
-    });
+    return NextResponse.json(user);
   }
   catch (error) {
-    return new Response(JSON.stringify({ error: `Admin not found: ${error}` }), {
-      status: 500,
-      headers: {
-        'Content-Type': 'application/json',
-      },
-    });
+    console.error(error);
+    return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
   }
 }
 

--- a/frontend/app/api/retrieve/admins/route.ts
+++ b/frontend/app/api/retrieve/admins/route.ts
@@ -1,5 +1,6 @@
 import { IAdmin } from "../../../../types/models";
 import { Role } from '@prisma/client';
+import { NextResponse } from "next/server";
 import { requireRole } from "../../../../services/auth";
 import { prisma } from "../../../../lib/prisma";
 
@@ -17,19 +18,10 @@ const retrieveAdmins = async () => {
       },
     });
 
-    return new Response(JSON.stringify(admins), {
-      status: 200,
-      headers: {
-        'Content-Type': 'application/json',
-      },
-    });
+    return NextResponse.json(admins);
   } catch (error) {
-    return new Response(JSON.stringify({ error: `Error retrieving admins: ${error}` }), {
-      status: 500,
-      headers: {
-        'Content-Type': 'application/json',
-      },
-    });
+    console.error(error);
+    return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
   }
 }
 

--- a/frontend/app/api/update/admin/route.ts
+++ b/frontend/app/api/update/admin/route.ts
@@ -2,6 +2,7 @@ import { Prisma, Role } from "@prisma/client";
 import { NextResponse } from "next/server";
 import { requireRole } from "../../../../services/auth";
 import { prisma } from "../../../../lib/prisma";
+import { adminRoleUpdateSchema } from "../../../../util/admin/adminValidation";
 
 // Promote/demote an admin's role. Blocks demoting the last remaining Super
 // Admin (including self-demotion) so Super Admins can't lock everyone out.
@@ -10,11 +11,11 @@ export const PUT = async (request: Request) => {
     const auth = await requireRole(Role.SUPER_ADMIN);
     if (auth instanceof Response) return auth;
 
-    const { email, role } = await request.json() as { email: string; role: Role };
-
-    if (role !== Role.SUPER_ADMIN && role !== Role.ADMIN && role !== Role.USER) {
-      return NextResponse.json({ error: "Invalid role" }, { status: 400 });
+    const parsed = adminRoleUpdateSchema.safeParse(await request.json());
+    if (!parsed.success) {
+      return NextResponse.json({ error: "Invalid email or role", issues: parsed.error.issues }, { status: 400 });
     }
+    const { email, role } = parsed.data;
 
     // Serializable, not just read-committed: a plain count-then-update here would let two
     // concurrent demote requests both read "2 Super Admins left", both pass the check, and
@@ -23,13 +24,13 @@ export const PUT = async (request: Request) => {
     const updatedAdmin = await prisma.$transaction(async (tx) => {
       const target = await tx.admin.findUnique({ where: { email } });
       if (!target) {
-        throw new Response(JSON.stringify({ error: "Admin not found" }), { status: 404 });
+        throw NextResponse.json({ error: "Admin not found" }, { status: 404 });
       }
 
       if (target.role === Role.SUPER_ADMIN && role !== Role.SUPER_ADMIN) {
         const superAdminCount = await tx.admin.count({ where: { role: Role.SUPER_ADMIN } });
         if (superAdminCount <= 1) {
-          throw new Response(JSON.stringify({ error: "Cannot demote the last remaining Super Admin" }), { status: 400 });
+          throw NextResponse.json({ error: "Cannot demote the last remaining Super Admin" }, { status: 400 });
         }
       }
 

--- a/frontend/app/api/update/admin/route.ts
+++ b/frontend/app/api/update/admin/route.ts
@@ -11,7 +11,14 @@ export const PUT = async (request: Request) => {
     const auth = await requireRole(Role.SUPER_ADMIN);
     if (auth instanceof Response) return auth;
 
-    const parsed = adminRoleUpdateSchema.safeParse(await request.json());
+    let body: unknown;
+    try {
+      body = await request.json();
+    } catch {
+      return NextResponse.json({ error: "Invalid email or role" }, { status: 400 });
+    }
+
+    const parsed = adminRoleUpdateSchema.safeParse(body);
     if (!parsed.success) {
       return NextResponse.json({ error: "Invalid email or role", issues: parsed.error.issues }, { status: 400 });
     }

--- a/frontend/app/api/write/admin/route.ts
+++ b/frontend/app/api/write/admin/route.ts
@@ -1,7 +1,8 @@
-import { Role } from "@prisma/client";
+import { Prisma, Role } from "@prisma/client";
 import { NextResponse } from "next/server";
 import { requireRole } from "../../../../services/auth";
 import { prisma } from "../../../../lib/prisma";
+import { adminInviteSchema } from "../../../../util/admin/adminValidation";
 
 // Invite an admin by email; name is unknown until they sign in, so it's created
 // empty and filled from the Google profile on that person's first login (see
@@ -11,34 +12,27 @@ export const POST = async (request: Request) => {
     const auth = await requireRole(Role.SUPER_ADMIN);
     if (auth instanceof Response) return auth;
 
-    const { email, role } = await request.json() as { email: string; role?: Role };
-
-    if (!email) {
-      return NextResponse.json({ error: "email is required" }, { status: 400 });
+    const parsed = adminInviteSchema.safeParse(await request.json());
+    if (!parsed.success) {
+      return NextResponse.json({ error: "Invalid email or role", issues: parsed.error.issues }, { status: 400 });
     }
-
-    const resolvedRole = role ?? Role.ADMIN;
-    if (resolvedRole !== Role.SUPER_ADMIN && resolvedRole !== Role.ADMIN && resolvedRole !== Role.USER) {
-      return NextResponse.json({ error: "Invalid role" }, { status: 400 });
-    }
+    const { email, role } = parsed.data;
 
     const createdUser = await prisma.admin.create({
       data: {
         email,
         name: "",
-        role: resolvedRole,
+        role: role ?? Role.ADMIN,
       },
       select: { name: true, email: true, role: true },
     });
 
     return NextResponse.json(createdUser);
   } catch (error) {
+    if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002") {
+      return NextResponse.json({ error: "An admin with this email already exists." }, { status: 409 });
+    }
     console.error(error);
-    return new Response(JSON.stringify({ error: "Internal Server Error" }), {
-      status: 500,
-      headers: {
-        'Content-Type': 'application/json',
-      },
-    });
+    return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
   }
 }

--- a/frontend/app/api/write/admin/route.ts
+++ b/frontend/app/api/write/admin/route.ts
@@ -12,7 +12,14 @@ export const POST = async (request: Request) => {
     const auth = await requireRole(Role.SUPER_ADMIN);
     if (auth instanceof Response) return auth;
 
-    const parsed = adminInviteSchema.safeParse(await request.json());
+    let body: unknown;
+    try {
+      body = await request.json();
+    } catch {
+      return NextResponse.json({ error: "Invalid email or role" }, { status: 400 });
+    }
+
+    const parsed = adminInviteSchema.safeParse(body);
     if (!parsed.success) {
       return NextResponse.json({ error: "Invalid email or role", issues: parsed.error.issues }, { status: 400 });
     }

--- a/frontend/tests/integration/admin-error-response-shape.test.ts
+++ b/frontend/tests/integration/admin-error-response-shape.test.ts
@@ -1,0 +1,36 @@
+// Unlike the other integration tests, this mocks lib/prisma entirely (no real DB) --
+// the only way to force the 500 branch on demand and confirm it never echoes the raw
+// Prisma error into the response body (the bug this file guards against).
+jest.mock("../../services/auth", () => ({
+  requireRole: jest.fn().mockResolvedValue({
+    user: { role: "SUPER_ADMIN" },
+  }),
+}));
+
+jest.mock("../../lib/prisma", () => ({
+  prisma: {
+    admin: {
+      findUnique: jest.fn().mockRejectedValue(new Error("connection to server at db.internal.example, port 5432 failed")),
+      findMany: jest.fn().mockRejectedValue(new Error("connection to server at db.internal.example, port 5432 failed")),
+    },
+  },
+}));
+
+import { NextRequest } from "next/server";
+import { GET as getAdmin } from "../../app/api/retrieve/admin/route";
+import { GET as getAdmins } from "../../app/api/retrieve/admins/route";
+
+test("GET /api/retrieve/admin never echoes the raw DB error into the response body", async () => {
+  const request = new NextRequest("http://localhost/api/retrieve/admin?email=someone@test.icr");
+  const response = await getAdmin(request);
+  const body = await response.json();
+  expect(response.status).toBe(500);
+  expect(body).toEqual({ error: "Internal Server Error" });
+});
+
+test("GET /api/retrieve/admins never echoes the raw DB error into the response body", async () => {
+  const response = await getAdmins();
+  const body = await response.json();
+  expect(response.status).toBe(500);
+  expect(body).toEqual({ error: "Internal Server Error" });
+});

--- a/frontend/tests/integration/admin-routes-validation.test.ts
+++ b/frontend/tests/integration/admin-routes-validation.test.ts
@@ -1,0 +1,44 @@
+import { seedAdmin } from "../factories/admin";
+import { disconnectTestPrismaClient } from "../factories/db";
+
+jest.mock("../../services/auth", () => ({
+  requireRole: jest.fn().mockResolvedValue({
+    user: { role: "SUPER_ADMIN" },
+  }),
+}));
+
+import { POST } from "../../app/api/write/admin/route";
+import { PUT } from "../../app/api/update/admin/route";
+
+afterAll(async () => {
+  await disconnectTestPrismaClient();
+});
+
+test("inviting an admin with a malformed email returns 400", async () => {
+  const request = new Request("http://localhost/api/write/admin", {
+    method: "POST",
+    body: JSON.stringify({ email: "not-an-email" }),
+  });
+  const response = await POST(request);
+  expect(response.status).toBe(400);
+});
+
+test("inviting an admin with an already-registered email returns 409, not 500", async () => {
+  const existing = await seedAdmin();
+  const request = new Request("http://localhost/api/write/admin", {
+    method: "POST",
+    body: JSON.stringify({ email: existing.email }),
+  });
+  const response = await POST(request);
+  expect(response.status).toBe(409);
+});
+
+test("updating an admin's role with an invalid role string returns 400", async () => {
+  // Zod validation runs before any DB lookup, so this 400s without needing a seeded admin.
+  const request = new Request("http://localhost/api/update/admin", {
+    method: "PUT",
+    body: JSON.stringify({ email: "someone@test.icr", role: "NOT_A_ROLE" }),
+  });
+  const response = await PUT(request);
+  expect(response.status).toBe(400);
+});

--- a/frontend/tests/integration/admin-routes-validation.test.ts
+++ b/frontend/tests/integration/admin-routes-validation.test.ts
@@ -42,3 +42,21 @@ test("updating an admin's role with an invalid role string returns 400", async (
   const response = await PUT(request);
   expect(response.status).toBe(400);
 });
+
+test("inviting an admin with a malformed JSON body returns 400, not 500", async () => {
+  const request = new Request("http://localhost/api/write/admin", {
+    method: "POST",
+    body: "{not valid json",
+  });
+  const response = await POST(request);
+  expect(response.status).toBe(400);
+});
+
+test("updating an admin's role with a malformed JSON body returns 400, not 500", async () => {
+  const request = new Request("http://localhost/api/update/admin", {
+    method: "PUT",
+    body: "{not valid json",
+  });
+  const response = await PUT(request);
+  expect(response.status).toBe(400);
+});

--- a/frontend/util/admin/adminValidation.ts
+++ b/frontend/util/admin/adminValidation.ts
@@ -1,0 +1,14 @@
+import { z } from "zod";
+import { Role } from "@prisma/client";
+
+// One schema per route (not a single shared schema with an optional role) because write's
+// role is optional (defaults to ADMIN) while update's is required.
+export const adminInviteSchema = z.object({
+  email: z.email(),
+  role: z.enum(Role).optional(),
+});
+
+export const adminRoleUpdateSchema = z.object({
+  email: z.email(),
+  role: z.enum(Role),
+});


### PR DESCRIPTION
Resolves #416

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added validation for admin invitations and role updates, including clear errors for invalid emails and roles.
  * Added conflict responses when inviting duplicate admins.
* **Bug Fixes**
  * Standardized admin API success and error responses.
  * Prevented internal database error details from being exposed.
  * Improved handling of missing admins and attempts to remove or demote the last Super Admin.
* **Documentation**
  * Documented validation and concurrent-conflict errors in the API reference.
* **Tests**
  * Added integration coverage for validation, duplicate invitations, and safe error responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

**Stacked on #420** — this branch is based on `fix/admin-data-exposure`, not `master`, since it edits the same 5 admin routes PR #420 already touched (adding `select` clauses there). Merge #420 first.

## Description
- **`util/admin/adminValidation.ts`** (new): zod schemas (`adminInviteSchema`, `adminRoleUpdateSchema`) built on Prisma's `Role` enum, mirroring `util/meetings/meetingValidation.ts`'s existing convention. Replaces the hand-rolled `!== SUPER_ADMIN && !== ADMIN && !== USER` tri-checks in `write/admin` and `update/admin`, and adds the email-format validation neither route had before.
- **`app/api/write/admin/route.ts`**: now validates against `adminInviteSchema`; catches Prisma `P2002` (unique constraint on `email`) and returns `409` instead of falling through to a generic `500` on a duplicate invite.
- **`app/api/update/admin/route.ts`**: now validates against `adminRoleUpdateSchema`.
- **`app/api/retrieve/admin/route.ts`, `app/api/retrieve/admins/route.ts`**: the actual security-relevant fix — both previously interpolated the raw caught error straight into the response body (e.g. `` `Admin not found: ${error}` ``), leaking raw Prisma internals to the client. Now return a generic `"Internal Server Error"` message; the real detail goes to `console.error` (server-side only).
- **All 5 admin routes** (`write`, `update`, `delete`, `retrieve/admin`, `retrieve/admins`): standardized every response — success, 4xx, and 500 — on `NextResponse.json(...)`, replacing the mix of raw `new Response(JSON.stringify(...), {headers: {...}})` calls that existed before.
- **`docs/03-development/api-reference.md`**: documented the new `400`/`409` error responses for `write/admin` and `update/admin`, and added the previously-undocumented `409` (concurrent-conflict retry) response that `update/admin`/`delete/admin` already returned.

**Scope note:** issue #416's background also flags `retrieve/meeting/day|week|range` for using the same non-`NextResponse.json` envelope. Verified those routes don't interpolate raw errors (they already use generic messages) — the AC "no route returns a raw caught-error object or its string interpolation" is fully satisfied by this PR. Unifying the response *envelope* across the public meeting-read routes too is a separate, larger, and lower-value cleanup (higher-traffic hot path, no security implication) that this PR deliberately doesn't attempt.

## Testing
- [x] `yarn test:all` (lint, lint:css, typecheck, unit, component, integration, e2e) — full pass.
- [x] Two new integration test files: `tests/integration/admin-routes-validation.test.ts` (real test DB — malformed-email 400, duplicate-email 409, invalid-role 400) and `tests/integration/admin-error-response-shape.test.ts` (mocks `lib/prisma` to force the 500 path and asserts the body is exactly `{error: "Internal Server Error"}`, never the raw mocked DB error).

## Area(s) Touched
**Product areas**
- [x] admin — /admin shell (Diagnostics, Users, Import, Export tabs)

**Engineering**
- [x] security — auth hardening, data exposure, dependency/security scanning
- [x] testing — test suite (Jest/Playwright) changes
- [x] cleanup — refactor or dead-code removal, no behavior change

## Pre-merge Checklist
- [x] Code follows current formatting conventions and passes lint (`yarn lint`).
- [x] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
- [x] All test suites pass, both run locally and green in GitHub CI. **Do not merge if any test suite is failing.**
- [x] A test suite was added or updated for the feature/fix in this PR. **Double-check this if you change a feature and did not update the test suites**.
- [x] Only files relevant to this change are committed — no stray or unrelated files.
- [x] If this branch has a merge conflict with master, master was merged into this branch first (not the other way around).
- [x] The rest of this PR description (Description, Testing) is filled out, not left as template placeholders.
