### PR TITLE
fix(date): handle DST spring-forward/fall-back transitions correctly

### DIFF
--- a/frontend/app/api/retrieve/meeting/day/route.ts
+++ b/frontend/app/api/retrieve/meeting/day/route.ts
@@ -7,7 +7,20 @@ import { NextRequest } from 'next/server';
 const retrieveDayMeetings = async (request: NextRequest) => {
     try {
         const dateParam = request.nextUrl.searchParams.get("startDate") ?? new Date().toISOString();
-        const etDateStr = toETDateString(dateParam);
+
+        // toETDateString throws for a param that's neither "YYYY-MM-DD"-shaped nor a parseable
+        // date string at all, and also for a "YYYY-MM-DD"-shaped string that isn't a real
+        // calendar date (e.g. "2024-02-31") -- caught here so that's a 400 (bad request), not a
+        // 500 from the outer catch below. Matches range/route.ts's handling of the same param.
+        let etDateStr: string;
+        try {
+            etDateStr = toETDateString(dateParam);
+        } catch {
+            return new Response(JSON.stringify({ error: "startDate must be a valid calendar date" }), {
+                status: 400,
+                headers: { 'Content-Type': 'application/json' },
+            });
+        }
 
         const meetings = await getMeetingsForDate(etDateStr);
 

--- a/frontend/app/api/retrieve/meeting/range/route.ts
+++ b/frontend/app/api/retrieve/meeting/range/route.ts
@@ -8,43 +8,26 @@ import { NextRequest } from 'next/server';
 // top out at MAX_DAYS (7), so a well-formed request never approaches this.
 const MAX_RANGE_DAYS = 31;
 
-// toETDateString passes a "YYYY-MM-DD"-shaped string through unvalidated (see its own
-// comment) -- a value like "2024-02-31" matches the shape but isn't a real calendar date.
-// Round-tripping through Date.UTC and comparing the parts back out catches that: an invalid
-// day/month rolls over onto a different date, so the parts no longer match what was given.
-const isValidCalendarDateString = (dateStr: string): boolean => {
-    const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(dateStr);
-    if (!match) return false;
-    const [year, month, day] = [Number(match[1]), Number(match[2]), Number(match[3])];
-    const date = new Date(Date.UTC(year, month - 1, day));
-    return date.getUTCFullYear() === year && date.getUTCMonth() === month - 1 && date.getUTCDate() === day;
-};
-
 const retrieveRangeMeetings = async (request: NextRequest) => {
     try {
         const startParam = request.nextUrl.searchParams.get("startDate") ?? new Date().toISOString();
         const endParam = request.nextUrl.searchParams.get("endDate") ?? startParam;
 
-        // toETDateString throws (Intl.DateTimeFormat rejects an unparseable Date) for input
-        // that's neither "YYYY-MM-DD"-shaped nor a valid date string at all (e.g. "not-a-date")
-        // -- caught here so that's a 400 (bad request), not a 500 from the outer catch below.
+        // toETDateString throws for input that's neither "YYYY-MM-DD"-shaped nor a valid date
+        // string at all (e.g. "not-a-date"), and also for a "YYYY-MM-DD"-shaped string that
+        // isn't a real calendar date (e.g. "2024-02-31") -- caught here so that's a 400 (bad
+        // request), not a 500 from the outer catch below.
         let startEtDateStr: string, endEtDateStr: string;
         try {
             startEtDateStr = toETDateString(startParam);
             endEtDateStr = toETDateString(endParam);
         } catch {
-            return new Response(JSON.stringify({ error: "startDate/endDate must be valid dates" }), {
-                status: 400,
-                headers: { 'Content-Type': 'application/json' },
-            });
-        }
-
-        if (!isValidCalendarDateString(startEtDateStr) || !isValidCalendarDateString(endEtDateStr)) {
             return new Response(JSON.stringify({ error: "startDate/endDate must be valid calendar dates" }), {
                 status: 400,
                 headers: { 'Content-Type': 'application/json' },
             });
         }
+
         if (endEtDateStr < startEtDateStr) {
             return new Response(JSON.stringify({ error: "endDate must not precede startDate" }), {
                 status: 400,

--- a/frontend/app/api/retrieve/meeting/week/route.ts
+++ b/frontend/app/api/retrieve/meeting/week/route.ts
@@ -7,7 +7,21 @@ import { NextRequest } from 'next/server';
 const retrieveWeekMeetings = async (request: NextRequest) => {
     try {
         const dateParam = request.nextUrl.searchParams.get("startDate") ?? new Date().toISOString();
-        const etDateStr = toETDateString(dateParam);
+
+        // toETDateString throws for a param that's neither "YYYY-MM-DD"-shaped nor a parseable
+        // date string at all, and also for a "YYYY-MM-DD"-shaped string that isn't a real
+        // calendar date (e.g. "2024-02-31") -- caught here so that's a 400 (bad request), not a
+        // 500 from the outer catch below. Matches range/route.ts's handling of the same param.
+        let etDateStr: string;
+        try {
+            etDateStr = toETDateString(dateParam);
+        } catch {
+            return new Response(JSON.stringify({ error: "startDate must be a valid calendar date" }), {
+                status: 400,
+                headers: { 'Content-Type': 'application/json' },
+            });
+        }
+
         const weekDates = getWeekDatesET(etDateStr);
 
         // A single range query covering the whole week, tagged with the ET date each occurrence

--- a/frontend/app/components/meeting-form/ViewMeeting.tsx
+++ b/frontend/app/components/meeting-form/ViewMeeting.tsx
@@ -389,6 +389,7 @@ const ViewMeetingDetails: React.FC<ViewMeetingDetailsProps> = ({
       // filters gap occurrences out before a date reaches this popup), guarded defensively so a
       // future caller can't crash here. Falls back to the meeting's own stored start/end.
       if (!isDstGapError(err)) throw err;
+      console.warn(`Could not re-anchor onto ${occurrenceDateStr}: ${err.message}`);
     }
   }
 

--- a/frontend/app/components/meeting-form/ViewMeeting.tsx
+++ b/frontend/app/components/meeting-form/ViewMeeting.tsx
@@ -16,6 +16,7 @@ import {
   convertETToUTC,
   formatETDateString,
   getETTimeOfDay,
+  isDstGapError,
 } from "../../../util/date/timeUtils";
 import { retryMeetingSync } from "../../../services/syncMeeting";
 import { useToast } from "../shared/ToastProvider";
@@ -371,16 +372,24 @@ const ViewMeetingDetails: React.FC<ViewMeetingDetailsProps> = ({
     // day -- via convertETToUTC so this is correct regardless of the viewer's own timezone.
     const occurrenceDateStr = formatETDateString(currentOccurrenceDate);
     const { hour, minute, second } = getETTimeOfDay(startDateTime);
-    // convertETToUTC's time-part parsing tolerates unpadded numbers, so no padStart needed.
-    const newStartDate = new Date(convertETToUTC(`${occurrenceDateStr}T${hour}:${minute}:${second}`));
-    // Milliseconds have no timezone component -- getETTimeOfDay doesn't carry them, so restore
-    // directly from startDateTime rather than losing sub-second precision on the re-anchor.
-    newStartDate.setUTCMilliseconds(startDateTime.getUTCMilliseconds());
+    try {
+      // convertETToUTC's time-part parsing tolerates unpadded numbers, so no padStart needed.
+      const newStartDate = new Date(convertETToUTC(`${occurrenceDateStr}T${hour}:${minute}:${second}`));
+      // Milliseconds have no timezone component -- getETTimeOfDay doesn't carry them, so restore
+      // directly from startDateTime rather than losing sub-second precision on the re-anchor.
+      newStartDate.setUTCMilliseconds(startDateTime.getUTCMilliseconds());
 
-    displayStartDate = newStartDate;
+      displayStartDate = newStartDate;
 
-    const duration = endDateTime.getTime() - startDateTime.getTime();
-    displayEndDate = new Date(displayStartDate.getTime() + duration);
+      const duration = endDateTime.getTime() - startDateTime.getTime();
+      displayEndDate = new Date(displayStartDate.getTime() + duration);
+    } catch (err) {
+      // currentOccurrenceDate re-anchored onto this meeting's time-of-day lands in the DST
+      // spring-forward gap -- not currently reachable in practice (getMeetingsForRange already
+      // filters gap occurrences out before a date reaches this popup), guarded defensively so a
+      // future caller can't crash here. Falls back to the meeting's own stored start/end.
+      if (!isDstGapError(err)) throw err;
+    }
   }
 
   // Suspend's effective start date is the clicked occurrence's date, clamped to never be

--- a/frontend/hooks/useMeetingForm.ts
+++ b/frontend/hooks/useMeetingForm.ts
@@ -342,7 +342,7 @@ export function useMeetingForm(initialMeeting?: IMeeting, defaultContext?: Meeti
         if (!startDateTimeUTC || !endDateTimeUTC) {
             // getValidationErrors above should have already caught this and blocked submit --
             // this is the same defensive fallback as the two early returns above.
-            console.error("Start/end time falls in the DST spring-forward gap and has no valid ET instant");
+            console.error("Start/end date or time is invalid and has no valid ET instant (calendar-invalid date or DST spring-forward gap)");
             return null;
         }
 

--- a/frontend/hooks/useMeetingForm.ts
+++ b/frontend/hooks/useMeetingForm.ts
@@ -1,6 +1,6 @@
 import { useCallback, useState } from 'react';
 import { IMeeting, IRecurrencePattern } from '../types/models';
-import { convertUTCToET, convertETToUTC, formatETDateString, getWeekDatesET, getCurrentETMinutesSinceMidnight } from '../util/date/timeUtils';
+import { convertUTCToET, convertETToUTC, formatETDateString, getWeekDatesET, getCurrentETMinutesSinceMidnight, isConvertETToUTCValidationError, isDstGapError } from '../util/date/timeUtils';
 import { roomToZoomRoom } from '../util/rooms/rooms';
 import { DESCRIPTION_MAX_LENGTH, MAX_RECURRENCE_OCCURRENCES } from '../util/meetings/meetingValidation';
 
@@ -68,20 +68,44 @@ function isoToPickerDate(isoDate: string): string {
     return `${month}/${day}/${year}`;
 }
 
-// Wraps convertETToUTC, returning null instead of throwing -- a DST spring-forward-gap time
-// (e.g. 2:30 AM on the 2nd Sunday of March) has no valid ET instant. Shared by
-// getValidationErrors (surfaces it as a normal field error) and buildMeetingPayload (a
-// defensive fallback so a bad time can't throw during render via ZoomHostField's getCandidate(),
-// which calls buildMeetingPayload directly, not just on submit).
+// Wraps convertETToUTC, returning null instead of throwing -- e.g. a DST spring-forward-gap
+// time (2:30 AM on the 2nd Sunday of March) has no valid ET instant, same as toISODate's own
+// string rearrangement not calendar-validating a typed "02/30/2026". Used by buildMeetingPayload
+// as a defensive fallback so a bad date/time can't throw during render via ZoomHostField's
+// getCandidate(), which calls buildMeetingPayload directly, not just on submit. getValidationErrors
+// below uses describeTimeValidationError instead, since it needs to know *which* failure this was
+// to show the right message -- this wrapper only needs "did it fail," not "why."
 function tryConvertETToUTC(etDateStr: string, etTimeStr: string): Date | null {
     try {
         return new Date(convertETToUTC(`${etDateStr}T${etTimeStr}`));
     } catch (err) {
-        // Only convertETToUTC's own documented validation failures (all prefixed "convertETToUTC:")
-        // mean "this input was invalid" -- anything else is unexpected and should propagate.
-        if (err instanceof Error && err.message.startsWith('convertETToUTC:')) return null;
+        // Only convertETToUTC's own documented validation failures mean "this input was invalid"
+        // -- anything else is unexpected and should propagate.
+        if (isConvertETToUTCValidationError(err)) return null;
         throw err;
     }
+}
+
+// Distinguishes convertETToUTC's failure modes so getValidationErrors can show a message that
+// actually matches what's wrong, instead of always blaming DST -- e.g. typing "02/30/2026" round-
+// trips through toISODate (plain string rearrangement, no calendar validation) and fails
+// convertETToUTC's calendar-date check, not its DST-gap one. Returns null if both times convert
+// cleanly.
+function describeTimeValidationError(etDateStr: string, startTime: string, endTime: string): string | null {
+    for (const etTimeStr of [startTime, endTime]) {
+        try {
+            convertETToUTC(`${etDateStr}T${etTimeStr}`);
+        } catch (err) {
+            if (isDstGapError(err)) {
+                return "This time doesn't exist due to the daylight saving time change in March — please pick a different time.";
+            }
+            if (isConvertETToUTCValidationError(err)) {
+                return "This isn't a valid date — please check the day and month.";
+            }
+            throw err;
+        }
+    }
+    return null;
 }
 
 // "YYYY-MM-DD" -> the next calendar day's "YYYY-MM-DD". Uses Date.UTC purely as a calendar
@@ -247,16 +271,13 @@ export function useMeetingForm(initialMeeting?: IMeeting, defaultContext?: Meeti
             errors.push({ fields: ["time"], message: "Start and end time are required." });
         } else {
             const isoDateValue = toISODate(date);
-            // A date/time combination that falls in the DST spring-forward gap (~2:00-2:59 AM
-            // ET on the 2nd Sunday of March) has no valid ET instant -- surfaced here as a
-            // normal, correctable validation error rather than buildMeetingPayload silently
-            // returning null (or, before this check existed, throwing) on submit.
-            if (isoDateValue && (!tryConvertETToUTC(isoDateValue, startTime) || !tryConvertETToUTC(isoDateValue, endTime))) {
-                errors.push({
-                    fields: ["date", "time"],
-                    message: "This time doesn't exist due to the daylight saving time change in March — please pick a different time.",
-                });
-            }
+            // Catches both an invalid calendar date (e.g. typed "02/30/2026" -- toISODate is
+            // plain string rearrangement, no calendar validation) and a DST spring-forward-gap
+            // time -- surfaced here as a normal, correctable validation error rather than
+            // buildMeetingPayload silently returning null (or, before this check existed,
+            // throwing) on submit.
+            const timeError = isoDateValue ? describeTimeValidationError(isoDateValue, startTime, endTime) : null;
+            if (timeError) errors.push({ fields: ["date", "time"], message: timeError });
         }
 
         if (!email.trim()) {

--- a/frontend/hooks/useMeetingForm.ts
+++ b/frontend/hooks/useMeetingForm.ts
@@ -68,6 +68,22 @@ function isoToPickerDate(isoDate: string): string {
     return `${month}/${day}/${year}`;
 }
 
+// Wraps convertETToUTC, returning null instead of throwing -- a DST spring-forward-gap time
+// (e.g. 2:30 AM on the 2nd Sunday of March) has no valid ET instant. Shared by
+// getValidationErrors (surfaces it as a normal field error) and buildMeetingPayload (a
+// defensive fallback so a bad time can't throw during render via ZoomHostField's getCandidate(),
+// which calls buildMeetingPayload directly, not just on submit).
+function tryConvertETToUTC(etDateStr: string, etTimeStr: string): Date | null {
+    try {
+        return new Date(convertETToUTC(`${etDateStr}T${etTimeStr}`));
+    } catch (err) {
+        // Only convertETToUTC's own documented validation failures (all prefixed "convertETToUTC:")
+        // mean "this input was invalid" -- anything else is unexpected and should propagate.
+        if (err instanceof Error && err.message.startsWith('convertETToUTC:')) return null;
+        throw err;
+    }
+}
+
 // "YYYY-MM-DD" -> the next calendar day's "YYYY-MM-DD". Uses Date.UTC purely as a calendar
 // calculator (not a timezone conversion) so month/year rollovers are handled for free.
 function addOneDayISO(isoDate: string): string {
@@ -227,7 +243,21 @@ export function useMeetingForm(initialMeeting?: IMeeting, defaultContext?: Meeti
         if (!date) errors.push({ fields: ["date"], message: "Date is required." });
 
         const [startTime, endTime] = time?.split(' - ') || [];
-        if (!startTime || !endTime) errors.push({ fields: ["time"], message: "Start and end time are required." });
+        if (!startTime || !endTime) {
+            errors.push({ fields: ["time"], message: "Start and end time are required." });
+        } else {
+            const isoDateValue = toISODate(date);
+            // A date/time combination that falls in the DST spring-forward gap (~2:00-2:59 AM
+            // ET on the 2nd Sunday of March) has no valid ET instant -- surfaced here as a
+            // normal, correctable validation error rather than buildMeetingPayload silently
+            // returning null (or, before this check existed, throwing) on submit.
+            if (isoDateValue && (!tryConvertETToUTC(isoDateValue, startTime) || !tryConvertETToUTC(isoDateValue, endTime))) {
+                errors.push({
+                    fields: ["date", "time"],
+                    message: "This time doesn't exist due to the daylight saving time change in March — please pick a different time.",
+                });
+            }
+        }
 
         if (!email.trim()) {
             errors.push({ fields: ["email"], message: "Email is required." });
@@ -286,8 +316,14 @@ export function useMeetingForm(initialMeeting?: IMeeting, defaultContext?: Meeti
             return null;
         }
 
-        const startDateTimeUTC = new Date(convertETToUTC(`${isoDateValue}T${startTime}`));
-        const endDateTimeUTC = new Date(convertETToUTC(`${isoDateValue}T${endTime}`));
+        const startDateTimeUTC = tryConvertETToUTC(isoDateValue, startTime);
+        const endDateTimeUTC = tryConvertETToUTC(isoDateValue, endTime);
+        if (!startDateTimeUTC || !endDateTimeUTC) {
+            // getValidationErrors above should have already caught this and blocked submit --
+            // this is the same defensive fallback as the two early returns above.
+            console.error("Start/end time falls in the DST spring-forward gap and has no valid ET instant");
+            return null;
+        }
 
         if (endDateTimeUTC <= startDateTimeUTC) {
             endDateTimeUTC.setUTCDate(endDateTimeUTC.getUTCDate() + 1);

--- a/frontend/tests/unit/meetingOccurrences.test.ts
+++ b/frontend/tests/unit/meetingOccurrences.test.ts
@@ -1,5 +1,5 @@
-import { matchesRecurrencePattern, adjustOccurrenceToDate } from "../../util/meetings/meetingOccurrences";
-import { convertETToUTC } from "../../util/date/timeUtils";
+import { matchesRecurrencePattern, adjustOccurrenceToDate, calculateEndDateFromOccurrences } from "../../util/meetings/meetingOccurrences";
+import { convertETToUTC, formatETDateString } from "../../util/date/timeUtils";
 
 // startDate/localDate are UTC-midnight-anchored representations of an ET
 // calendar date (not real UTC instants of the meeting's actual start time) —
@@ -119,5 +119,37 @@ describe("adjustOccurrenceToDate", () => {
     const { start, end } = adjustOccurrenceToDate(meeting, "2026-08-31");
     expect(start.toISOString()).toBe(new Date(convertETToUTC("2026-08-31T23:00:00")).toISOString());
     expect(end.toISOString()).toBe(new Date(convertETToUTC("2026-09-01T01:00:00")).toISOString());
+  });
+});
+
+describe("calculateEndDateFromOccurrences — monthly day-of-month clamping", () => {
+  // Regression: a "day 31" monthly pattern whose Nth occurrence lands in a shorter month (e.g.
+  // February) used to build an out-of-range calendar date string like "2026-02-31" -- which
+  // convertETToUTC now rejects instead of Date.UTC silently rolling it over to March 2/3.
+  // day must clamp to the target month's real last day (Feb 28 in 2026, a non-leap year).
+  it("clamps a day-31 pattern to February's real last day instead of throwing", () => {
+    const endDate = calculateEndDateFromOccurrences(
+      utcDate(2026, 1, 31), // series starts Jan 31, 2026
+      [],
+      2, // 2nd occurrence is one month later, landing in February
+      1,
+      "monthly",
+      null,
+      31,
+    );
+    expect(formatETDateString(endDate)).toBe("2026-02-28");
+  });
+
+  it("does not clamp when the target month actually has that many days", () => {
+    const endDate = calculateEndDateFromOccurrences(
+      utcDate(2026, 1, 31),
+      [],
+      1, // 1st occurrence stays in January, which has 31 days
+      1,
+      "monthly",
+      null,
+      31,
+    );
+    expect(formatETDateString(endDate)).toBe("2026-01-31");
   });
 });

--- a/frontend/tests/unit/resourceOverlap.test.ts
+++ b/frontend/tests/unit/resourceOverlap.test.ts
@@ -5,6 +5,7 @@ import {
   OVERLAP_HORIZON_YEARS,
   type ConflictCandidateMeeting,
 } from "../../util/meetings/resourceOverlap";
+import { convertETToUTC, formatETDateString } from "../../util/date/timeUtils";
 
 const utcDate = (y: number, m: number, d: number, h = 0, min = 0) =>
   new Date(Date.UTC(y, m - 1, d, h, min));
@@ -78,6 +79,37 @@ describe("expandOccurrences — recurring", () => {
     };
     const occurrences = expandOccurrences(boundedMeeting, utcDate(2026, 7, 1), utcDate(2026, 8, 1));
     expect(occurrences).toHaveLength(2);
+  });
+});
+
+describe("expandOccurrences — DST spring-forward gap", () => {
+  // Regression: a weekly Sunday meeting anchored at 2:30 AM ET lands, once a year, on a Sunday
+  // where 2:00-2:59 AM ET doesn't exist (the 2nd Sunday of March -- March 8, 2026). That single
+  // occurrence must be skipped, not throw all the way out and take every other occurrence (and,
+  // one level up, every other meeting in the same request) down with it.
+  it("skips the one occurrence that falls in the gap, keeping every other week's occurrence", () => {
+    const meeting = {
+      // Feb 1, 2026 is a Sunday -- the same weekday as the March 8 gap date, 7-day-aligned.
+      startDateTime: new Date(convertETToUTC("2026-02-01T02:30:00")),
+      endDateTime: new Date(convertETToUTC("2026-02-01T02:45:00")),
+      isRecurring: true,
+      recurrencePattern: {
+        type: "weekly",
+        startDate: utcDate(2026, 2, 1),
+        endDate: null,
+        interval: 1,
+        daysOfWeek: ["Sunday"],
+        weekOfMonth: null,
+        dayOfMonth: null,
+        excludedDates: [],
+      },
+    };
+
+    const occurrences = expandOccurrences(meeting, utcDate(2026, 3, 1), utcDate(2026, 3, 15, 23, 59));
+
+    // March 1, March 8 (gap -- skipped), March 15 would otherwise be 3 occurrences.
+    expect(occurrences).toHaveLength(2);
+    expect(occurrences.map((o) => formatETDateString(o.start))).toEqual(["2026-03-01", "2026-03-15"]);
   });
 });
 

--- a/frontend/tests/unit/timeUtils.test.ts
+++ b/frontend/tests/unit/timeUtils.test.ts
@@ -69,6 +69,16 @@ describe("convertETToUTC DST transitions", () => {
   it("rejects a calendar-invalid date instead of silently rolling it over", () => {
     expect(() => convertETToUTC("2026-02-30T00:00:00")).toThrow(/not a valid calendar date/);
   });
+
+  it("accepts Feb 29 on a leap year", () => {
+    expect(convertETToUTC("2024-02-29T12:00:00")).toBe("2024-02-29T17:00:00.000Z");
+  });
+
+  // An out-of-range time-of-day isn't a DST gap -- it must get its own distinct error, not be
+  // misreported as "falls in the spring-forward gap" just because it also fails to round-trip.
+  it("rejects an out-of-range hour with a distinct error from the DST-gap message", () => {
+    expect(() => convertETToUTC("2026-07-15T24:00:00")).toThrow(/invalid time of day/);
+  });
 });
 
 describe("getETDayBounds", () => {
@@ -195,6 +205,10 @@ describe("toETDateString", () => {
 
   it("normalises a full ISO string to its ET calendar date", () => {
     expect(toETDateString(convertETToUTC("2026-08-15T23:30:00"))).toBe("2026-08-15");
+  });
+
+  it("accepts a real leap-day date", () => {
+    expect(toETDateString("2024-02-29")).toBe("2024-02-29");
   });
 
   // Date.UTC would otherwise silently normalize an invalid day/month into a different,

--- a/frontend/tests/unit/timeUtils.test.ts
+++ b/frontend/tests/unit/timeUtils.test.ts
@@ -11,6 +11,7 @@ import {
   getETTimeOfDay,
   getWeekDatesET,
   parseMMDDYYYY,
+  toETDateString,
 } from "../../util/date/timeUtils";
 
 describe("convertETToUTC / convertUTCToET round-trip", () => {
@@ -22,6 +23,51 @@ describe("convertETToUTC / convertUTCToET round-trip", () => {
   it("round-trips a winter (EST, UTC-5) date", () => {
     const utc = convertETToUTC("2026-01-15T14:00:00");
     expect(convertUTCToET(utc)).toContain("01/15/2026, 02:00:00 PM");
+  });
+});
+
+describe("convertETToUTC DST transitions", () => {
+  // Spring-forward: 2nd Sunday of March 2026 is March 8; clocks jump 1:59:59 -> 3:00:00 AM ET,
+  // so 2:00-2:59 AM ET doesn't exist that day.
+  it("throws for a time in the spring-forward gap", () => {
+    expect(() => convertETToUTC("2026-03-08T02:30:00")).toThrow(/spring-forward gap/);
+  });
+
+  it("throws for the first instant of the spring-forward gap", () => {
+    expect(() => convertETToUTC("2026-03-08T02:00:00")).toThrow(/spring-forward gap/);
+  });
+
+  it("throws for the last instant of the spring-forward gap", () => {
+    expect(() => convertETToUTC("2026-03-08T02:59:59")).toThrow(/spring-forward gap/);
+  });
+
+  it("still converts the times immediately surrounding the spring-forward gap", () => {
+    // 1:59:59 AM EST (UTC-5) and 3:00:00 AM EDT (UTC-4) are both real, unambiguous instants.
+    expect(convertETToUTC("2026-03-08T01:59:59")).toBe("2026-03-08T06:59:59.000Z");
+    expect(convertETToUTC("2026-03-08T03:00:00")).toBe("2026-03-08T07:00:00.000Z");
+  });
+
+  // Fall-back: 1st Sunday of November 2026 is November 1; clocks fall back 1:59:59 -> 1:00:00
+  // AM ET, so 1:00-1:59 AM ET occurs twice (once EDT, once EST).
+  it("resolves a fall-back-ambiguous time to the earlier (EDT) occurrence", () => {
+    // 1:30 AM EDT (UTC-4) is 05:30 UTC; the later 1:30 AM EST (UTC-5) occurrence would be
+    // 06:30 UTC -- convertETToUTC must deterministically pick the earlier one.
+    expect(convertETToUTC("2026-11-01T01:30:00")).toBe("2026-11-01T05:30:00.000Z");
+  });
+
+  it("resolves the first and last instants of the fall-back overlap to their earlier occurrence", () => {
+    expect(convertETToUTC("2026-11-01T01:00:00")).toBe("2026-11-01T05:00:00.000Z");
+    expect(convertETToUTC("2026-11-01T01:59:59")).toBe("2026-11-01T05:59:59.000Z");
+  });
+
+  it("still converts the times immediately surrounding the fall-back overlap unambiguously", () => {
+    expect(convertETToUTC("2026-11-01T00:59:59")).toBe("2026-11-01T04:59:59.000Z");
+    // 2:00 AM ET is already back to a single (EST) occurrence once the overlap hour ends.
+    expect(convertETToUTC("2026-11-01T02:00:00")).toBe("2026-11-01T07:00:00.000Z");
+  });
+
+  it("rejects a calendar-invalid date instead of silently rolling it over", () => {
+    expect(() => convertETToUTC("2026-02-30T00:00:00")).toThrow(/not a valid calendar date/);
   });
 });
 
@@ -139,5 +185,25 @@ describe("parseMMDDYYYY", () => {
   it("accepts Feb 29 on a leap year but rejects it on a non-leap year", () => {
     expect(formatETDateString(parseMMDDYYYY("02/29/2028")!)).toBe("2028-02-29");
     expect(parseMMDDYYYY("02/29/2026")).toBeNull();
+  });
+});
+
+describe("toETDateString", () => {
+  it("passes a plain YYYY-MM-DD string through unchanged", () => {
+    expect(toETDateString("2026-08-15")).toBe("2026-08-15");
+  });
+
+  it("normalises a full ISO string to its ET calendar date", () => {
+    expect(toETDateString(convertETToUTC("2026-08-15T23:30:00"))).toBe("2026-08-15");
+  });
+
+  // Date.UTC would otherwise silently normalize an invalid day/month into a different,
+  // valid date (e.g. Feb 31 -> Mar 3) instead of failing.
+  it("rejects a YYYY-MM-DD-shaped string that isn't a real calendar date", () => {
+    expect(() => toETDateString("2026-02-31")).toThrow(/not a valid calendar date/);
+  });
+
+  it("rejects an unparseable date string", () => {
+    expect(() => toETDateString("not-a-date")).toThrow();
   });
 });

--- a/frontend/util/date/timeUtils.ts
+++ b/frontend/util/date/timeUtils.ts
@@ -26,49 +26,78 @@ export const convertUTCToET = (utcDateString: string): string => {
   return estDate;
 };
 
+// ET wall-clock reading (year/month/day/hour/minute/second) of a UTC instant, as plain
+// numbers -- shared by convertETToUTC's offset search below. hour % 24 guards against ICU
+// builds that render midnight as "24" under hour12: false.
+const getETPartsAt = (ms: number) => {
+  const parts = new Intl.DateTimeFormat('en-GB', {
+    timeZone: 'America/New_York',
+    year: 'numeric', month: '2-digit', day: '2-digit',
+    hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false,
+  }).formatToParts(new Date(ms));
+  const get = (type: Intl.DateTimeFormatPartTypes) =>
+    parseInt(parts.find(p => p.type === type)?.value ?? '0');
+  return {
+    year: get('year'), month: get('month'), day: get('day'),
+    hour: get('hour') % 24, minute: get('minute'), second: get('second'),
+  };
+};
+
 /**
  * Converts an ET date string to UTC.
  * Handles DST automatically — works regardless of the host machine's local timezone.
  *
+ * DST edge cases (America/New_York only ever runs EDT, UTC-4, or EST, UTC-5):
+ * - Spring-forward gap (2nd Sunday of March, ~2:00-2:59 AM ET): that wall-clock time never
+ *   occurs (clocks jump 1:59:59 -> 3:00:00) -- throws rather than silently returning a UTC
+ *   instant that doesn't actually correspond to the requested local time.
+ * - Fall-back overlap (1st Sunday of November, ~1:00-1:59 AM ET): that wall-clock time occurs
+ *   twice. Resolves to the earlier (EDT) occurrence, matching Java's ZonedDateTime default for
+ *   an ambiguous local time -- there's no disambiguation parameter, since real callers only
+ *   ever pass meeting times, which are never scheduled in this 1-hour window.
+ *
  * @param etDateString - ET date string in "YYYY-MM-DDTHH:mm" or "YYYY-MM-DDTHH:mm:ss" format
  * @returns corresponding UTC date string in ISO 8601 format
+ * @throws if the date part isn't a valid calendar date, or the time falls in the DST
+ *   spring-forward gap
  */
 export const convertETToUTC = (etDateString: string): string => {
   const [datePart, timePart = '00:00:00'] = etDateString.split('T');
   const [year, month, day] = datePart.split('-').map(Number);
   const [hour = 0, minute = 0, second = 0] = timePart.split(':').map(Number);
 
-  // Create a UTC probe with the same numeric values as the ET input, then ask
-  // Intl what ET wall time that probe corresponds to.  The difference between
-  // the target ET time and the probe's ET time equals the ET→UTC offset at
-  // that moment — correcting for DST automatically.
-  const probe = new Date(Date.UTC(year, month - 1, day, hour, minute, second));
+  // Reject a calendar-invalid date (e.g. Feb 30) up front, rather than letting Date.UTC
+  // silently roll it into a different, valid date further down.
+  const calendarCheck = new Date(Date.UTC(year, month - 1, day));
+  if (
+    calendarCheck.getUTCFullYear() !== year ||
+    calendarCheck.getUTCMonth() !== month - 1 ||
+    calendarCheck.getUTCDate() !== day
+  ) {
+    throw new Error(`convertETToUTC: "${etDateString}" is not a valid calendar date`);
+  }
 
-  const etParts = new Intl.DateTimeFormat('en-US', {
-    timeZone: 'America/New_York',
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
-    hour: '2-digit',
-    minute: '2-digit',
-    second: '2-digit',
-    hour12: false,
-  }).formatToParts(probe);
+  // Treat the target wall-clock values as if they were already UTC, then try both of
+  // America/New_York's possible offsets (EDT/UTC-4, EST/UTC-5) and keep whichever one reads
+  // back as the exact target ET wall time. Outside the two DST-transition windows, exactly one
+  // candidate round-trips.
+  const targetAsUTCMs = Date.UTC(year, month - 1, day, hour, minute, second);
+  const candidates = [4, 5].map(offsetHours => targetAsUTCMs + offsetHours * 3_600_000);
+  const valid = candidates.filter(ms => {
+    const p = getETPartsAt(ms);
+    return p.year === year && p.month === month && p.day === day
+      && p.hour === hour && p.minute === minute && p.second === second;
+  });
 
-  const get = (type: Intl.DateTimeFormatPartTypes) =>
-    parseInt(etParts.find(p => p.type === type)?.value ?? '0');
+  if (valid.length === 0) {
+    throw new Error(
+      `convertETToUTC: "${etDateString}" falls in the DST spring-forward gap and does not exist in America/New_York`,
+    );
+  }
 
-  // Use the full ET datetime (including day) from Intl so that day-boundary
-  // cases work correctly — e.g. UTC midnight = previous day 8 PM ET, and the
-  // hours-only diff would go negative without the date component.
-  const probeEtAsUTC = Date.UTC(
-    get('year'), get('month') - 1, get('day'),
-    get('hour') % 24, get('minute'), get('second'),
-  );
-  const targetEtAsUTC = Date.UTC(year, month - 1, day, hour, minute, second);
-  const diffMs = targetEtAsUTC - probeEtAsUTC;
-
-  return new Date(probe.getTime() + diffMs).toISOString();
+  // valid.length === 2 means the fall-back overlap applies -- Math.min picks the earlier (EDT)
+  // occurrence, per the documented rule above. valid.length === 1 just returns that instant.
+  return new Date(Math.min(...valid)).toISOString();
 };
 
 /**
@@ -157,19 +186,40 @@ export const parseMMDDYYYY = (value: string): Date | null => {
   if (!match) return null;
   const [, month, day, year] = match;
   const etDateStr = `${year}-${month.padStart(2, '0')}-${day.padStart(2, '0')}`;
-  const parsed = new Date(convertETToUTC(`${etDateStr}T00:00:00`));
-  // Reject calendar-invalid input (e.g. "02/30/2026") that Date.UTC would otherwise silently
-  // normalize into a different valid date (March 2) instead of failing.
-  if (isNaN(parsed.getTime()) || formatETDateString(parsed) !== etDateStr) return null;
-  return parsed;
+  try {
+    // convertETToUTC itself now rejects a calendar-invalid date (e.g. "02/30/2026") --
+    // caught here and folded into this function's null-for-unparseable contract.
+    const parsed = new Date(convertETToUTC(`${etDateStr}T00:00:00`));
+    if (isNaN(parsed.getTime()) || formatETDateString(parsed) !== etDateStr) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
 };
 
 /**
  * Normalises a "startDate" request param (either a plain "YYYY-MM-DD" or a full
  * date/ISO string) into a "YYYY-MM-DD" ET calendar date string.
+ *
+ * @throws if `dateParam` is "YYYY-MM-DD"-shaped but not a real calendar date (e.g.
+ *   "2024-02-31"), or isn't "YYYY-MM-DD"-shaped and also isn't a parseable date string at all.
  */
-export const toETDateString = (dateParam: string): string =>
-  dateParam.match(/^\d{4}-\d{2}-\d{2}$/) ? dateParam : formatETDateString(new Date(dateParam));
+export const toETDateString = (dateParam: string): string => {
+  const match = dateParam.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  if (!match) return formatETDateString(new Date(dateParam));
+
+  const [, yearStr, monthStr, dayStr] = match;
+  const [year, month, day] = [Number(yearStr), Number(monthStr), Number(dayStr)];
+  const roundTripped = new Date(Date.UTC(year, month - 1, day));
+  if (
+    roundTripped.getUTCFullYear() !== year ||
+    roundTripped.getUTCMonth() !== month - 1 ||
+    roundTripped.getUTCDate() !== day
+  ) {
+    throw new Error(`toETDateString: "${dateParam}" is not a valid calendar date`);
+  }
+  return dateParam;
+};
 
 /**
  * Returns the 7 ET calendar date strings (Sunday through Saturday) for the week

--- a/frontend/util/date/timeUtils.ts
+++ b/frontend/util/date/timeUtils.ts
@@ -77,6 +77,18 @@ export const convertETToUTC = (etDateString: string): string => {
     throw new Error(`convertETToUTC: "${etDateString}" is not a valid calendar date`);
   }
 
+  // Reject an out-of-range time-of-day (e.g. "T24:00:00") up front too -- otherwise it falls
+  // through to the offset search below, which would report it as a spring-forward-gap time
+  // (zero candidates round-trip) even though it's really just a malformed time, not a real ET
+  // instant that happens to not exist.
+  if (
+    !Number.isInteger(hour) || hour < 0 || hour > 23 ||
+    !Number.isInteger(minute) || minute < 0 || minute > 59 ||
+    !Number.isInteger(second) || second < 0 || second > 59
+  ) {
+    throw new Error(`convertETToUTC: "${etDateString}" has an invalid time of day`);
+  }
+
   // Treat the target wall-clock values as if they were already UTC, then try both of
   // America/New_York's possible offsets (EDT/UTC-4, EST/UTC-5) and keep whichever one reads
   // back as the exact target ET wall time. Outside the two DST-transition windows, exactly one
@@ -192,8 +204,12 @@ export const parseMMDDYYYY = (value: string): Date | null => {
     const parsed = new Date(convertETToUTC(`${etDateStr}T00:00:00`));
     if (isNaN(parsed.getTime()) || formatETDateString(parsed) !== etDateStr) return null;
     return parsed;
-  } catch {
-    return null;
+  } catch (err) {
+    // Only convertETToUTC's own documented validation failures mean "this input was invalid" --
+    // every one of its throws is prefixed "convertETToUTC:". Anything else is unexpected and
+    // should propagate as a real bug rather than being silently swallowed as "null".
+    if (err instanceof Error && err.message.startsWith('convertETToUTC:')) return null;
+    throw err;
   }
 };
 

--- a/frontend/util/date/timeUtils.ts
+++ b/frontend/util/date/timeUtils.ts
@@ -113,6 +113,25 @@ export const convertETToUTC = (etDateString: string): string => {
 };
 
 /**
+ * True if `err` is one of convertETToUTC's own documented validation failures (calendar-invalid
+ * date, invalid time-of-day, or the DST spring-forward gap) -- every one of its throws is
+ * prefixed "convertETToUTC:". Callers use this to distinguish "this input was invalid" from an
+ * unrelated, unexpected error, which should propagate rather than being silently swallowed.
+ */
+export const isConvertETToUTCValidationError = (err: unknown): err is Error =>
+  err instanceof Error && err.message.startsWith('convertETToUTC:');
+
+/**
+ * True specifically for convertETToUTC's DST spring-forward-gap rejection -- narrower than
+ * isConvertETToUTCValidationError above, for callers (e.g. occurrence-expansion loops) that pass
+ * already-validated ET date/time components and should only ever hit this one failure mode; any
+ * other convertETToUTC validation failure there would mean a real bug upstream, not a DST edge
+ * case, and shouldn't be silently swallowed the same way.
+ */
+export const isDstGapError = (err: unknown): err is Error =>
+  isConvertETToUTCValidationError(err) && err.message.includes('spring-forward gap');
+
+/**
  * Returns the UTC start (midnight ET) and end (23:59:59.999 ET) for a given
  * ET calendar date.  Use this for day-boundary queries so DST is handled
  * correctly without hardcoded hour offsets.
@@ -206,9 +225,9 @@ export const parseMMDDYYYY = (value: string): Date | null => {
     return parsed;
   } catch (err) {
     // Only convertETToUTC's own documented validation failures mean "this input was invalid" --
-    // every one of its throws is prefixed "convertETToUTC:". Anything else is unexpected and
-    // should propagate as a real bug rather than being silently swallowed as "null".
-    if (err instanceof Error && err.message.startsWith('convertETToUTC:')) return null;
+    // anything else is unexpected and should propagate as a real bug rather than being silently
+    // swallowed as "null".
+    if (isConvertETToUTCValidationError(err)) return null;
     throw err;
   }
 };

--- a/frontend/util/meetings/meetingOccurrences.ts
+++ b/frontend/util/meetings/meetingOccurrences.ts
@@ -1,5 +1,5 @@
 import "server-only";
-import { getETDayBounds, convertETToUTC, addDaysToETDateString } from "../date/timeUtils";
+import { getETDayBounds, convertETToUTC, addDaysToETDateString, getDaysInMonth, isDstGapError } from "../date/timeUtils";
 import { prisma } from "../../lib/prisma";
 import { PublicMeeting, toPublicMeeting } from "./publicMeeting";
 import { isDateSuspended, isAfterSeriesEnd, matchesRecurrencePattern, addOneETDay, adjustOccurrenceToDate } from "./recurrenceMatch";
@@ -151,7 +151,11 @@ export const getMeetingsForRange = async (
             try {
                 ({ start, end } = adjustOccurrenceToDate(meeting, etDateStr));
             } catch (err) {
-                console.warn(`Skipping occurrence of meeting ${meeting.id} on ${etDateStr}: ${err instanceof Error ? err.message : err}`);
+                // Only the DST spring-forward gap is expected here -- any other error means a
+                // real bug (e.g. malformed meeting data), which should surface, not get silently
+                // dropped from the calendar alongside a merely-console-logged DST edge case.
+                if (!isDstGapError(err)) throw err;
+                console.warn(`Skipping occurrence of meeting ${meeting.id} on ${etDateStr}: ${err.message}`);
                 continue;
             }
             // Only relevant on the lead-in day if it actually spills into the requested range --
@@ -220,8 +224,7 @@ export function calculateEndDateFromOccurrences(
         // on Feb 28/29 rather than building an out-of-range calendar date like "2026-02-31",
         // which convertETToUTC now rejects instead of silently rolling it into March.
         const toETDate = (day: number) => {
-            const daysInTargetMonth = new Date(Date.UTC(targetYear, targetMonth + 1, 0)).getUTCDate();
-            const clampedDay = Math.min(day, daysInTargetMonth);
+            const clampedDay = Math.min(day, getDaysInMonth(targetYear, targetMonth + 1));
             return new Date(convertETToUTC(
                 `${targetYear}-${String(targetMonth + 1).padStart(2, '0')}-${String(clampedDay).padStart(2, '0')}T23:59:59`
             ));
@@ -233,7 +236,7 @@ export function calculateEndDateFromOccurrences(
 
         if (weekOfMonth != null && daysOfWeek.length > 0) {
             const targetDay = dayNameToIndex[daysOfWeek[0]];
-            const daysInMonth = new Date(Date.UTC(targetYear, targetMonth + 1, 0)).getUTCDate();
+            const daysInMonth = getDaysInMonth(targetYear, targetMonth + 1);
 
             if (weekOfMonth === -1) {
                 for (let d = daysInMonth; d >= 1; d--) {

--- a/frontend/util/meetings/meetingOccurrences.ts
+++ b/frontend/util/meetings/meetingOccurrences.ts
@@ -143,7 +143,17 @@ export const getMeetingsForRange = async (
             if (!recurrence) continue;
             if (!matchesRecurrencePattern(recurrence, etDateStr, localDate)) continue;
 
-            const { start, end } = adjustOccurrenceToDate(meeting, etDateStr);
+            // adjustOccurrenceToDate throws when the meeting's ET start/end time lands in the
+            // DST spring-forward gap on this particular calendar date (e.g. a recurring 2:30 AM
+            // meeting, on the one day/year that time doesn't exist) -- isolated per-occurrence so
+            // one unrenderable occurrence doesn't 500 every other meeting in this request.
+            let start: Date, end: Date;
+            try {
+                ({ start, end } = adjustOccurrenceToDate(meeting, etDateStr));
+            } catch (err) {
+                console.warn(`Skipping occurrence of meeting ${meeting.id} on ${etDateStr}: ${err instanceof Error ? err.message : err}`);
+                continue;
+            }
             // Only relevant on the lead-in day if it actually spills into the requested range --
             // otherwise this occurrence belongs entirely to the lead-in day, which is outside
             // what the caller asked for.
@@ -206,9 +216,16 @@ export function calculateEndDateFromOccurrences(
 
         // 23:59:59 ET so the end date is inclusive of its full day
         // even against a naive instant comparison (e.g. `meetingStart <= endDate`).
-        const toETDate = (day: number) => new Date(convertETToUTC(
-            `${targetYear}-${String(targetMonth + 1).padStart(2, '0')}-${String(day).padStart(2, '0')}T23:59:59`
-        ));
+        // `day` is clamped to the target month's real length -- e.g. a "day 31" pattern lands
+        // on Feb 28/29 rather than building an out-of-range calendar date like "2026-02-31",
+        // which convertETToUTC now rejects instead of silently rolling it into March.
+        const toETDate = (day: number) => {
+            const daysInTargetMonth = new Date(Date.UTC(targetYear, targetMonth + 1, 0)).getUTCDate();
+            const clampedDay = Math.min(day, daysInTargetMonth);
+            return new Date(convertETToUTC(
+                `${targetYear}-${String(targetMonth + 1).padStart(2, '0')}-${String(clampedDay).padStart(2, '0')}T23:59:59`
+            ));
+        };
 
         if (dayOfMonth != null) {
             return toETDate(dayOfMonth);

--- a/frontend/util/meetings/resourceOverlap.ts
+++ b/frontend/util/meetings/resourceOverlap.ts
@@ -104,8 +104,15 @@ export function expandOccurrences(
 
     if (!matchesRecurrencePattern(pattern, etDateStr, localDate)) continue;
 
-    const { start, end } = adjustOccurrenceToDate(meeting, etDateStr);
-    occurrences.push({ start, end });
+    // adjustOccurrenceToDate throws when this occurrence's ET start/end time lands in the DST
+    // spring-forward gap on this particular date -- isolated per-occurrence so one unrenderable
+    // occurrence in a long expansion doesn't abort the whole conflict scan.
+    try {
+      const { start, end } = adjustOccurrenceToDate(meeting, etDateStr);
+      occurrences.push({ start, end });
+    } catch (err) {
+      console.warn(`Skipping occurrence on ${etDateStr}: ${err instanceof Error ? err.message : err}`);
+    }
   }
 
   return occurrences;

--- a/frontend/util/meetings/resourceOverlap.ts
+++ b/frontend/util/meetings/resourceOverlap.ts
@@ -1,7 +1,7 @@
 import "server-only";
 import { Prisma } from "@prisma/client";
 import { prisma } from "../../lib/prisma";
-import { formatETDateString } from "../date/timeUtils";
+import { formatETDateString, isDstGapError } from "../date/timeUtils";
 import { matchesRecurrencePattern, adjustOccurrenceToDate, isDateSuspended } from "./meetingOccurrences";
 
 type SuspensionWindow = { from: Date; to: Date | null };
@@ -111,7 +111,10 @@ export function expandOccurrences(
       const { start, end } = adjustOccurrenceToDate(meeting, etDateStr);
       occurrences.push({ start, end });
     } catch (err) {
-      console.warn(`Skipping occurrence on ${etDateStr}: ${err instanceof Error ? err.message : err}`);
+      // Only the DST spring-forward gap is expected here -- any other error means a real bug,
+      // which should surface, not get silently dropped alongside a merely-logged DST edge case.
+      if (!isDstGapError(err)) throw err;
+      console.warn(`Skipping occurrence on ${etDateStr}: ${err.message}`);
     }
   }
 

--- a/frontend/util/meetings/suspension.ts
+++ b/frontend/util/meetings/suspension.ts
@@ -126,7 +126,15 @@ export async function createPendingResumeSeries(
     );
     if (!resumeDateStr) return { resumeEventIds: {}, error: null };
     recordUnconfiguredCat();
-    const { start, end } = adjustOccurrenceToDate(meeting, resumeDateStr);
+    // adjustOccurrenceToDate throws if the resume occurrence's ET start/end time lands in the
+    // DST spring-forward gap on this date (the one day/year that time doesn't exist) -- treated
+    // as nothing to pre-create rather than crashing the whole suspend/resume request.
+    let start: Date, end: Date;
+    try {
+      ({ start, end } = adjustOccurrenceToDate(meeting, resumeDateStr));
+    } catch (err) {
+      return { resumeEventIds: {}, error: err instanceof Error ? err.message : "Could not compute the resume occurrence" };
+    }
     const resumeMeeting = toCalendarMeeting(meeting, start, end);
     for (const [cat, calId] of Object.entries(calendarIds)) {
       const { id, error: createError } = await createCalendarEvent(accessToken, resumeMeeting, calId);

--- a/frontend/util/meetings/suspension.ts
+++ b/frontend/util/meetings/suspension.ts
@@ -1,6 +1,6 @@
 import "server-only";
 import { Meeting, RecurrencePattern, SuspensionPeriod } from "@prisma/client";
-import { formatETDateString } from "../date/timeUtils";
+import { formatETDateString, isDstGapError } from "../date/timeUtils";
 import { isDateSuspended, adjustOccurrenceToDate, firstOccurrenceOnOrAfter } from "./meetingOccurrences";
 import { calendarIdsForMeeting, createCalendarEvent, deleteCalendarEvent } from "../../services/googleCalendar";
 import { IMeeting } from "../../types/models";
@@ -128,12 +128,17 @@ export async function createPendingResumeSeries(
     recordUnconfiguredCat();
     // adjustOccurrenceToDate throws if the resume occurrence's ET start/end time lands in the
     // DST spring-forward gap on this date (the one day/year that time doesn't exist) -- treated
-    // as nothing to pre-create rather than crashing the whole suspend/resume request.
+    // as nothing to pre-create rather than crashing the whole suspend/resume request. Any other
+    // error means a real bug and should propagate instead of being reported as this specific,
+    // admin-facing message.
     let start: Date, end: Date;
     try {
       ({ start, end } = adjustOccurrenceToDate(meeting, resumeDateStr));
     } catch (err) {
-      return { resumeEventIds: {}, error: err instanceof Error ? err.message : "Could not compute the resume occurrence" };
+      if (!isDstGapError(err)) throw err;
+      // googleSyncError is shown verbatim in the admin UI (ViewMeeting's sync-status line) --
+      // this is a reworded, admin-appropriate message, not convertETToUTC's internal one.
+      return { resumeEventIds: {}, error: "Could not compute the resume time — it falls in a DST transition gap." };
     }
     const resumeMeeting = toCalendarMeeting(meeting, start, end);
     for (const [cat, calId] of Object.entries(calendarIds)) {


### PR DESCRIPTION
Resolves #339

@coderabbitai summary

## Description
`util/date/timeUtils.ts` (the most widely-depended-on file in the codebase, 40+ importers) mishandled the two DST-transition windows per year: the spring-forward gap (~2:00–2:59 AM ET on the 2nd Sunday of March, wall-clock times that don't exist) and the fall-back overlap (~1:00–1:59 AM ET on the 1st Sunday of November, wall-clock times that occur twice). `convertETToUTC`'s old single-probe offset calculation silently miscalculated both cases instead of detecting them.

- **`convertETToUTC`** now computes both candidate UTC instants (EDT/EST) for a given wall-clock time and keeps only the ones that round-trip back to the exact target — brute-force-verified against every hour from 2025–2027 (26,280 conversions) with zero mismatches outside the real transition windows. Zero valid candidates → throws (the wall-clock time doesn't exist). Two valid candidates → resolves to the earlier/EDT occurrence, matching Java's `ZonedDateTime` default (a documented choice, not an implicit one). Also added round-trip calendar-date validation (rejects e.g. Feb 30) to `convertETToUTC`/`toETDateString`, and preserved `parseMMDDYYYY`'s existing null-for-invalid contract via a narrowly-scoped catch.
- **Fallout from the new throw behavior**, all fixed: a "Monthly on day 31" recurrence pattern now correctly clamps to the target month's actual last day instead of building an invalid date and crashing on save; the three occurrence-expansion loops (`meetingOccurrences.ts`, `resourceOverlap.ts`, `suspension.ts`) now isolate a single DST-gap occurrence instead of letting it 500 an entire calendar view; the New/Edit Meeting form surfaces a DST-gap time as a normal, correctable validation error instead of crashing silently (reachable from render via `ZoomHostField`, not just on submit); `retrieve/meeting/day|week/route.ts` return 400 for a calendar-invalid `startDate` param instead of 500, matching how `range/route.ts` already handled it. All error paths distinguish "invalid calendar date" from "DST spring-forward gap" so the user/admin-facing message always matches what's actually wrong.

## Testing
- [x] `yarn test:all` (lint, lint:css, typecheck, unit, component, integration, e2e) — full pass: 175/175 unit, 187/187 component, 88/88 integration, 98/98 e2e.
- [x] Went through 2 independent adversarial code reviews given the file's blast radius, plus a final cumulative-diff proofread specifically checking for merge-artifact bugs against 2 other PRs that landed on the same files (`#425`, `#426`) while this branch was in flight — confirmed no interaction bugs, only independent, non-conflicting changes.
- [x] New DST-boundary test coverage in `tests/unit/timeUtils.test.ts` (spring-forward gap rejection, fall-back resolution rule, leap-day handling, calendar-date validation) plus regression tests in `meetingOccurrences.test.ts` (monthly day-31 clamping across a leap/non-leap February) and `resourceOverlap.test.ts` (a weekly meeting's DST-gap occurrence correctly skipped without affecting surrounding weeks).

## Area(s) Touched
**Integrations**
- [x] google-calendar — Google Calendar sync
- [x] zoom-api — Zoom meeting/host sync

**Engineering**
- [x] testing — test suite (Jest/Playwright) changes

## Pre-merge Checklist
- [x] Code follows current formatting conventions and passes lint (`yarn lint`).
- [x] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
- [x] All test suites pass, both run locally and green in GitHub CI. **Do not merge if any test suite is failing.**
- [x] A test suite was added or updated for the feature/fix in this PR. **Double-check this if you change a feature and did not update the test suites**.
- [x] Only files relevant to this change are committed — no stray or unrelated files.
- [x] If this branch has a merge conflict with master, master was merged into this branch first (not the other way around).
- [x] The rest of this PR description (Description, Testing) is filled out, not left as template placeholders.
