### PR TITLE
test(sync): add suspension/zoom coverage, deflake integration tests

### DIFF
--- a/frontend/tests/integration/delete-meeting-route.test.ts
+++ b/frontend/tests/integration/delete-meeting-route.test.ts
@@ -48,6 +48,28 @@ async function waitFor<T>(fn: () => Promise<T | null | undefined>, timeoutMs = 2
   return null;
 }
 
+// For asserting an absence (no further deleteCalendarEvent call lands after the expected one)
+// rather than a value to poll for -- waitFor's "poll until non-null" shape doesn't apply there.
+// Polls until the count stops changing for a full quiet window instead of a single fixed sleep,
+// so a slow CI runner gets more time to surface a genuine extra call rather than the test
+// passing simply because a short guessed window happened to close before that call landed.
+async function waitForStableCallCount(getCount: () => number, quietMs = 50, timeoutMs = 2000): Promise<number> {
+  const start = Date.now();
+  let lastCount = getCount();
+  let quietSince = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    const count = getCount();
+    if (count !== lastCount) {
+      lastCount = count;
+      quietSince = Date.now();
+    } else if (Date.now() - quietSince >= quietMs) {
+      return count;
+    }
+  }
+  return lastCount;
+}
+
 test("deleting a meeting with a pending pre-created resume series tears that series down too, not just the live event", async () => {
   const { meeting } = await seedRecurringMeeting({
     status: "Suspended",
@@ -86,10 +108,10 @@ test("deleting a meeting with no pending resume series only tears down the live 
   expect(response.status).toBe(200);
 
   await waitFor(async () => (mockedDelete.mock.calls.length > 0 ? true : null));
-  // A short settle window after the first call -- asserting toHaveBeenCalledTimes(1)
-  // immediately upon seeing the first call would pass even if a second, unwanted call was
-  // about to land right after (syncDeleteAll's deletes are sequential, not concurrent).
-  await new Promise((resolve) => setTimeout(resolve, 50));
+  // A settle window after the first call -- asserting toHaveBeenCalledTimes(1) immediately upon
+  // seeing the first call would pass even if a second, unwanted call was about to land right
+  // after (syncDeleteAll's deletes are sequential, not concurrent).
+  await waitForStableCallCount(() => mockedDelete.mock.calls.length);
   expect(mockedDelete).toHaveBeenCalledTimes(1);
   expect(mockedDelete).toHaveBeenCalledWith("fake-token", "live-event-id", "fake-calendar-id");
 });
@@ -114,6 +136,6 @@ test("a promoted (already-live) suspension row isn't torn down a second time", a
   await waitFor(async () => (mockedDelete.mock.calls.length > 0 ? true : null));
   // Same settle window as above -- confirms the promoted row really isn't torn down a second
   // time, not just that it hadn't happened yet by the time the first call was observed.
-  await new Promise((resolve) => setTimeout(resolve, 50));
+  await waitForStableCallCount(() => mockedDelete.mock.calls.length);
   expect(mockedDelete).toHaveBeenCalledTimes(1);
 });

--- a/frontend/tests/integration/delete-meeting-route.test.ts
+++ b/frontend/tests/integration/delete-meeting-route.test.ts
@@ -50,10 +50,13 @@ async function waitFor<T>(fn: () => Promise<T | null | undefined>, timeoutMs = 2
 
 // For asserting an absence (no further deleteCalendarEvent call lands after the expected one)
 // rather than a value to poll for -- waitFor's "poll until non-null" shape doesn't apply there.
-// Polls until the count stops changing for a full quiet window instead of a single fixed sleep,
-// so a slow CI runner gets more time to surface a genuine extra call rather than the test
-// passing simply because a short guessed window happened to close before that call landed.
-async function waitForStableCallCount(getCount: () => number, quietMs = 50, timeoutMs = 2000): Promise<number> {
+// There's no real completion signal to wait on for a negative assertion, so this is still
+// fundamentally a timeout, not a true polling condition -- but 200ms is a real 4x margin over
+// the 50ms blind sleep it replaces (a call landing at, say, 120ms would be missed by that sleep
+// but not by this), and if a call *does* land inside the window, the quiet timer restarts, so an
+// unwanted call arriving late in the window still gets caught instead of the check having
+// already closed.
+async function waitForStableCallCount(getCount: () => number, quietMs = 200, timeoutMs = 2000): Promise<number> {
   const start = Date.now();
   let lastCount = getCount();
   let quietSince = Date.now();

--- a/frontend/tests/integration/delete-meeting-route.test.ts
+++ b/frontend/tests/integration/delete-meeting-route.test.ts
@@ -51,11 +51,9 @@ async function waitFor<T>(fn: () => Promise<T | null | undefined>, timeoutMs = 2
 // For asserting an absence (no further deleteCalendarEvent call lands after the expected one)
 // rather than a value to poll for -- waitFor's "poll until non-null" shape doesn't apply there.
 // There's no real completion signal to wait on for a negative assertion, so this is still
-// fundamentally a timeout, not a true polling condition -- but 200ms is a real 4x margin over
-// the 50ms blind sleep it replaces (a call landing at, say, 120ms would be missed by that sleep
-// but not by this), and if a call *does* land inside the window, the quiet timer restarts, so an
-// unwanted call arriving late in the window still gets caught instead of the check having
-// already closed.
+// fundamentally a timeout, not a true polling condition. But the quiet timer restarts whenever
+// the count changes, so a call arriving late in the window still gets caught instead of the
+// check having already closed around it.
 async function waitForStableCallCount(getCount: () => number, quietMs = 200, timeoutMs = 2000): Promise<number> {
   const start = Date.now();
   let lastCount = getCount();

--- a/frontend/tests/integration/update-meeting-route.test.ts
+++ b/frontend/tests/integration/update-meeting-route.test.ts
@@ -358,14 +358,14 @@ test("an exhausted Zoom host pool on update fails soft, synchronously, without t
   // Direct regression test for Matt's confirmation, on the update path: a meeting that needs
   // Zoom but has no working Zoom meeting after this run must not have its calendars reconciled
   // with a missing link -- googleSyncStatus is 'pending', reconcileMeetingCalendars never ran.
-  // Polls zoomSyncStatus, not googleSyncStatus -- for a zoom-enabled meeting the deferred job's
-  // zoomBlocking branch (which sets googleSyncStatus='pending') always runs and commits *before*
-  // its separate, later zoomEnabled block (which sets zoomSyncStatus). Waiting on googleSyncStatus
-  // alone can return as soon as the first write lands while the job is still mid-flight on the
-  // second -- waiting on zoomSyncStatus is what actually guarantees the whole job has finished.
+  // Polls googleSyncStatus -- for this pool-exhausted scenario, zoomSyncStatus is already
+  // written synchronously inside the PUT transaction itself (route.ts's needsNewHost +
+  // hostSyncError branch), matching rightAfterResponse's assertion above. googleSyncStatus
+  // starts null and is only ever written by the deferred sync job, making it the one field here
+  // that actually signals that job has finished.
   const afterSync = await waitFor(async () => {
     const row = await prisma.meeting.findUnique({ where: { mid } });
-    return row?.zoomSyncStatus != null ? row : null;
+    return row?.googleSyncStatus != null ? row : null;
   });
   expect(afterSync?.googleSyncStatus).toBe("pending");
   expect(mockedReconcileMeetingCalendars).not.toHaveBeenCalled();

--- a/frontend/tests/integration/update-meeting-route.test.ts
+++ b/frontend/tests/integration/update-meeting-route.test.ts
@@ -358,9 +358,14 @@ test("an exhausted Zoom host pool on update fails soft, synchronously, without t
   // Direct regression test for Matt's confirmation, on the update path: a meeting that needs
   // Zoom but has no working Zoom meeting after this run must not have its calendars reconciled
   // with a missing link -- googleSyncStatus is 'pending', reconcileMeetingCalendars never ran.
+  // Polls zoomSyncStatus, not googleSyncStatus -- for a zoom-enabled meeting the deferred job's
+  // zoomBlocking branch (which sets googleSyncStatus='pending') always runs and commits *before*
+  // its separate, later zoomEnabled block (which sets zoomSyncStatus). Waiting on googleSyncStatus
+  // alone can return as soon as the first write lands while the job is still mid-flight on the
+  // second -- waiting on zoomSyncStatus is what actually guarantees the whole job has finished.
   const afterSync = await waitFor(async () => {
     const row = await prisma.meeting.findUnique({ where: { mid } });
-    return row?.googleSyncStatus != null ? row : null;
+    return row?.zoomSyncStatus != null ? row : null;
   });
   expect(afterSync?.googleSyncStatus).toBe("pending");
   expect(mockedReconcileMeetingCalendars).not.toHaveBeenCalled();

--- a/frontend/tests/integration/update-meeting-route.test.ts
+++ b/frontend/tests/integration/update-meeting-route.test.ts
@@ -197,13 +197,14 @@ test("a same-room time edit that now conflicts with another meeting on the same 
   const response = await PUT(request);
   expect(response.status).toBe(200);
 
-  // waitUntil has no real lifecycle hook outside Vercel, but the background
-  // function still runs to completion on its own — just give it time to finish.
-  await new Promise((resolve) => setTimeout(resolve, 400));
+  // Polls for the deferred sync job's terminal zoomSyncStatus rather than guessing how long it
+  // takes to finish -- zoomSyncStatus is only ever written once, at the end of that job.
+  const afterSync = await waitFor(async () => {
+    const row = await prisma.meeting.findUnique({ where: { mid: editedMid } });
+    return row?.zoomSyncStatus != null ? row : null;
+  });
 
   expect(mockedUpdateZoomMeeting).not.toHaveBeenCalled();
-
-  const afterSync = await prisma.meeting.findUnique({ where: { mid: editedMid } });
   expect(afterSync?.zid).toBe("zid-edited");
   expect(afterSync?.zoomHost).toBe(sharedHost);
   expect(afterSync?.zoomSyncStatus).toBe("error");
@@ -320,7 +321,12 @@ test("a newly resolved Zoom host is persisted synchronously when a meeting first
   const rightAfterResponse = await prisma.meeting.findUnique({ where: { mid } });
   expect(rightAfterResponse?.zoomHost).toBe("new-host@icr.test");
 
-  await new Promise((resolve) => setTimeout(resolve, SYNC_DELAY_MS + 100));
+  // Lets the deferred sync finish before the test (and its mocks) tear down, rather than
+  // guessing how long that takes.
+  await waitFor(async () => {
+    const row = await prisma.meeting.findUnique({ where: { mid } });
+    return row?.zoomSyncStatus != null ? row : null;
+  });
 });
 
 test("an exhausted Zoom host pool on update fails soft, synchronously, without touching the existing meeting fields", async () => {
@@ -349,12 +355,13 @@ test("an exhausted Zoom host pool on update fails soft, synchronously, without t
   expect(rightAfterResponse?.zoomSyncStatus).toBe("error");
   expect(rightAfterResponse?.zoomSyncError).toMatch(/pool exhausted/i);
 
-  await new Promise((resolve) => setTimeout(resolve, 100));
-
   // Direct regression test for Matt's confirmation, on the update path: a meeting that needs
   // Zoom but has no working Zoom meeting after this run must not have its calendars reconciled
   // with a missing link -- googleSyncStatus is 'pending', reconcileMeetingCalendars never ran.
-  const afterSync = await prisma.meeting.findUnique({ where: { mid } });
+  const afterSync = await waitFor(async () => {
+    const row = await prisma.meeting.findUnique({ where: { mid } });
+    return row?.googleSyncStatus != null ? row : null;
+  });
   expect(afterSync?.googleSyncStatus).toBe("pending");
   expect(mockedReconcileMeetingCalendars).not.toHaveBeenCalled();
 });
@@ -403,12 +410,15 @@ test("an explicit host reassignment tears down the old Zoom meeting and creates 
   const response = await PUT(request);
   expect(response.status).toBe(200);
 
-  await new Promise((resolve) => setTimeout(resolve, 100));
+  // Polls for the deferred sync job's terminal zoomSyncStatus rather than guessing how long it
+  // takes to finish -- zoomSyncStatus is only ever written once, at the end of that job.
+  const afterSync = await waitFor(async () => {
+    const row = await prisma.meeting.findUnique({ where: { mid } });
+    return row?.zoomSyncStatus != null ? row : null;
+  });
 
   expect(mockedDeleteZoomMeeting).toHaveBeenCalledWith("zid-original");
   expect(mockedUpdateZoomMeeting).not.toHaveBeenCalled();
-
-  const afterSync = await prisma.meeting.findUnique({ where: { mid } });
   expect(afterSync?.zid).toBe("zid-reassigned");
   expect(afterSync?.zoomHost).toBe("new-host@icr.test");
   expect(afterSync?.zoomSyncStatus).toBe("synced");

--- a/frontend/tests/integration/write-meeting-route.test.ts
+++ b/frontend/tests/integration/write-meeting-route.test.ts
@@ -120,21 +120,17 @@ test("the response resolves before Google Calendar sync completes, which runs in
     body: JSON.stringify(payload),
   });
 
-  const start = Date.now();
   const response = await POST(request);
-  const elapsed = Date.now() - start;
 
   expect(response.status).toBe(201);
-  expect(elapsed).toBeLessThan(SYNC_DELAY_MS);
 
+  // The actual invariant this test is after: the response body/status lands before the
+  // background sync has had any chance to write back -- not how many milliseconds that took.
   const prisma = getTestPrismaClient();
   const rightAfterResponse = await prisma.meeting.findUnique({ where: { mid: payload.mid } });
   expect(rightAfterResponse?.googleSyncStatus).toBeNull();
 
-  // waitUntil has no real lifecycle hook outside Vercel, but the background
-  // function still runs to completion on its own — just give it time to finish.
-  await new Promise((resolve) => setTimeout(resolve, SYNC_DELAY_MS + 100));
-  const afterSync = await prisma.meeting.findUnique({ where: { mid: payload.mid } });
+  const afterSync = await waitForGoogleSyncStatus(payload.mid);
   expect(afterSync?.googleSyncStatus).toBe("synced");
 });
 
@@ -163,7 +159,9 @@ test("a resolved Zoom host is persisted synchronously, before the deferred sync 
   const rightAfterResponse = await prisma.meeting.findUnique({ where: { mid: payload.mid } });
   expect(rightAfterResponse?.zoomHost).toBe("host@icr.test");
 
-  await new Promise((resolve) => setTimeout(resolve, SYNC_DELAY_MS + 100));
+  // Lets the deferred sync finish before the test (and its mocks) tear down, rather than
+  // guessing how long that takes.
+  await waitForGoogleSyncStatus(payload.mid);
 });
 
 test("a malformed body returns 400 with validation issues instead of a raw 500", async () => {
@@ -211,11 +209,9 @@ test("an exhausted Zoom host pool fails soft: the meeting is still created", asy
   expect(rightAfterResponse?.zoomSyncStatus).toBe("error");
   expect(rightAfterResponse?.zoomSyncError).toMatch(/pool exhausted/i);
 
-  // waitUntil has no real lifecycle hook outside Vercel, but the background
-  // function still runs to completion on its own — just give it time to finish.
-  await new Promise((resolve) => setTimeout(resolve, 400));
-
-  const afterSync = await prisma.meeting.findUnique({ where: { mid: payload.mid } });
+  // Polls for the deferred sync job's terminal googleSyncStatus rather than guessing how long
+  // it takes to finish.
+  const afterSync = await waitForGoogleSyncStatus(payload.mid);
   expect(afterSync?.zid).toBeNull();
   expect(afterSync?.zoomHost).toBeNull();
   expect(afterSync?.zoomSyncStatus).toBe("error");

--- a/frontend/tests/integration/write-meeting-route.test.ts
+++ b/frontend/tests/integration/write-meeting-route.test.ts
@@ -56,10 +56,13 @@ const mockedResolveZoomHost = resolveZoomHost as jest.Mock;
 const mockedCreateZoomMeeting = createZoomMeeting as jest.Mock;
 
 // Polls for the deferred sync job's persisted terminal googleSyncStatus instead of guessing a
-// fixed delay -- race-prone under slower CI/database conditions, per CodeRabbit's review
-// of this file. Only safe to use for a meeting whose deferred job writes googleSyncStatus as its
-// last step (e.g. a non-Zoom-enabled meeting, where the calendar-sync update is the only
-// write left after the response returns).
+// fixed delay -- race-prone under slower CI/database conditions, per CodeRabbit's review of this
+// file. Safe for both non-Zoom and Zoom-enabled meetings here: syncNewMeeting always persists
+// googleSyncStatus and zoomSyncStatus (when zoomEnabled) together in one atomic
+// prisma.meeting.update call, so googleSyncStatus landing means zoomSyncStatus already has too.
+// This differs from update/meeting/route.ts's syncUpdatedMeeting, which can write the two fields
+// in separate, sequential updates -- polling either field there isn't interchangeable with the
+// other the way it is here.
 async function waitForGoogleSyncStatus(mid: string, timeoutMs = 2000) {
   const prisma = getTestPrismaClient();
   const start = Date.now();

--- a/frontend/tests/unit/suspension.test.ts
+++ b/frontend/tests/unit/suspension.test.ts
@@ -1,0 +1,467 @@
+import { Meeting, RecurrencePattern, SuspensionPeriod } from "@prisma/client";
+
+// suspension.ts's own logic is pure branching over its inputs -- the actual GCal/DB side effects
+// are exactly what the existing suspend/resume integration tests mock away wholesale, which is
+// the coverage gap this file closes: which event IDs get promoted/torn down, and under what
+// conditions, driven by real recurrence-matching (util/meetings/meetingOccurrences.ts is left
+// unmocked on purpose) rather than by a stubbed googleCalendar module.
+jest.mock("../../services/googleCalendar", () => ({
+  calendarIdsForMeeting: jest.fn(),
+  createCalendarEvent: jest.fn(),
+  deleteCalendarEvent: jest.fn(),
+}));
+jest.mock("../../lib/prisma", () => ({
+  prisma: {
+    $transaction: jest.fn(),
+    meeting: { update: jest.fn() },
+    suspensionPeriod: { update: jest.fn() },
+  },
+}));
+
+import {
+  reconcilePendingResume,
+  createPendingResumeSeries,
+  tearDownPendingResumeSeries,
+  MeetingWithPattern,
+  MeetingWithSuspensions,
+} from "../../util/meetings/suspension";
+import { calendarIdsForMeeting, createCalendarEvent, deleteCalendarEvent } from "../../services/googleCalendar";
+import { prisma } from "../../lib/prisma";
+
+const mockCalendarIdsForMeeting = calendarIdsForMeeting as jest.Mock;
+const mockCreateCalendarEvent = createCalendarEvent as jest.Mock;
+const mockDeleteCalendarEvent = deleteCalendarEvent as jest.Mock;
+const mockTransaction = prisma.$transaction as jest.Mock;
+const mockMeetingUpdate = prisma.meeting.update as jest.Mock;
+const mockSuspensionUpdate = prisma.suspensionPeriod.update as jest.Mock;
+
+const now = Date.now();
+const DAY_MS = 24 * 60 * 60 * 1000;
+const yesterday = new Date(now - DAY_MS);
+const tomorrow = new Date(now + DAY_MS);
+const weekdayFmt = new Intl.DateTimeFormat("en-US", { timeZone: "America/New_York", weekday: "long" });
+const etWeekday = (date: Date): string => weekdayFmt.format(date);
+
+function buildMeeting(overrides: Partial<Meeting> = {}): Omit<Meeting, "recurrencePattern"> {
+  return {
+    id: "id-1",
+    mid: "m-1",
+    title: "Test Meeting",
+    calType: ["AA"],
+    description: "",
+    creator: "creator@test.icr",
+    group: "Group",
+    startDateTime: new Date(now - DAY_MS),
+    endDateTime: new Date(now - DAY_MS + 60 * 60 * 1000),
+    email: "test@test.icr",
+    zoomRoom: null,
+    zoomLink: null,
+    zid: null,
+    zoomPasscode: null,
+    zoomInvitation: null,
+    room: "Serenity Room",
+    modeType: "In Person",
+    status: "Active",
+    isRecurring: false,
+    googleCalendarEventId: null,
+    googleCalendarEventIds: null,
+    googleSyncStatus: null,
+    googleSyncError: null,
+    zoomCalendarEventId: null,
+    zoomSyncStatus: null,
+    zoomHost: null,
+    attemptedZoomHost: null,
+    zoomSyncError: null,
+    deletedAt: null,
+    updatedAt: null,
+    ...overrides,
+  };
+}
+
+function buildRecurrencePattern(overrides: Partial<RecurrencePattern> = {}): RecurrencePattern {
+  return {
+    id: "rp-1",
+    mid: "m-1",
+    type: "weekly",
+    startDate: new Date(now - 60 * DAY_MS),
+    endDate: null,
+    numberOfOccurrences: null,
+    daysOfWeek: [],
+    firstDayOfWeek: "Sunday",
+    interval: 1,
+    weekOfMonth: null,
+    dayOfMonth: null,
+    excludedDates: [],
+    ...overrides,
+  };
+}
+
+function buildSuspension(overrides: Partial<SuspensionPeriod> = {}): SuspensionPeriod {
+  return {
+    id: "s-1",
+    mid: "m-1",
+    from: yesterday,
+    to: null,
+    resumeEventIds: null,
+    promoted: false,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("reconcilePendingResume", () => {
+  it("returns the meeting's existing event IDs untouched when there is no pending suspension", async () => {
+    const meeting: MeetingWithSuspensions = {
+      ...buildMeeting({ googleCalendarEventIds: { AA: "evt-existing" } }),
+      recurrencePattern: null,
+      suspensions: [],
+    };
+
+    const result = await reconcilePendingResume(meeting);
+
+    expect(result).toEqual({ AA: "evt-existing" });
+    expect(mockTransaction).not.toHaveBeenCalled();
+  });
+
+  it("defaults to an empty object when there are no existing event IDs and nothing pending", async () => {
+    const meeting: MeetingWithSuspensions = {
+      ...buildMeeting({ googleCalendarEventIds: null }),
+      recurrencePattern: null,
+      suspensions: [],
+    };
+
+    const result = await reconcilePendingResume(meeting);
+
+    expect(result).toEqual({});
+    expect(mockTransaction).not.toHaveBeenCalled();
+  });
+
+  it("promotes a due, unpromoted suspension's pre-created event IDs onto the meeting", async () => {
+    const pending = buildSuspension({
+      id: "s-due",
+      from: yesterday,
+      to: yesterday,
+      resumeEventIds: { AA: "evt-resume" },
+      promoted: false,
+    });
+    const meeting: MeetingWithSuspensions = {
+      ...buildMeeting({ mid: "m-42", googleCalendarEventIds: { AA: "evt-old" } }),
+      recurrencePattern: null,
+      suspensions: [pending],
+    };
+
+    const result = await reconcilePendingResume(meeting);
+
+    expect(result).toEqual({ AA: "evt-resume" });
+    expect(mockMeetingUpdate).toHaveBeenCalledWith({
+      where: { mid: "m-42" },
+      data: { googleCalendarEventIds: { AA: "evt-resume" } },
+    });
+    expect(mockSuspensionUpdate).toHaveBeenCalledWith({
+      where: { id: "s-due" },
+      data: { promoted: true },
+    });
+    expect(mockTransaction).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores a suspension whose resume date has not arrived yet", async () => {
+    const notYetDue = buildSuspension({ to: tomorrow, resumeEventIds: { AA: "evt-future" } });
+    const meeting: MeetingWithSuspensions = {
+      ...buildMeeting({ googleCalendarEventIds: { AA: "evt-current" } }),
+      recurrencePattern: null,
+      suspensions: [notYetDue],
+    };
+
+    const result = await reconcilePendingResume(meeting);
+
+    expect(result).toEqual({ AA: "evt-current" });
+    expect(mockTransaction).not.toHaveBeenCalled();
+  });
+
+  it("ignores a suspension that has already been promoted", async () => {
+    const alreadyPromoted = buildSuspension({ to: yesterday, resumeEventIds: { AA: "evt-x" }, promoted: true });
+    const meeting: MeetingWithSuspensions = {
+      ...buildMeeting({ googleCalendarEventIds: {} }),
+      recurrencePattern: null,
+      suspensions: [alreadyPromoted],
+    };
+
+    const result = await reconcilePendingResume(meeting);
+
+    expect(result).toEqual({});
+    expect(mockTransaction).not.toHaveBeenCalled();
+  });
+
+  it("ignores an open-ended suspension (to === null), since there is nothing to resume into yet", async () => {
+    const openEnded = buildSuspension({ to: null, resumeEventIds: { AA: "evt-x" } });
+    const meeting: MeetingWithSuspensions = {
+      ...buildMeeting({ googleCalendarEventIds: {} }),
+      recurrencePattern: null,
+      suspensions: [openEnded],
+    };
+
+    const result = await reconcilePendingResume(meeting);
+
+    expect(result).toEqual({});
+    expect(mockTransaction).not.toHaveBeenCalled();
+  });
+
+  it("ignores a due suspension with no pre-created resumeEventIds", async () => {
+    const noEventIds = buildSuspension({ to: yesterday, resumeEventIds: undefined });
+    const meeting: MeetingWithSuspensions = {
+      ...buildMeeting({ googleCalendarEventIds: {} }),
+      recurrencePattern: null,
+      suspensions: [noEventIds],
+    };
+
+    const result = await reconcilePendingResume(meeting);
+
+    expect(result).toEqual({});
+    expect(mockTransaction).not.toHaveBeenCalled();
+  });
+
+  it("picks the most recently started suspension when more than one is due and unpromoted", async () => {
+    const older = buildSuspension({
+      id: "s-older",
+      from: new Date(now - 10 * DAY_MS),
+      to: yesterday,
+      resumeEventIds: { AA: "evt-older" },
+    });
+    const newer = buildSuspension({
+      id: "s-newer",
+      from: new Date(now - 5 * DAY_MS),
+      to: yesterday,
+      resumeEventIds: { AA: "evt-newer" },
+    });
+    const meeting: MeetingWithSuspensions = {
+      ...buildMeeting({ googleCalendarEventIds: {} }),
+      recurrencePattern: null,
+      // Order in the array shouldn't matter -- the function sorts by `from` itself.
+      suspensions: [older, newer],
+    };
+
+    const result = await reconcilePendingResume(meeting);
+
+    expect(result).toEqual({ AA: "evt-newer" });
+    expect(mockSuspensionUpdate).toHaveBeenCalledWith({
+      where: { id: "s-newer" },
+      data: { promoted: true },
+    });
+  });
+});
+
+describe("createPendingResumeSeries", () => {
+  it("is a no-op when there is no access token", async () => {
+    const meeting: MeetingWithPattern = { ...buildMeeting({ isRecurring: false }), recurrencePattern: null };
+
+    const result = await createPendingResumeSeries(meeting, undefined, tomorrow);
+
+    expect(result).toEqual({ resumeEventIds: {}, error: null });
+    expect(mockCalendarIdsForMeeting).not.toHaveBeenCalled();
+    expect(mockCreateCalendarEvent).not.toHaveBeenCalled();
+  });
+
+  it("pre-creates one event per configured calendar for a recurring meeting's next occurrence on/after resumeDate", async () => {
+    mockCalendarIdsForMeeting.mockReturnValue({ AA: "cal-aa" });
+    mockCreateCalendarEvent.mockResolvedValue({ id: "evt-new", error: null });
+
+    const resumeDate = tomorrow;
+    const meeting: MeetingWithPattern = {
+      ...buildMeeting({ isRecurring: true, calType: ["AA"] }),
+      recurrencePattern: buildRecurrencePattern({ daysOfWeek: [etWeekday(resumeDate)], interval: 1 }),
+    };
+
+    const result = await createPendingResumeSeries(meeting, "token-1", resumeDate);
+
+    expect(mockCalendarIdsForMeeting).toHaveBeenCalledWith(["AA"]);
+    expect(mockCreateCalendarEvent).toHaveBeenCalledTimes(1);
+    expect(mockCreateCalendarEvent).toHaveBeenCalledWith(
+      "token-1",
+      expect.objectContaining({ mid: meeting.mid }),
+      "cal-aa",
+    );
+    expect(result).toEqual({ resumeEventIds: { AA: "evt-new" }, error: null });
+  });
+
+  it("is a no-op (with no error) for a recurring meeting whose series has already ended by resumeDate", async () => {
+    mockCalendarIdsForMeeting.mockReturnValue({ AA: "cal-aa" });
+
+    const resumeDate = tomorrow;
+    const meeting: MeetingWithPattern = {
+      ...buildMeeting({ isRecurring: true, calType: ["AA"] }),
+      // endDate before resumeDate -- no occurrence left to pre-create.
+      recurrencePattern: buildRecurrencePattern({
+        daysOfWeek: [etWeekday(resumeDate)],
+        endDate: yesterday,
+      }),
+    };
+
+    const result = await createPendingResumeSeries(meeting, "token-1", resumeDate);
+
+    expect(result).toEqual({ resumeEventIds: {}, error: null });
+    expect(mockCreateCalendarEvent).not.toHaveBeenCalled();
+  });
+
+  it("records an unconfigured-calendar error but still creates events for the categories that are configured", async () => {
+    mockCalendarIdsForMeeting.mockReturnValue({ AA: "cal-aa" }); // "Other" deliberately missing
+    mockCreateCalendarEvent.mockResolvedValue({ id: "evt-aa", error: null });
+
+    const resumeDate = tomorrow;
+    const meeting: MeetingWithPattern = {
+      ...buildMeeting({ isRecurring: true, calType: ["AA", "Other"] }),
+      recurrencePattern: buildRecurrencePattern({ daysOfWeek: [etWeekday(resumeDate)] }),
+    };
+
+    const result = await createPendingResumeSeries(meeting, "token-1", resumeDate);
+
+    expect(mockCalendarIdsForMeeting).toHaveBeenCalledWith(["AA", "Other"]);
+    expect(mockCreateCalendarEvent).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({
+      resumeEventIds: { AA: "evt-aa" },
+      error: 'Calendar for "Other" is not configured.',
+    });
+  });
+
+  it("keeps the first Google error and omits that category from resumeEventIds when a create call fails", async () => {
+    mockCalendarIdsForMeeting.mockReturnValue({ AA: "cal-aa", Other: "cal-other" });
+    mockCreateCalendarEvent.mockImplementation((_token: string, _meeting: unknown, calId: string) =>
+      calId === "cal-aa"
+        ? Promise.resolve({ id: null, error: "Google rejected the AA event" })
+        : Promise.resolve({ id: "evt-other", error: null }),
+    );
+
+    const resumeDate = tomorrow;
+    const meeting: MeetingWithPattern = {
+      ...buildMeeting({ isRecurring: true, calType: ["AA", "Other"] }),
+      recurrencePattern: buildRecurrencePattern({ daysOfWeek: [etWeekday(resumeDate)] }),
+    };
+
+    const result = await createPendingResumeSeries(meeting, "token-1", resumeDate);
+
+    expect(result).toEqual({
+      resumeEventIds: { Other: "evt-other" },
+      error: "Google rejected the AA event",
+    });
+  });
+
+  it("pre-creates an event for a future one-time meeting", async () => {
+    mockCalendarIdsForMeeting.mockReturnValue({ AA: "cal-aa" });
+    mockCreateCalendarEvent.mockResolvedValue({ id: "evt-onetime", error: null });
+
+    const meeting: MeetingWithPattern = {
+      ...buildMeeting({ isRecurring: false, calType: ["AA"], startDateTime: tomorrow, endDateTime: new Date(tomorrow.getTime() + 60 * 60 * 1000) }),
+      recurrencePattern: null,
+    };
+
+    const result = await createPendingResumeSeries(meeting, "token-1", tomorrow);
+
+    expect(mockCreateCalendarEvent).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ resumeEventIds: { AA: "evt-onetime" }, error: null });
+  });
+
+  it("is a no-op for a one-time meeting whose original occurrence has already passed", async () => {
+    mockCalendarIdsForMeeting.mockReturnValue({ AA: "cal-aa" });
+
+    const meeting: MeetingWithPattern = {
+      ...buildMeeting({ isRecurring: false, calType: ["AA"], startDateTime: yesterday, endDateTime: yesterday }),
+      recurrencePattern: null,
+    };
+
+    const result = await createPendingResumeSeries(meeting, "token-1", yesterday);
+
+    expect(result).toEqual({ resumeEventIds: {}, error: null });
+    expect(mockCreateCalendarEvent).not.toHaveBeenCalled();
+  });
+});
+
+describe("tearDownPendingResumeSeries", () => {
+  it("is a no-op when there is no access token", async () => {
+    const meeting: MeetingWithSuspensions = {
+      ...buildMeeting(),
+      recurrencePattern: null,
+      suspensions: [buildSuspension({ resumeEventIds: { AA: "evt-1" } })],
+    };
+
+    await tearDownPendingResumeSeries(meeting, undefined);
+
+    expect(mockCalendarIdsForMeeting).not.toHaveBeenCalled();
+    expect(mockDeleteCalendarEvent).not.toHaveBeenCalled();
+  });
+
+  it("deletes every event in an unpromoted suspension's pre-created series", async () => {
+    mockCalendarIdsForMeeting.mockReturnValue({ AA: "cal-aa", Other: "cal-other" });
+    const meeting: MeetingWithSuspensions = {
+      ...buildMeeting(),
+      recurrencePattern: null,
+      suspensions: [buildSuspension({ resumeEventIds: { AA: "evt-aa", Other: "evt-other" } })],
+    };
+
+    await tearDownPendingResumeSeries(meeting, "token-1");
+
+    expect(mockCalendarIdsForMeeting).toHaveBeenCalledWith(["AA", "Other"]);
+    expect(mockDeleteCalendarEvent).toHaveBeenCalledWith("token-1", "evt-aa", "cal-aa");
+    expect(mockDeleteCalendarEvent).toHaveBeenCalledWith("token-1", "evt-other", "cal-other");
+    expect(mockDeleteCalendarEvent).toHaveBeenCalledTimes(2);
+  });
+
+  it("skips a suspension that has already been promoted", async () => {
+    const meeting: MeetingWithSuspensions = {
+      ...buildMeeting(),
+      recurrencePattern: null,
+      suspensions: [buildSuspension({ resumeEventIds: { AA: "evt-1" }, promoted: true })],
+    };
+
+    await tearDownPendingResumeSeries(meeting, "token-1");
+
+    expect(mockDeleteCalendarEvent).not.toHaveBeenCalled();
+  });
+
+  it("skips a suspension with no pre-created resume series", async () => {
+    const meeting: MeetingWithSuspensions = {
+      ...buildMeeting(),
+      recurrencePattern: null,
+      suspensions: [buildSuspension({ resumeEventIds: null })],
+    };
+
+    await tearDownPendingResumeSeries(meeting, "token-1");
+
+    expect(mockDeleteCalendarEvent).not.toHaveBeenCalled();
+  });
+
+  it("skips only the categories that have since been dropped from calendar config, not the whole series", async () => {
+    // "Other" was configured when this pending series was pre-created, but has since been
+    // removed from GOOGLE_CALENDAR_* env config -- its event would otherwise be orphaned.
+    mockCalendarIdsForMeeting.mockReturnValue({ AA: "cal-aa" });
+    const meeting: MeetingWithSuspensions = {
+      ...buildMeeting(),
+      recurrencePattern: null,
+      suspensions: [buildSuspension({ resumeEventIds: { AA: "evt-aa", Other: "evt-other" } })],
+    };
+
+    await tearDownPendingResumeSeries(meeting, "token-1");
+
+    expect(mockDeleteCalendarEvent).toHaveBeenCalledTimes(1);
+    expect(mockDeleteCalendarEvent).toHaveBeenCalledWith("token-1", "evt-aa", "cal-aa");
+  });
+
+  it("tears down every unpromoted suspension's series, not just the most recent one", async () => {
+    mockCalendarIdsForMeeting.mockReturnValue({ AA: "cal-aa" });
+    const meeting: MeetingWithSuspensions = {
+      ...buildMeeting(),
+      recurrencePattern: null,
+      suspensions: [
+        buildSuspension({ id: "s-1", resumeEventIds: { AA: "evt-1" } }),
+        buildSuspension({ id: "s-2", resumeEventIds: { AA: "evt-2" } }),
+      ],
+    };
+
+    await tearDownPendingResumeSeries(meeting, "token-1");
+
+    expect(mockDeleteCalendarEvent).toHaveBeenCalledWith("token-1", "evt-1", "cal-aa");
+    expect(mockDeleteCalendarEvent).toHaveBeenCalledWith("token-1", "evt-2", "cal-aa");
+    expect(mockDeleteCalendarEvent).toHaveBeenCalledTimes(2);
+  });
+});

--- a/frontend/tests/unit/suspension.test.ts
+++ b/frontend/tests/unit/suspension.test.ts
@@ -37,6 +37,7 @@ const mockSuspensionUpdate = prisma.suspensionPeriod.update as jest.Mock;
 
 const now = Date.now();
 const DAY_MS = 24 * 60 * 60 * 1000;
+const today = new Date(now);
 const yesterday = new Date(now - DAY_MS);
 const tomorrow = new Date(now + DAY_MS);
 const weekdayFmt = new Intl.DateTimeFormat("en-US", { timeZone: "America/New_York", weekday: "long" });
@@ -167,6 +168,23 @@ describe("reconcilePendingResume", () => {
     expect(mockTransaction).toHaveBeenCalledTimes(1);
   });
 
+  it("promotes a suspension whose resume date is exactly today (the <= boundary, not just already-past)", async () => {
+    const dueToday = buildSuspension({ id: "s-today", to: today, resumeEventIds: { AA: "evt-today" } });
+    const meeting: MeetingWithSuspensions = {
+      ...buildMeeting({ googleCalendarEventIds: {} }),
+      recurrencePattern: null,
+      suspensions: [dueToday],
+    };
+
+    const result = await reconcilePendingResume(meeting);
+
+    expect(result).toEqual({ AA: "evt-today" });
+    expect(mockSuspensionUpdate).toHaveBeenCalledWith({
+      where: { id: "s-today" },
+      data: { promoted: true },
+    });
+  });
+
   it("ignores a suspension whose resume date has not arrived yet", async () => {
     const notYetDue = buildSuspension({ to: tomorrow, resumeEventIds: { AA: "evt-future" } });
     const meeting: MeetingWithSuspensions = {
@@ -210,7 +228,9 @@ describe("reconcilePendingResume", () => {
   });
 
   it("ignores a due suspension with no pre-created resumeEventIds", async () => {
-    const noEventIds = buildSuspension({ to: yesterday, resumeEventIds: undefined });
+    // Relies on buildSuspension's own default (null) -- a real SuspensionPeriod row's
+    // resumeEventIds is never `undefined`, only `null` or a populated Json value.
+    const noEventIds = buildSuspension({ to: yesterday });
     const meeting: MeetingWithSuspensions = {
       ...buildMeeting({ googleCalendarEventIds: {} }),
       recurrencePattern: null,
@@ -248,6 +268,10 @@ describe("reconcilePendingResume", () => {
     expect(result).toEqual({ AA: "evt-newer" });
     expect(mockSuspensionUpdate).toHaveBeenCalledWith({
       where: { id: "s-newer" },
+      data: { promoted: true },
+    });
+    expect(mockSuspensionUpdate).not.toHaveBeenCalledWith({
+      where: { id: "s-older" },
       data: { promoted: true },
     });
   });
@@ -305,6 +329,32 @@ describe("createPendingResumeSeries", () => {
     expect(mockCreateCalendarEvent).not.toHaveBeenCalled();
   });
 
+  it("stays a genuine no-op (error: null) when there's no upcoming occurrence, even if the meeting also has an unconfigured category", async () => {
+    mockCalendarIdsForMeeting.mockReturnValue({ AA: "cal-aa" }); // "Missing" deliberately absent
+
+    const resumeDate = tomorrow;
+    const meeting: MeetingWithPattern = {
+      ...buildMeeting({ isRecurring: true, calType: ["AA", "Missing"] }),
+      // endDate before resumeDate -- no occurrence left to pre-create, same as the test above,
+      // but combined with a category that's also unconfigured.
+      recurrencePattern: buildRecurrencePattern({
+        daysOfWeek: [etWeekday(resumeDate)],
+        endDate: yesterday,
+      }),
+    };
+
+    const result = await createPendingResumeSeries(meeting, "token-1", resumeDate);
+
+    // "No occurrence" must stay a genuine no-op -- it must not surface a misconfiguration error
+    // just because an unrelated category also happens to be unconfigured.
+    expect(result).toEqual({ resumeEventIds: {}, error: null });
+    // calendarIds is resolved unconditionally up front, before the recurring/one-time branch
+    // even runs -- "Missing" was still looked up, it's the *reporting* of it that's correctly
+    // suppressed here, not the lookup itself.
+    expect(mockCalendarIdsForMeeting).toHaveBeenCalledWith(["AA", "Missing"]);
+    expect(mockCreateCalendarEvent).not.toHaveBeenCalled();
+  });
+
   it("records an unconfigured-calendar error but still creates events for the categories that are configured", async () => {
     mockCalendarIdsForMeeting.mockReturnValue({ AA: "cal-aa" }); // "Other" deliberately missing
     mockCreateCalendarEvent.mockResolvedValue({ id: "evt-aa", error: null });
@@ -344,6 +394,31 @@ describe("createPendingResumeSeries", () => {
     expect(result).toEqual({
       resumeEventIds: { Other: "evt-other" },
       error: "Google rejected the AA event",
+    });
+  });
+
+  it("keeps the unconfigured-category error as the first error, not overwritten by a later create failure", async () => {
+    // Two independent failure sources: "Missing" is unconfigured (recorded before the create
+    // loop even starts), and the configured "AA" category's create call also fails. The
+    // unconfigured-category error must win -- it happened first.
+    mockCalendarIdsForMeeting.mockReturnValue({ AA: "cal-aa", Other: "cal-other" }); // "Missing" deliberately absent
+    mockCreateCalendarEvent.mockImplementation((_token: string, _meeting: unknown, calId: string) =>
+      calId === "cal-aa"
+        ? Promise.resolve({ id: null, error: "Google rejected the AA event" })
+        : Promise.resolve({ id: "evt-other", error: null }),
+    );
+
+    const resumeDate = tomorrow;
+    const meeting: MeetingWithPattern = {
+      ...buildMeeting({ isRecurring: true, calType: ["AA", "Missing", "Other"] }),
+      recurrencePattern: buildRecurrencePattern({ daysOfWeek: [etWeekday(resumeDate)] }),
+    };
+
+    const result = await createPendingResumeSeries(meeting, "token-1", resumeDate);
+
+    expect(result).toEqual({
+      resumeEventIds: { Other: "evt-other" },
+      error: 'Calendar for "Missing" is not configured.',
     });
   });
 

--- a/frontend/tests/unit/zoom.test.ts
+++ b/frontend/tests/unit/zoom.test.ts
@@ -56,16 +56,17 @@ function buildMeeting(overrides: Partial<IMeeting> = {}): IMeeting {
   };
 }
 
-// Mocks fetch to succeed on the token endpoint (by default) and record the JSON body sent to
-// whichever Zoom meetings-API call the test triggers.
-function mockFetchCapturingBody(opts: { tokenOk?: boolean; tokenStatus?: number } = {}) {
+// Mocks fetch to succeed on the token endpoint and record the JSON body sent to whichever Zoom
+// meetings-API call the test triggers. Token-fetch failure paths are covered separately below
+// with their own inline fetch mocks (a token-status knob here was never actually exercised by
+// any call site).
+function mockFetchCapturingBody() {
   let capturedBody: Record<string, unknown> | undefined;
   const fetchMock = jest.fn((url: string, init?: RequestInit) => {
     if (url.includes("oauth/token")) {
-      const ok = opts.tokenOk ?? true;
       return Promise.resolve({
-        ok,
-        status: opts.tokenStatus ?? (ok ? 200 : 500),
+        ok: true,
+        status: 200,
         json: async () => ({ access_token: "tok-1", expires_in: 3600 }),
       });
     }
@@ -109,17 +110,18 @@ describe("toZoomStartTime / buildZoomMeetingBody (via createZoomMeeting's reques
     expect(getCapturedBody()?.duration).toBe(90);
   });
 
-  it("rounds a fractional-minute duration to the nearest whole minute", async () => {
+  it("rounds a fractional-minute duration to the nearest whole minute, not ceil", async () => {
     const { getCapturedBody } = mockFetchCapturingBody();
     const meeting = buildMeeting({
       startDateTime: new Date("2026-03-10T22:00:00.000Z"),
-      // 5 minutes 30 seconds -> 5.5 minutes, Math.round rounds to 6.
-      endDateTime: new Date("2026-03-10T22:05:30.000Z"),
+      // 5 minutes 20 seconds -> 5.33 minutes: Math.round gives 5, Math.ceil would give 6 --
+      // 5.5 (5m30s) can't distinguish the two, since both round and ceil agree on it.
+      endDateTime: new Date("2026-03-10T22:05:20.000Z"),
     });
 
     await createZoomMeeting(meeting, "host@test.icr");
 
-    expect(getCapturedBody()?.duration).toBe(6);
+    expect(getCapturedBody()?.duration).toBe(5);
   });
 
   it("carries the meeting's title/description into topic/agenda and fixes type: 2 (reused stable meeting)", async () => {

--- a/frontend/tests/unit/zoom.test.ts
+++ b/frontend/tests/unit/zoom.test.ts
@@ -57,9 +57,8 @@ function buildMeeting(overrides: Partial<IMeeting> = {}): IMeeting {
 }
 
 // Mocks fetch to succeed on the token endpoint and record the JSON body sent to whichever Zoom
-// meetings-API call the test triggers. Token-fetch failure paths are covered separately below
-// with their own inline fetch mocks (a token-status knob here was never actually exercised by
-// any call site).
+// meetings-API call the test triggers. Token-fetch failure paths are covered separately below,
+// each with its own inline fetch mock.
 function mockFetchCapturingBody() {
   let capturedBody: Record<string, unknown> | undefined;
   const fetchMock = jest.fn((url: string, init?: RequestInit) => {

--- a/frontend/tests/unit/zoom.test.ts
+++ b/frontend/tests/unit/zoom.test.ts
@@ -1,0 +1,206 @@
+import type {
+  createZoomMeeting as CreateZoomMeetingFn,
+  updateZoomMeeting as UpdateZoomMeetingFn,
+  checkZoomReachable as CheckZoomReachableFn,
+} from "../../services/zoom";
+import type { IMeeting } from "../../types/models";
+
+// toZoomStartTime and buildZoomMeetingBody aren't exported (they're internal to every
+// create/update call), so they're exercised the same way zoomTokenCache.test.ts exercises the
+// module's other internals: through a public entry point, inspecting the outgoing fetch body.
+// Covers what zoomTokenCache.test.ts (caching/coalescing/401-invalidation) deliberately leaves
+// out -- the request-shaping math itself, and token-*fetch*-failure paths (non-2xx, network
+// error, malformed response) as opposed to cache-behavior paths.
+let createZoomMeeting: typeof CreateZoomMeetingFn;
+let updateZoomMeeting: typeof UpdateZoomMeetingFn;
+let checkZoomReachable: typeof CheckZoomReachableFn;
+
+const originalFetch = global.fetch;
+const ENV_KEYS = ["ZOOM_CLIENT_ID", "ZOOM_CLIENT_SECRET", "ZOOM_ACCOUNT_ID"] as const;
+const originalEnv: Partial<Record<(typeof ENV_KEYS)[number], string>> = {};
+
+beforeEach(async () => {
+  for (const key of ENV_KEYS) originalEnv[key] = process.env[key];
+  process.env.ZOOM_CLIENT_ID = "test-client-id";
+  process.env.ZOOM_CLIENT_SECRET = "test-client-secret";
+  process.env.ZOOM_ACCOUNT_ID = "test-account-id";
+
+  // Module-level token cache -- fresh module instance per test, same as zoomTokenCache.test.ts.
+  jest.resetModules();
+  ({ createZoomMeeting, updateZoomMeeting, checkZoomReachable } = await import("../../services/zoom"));
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  for (const key of ENV_KEYS) {
+    if (originalEnv[key] === undefined) delete process.env[key];
+    else process.env[key] = originalEnv[key];
+  }
+});
+
+function buildMeeting(overrides: Partial<IMeeting> = {}): IMeeting {
+  return {
+    title: "Test Meeting",
+    mid: "m-1",
+    description: "A test meeting",
+    creator: "creator@test.icr",
+    group: "Group",
+    startDateTime: new Date("2026-03-10T22:00:00.000Z"),
+    endDateTime: new Date("2026-03-10T23:00:00.000Z"),
+    email: "test@test.icr",
+    calType: ["AA"],
+    modeType: "Virtual",
+    room: "Zoom",
+    isRecurring: false,
+    ...overrides,
+  };
+}
+
+// Mocks fetch to succeed on the token endpoint (by default) and record the JSON body sent to
+// whichever Zoom meetings-API call the test triggers.
+function mockFetchCapturingBody(opts: { tokenOk?: boolean; tokenStatus?: number } = {}) {
+  let capturedBody: Record<string, unknown> | undefined;
+  const fetchMock = jest.fn((url: string, init?: RequestInit) => {
+    if (url.includes("oauth/token")) {
+      const ok = opts.tokenOk ?? true;
+      return Promise.resolve({
+        ok,
+        status: opts.tokenStatus ?? (ok ? 200 : 500),
+        json: async () => ({ access_token: "tok-1", expires_in: 3600 }),
+      });
+    }
+    capturedBody = init?.body ? JSON.parse(init.body as string) : undefined;
+    return Promise.resolve({
+      ok: true,
+      status: 200,
+      json: async () => ({ id: 123, join_url: "https://zoom.us/j/123", password: "pw" }),
+      text: async () => "",
+    });
+  });
+  global.fetch = fetchMock as unknown as typeof fetch;
+  return { getCapturedBody: () => capturedBody, fetchMock };
+}
+
+describe("toZoomStartTime / buildZoomMeetingBody (via createZoomMeeting's request body)", () => {
+  it("sends the ET wall-clock start time (not the UTC instant) as start_time", async () => {
+    const { getCapturedBody } = mockFetchCapturingBody();
+    // 2026-03-10T22:00:00Z is 2026-03-10 18:00 ET (already EDT that year -- DST starts March 8).
+    const meeting = buildMeeting({
+      startDateTime: new Date("2026-03-10T22:00:00.000Z"),
+      endDateTime: new Date("2026-03-10T23:00:00.000Z"),
+    });
+
+    await createZoomMeeting(meeting, "host@test.icr");
+
+    const body = getCapturedBody();
+    expect(body?.start_time).toBe("2026-03-10T18:00:00");
+    expect(body?.timezone).toBe("America/New_York");
+  });
+
+  it("computes duration in whole minutes from the meeting's start/end", async () => {
+    const { getCapturedBody } = mockFetchCapturingBody();
+    const meeting = buildMeeting({
+      startDateTime: new Date("2026-03-10T22:00:00.000Z"),
+      endDateTime: new Date("2026-03-10T23:30:00.000Z"), // 90 minutes
+    });
+
+    await createZoomMeeting(meeting, "host@test.icr");
+
+    expect(getCapturedBody()?.duration).toBe(90);
+  });
+
+  it("rounds a fractional-minute duration to the nearest whole minute", async () => {
+    const { getCapturedBody } = mockFetchCapturingBody();
+    const meeting = buildMeeting({
+      startDateTime: new Date("2026-03-10T22:00:00.000Z"),
+      // 5 minutes 30 seconds -> 5.5 minutes, Math.round rounds to 6.
+      endDateTime: new Date("2026-03-10T22:05:30.000Z"),
+    });
+
+    await createZoomMeeting(meeting, "host@test.icr");
+
+    expect(getCapturedBody()?.duration).toBe(6);
+  });
+
+  it("carries the meeting's title/description into topic/agenda and fixes type: 2 (reused stable meeting)", async () => {
+    const { getCapturedBody } = mockFetchCapturingBody();
+    const meeting = buildMeeting({ title: "Wednesday AA", description: "Weekly meeting" });
+
+    await createZoomMeeting(meeting, "host@test.icr");
+
+    const body = getCapturedBody();
+    expect(body?.topic).toBe("Wednesday AA");
+    expect(body?.agenda).toBe("Weekly meeting");
+    expect(body?.type).toBe(2);
+  });
+
+  it("builds the same request body shape for updateZoomMeeting as for createZoomMeeting", async () => {
+    const { getCapturedBody } = mockFetchCapturingBody();
+    const meeting = buildMeeting({
+      startDateTime: new Date("2026-03-10T22:00:00.000Z"),
+      endDateTime: new Date("2026-03-10T23:15:00.000Z"), // 75 minutes
+    });
+
+    await updateZoomMeeting("zid-1", meeting);
+
+    const body = getCapturedBody();
+    expect(body?.start_time).toBe("2026-03-10T18:00:00");
+    expect(body?.duration).toBe(75);
+  });
+});
+
+describe("token-fetch failure paths", () => {
+  it("returns null/false without throwing when Zoom credentials aren't configured", async () => {
+    delete process.env.ZOOM_CLIENT_ID;
+    const fetchMock = jest.fn();
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const result = await createZoomMeeting(buildMeeting(), "host@test.icr");
+
+    expect(result).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("returns false when the token endpoint responds with a non-2xx status", async () => {
+    global.fetch = jest.fn(() =>
+      Promise.resolve({ ok: false, status: 401, json: async () => ({}) }),
+    ) as unknown as typeof fetch;
+
+    const reachable = await checkZoomReachable();
+
+    expect(reachable).toBe(false);
+  });
+
+  it("returns null without throwing when the token request itself rejects (network error)", async () => {
+    global.fetch = jest.fn(() => Promise.reject(new Error("network down"))) as unknown as typeof fetch;
+
+    const result = await createZoomMeeting(buildMeeting(), "host@test.icr");
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null when the token endpoint responds 200 but omits access_token", async () => {
+    global.fetch = jest.fn(() =>
+      Promise.resolve({ ok: true, status: 200, json: async () => ({ expires_in: 3600 }) }),
+    ) as unknown as typeof fetch;
+
+    const result = await createZoomMeeting(buildMeeting(), "host@test.icr");
+
+    expect(result).toBeNull();
+  });
+
+  it("does not attempt the meetings-API call at all when the token fetch fails", async () => {
+    const fetchMock = jest.fn((url: string) => {
+      if (url.includes("oauth/token")) {
+        return Promise.resolve({ ok: false, status: 500, json: async () => ({}) });
+      }
+      throw new Error("should not reach the meetings API without a token");
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const result = await createZoomMeeting(buildMeeting(), "host@test.icr");
+
+    expect(result).toBeNull();
+    expect(fetchMock).toHaveBeenCalledTimes(1); // only the token attempt
+  });
+});


### PR DESCRIPTION
Resolves #417
Resolves #409

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved integration test reliability by waiting for synchronization jobs to reach completion rather than relying on fixed delays.
  * Added comprehensive coverage for suspension calendar workflows, including recurring events, promotions, errors, and cleanup.
  * Added isolated coverage for Zoom meeting creation, updates, authentication failures, malformed responses, and network errors.
  * Added checks confirming deferred synchronization behavior and preventing API calls when credentials are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description
- **New unit test coverage for `util/meetings/suspension.ts`** (24 tests): direct coverage of `reconcilePendingResume`, `createPendingResumeSeries`, and `tearDownPendingResumeSeries` — the pre-created-GCal-series promotion/teardown machinery, previously only exercised indirectly through integration tests that fully mock `googleCalendar`, leaving the actual "which event IDs get promoted/torn down" branching untested despite being, per the original issue, "arguably the subtlest logic in the codebase — a wrong branch here can orphan events on ICR's real, public Google Calendar." Every test was mutation-verified (the underlying logic was deliberately broken and confirmed the corresponding test catches it, then reverted) rather than just asserting the happy path.
- **New unit test coverage for `services/zoom.ts`** (10 tests): `toZoomStartTime`'s ET-anchored formatting and `buildZoomMeetingBody`'s duration math (exercised through `createZoomMeeting`/`updateZoomMeeting`'s outgoing fetch body, since neither helper is exported), plus token-fetch failure paths not already covered by the existing `zoomTokenCache.test.ts` (missing credentials, non-2xx response, network error, a 200 with no `access_token`, and confirming the meetings API is never called when the token fetch itself fails).
- **Deflaked 3 integration test files** (`write-meeting-route.test.ts`, `update-meeting-route.test.ts`, `delete-meeting-route.test.ts`): replaced fixed-duration `sleep`/`setTimeout` waits with polling for the actual deferred-sync condition, and dropped a flaky wall-clock `elapsed < 300ms` assertion in favor of the invariant check that already sat next to it. Added `waitForStableCallCount` for the two places asserting an *absence* of further calls (polls until a call count stops changing for a quiet window, since value-polling doesn't apply to proving a negative).

## Testing
- [x] `yarn test:all` (lint, lint:css, typecheck, unit, component, integration, e2e) — full pass: 213/213 unit, 187/187 component, 93/93 integration, 98/98 e2e.
- [x] Went through an adversarial review that used mutation testing throughout — not just reading the tests, but deliberately breaking the underlying source logic and confirming each new/changed test actually fails against the broken code. This caught 7 real gaps (several tests that would have passed even with subtly wrong logic) in the first round, and one genuine bug in the deflaking itself (a poll watching a field that's written synchronously rather than by the deferred job it was meant to wait for, making the wait a no-op and *reducing* the race margin below what the original fixed sleep had) in the final proofread pass — both fully addressed and re-verified with the same technique.
- [x] The specific race-condition fix (`update-meeting-route.test.ts`'s "exhausted Zoom host pool on update" test) was run 5 times in isolation for stability before this was considered done, and confirmed stable again in the final official test pass.

## Area(s) Touched
**Integrations**
- [x] google-calendar — Google Calendar sync
- [x] zoom-api — Zoom meeting/host sync

**Engineering**
- [x] testing — test suite (Jest/Playwright) changes

## Pre-merge Checklist
- [x] Code follows current formatting conventions and passes lint (`yarn lint`).
- [x] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
- [x] All test suites pass, both run locally and green in GitHub CI. **Do not merge if any test suite is failing.**
- [x] A test suite was added or updated for the feature/fix in this PR. **Double-check this if you change a feature and did not update the test suites**. — this PR *is* the test suite change.
- [x] Only files relevant to this change are committed — no stray or unrelated files.
- [x] If this branch has a merge conflict with master, master was merged into this branch first (not the other way around).
- [x] The rest of this PR description (Description, Testing) is filled out, not left as template placeholders.

**Note:** while deflaking these files, a pre-existing, unrelated cross-file DB contention flake was identified (`update-meeting-route.test.ts`'s room-conflict test can intermittently fail when the full integration suite runs multiple route test files together in one jest invocation) — confirmed to reproduce on unmodified `master` too, so it's out of scope for this PR, but worth a follow-up ticket if it becomes disruptive.
