### PR TITLE
fix(tests): replace timeout-based waits with real completion signals

### DIFF
--- a/frontend/tests/integration/delete-meeting-route.test.ts
+++ b/frontend/tests/integration/delete-meeting-route.test.ts
@@ -1,9 +1,16 @@
 import { getTestPrismaClient, disconnectTestPrismaClient } from "../factories/db";
 import { seedMeeting, seedRecurringMeeting, seedSuspensionPeriod } from "../factories/meeting";
 
+// The route always passes an already-started promise to after() (syncDeleteAll etc. are invoked
+// eagerly as part of constructing the argument, before after() ever sees it) -- capturing that
+// promise here gives tests a real completion signal to await (see drainAfterTasks below),
+// instead of inferring "the background sync must be done by now" from elapsed time.
+const mockCapturedAfterTasks: Promise<unknown>[] = [];
 jest.mock("next/server", () => ({
   ...jest.requireActual("next/server"),
-  after: () => {},
+  after: (task: unknown) => {
+    mockCapturedAfterTasks.push(Promise.resolve(task));
+  },
 }));
 
 jest.mock("../../services/auth", () => ({
@@ -36,39 +43,16 @@ afterAll(async () => {
 
 beforeEach(() => {
   mockedDelete.mockClear();
+  mockCapturedAfterTasks.length = 0;
 });
 
-async function waitFor<T>(fn: () => Promise<T | null | undefined>, timeoutMs = 2000): Promise<T | null> {
-  const start = Date.now();
-  while (Date.now() - start < timeoutMs) {
-    const result = await fn();
-    if (result != null) return result;
-    await new Promise((resolve) => setTimeout(resolve, 25));
-  }
-  return null;
-}
-
-// For asserting an absence (no further deleteCalendarEvent call lands after the expected one)
-// rather than a value to poll for -- waitFor's "poll until non-null" shape doesn't apply there.
-// There's no real completion signal to wait on for a negative assertion, so this is still
-// fundamentally a timeout, not a true polling condition. But the quiet timer restarts whenever
-// the count changes, so a call arriving late in the window still gets caught instead of the
-// check having already closed around it.
-async function waitForStableCallCount(getCount: () => number, quietMs = 200, timeoutMs = 2000): Promise<number> {
-  const start = Date.now();
-  let lastCount = getCount();
-  let quietSince = Date.now();
-  while (Date.now() - start < timeoutMs) {
-    await new Promise((resolve) => setTimeout(resolve, 10));
-    const count = getCount();
-    if (count !== lastCount) {
-      lastCount = count;
-      quietSince = Date.now();
-    } else if (Date.now() - quietSince >= quietMs) {
-      return count;
-    }
-  }
-  return lastCount;
+// Awaits every after()-deferred task captured by a DELETE call so far, then clears the list.
+// This is the actual condition these tests need -- "the background sync has fully finished,
+// including every sequential await inside it" -- not a guess at how long that takes; it works
+// equally well for a positive assertion (an event ID that should now exist) and a negative one
+// (asserting no further call landed), since either way nothing is left in flight once it resolves.
+async function drainAfterTasks(): Promise<void> {
+  await Promise.all(mockCapturedAfterTasks.splice(0, mockCapturedAfterTasks.length));
 }
 
 test("deleting a meeting with a pending pre-created resume series tears that series down too, not just the live event", async () => {
@@ -86,14 +70,14 @@ test("deleting a meeting with a pending pre-created resume series tears that ser
   const response = await DELETE(request);
   expect(response.status).toBe(200);
 
+  // deletedAt is written synchronously in the route, before after() is even called -- no wait
+  // needed for it.
   const prisma = getTestPrismaClient();
-  const deleted = await waitFor(async () => {
-    const m = await prisma.meeting.findUnique({ where: { mid: meeting.mid } });
-    return m?.deletedAt ? m : null;
-  });
+  const deleted = await prisma.meeting.findUnique({ where: { mid: meeting.mid } });
   expect(deleted?.deletedAt).not.toBeNull();
 
-  await waitFor(async () => (mockedDelete.mock.calls.length >= 2 ? true : null));
+  await drainAfterTasks();
+  expect(mockedDelete).toHaveBeenCalledTimes(2);
   expect(mockedDelete).toHaveBeenCalledWith("fake-token", "live-event-id", "fake-calendar-id");
   expect(mockedDelete).toHaveBeenCalledWith("fake-token", "pending-future-event-id", "fake-calendar-id");
 });
@@ -108,11 +92,11 @@ test("deleting a meeting with no pending resume series only tears down the live 
   const response = await DELETE(request);
   expect(response.status).toBe(200);
 
-  await waitFor(async () => (mockedDelete.mock.calls.length > 0 ? true : null));
-  // A settle window after the first call -- asserting toHaveBeenCalledTimes(1) immediately upon
-  // seeing the first call would pass even if a second, unwanted call was about to land right
-  // after (syncDeleteAll's deletes are sequential, not concurrent).
-  await waitForStableCallCount(() => mockedDelete.mock.calls.length);
+  // Awaiting the actual syncDeleteAll promise (not a settle-window guess) is what proves no
+  // further deleteCalendarEvent call is still in flight -- every sequential await inside it,
+  // including tearDownPendingResumeSeries and the Zoom-room calendar delete, has resolved by
+  // the time this returns.
+  await drainAfterTasks();
   expect(mockedDelete).toHaveBeenCalledTimes(1);
   expect(mockedDelete).toHaveBeenCalledWith("fake-token", "live-event-id", "fake-calendar-id");
 });
@@ -134,9 +118,8 @@ test("a promoted (already-live) suspension row isn't torn down a second time", a
   const response = await DELETE(request);
   expect(response.status).toBe(200);
 
-  await waitFor(async () => (mockedDelete.mock.calls.length > 0 ? true : null));
-  // Same settle window as above -- confirms the promoted row really isn't torn down a second
-  // time, not just that it hadn't happened yet by the time the first call was observed.
-  await waitForStableCallCount(() => mockedDelete.mock.calls.length);
+  // Same reasoning as above -- confirms the promoted row really isn't torn down a second time,
+  // not just that it hadn't happened yet by some guessed deadline.
+  await drainAfterTasks();
   expect(mockedDelete).toHaveBeenCalledTimes(1);
 });

--- a/frontend/tests/integration/update-meeting-route.test.ts
+++ b/frontend/tests/integration/update-meeting-route.test.ts
@@ -63,14 +63,16 @@ const mockedResolveZoomHost = resolveZoomHost as jest.Mock;
 const mockedReconcileMeetingCalendars = reconcileMeetingCalendars as jest.Mock;
 const mockedCreateCalendarEvent = createCalendarEvent as jest.Mock;
 
-async function waitFor<T>(fn: () => Promise<T | null | undefined>, timeoutMs = 2000): Promise<T | null> {
+async function waitFor<T>(fn: () => Promise<T | null | undefined>, timeoutMs = 2000): Promise<T> {
   const start = Date.now();
   while (Date.now() - start < timeoutMs) {
     const result = await fn();
     if (result != null) return result;
     await new Promise((resolve) => setTimeout(resolve, 25));
   }
-  return null;
+  // Throws instead of returning null -- a caller using the result un-checked would otherwise
+  // fail downstream with a confusing null-dereference instead of a clear "this never happened."
+  throw new Error(`waitFor: condition not met within ${timeoutMs}ms`);
 }
 
 function buildMeetingPayload(overrides: Partial<IMeeting> = {}): IMeeting {

--- a/frontend/tests/integration/write-meeting-route.test.ts
+++ b/frontend/tests/integration/write-meeting-route.test.ts
@@ -71,7 +71,10 @@ async function waitForGoogleSyncStatus(mid: string, timeoutMs = 2000) {
     if (meeting?.googleSyncStatus != null) return meeting;
     await new Promise((resolve) => setTimeout(resolve, 25));
   }
-  return prisma.meeting.findUnique({ where: { mid } });
+  // Throws instead of silently returning whatever findUnique last saw (possibly a row with
+  // googleSyncStatus still null) -- a caller using that value un-checked would otherwise fail
+  // downstream with a confusing null-dereference instead of a clear "the sync never finished."
+  throw new Error(`waitForGoogleSyncStatus: googleSyncStatus for meeting ${mid} was still null after ${timeoutMs}ms`);
 }
 
 function buildMeetingPayload(overrides: Partial<IMeeting> = {}): IMeeting {
@@ -109,10 +112,14 @@ beforeEach(() => {
 });
 
 test("the response resolves before Google Calendar sync completes, which runs in the background", async () => {
-  const SYNC_DELAY_MS = 300;
-  mockedCreateCalendarEvent.mockImplementation(
-    () => new Promise((resolve) => setTimeout(() => resolve({ id: "fake-event-id", error: null }), SYNC_DELAY_MS)),
-  );
+  // Manually gated instead of a fixed timer -- resolved explicitly right after the
+  // response-ordering assertion below, so this test can't itself become timing-dependent (a
+  // fixed timer could in theory be outraced by a slow enough CI machine).
+  let resolveCreateCalendarEvent: (result: { id: string; error: null }) => void;
+  const createCalendarEventGate = new Promise<{ id: string; error: null }>((resolve) => {
+    resolveCreateCalendarEvent = resolve;
+  });
+  mockedCreateCalendarEvent.mockImplementation(() => createCalendarEventGate);
 
   // Distinct room -- buildMeetingPayload's default ("Serenity Room") is shared by other tests
   // in this suite; the room conflict check would otherwise make this order-dependent on
@@ -132,6 +139,9 @@ test("the response resolves before Google Calendar sync completes, which runs in
   const prisma = getTestPrismaClient();
   const rightAfterResponse = await prisma.meeting.findUnique({ where: { mid: payload.mid } });
   expect(rightAfterResponse?.googleSyncStatus).toBeNull();
+
+  // Only now let the deferred sync's Google Calendar call resolve.
+  resolveCreateCalendarEvent!({ id: "fake-event-id", error: null });
 
   const afterSync = await waitForGoogleSyncStatus(payload.mid);
   expect(afterSync?.googleSyncStatus).toBe("synced");


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved integration test reliability by waiting for deferred background tasks to complete before validating results.
  * Added explicit timeout failures for asynchronous waits and calendar synchronization checks.
  * Strengthened background-sync timing coverage to verify responses can arrive before synchronization finishes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Small follow-up to #431 (`test/zoom-suspension-coverage-and-deflake`, which squash-merged before CodeRabbit's review finished) addressing all 3 findings from that PR's review.

## Description
- **`tests/integration/delete-meeting-route.test.ts`**: `waitForStableCallCount` was still fundamentally a timeout-based "nothing happened for N ms" proof of absence, not a true completion signal — a call landing right as the quiet window closed could theoretically still be missed. Replaced it with a real completion signal: the `next/server` mock now captures the actual promise the route passes to `after()` (already-started by the time `after()` sees it, since `syncDeleteAll(...)` is invoked eagerly as the argument expression), and a new `drainAfterTasks()` helper awaits it directly. This works for both the positive case (an expected `deleteCalendarEvent` call landed) and the negative case (no further call landed) — once the awaited promise resolves, every sequential step inside the deferred sync (including `tearDownPendingResumeSeries` and the Zoom-room calendar delete) has genuinely finished, not just "probably finished by now." Also tightened one assertion from `>= 2` calls to an exact `toHaveBeenCalledTimes(2)` while in there.
- **`tests/integration/update-meeting-route.test.ts`, `write-meeting-route.test.ts`**: the shared `waitFor`/`waitForGoogleSyncStatus` polling helpers previously returned `null` silently on timeout, and several call sites didn't check for that — meaning a timed-out poll could let a test proceed with an incomplete/null row and fail downstream with a confusing error instead of a clear "the deferred sync didn't complete in time." Both helpers now throw explicitly on timeout, fixing every call site at once rather than patching each individually.
- **`write-meeting-route.test.ts`**: the "response resolves before background sync completes" test used a fixed 300ms timer to simulate a slow Google Calendar API call — theoretically racy on a sufficiently slow CI machine, since a real completion could in principle land before the timer fired. Replaced with a manually-controlled deferred promise, resolved explicitly right after the response-ordering assertion runs, so the test can no longer be outraced by machine speed.

## Testing
- [x] `yarn test:all` (lint, lint:css, typecheck, unit, component, integration, e2e) — full pass: 213/213 unit, 208/208 component, 93/93 integration, 98/98 e2e.
- [x] Independently verified the completion-signal fix by reading the full diff directly — confirmed the captured promise is genuinely the same one driving the deferred work (not a copy or an unrelated proxy), and that `drainAfterTasks()`'s `Promise.all` + `splice` correctly awaits and clears everything captured since the last drain.

## Area(s) Touched
**Engineering**
- [x] testing — test suite (Jest/Playwright) changes

## Pre-merge Checklist
- [x] Code follows current formatting conventions and passes lint (`yarn lint`).
- [x] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
- [x] All test suites pass, both run locally and green in GitHub CI. **Do not merge if any test suite is failing.**
- [x] A test suite was added or updated for the feature/fix in this PR. **Double-check this if you change a feature and did not update the test suites**. — this PR *is* the test-reliability fix.
- [x] Only files relevant to this change are committed — no stray or unrelated files.
- [x] If this branch has a merge conflict with master, master was merged into this branch first (not the other way around).
- [x] The rest of this PR description (Description, Testing) is filled out, not left as template placeholders.
