### PR TITLE
feat(admin): add Super-Admin Backups tab with mock data, hidden in production

### DIFF
--- a/frontend/app/api/admin/diagnostics/system-status/route.ts
+++ b/frontend/app/api/admin/diagnostics/system-status/route.ts
@@ -4,6 +4,7 @@ import { requireRole } from "../../../../../services/auth";
 import { calendarIdForCategory, checkCalendarReachable } from "../../../../../services/googleCalendar";
 import { checkZoomReachable, zoomRoomCalendarId, zoomHostPool, checkZoomHostPool } from "../../../../../services/zoom";
 import { prisma } from "../../../../../lib/prisma";
+import pkg from "../../../../../package.json";
 
 const CHECK_TIMEOUT_MS = 8000;
 
@@ -26,8 +27,8 @@ function withTimeout<T>(promise: Promise<T>, fallback: T, ms = CHECK_TIMEOUT_MS)
 
 // Built as an array first, in `ids`' own key order, then assembled into an object in one pass
 // -- object key order otherwise follows whichever check happens to resolve first, which varies
-// run to run (SystemStatusCard.tsx renders these via Object.entries(), so insertion order is
-// what determines on-screen row order).
+// run to run. SystemStatusCard.tsx's nested calendar/host-pool rows DO render via
+// Object.entries() over this map, so insertion order is what determines their on-screen order.
 async function reachableMap(ids: Record<string, string>, token: string | undefined): Promise<Record<string, boolean>> {
   const keys = Object.keys(ids);
   if (!token) return Object.fromEntries(keys.map((k) => [k, false]));
@@ -66,11 +67,20 @@ export const GET = async () => {
       googleCalendar: { categories: googleCalendarCategories },
       zoom: { reachable: zoomReachable, roomCalendars, hostPool },
       session: { email: auth.user?.email ?? null, role: auth.user?.role ?? null },
+      // Kept in the same shape/order as SystemStatusCard.tsx's hardcoded top-level rows
+      // (readability only -- those rows are fixed JSX, not driven by this object's key order;
+      // only the nested calendar/host-pool maps render via Object.entries()).
+      application: { version: pkg.version, deployedAt: process.env.NEXT_PUBLIC_BUILD_DATE ?? null },
     });
   } catch (error) {
     console.error("Error retrieving system status: ", error);
     return NextResponse.json(
-      { database: { ok: false, latencyMs: null }, error: "Error retrieving system status" },
+      {
+        database: { ok: false, latencyMs: null },
+        // Mirrors the success payload's key order/invariant above.
+        application: { version: pkg.version, deployedAt: process.env.NEXT_PUBLIC_BUILD_DATE ?? null },
+        error: "Error retrieving system status",
+      },
       { status: 500 },
     );
   }

--- a/frontend/app/components/admin/AdminShell.tsx
+++ b/frontend/app/components/admin/AdminShell.tsx
@@ -6,6 +6,7 @@ import Icon from "../ui/displays/Icon";
 import DiagnosticsTab from "./diagnostics/DiagnosticsTab";
 import SignageTab from "./signage/SignageTab";
 import UsersTab from "./users/UsersTab";
+import BackupsTab from "./backups/BackupsTab";
 import ExportTab from "./export/ExportTab";
 import { useViewport } from "../../../hooks/useViewport";
 import { useToast } from "../shared/ToastProvider";
@@ -16,12 +17,17 @@ interface AdminShellProps {
   email: string;
 }
 
-type TabKey = "diagnostics" | "signage" | "users" | "export";
+type TabKey = "diagnostics" | "signage" | "users" | "backups" | "export";
 
 const allTabs: { key: TabKey; label: string; superAdminOnly: boolean }[] = [
   { key: "diagnostics", label: "Diagnostics", superAdminOnly: false },
   { key: "signage", label: "Signage", superAdminOnly: false },
   { key: "users", label: "Users", superAdminOnly: true },
+  // TODO(backups-api): drop the NODE_ENV guard once real API wiring lands -- this UI-only PR
+  // ships mock data only, so the tab stays dev-only until then.
+  ...(process.env.NODE_ENV !== "production"
+    ? [{ key: "backups" as const, label: "Backups", superAdminOnly: true }]
+    : []),
   { key: "export", label: "Export", superAdminOnly: true },
 ];
 
@@ -83,6 +89,7 @@ const AdminShell: React.FC<AdminShellProps> = ({ role, email }) => {
         {effectiveTab === "diagnostics" && <DiagnosticsTab email={email} role={role} />}
         {effectiveTab === "signage" && <SignageTab />}
         {effectiveTab === "users" && isSuperAdmin && <UsersTab />}
+        {effectiveTab === "backups" && isSuperAdmin && <BackupsTab />}
         {effectiveTab === "export" && isSuperAdmin && <ExportTab />}
       </div>
     </div>

--- a/frontend/app/components/admin/backups/BackupHealthCard.tsx
+++ b/frontend/app/components/admin/backups/BackupHealthCard.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import React from "react";
+import Icon from "../../ui/displays/Icon";
+import Card from "../shared/Card";
+import type { BackupHealth, BackupReplica } from "../../../../types/backups";
+import { convertUTCToET } from "../../../../util/date/timeUtils";
+import styles from "./BackupsTab.module.scss";
+
+interface BackupHealthCardProps {
+  health: BackupHealth;
+  /** Reference instant for relative-age labels -- passed in, never read from Date.now() here. */
+  now: Date;
+}
+
+const REPLICA_LABEL: Record<BackupReplica, string> = {
+  "gcs-working": "GCS (working)",
+  "gcs-archive": "GCS (archive)",
+  r2: "Cloudflare R2",
+};
+
+const FRESHNESS_LABEL: Record<BackupHealth["freshness"], string> = {
+  ok: "Healthy",
+  warn: "Aging",
+  error: "Stale",
+};
+
+const freshnessPillClass: Record<BackupHealth["freshness"], string> = {
+  ok: styles.freshnessOk,
+  warn: styles.freshnessWarn,
+  error: styles.freshnessError,
+};
+
+// Coarse relative age ("3h ago", "2d ago") -- getTime() diffs against the passed-in `now`
+// only, no Date.now() (would mismatch between server render and client hydration) and no
+// local-timezone Date accessors (banned by the repo's ESLint rule).
+const formatRelativeAge = (sinceIso: string, now: Date): string => {
+  const diffMs = Math.max(0, now.getTime() - new Date(sinceIso).getTime());
+  const diffHours = Math.floor(diffMs / (60 * 60 * 1000));
+  if (diffHours < 1) return "just now";
+  if (diffHours < 24) return `${diffHours}h ago`;
+  const diffDays = Math.floor(diffHours / 24);
+  return `${diffDays}d ago`;
+};
+
+const formatBytes = (bytes: number): string => {
+  if (bytes === 0) return "0 B";
+  const units = ["B", "KB", "MB", "GB", "TB"];
+  const exp = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
+  const value = bytes / 1024 ** exp;
+  return `${value >= 10 || exp === 0 ? Math.round(value) : value.toFixed(1)} ${units[exp]}`;
+};
+
+// Headroom bar switches to warn/error fill once usage crosses these fractions of the free-tier
+// ceiling -- matches the freshness pill's own two-threshold shape for visual consistency.
+const HEADROOM_WARN_FRACTION = 0.7;
+const HEADROOM_ERROR_FRACTION = 0.9;
+
+const headroomFillClass = (fraction: number): string => {
+  if (fraction >= HEADROOM_ERROR_FRACTION) return `${styles.headroomFill} ${styles.headroomFillError}`;
+  if (fraction >= HEADROOM_WARN_FRACTION) return `${styles.headroomFill} ${styles.headroomFillWarn}`;
+  return styles.headroomFill;
+};
+
+const BackupHealthCard: React.FC<BackupHealthCardProps> = ({ health, now }) => {
+  // Free-tier headroom is measured against the tightest of the three storage ceilings -- a
+  // single-bar summary can't represent three independent limits, and the tightest one is the
+  // one that will actually block a write first.
+  const tightestLimitBytes = Math.min(
+    health.freeTierLimits.gcsWorkingBytes,
+    health.freeTierLimits.gcsArchiveBytes,
+    health.freeTierLimits.r2Bytes,
+  );
+  const headroomFraction = tightestLimitBytes > 0
+    ? Math.min(1, health.totals.totalSizeBytes / tightestLimitBytes)
+    : 0;
+
+  return (
+    <Card accent="systemStatus">
+      <div className={styles.panelHeader}>
+        <Icon name="backup" className={styles.panelIcon} />
+        Backup Health
+      </div>
+
+      <div className={styles.healthGrid}>
+        <div className={styles.healthRow}>
+          <span className={styles.healthLabel}>Last successful backup</span>
+          <span className={styles.healthValue}>
+            {health.lastSuccessfulBackupAt ? (
+              <>
+                {formatRelativeAge(health.lastSuccessfulBackupAt, now)}
+                {" "}
+                <span className={`${styles.freshnessPill} ${freshnessPillClass[health.freshness]}`}>
+                  {FRESHNESS_LABEL[health.freshness]}
+                </span>
+              </>
+            ) : (
+              <span className={styles.emptyState}>No successful backup yet</span>
+            )}
+          </span>
+        </div>
+
+        <div className={styles.healthRow}>
+          <span className={styles.healthLabel}>Last verified restore</span>
+          <span className={styles.healthValue}>
+            {health.lastVerifiedRestoreAt
+              ? `${formatRelativeAge(health.lastVerifiedRestoreAt, now)} (${convertUTCToET(health.lastVerifiedRestoreAt)} ET)`
+              : "Never — quarterly drill pending"}
+          </span>
+        </div>
+
+        <div className={styles.healthRow}>
+          <span className={styles.healthLabel}>Next scheduled run</span>
+          <span className={styles.healthValue}>{convertUTCToET(health.nextScheduledRunAt)} ET</span>
+        </div>
+
+        <div className={styles.healthRow}>
+          <span className={styles.healthLabel}>Replica status</span>
+          <div className={`${styles.healthValue} ${styles.replicaStatusList}`}>
+            {health.replicaStatus.map((status) => (
+              <div key={status.replica} className={styles.replicaStatusRow}>
+                <span className={styles.replicaStatusName}>{REPLICA_LABEL[status.replica]}</span>
+                <span>
+                  {status.hasLatest ? "Latest present" : "Missing latest"} · {status.objectCount} objects
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className={styles.healthRow}>
+          <span className={styles.healthLabel}>Storage vs. free tier</span>
+          <span className={styles.healthValue}>
+            {formatBytes(health.totals.totalSizeBytes)} · {health.totals.objectCount} objects
+          </span>
+        </div>
+      </div>
+
+      <div className={styles.headroomBar}>
+        <div className={headroomFillClass(headroomFraction)} style={{ width: `${headroomFraction * 100}%` }} />
+      </div>
+      <div className={styles.headroomCaption}>
+        {formatBytes(health.totals.totalSizeBytes)} of {formatBytes(tightestLimitBytes)} free-tier headroom used
+        (tightest of the three storage targets)
+      </div>
+    </Card>
+  );
+};
+
+export default BackupHealthCard;

--- a/frontend/app/components/admin/backups/BackupsTab.module.scss
+++ b/frontend/app/components/admin/backups/BackupsTab.module.scss
@@ -1,0 +1,534 @@
+@import '../../../../styles/Variables.module';
+
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.panelHeader {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 16px;
+  font-weight: 600;
+  color: $black-color;
+  margin-bottom: 4px;
+}
+
+.panelIcon {
+  display: inline-block;
+  flex-shrink: 0;
+  width: 18px !important;
+  height: 18px !important;
+  color: $medium-grey-color;
+}
+
+.panelSubhead {
+  font-size: 13px;
+  color: #555;
+  margin-bottom: 12px;
+}
+
+.emptyState {
+  color: $medium-grey-color;
+  font-size: 14px;
+}
+
+.errorState {
+  color: $danger-color;
+  font-size: 14px;
+}
+
+// A `backup-db.yml` run in progress (concurrency: db-backup) locks out a second dispatch --
+// shown across Backup Health and Snapshots so the constraint is visible wherever a write
+// action might otherwise be attempted.
+.lockedBanner {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: $info-bg-color;
+  color: $info-text-color;
+  border-radius: $radius-sm;
+  padding: 8px 12px;
+  font-size: 13px;
+  margin-bottom: 12px;
+}
+
+/* ---------- Backup Health card ---------- */
+
+.healthGrid {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.healthRow {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid $grey-lightest-color;
+
+  &:last-child {
+    padding-bottom: 0;
+    border-bottom: none;
+  }
+
+  @media (width <= $breakpoint-phone) {
+    flex-direction: column;
+    gap: 2px;
+  }
+}
+
+.healthLabel {
+  font-weight: 600;
+  color: $black-color;
+  font-size: 14px;
+}
+
+.healthValue {
+  color: #555;
+  font-size: 14px;
+  text-align: right;
+
+  @media (width <= $breakpoint-phone) {
+    text-align: left;
+  }
+}
+
+// Freshness pill on the "last successful backup" row -- ok (<26h), warn (>=26h), error (>=72h).
+.freshnessPill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 10px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.freshnessOk {
+  background: $success-bg-color;
+  color: $success-text-color;
+}
+
+.freshnessWarn {
+  background: $warning-bg-color;
+  color: $warning-text-color;
+}
+
+.freshnessError {
+  background: $danger-bg-color;
+  color: $danger-color;
+}
+
+.replicaStatusList {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.replicaStatusRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  font-size: 13px;
+  color: #555;
+}
+
+.replicaStatusName {
+  font-family: 'Source Sans Pro', sans-serif;
+  color: $black-color;
+}
+
+// Storage-vs-free-tier headroom bar (Backup Health's totals row).
+.headroomBar {
+  position: relative;
+  height: 6px;
+  border-radius: 999px;
+  background: $grey-lightest-color;
+  overflow: hidden;
+  margin-top: 4px;
+}
+
+.headroomFill {
+  position: absolute;
+  inset: 0;
+  border-radius: 999px;
+  background: $success-text-color;
+}
+
+.headroomFillWarn {
+  background: $warning-text-color;
+}
+
+.headroomFillError {
+  background: $danger-color;
+}
+
+.headroomCaption {
+  font-size: 12px;
+  color: $medium-grey-color;
+  margin-top: 4px;
+}
+
+/* ---------- Snapshots card ---------- */
+
+.tableWrapper {
+  width: 100%;
+
+  @media (width <= $breakpoint-tablet) {
+    overflow-x: auto;
+  }
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+
+  @media (width <= $breakpoint-tablet) {
+    min-width: 760px;
+  }
+
+  th {
+    text-align: left;
+    font-size: 13px;
+    font-weight: 600;
+    color: $medium-grey-color;
+    border-bottom: 1.5px solid $border-divider-color;
+    padding: 0 8px 10px;
+    white-space: nowrap;
+  }
+
+  td {
+    padding: 10px 8px;
+    border-bottom: 1px solid $grey-lightest-color;
+    font-size: 14px;
+    color: $black-color;
+    vertical-align: middle;
+  }
+
+  tr:last-child td {
+    border-bottom: none;
+  }
+}
+
+.row:hover {
+  background: $grey-lightest-color;
+}
+
+.rowSelected {
+  background: $info-bg-color;
+}
+
+.checkboxCell {
+  width: 32px;
+}
+
+.dateCell {
+  white-space: nowrap;
+  color: #555;
+}
+
+.sourceBadge {
+  font-size: 12px;
+  color: $medium-grey-color;
+}
+
+.sizeCell {
+  color: #555;
+  white-space: nowrap;
+}
+
+.versionCell {
+  color: $medium-grey-color;
+  font-size: 13px;
+  white-space: nowrap;
+}
+
+.expiresCell {
+  white-space: nowrap;
+  color: #555;
+}
+
+.expiresNever {
+  color: $medium-grey-color;
+  font-style: italic;
+}
+
+// Tier pill -- three GFS tiers only (daily/monthly/permanent), each its own hue so the
+// Snapshots table reads as GFS at a glance rather than a flat chronological list.
+.tierPill {
+  display: inline-flex;
+  align-items: center;
+  padding: 3px 10px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.tierDaily {
+  background: $info-bg-color;
+  color: $info-text-color;
+}
+
+.tierMonthly {
+  background: #EFE6FB;
+  color: #6A3FA0;
+}
+
+.tierPermanent {
+  background: $grey-lightest-color;
+  color: $navy-color;
+}
+
+// Verified indicator -- meta.json's `verified` boolean is free evidence of 3-2-1-1-0's
+// "0 errors"; an unverified row must read as visually distinct, not just an absent checkmark.
+.verifiedIndicator {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 13px;
+}
+
+.verifiedYes {
+  color: $success-text-color;
+}
+
+.verifiedNo {
+  color: $warning-text-color;
+}
+
+// Replicas column -- three dots, one per storage target, in a fixed gcs-working / gcs-archive /
+// r2 order so a viewer can learn the column's meaning once and read every row the same way.
+.replicaDots {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.replicaDot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: $success-text-color;
+}
+
+.replicaDotMissing {
+  background: $light-grey-color;
+}
+
+.downloadButton {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: #fff;
+  border: 1px solid $grey-border-color;
+  border-radius: 6px;
+  padding: 6px 12px;
+  color: $black-color;
+  font-size: 13px;
+  font-family: 'Source Sans Pro', sans-serif;
+  cursor: pointer;
+  white-space: nowrap;
+
+  &:hover:not(:disabled) {
+    border-color: $medium-grey-color;
+  }
+
+  &:disabled {
+    cursor: default;
+    opacity: 0.6;
+  }
+}
+
+.paginationBar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-top: 14px;
+
+  @media (width <= $breakpoint-phone) {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}
+
+.paginationInfo {
+  font-size: 13px;
+  color: $medium-grey-color;
+}
+
+.paginationControls {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.pageButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 30px;
+  height: 30px;
+  background: #fff;
+  border: 1px solid $grey-border-color;
+  border-radius: 6px;
+  color: $black-color;
+  font-size: 13px;
+  cursor: pointer;
+
+  &:hover:not(:disabled) {
+    border-color: $medium-grey-color;
+  }
+
+  &:disabled {
+    cursor: default;
+    opacity: 0.5;
+  }
+}
+
+.pageButtonActive {
+  background: $navy-color;
+  border-color: $navy-color;
+  color: #fff;
+}
+
+/* ---------- Restore Runbook card ---------- */
+
+.runbookPrereqs {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-bottom: 14px;
+  font-size: 13px;
+  color: #555;
+}
+
+.runbookPrereq {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+}
+
+.runbookCommandBox {
+  position: relative;
+  background: $navy-color;
+  border-radius: $radius-sm;
+  padding: 12px 44px 12px 14px;
+}
+
+.runbookCommand {
+  font-family: Menlo, Monaco, monospace;
+  font-size: 13px;
+  color: #fff;
+  overflow-x: auto;
+  white-space: pre;
+  margin: 0;
+}
+
+.copyButton {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: rgb(255 255 255 / 10%);
+  border: 1px solid rgb(255 255 255 / 25%);
+  border-radius: $radius-sm;
+  color: #fff;
+  cursor: pointer;
+  padding: 4px 6px;
+
+  &:hover {
+    background: rgb(255 255 255 / 20%);
+  }
+}
+
+.copyButtonCopied {
+  background: $success-text-color;
+  border-color: $success-text-color;
+}
+
+.runbookNoSelection {
+  color: $medium-grey-color;
+  font-size: 14px;
+}
+
+/* ---------- Recent Activity card ---------- */
+
+.activityList {
+  display: flex;
+  flex-direction: column;
+}
+
+.activityRow {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 10px 0;
+  border-top: 1px solid $grey-lightest-color;
+
+  &:first-child {
+    border-top: none;
+    padding-top: 0;
+  }
+}
+
+.activityConclusionDot {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  margin-top: 5px;
+}
+
+.activityConclusionSuccess {
+  background: $success-text-color;
+}
+
+.activityConclusionFailure {
+  background: $danger-color;
+}
+
+.activityConclusionInProgress {
+  background: $warning-text-color;
+}
+
+.activityBody {
+  flex: 1;
+  min-width: 0;
+}
+
+.activityTitle {
+  font-size: 14px;
+  color: $black-color;
+  font-weight: 600;
+}
+
+.activityMeta {
+  font-size: 12px;
+  color: $medium-grey-color;
+  margin-top: 2px;
+}
+
+.activityTriggerBadge {
+  display: inline-flex;
+  align-items: center;
+  padding: 1px 8px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 600;
+  background: $grey-lightest-color;
+  color: $medium-grey-color;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+}

--- a/frontend/app/components/admin/backups/BackupsTab.tsx
+++ b/frontend/app/components/admin/backups/BackupsTab.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import React, { useState } from "react";
+import BackupHealthCard from "./BackupHealthCard";
+import SnapshotsCard from "./SnapshotsCard";
+import RestoreRunbookCard from "./RestoreRunbookCard";
+import RecentActivityCard from "./RecentActivityCard";
+import SolidButton from "../../ui/buttons/SolidButton";
+import { generateMockActivityEvents, generateMockBackupHealth, generateMockBackupRows } from "./mockBackups";
+import { useToast } from "../../shared/ToastProvider";
+import styles from "./BackupsTab.module.scss";
+
+// Mock dispatch takes this long before the transient lock clears -- long enough to read the
+// toast, short enough not to feel broken in this UI-only PR.
+const MOCK_DISPATCH_MS = 2500;
+
+/**
+ * Backups admin tab. UI-only in this PR: every data source below is a deterministic mock
+ * fixture (see mockBackups.ts), not a live fetch. Every seam that becomes a real endpoint in
+ * the follow-up API-wiring PR is marked `// TODO(backups-api)`. All state lives here per the
+ * plan's F7 scope -- the four cards below are pure presentational.
+ */
+const BackupsTab: React.FC = () => {
+  // Single `now` anchor for this render tree's lifetime -- matches the pattern the mock
+  // generators require (explicit `now: Date` param, no Date.now() at module scope) and keeps
+  // "Expires in"/freshness/relative-age labels consistent across all four cards on one mount.
+  const [now] = useState(() => new Date());
+
+  // TODO(backups-api): replace with GET /api/admin/backups (rows) once the read-only GCS
+  // listing route lands.
+  const [rows] = useState(() => generateMockBackupRows(now));
+  // TODO(backups-api): replace with GET /api/admin/backups/health.
+  const [health] = useState(() => generateMockBackupHealth(now, rows));
+  // TODO(backups-api): replace with GET /api/admin/backups/activity (GitHub Actions runs API).
+  const [activity] = useState(() => generateMockActivityEvents(now));
+
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [page, setPage] = useState(0);
+
+  // Mirrors the real `concurrency: db-backup` guard: Back Up Now is disabled while a run is
+  // "in flight" so a double-click can't double-dispatch, same invariant the real
+  // workflow_dispatch caller will need (see the plan's follow-up section on correlating runs).
+  const [creating, setCreating] = useState(false);
+  const [lockedBy, setLockedBy] = useState<string | null>(null);
+
+  const { showToast } = useToast();
+
+  const selectedRow = rows.find((row) => row.id === selectedId) ?? null;
+
+  const handleBackUpNow = () => {
+    if (lockedBy) return;
+    setCreating(true);
+    setLockedBy("admin@ithacarecovery.org");
+    showToast({
+      variant: "info",
+      title: "Backup dispatched — runs appear in Recent Activity",
+    });
+
+    // TODO(backups-api): replace with POST /api/admin/backups (workflow_dispatch via a
+    // fine-grained PAT). workflow_dispatch doesn't return a run id -- the real handler must
+    // hold this same optimistic lock while polling for a run carrying the dispatch `reason`.
+    window.setTimeout(() => {
+      setCreating(false);
+      setLockedBy(null);
+    }, MOCK_DISPATCH_MS);
+  };
+
+  const handleDownload = (_id: string) => {
+    // TODO(backups-api): replace with GET /api/admin/backups/:id/download (5-minute V4 signed
+    // URL, audit-logged). No real file transfer happens in this PR.
+    showToast({
+      variant: "info",
+      title: "Signed-URL download arrives with the API wiring PR",
+    });
+  };
+
+  return (
+    <div className={styles.container}>
+      <SolidButton
+        label="Back Up Now"
+        onClick={handleBackUpNow}
+        loading={creating}
+        disabled={!!lockedBy}
+      />
+
+      <BackupHealthCard health={health} now={now} />
+      <SnapshotsCard
+        rows={rows}
+        selectedId={selectedId}
+        onSelect={(id) => setSelectedId((prev) => (prev === id ? null : id))}
+        page={page}
+        onPageChange={setPage}
+        onDownload={handleDownload}
+        now={now}
+      />
+      <RestoreRunbookCard selected={selectedRow} />
+      <RecentActivityCard events={activity} now={now} />
+    </div>
+  );
+};
+
+export default BackupsTab;

--- a/frontend/app/components/admin/backups/RecentActivityCard.tsx
+++ b/frontend/app/components/admin/backups/RecentActivityCard.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import React from "react";
+import Card from "../shared/Card";
+import Icon from "../../ui/displays/Icon";
+import { ActivityConclusion, ActivityEvent } from "../../../../types/backups";
+import styles from "./BackupsTab.module.scss";
+
+interface RecentActivityCardProps {
+  events: ActivityEvent[];
+  /** Reference instant for relative-time labels -- passed in, never read from Date.now() here. */
+  now: Date;
+}
+
+const CONCLUSION_DOT_CLASS: Record<ActivityConclusion, string> = {
+  success: styles.activityConclusionSuccess,
+  failure: styles.activityConclusionFailure,
+  in_progress: styles.activityConclusionInProgress,
+};
+
+const CONCLUSION_LABEL: Record<ActivityConclusion, string> = {
+  success: "succeeded",
+  failure: "failed",
+  in_progress: "in progress",
+};
+
+// GitHub Actions run history IS the audit log for this feature (no separate audit table --
+// see the backups admin tab plan, Part 1). This card is purely presentational: F7 owns the
+// fetch and passes rows shaped like `GET .../actions/workflows/backup-db.yml/runs`.
+const RecentActivityCard: React.FC<RecentActivityCardProps> = ({ events, now }) => (
+  <Card data-testid="backups-recent-activity-panel">
+    <div className={styles.panelHeader}>
+      <Icon name="clock" className={styles.panelIcon} />
+      Recent Activity
+    </div>
+    {events.length === 0 ? (
+      <div className={styles.emptyState}>No backup runs recorded yet.</div>
+    ) : (
+      <ul className={styles.activityList}>
+        {events.map((event) => (
+          <li key={event.id} className={styles.activityRow}>
+            <span
+              className={`${styles.activityConclusionDot} ${CONCLUSION_DOT_CLASS[event.conclusion]}`}
+              aria-hidden="true"
+            />
+            <div className={styles.activityBody}>
+              <div className={styles.activityTitle}>
+                {activityTitle(event)}{" "}
+                <span className={styles.activityTriggerBadge}>{event.trigger === "schedule" ? "Scheduled" : "Manual"}</span>
+              </div>
+              <div className={styles.activityMeta}>
+                {event.actor} · {formatRelativeTime(event.startedAt, now)} · {formatDuration(event.durationSeconds)}
+                {" · "}
+                {CONCLUSION_LABEL[event.conclusion]}
+              </div>
+            </div>
+          </li>
+        ))}
+      </ul>
+    )}
+  </Card>
+);
+
+// "Scheduled backup" for cron-triggered runs, "Manual backup — <reason>" for workflow_dispatch
+// runs that carried an operator-supplied reason (see BackupMeta.reason in types/backups.ts).
+const activityTitle = (event: ActivityEvent): string => {
+  const base = event.trigger === "schedule" ? "Scheduled backup" : "Manual backup";
+  return event.trigger === "workflow_dispatch" && event.reason ? `${base} — ${event.reason}` : base;
+};
+
+// Coarse relative time (minutes/hours/days) -- getTime() diffs against the passed-in `now`
+// only, no Date.now() (would mismatch between server render and client hydration) and no
+// local-timezone Date accessors (banned by the repo's ESLint rule).
+const formatRelativeTime = (isoTimestamp: string, now: Date): string => {
+  const deltaMs = now.getTime() - new Date(isoTimestamp).getTime();
+  const deltaMinutes = Math.round(deltaMs / 60_000);
+  if (deltaMinutes < 1) return "just now";
+  if (deltaMinutes < 60) return `${deltaMinutes}m ago`;
+  const deltaHours = Math.round(deltaMinutes / 60);
+  if (deltaHours < 24) return `${deltaHours}h ago`;
+  const deltaDays = Math.round(deltaHours / 24);
+  return `${deltaDays}d ago`;
+};
+
+const formatDuration = (durationSeconds: number): string => {
+  if (durationSeconds < 60) return `${durationSeconds}s`;
+  const minutes = Math.floor(durationSeconds / 60);
+  const seconds = durationSeconds % 60;
+  return seconds === 0 ? `${minutes}m` : `${minutes}m ${seconds}s`;
+};
+
+export default RecentActivityCard;

--- a/frontend/app/components/admin/backups/RestoreRunbookCard.tsx
+++ b/frontend/app/components/admin/backups/RestoreRunbookCard.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { useState } from "react";
+import type { BackupListRow } from "../../../../types/backups";
+import Card from "../shared/Card";
+import styles from "./BackupsTab.module.scss";
+
+export interface RestoreRunbookCardProps {
+  /** The currently selected Snapshots row, or null when nothing is selected. */
+  selected: BackupListRow | null;
+}
+
+/**
+ * Break-glass restore runbook. Deliberately presentational and non-destructive: there is no
+ * restore endpoint and never will be (see Part 1 of the Backups admin tab plan) — a Vercel
+ * route cannot decrypt an offline-key `.dump.age` artifact. This card only surfaces the
+ * prerequisites and a copy-pasteable `restore-db.sh` invocation for a human to run out-of-band.
+ */
+export default function RestoreRunbookCard({ selected }: RestoreRunbookCardProps) {
+  const [copied, setCopied] = useState(false);
+  const [copyFailed, setCopyFailed] = useState(false);
+
+  // `id` is already `backup-<yyyymmddThhmmssZ>` — the artifact filename is that plus the
+  // `.dump.age` extension (mirrors mockBackups.ts#artifactFileName without importing a
+  // fixture-only module into a real component). RESTORE_TARGET_URL is required (the script
+  // hard-requires a target) and the artifact path is local (./) since it must already be
+  // downloaded before this command can run.
+  const command = selected
+    ? `AGE_IDENTITY_FILE=/path/to/key RESTORE_TARGET_URL=<neon-branch-url> ./frontend/scripts/restore-db.sh ./${selected.id}.dump.age`
+    : null;
+
+  const handleCopy = async () => {
+    if (!command) return;
+    try {
+      await navigator.clipboard.writeText(command);
+      setCopyFailed(false);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Clipboard permissions can be denied/unavailable outside a secure or user-gesture
+      // context -- keep the button un-flipped and tell the operator to select the text by hand.
+      setCopied(false);
+      setCopyFailed(true);
+    }
+  };
+
+  return (
+    <Card>
+      <div className={styles.panelHeader}>Restore Runbook</div>
+      <div className={styles.panelSubhead}>
+        Restoring is a deliberate, out-of-band operation — not a button in this app.
+      </div>
+
+      <ul className={styles.runbookPrereqs}>
+        <li className={styles.runbookPrereq}>
+          <span>1.</span>
+          <span>An <code>age</code> private key (holder A or B).</span>
+        </li>
+        <li className={styles.runbookPrereq}>
+          <span>2.</span>
+          <span>Direct access to the Neon production project.</span>
+        </li>
+        <li className={styles.runbookPrereq}>
+          <span>3.</span>
+          <span>A scratch Neon branch connection string, unpooled — the script refuses <code>-pooler</code> URLs.</span>
+        </li>
+      </ul>
+
+      <div className={styles.panelSubhead}>
+        Full steps: docs/02-handoff/backups-and-recovery.md (break-glass runbook).
+      </div>
+
+      {selected && command ? (
+        <div className={styles.runbookCommandBox}>
+          <pre className={styles.runbookCommand}>{command}</pre>
+          <button
+            type="button"
+            className={`${styles.copyButton} ${copied ? styles.copyButtonCopied : ""}`}
+            onClick={handleCopy}
+            aria-label="Copy restore command"
+            title={copyFailed ? "Copy failed — select the text manually" : undefined}
+          >
+            {copied ? "Copied" : copyFailed ? "Copy failed" : "Copy"}
+          </button>
+        </div>
+      ) : (
+        <div className={styles.runbookNoSelection}>Select a snapshot above to generate its restore command.</div>
+      )}
+    </Card>
+  );
+}

--- a/frontend/app/components/admin/backups/SnapshotsCard.tsx
+++ b/frontend/app/components/admin/backups/SnapshotsCard.tsx
@@ -1,0 +1,238 @@
+"use client";
+
+import React from "react";
+import Icon from "../../ui/displays/Icon";
+import Card from "../shared/Card";
+import CardHeader from "../shared/CardHeader";
+import type { BackupListRow, BackupReplica, BackupTier } from "../../../../types/backups";
+import { ALL_BACKUP_REPLICAS } from "../../../../types/backups";
+import { formatETLongDateTime } from "../../../../util/date/timeUtils";
+import styles from "./BackupsTab.module.scss";
+
+const TIER_LABEL: Record<BackupTier, string> = {
+  daily: "Daily",
+  monthly: "Monthly",
+  permanent: "Permanent",
+};
+
+const TIER_CLASS: Record<BackupTier, string> = {
+  daily: styles.tierDaily,
+  monthly: styles.tierMonthly,
+  permanent: styles.tierPermanent,
+};
+
+const REPLICA_LABEL: Record<BackupReplica, string> = {
+  "gcs-working": "GCS (working)",
+  "gcs-archive": "GCS (archive)",
+  r2: "Cloudflare R2",
+};
+
+const SOURCE_LABEL: Record<BackupListRow["source"], string> = {
+  automatic: "Automatic",
+  manual: "Manual",
+};
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+const DOWNLOAD_TOOLTIP =
+  "Downloads the encrypted .dump.age artifact. Requires the offline age private key to decrypt -- unusable on its own.";
+
+/** Human-readable size (e.g. "4.2 MB", "512 KB") -- no shared formatter exists yet in util/. */
+function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  const kb = bytes / 1024;
+  if (kb < 1024) return `${kb.toFixed(1)} KB`;
+  const mb = kb / 1024;
+  if (mb < 1024) return `${mb.toFixed(1)} MB`;
+  return `${(mb / 1024).toFixed(2)} GB`;
+}
+
+/** "N days" / "today" / "N days ago" for an expiry instant, relative to `now`. */
+function formatExpiresIn(expiresAt: string, now: Date): string {
+  const diffDays = Math.round((new Date(expiresAt).getTime() - now.getTime()) / DAY_MS);
+  if (diffDays <= 0) return "today";
+  if (diffDays === 1) return "1 day";
+  return `${diffDays} days`;
+}
+
+const PAGE_SIZE = 10;
+
+interface SnapshotsCardProps {
+  rows: BackupListRow[];
+  /** Single-select: which row id (if any) drives the Restore Runbook card below. */
+  selectedId: string | null;
+  onSelect: (id: string) => void;
+  page: number;
+  onPageChange: (page: number) => void;
+  onDownload: (id: string) => void;
+  /** Reference instant for "Expires in" -- passed in, never read from Date.now() here. */
+  now: Date;
+}
+
+interface SnapshotRowProps {
+  row: BackupListRow;
+  selected: boolean;
+  onSelect: (id: string) => void;
+  onDownload: (id: string) => void;
+  now: Date;
+}
+
+const SnapshotRow: React.FC<SnapshotRowProps> = ({ row, selected, onSelect, onDownload, now }) => (
+  <tr
+    className={`${styles.row} ${selected ? styles.rowSelected : ""}`}
+    onClick={() => onSelect(row.id)}
+  >
+    <td className={styles.checkboxCell} onClick={(e) => e.stopPropagation()}>
+      <input
+        type="checkbox"
+        checked={selected}
+        aria-label={`Select snapshot from ${formatETLongDateTime(new Date(row.createdAt))}`}
+        onChange={() => onSelect(row.id)}
+      />
+    </td>
+    <td className={styles.dateCell}>{formatETLongDateTime(new Date(row.createdAt))}</td>
+    <td>
+      <span className={`${styles.tierPill} ${TIER_CLASS[row.tier]}`}>{TIER_LABEL[row.tier]}</span>
+    </td>
+    <td className={styles.sourceBadge}>{SOURCE_LABEL[row.source]}</td>
+    <td className={styles.sizeCell}>{formatSize(row.sizeBytes)}</td>
+    <td className={styles.versionCell}>{row.appVersion}</td>
+    <td>
+      <span className={`${styles.verifiedIndicator} ${row.verified ? styles.verifiedYes : styles.verifiedNo}`}>
+        <Icon name={row.verified ? "check" : "warning-circle"} size={14} />
+        {row.verified ? "Verified" : "Unverified"}
+      </span>
+    </td>
+    <td>
+      <span className={styles.replicaDots}>
+        {ALL_BACKUP_REPLICAS.map((replica) => {
+          const present = row.replicas.includes(replica);
+          return (
+            <span
+              key={replica}
+              className={`${styles.replicaDot} ${present ? "" : styles.replicaDotMissing}`}
+              title={present ? `Present in ${REPLICA_LABEL[replica]}` : `Missing from ${REPLICA_LABEL[replica]}`}
+            />
+          );
+        })}
+      </span>
+    </td>
+    <td className={styles.expiresCell}>
+      {row.expiresAt ? (
+        formatExpiresIn(row.expiresAt, now)
+      ) : (
+        <span className={styles.expiresNever}>never</span>
+      )}
+    </td>
+    <td onClick={(e) => e.stopPropagation()}>
+      <button
+        className={styles.downloadButton}
+        title={DOWNLOAD_TOOLTIP}
+        aria-label={`Download encrypted snapshot from ${formatETLongDateTime(new Date(row.createdAt))}`}
+        onClick={() => onDownload(row.id)}
+      >
+        <Icon name="backup" size={14} />
+        Download (encrypted)
+      </button>
+    </td>
+  </tr>
+);
+
+/**
+ * Snapshots table -- pure presentational, all state (rows/selection/paging) owned by the
+ * parent tab. Single-select checkbox drives the Restore Runbook card; onDownload fires a
+ * stub handler in this PR (no real file transfer -- see the tooltip and label wording).
+ */
+const SnapshotsCard: React.FC<SnapshotsCardProps> = ({
+  rows,
+  selectedId,
+  onSelect,
+  page,
+  onPageChange,
+  onDownload,
+  now,
+}) => {
+  const totalPages = Math.max(1, Math.ceil(rows.length / PAGE_SIZE));
+  const clampedPage = Math.min(page, totalPages - 1);
+  const pageRows = rows.slice(clampedPage * PAGE_SIZE, clampedPage * PAGE_SIZE + PAGE_SIZE);
+  const rangeStart = rows.length === 0 ? 0 : clampedPage * PAGE_SIZE + 1;
+  const rangeEnd = Math.min(rows.length, clampedPage * PAGE_SIZE + PAGE_SIZE);
+
+  return (
+    <Card>
+      <CardHeader icon={<Icon name="backup" size={16} />} title={`Snapshots (${rows.length})`} />
+      {rows.length === 0 ? (
+        <div className={styles.emptyState}>No snapshots yet.</div>
+      ) : (
+        <>
+          <div className={styles.tableWrapper}>
+            <table className={styles.table}>
+              <thead>
+                <tr>
+                  <th className={styles.checkboxCell}></th>
+                  <th>Created</th>
+                  <th>Tier</th>
+                  <th>Source</th>
+                  <th>Size</th>
+                  <th>App version</th>
+                  <th>Verified</th>
+                  <th>Replicas</th>
+                  <th>Expires in</th>
+                  <th>Download</th>
+                </tr>
+              </thead>
+              <tbody>
+                {pageRows.map((row) => (
+                  <SnapshotRow
+                    key={row.id}
+                    row={row}
+                    selected={row.id === selectedId}
+                    onSelect={onSelect}
+                    onDownload={onDownload}
+                    now={now}
+                  />
+                ))}
+              </tbody>
+            </table>
+          </div>
+          <div className={styles.paginationBar}>
+            <div className={styles.paginationInfo}>
+              {rangeStart}-{rangeEnd} of {rows.length}
+            </div>
+            <div className={styles.paginationControls}>
+              <button
+                className={styles.pageButton}
+                aria-label="Previous page"
+                disabled={clampedPage === 0}
+                onClick={() => onPageChange(clampedPage - 1)}
+              >
+                <Icon name="drop-up-arrow" size={16} />
+              </button>
+              {Array.from({ length: totalPages }, (_, i) => (
+                <button
+                  key={i}
+                  className={`${styles.pageButton} ${i === clampedPage ? styles.pageButtonActive : ""}`}
+                  aria-label={`Page ${i + 1}`}
+                  aria-current={i === clampedPage ? "page" : undefined}
+                  onClick={() => onPageChange(i)}
+                >
+                  {i + 1}
+                </button>
+              ))}
+              <button
+                className={styles.pageButton}
+                aria-label="Next page"
+                disabled={clampedPage >= totalPages - 1}
+                onClick={() => onPageChange(clampedPage + 1)}
+              >
+                <Icon name="drop-down-arrow" size={16} />
+              </button>
+            </div>
+          </div>
+        </>
+      )}
+    </Card>
+  );
+};
+
+export default SnapshotsCard;

--- a/frontend/app/components/admin/backups/SnapshotsCard.tsx
+++ b/frontend/app/components/admin/backups/SnapshotsCard.tsx
@@ -50,7 +50,10 @@ function formatSize(bytes: number): string {
 /** "N days" / "today" / "N days ago" for an expiry instant, relative to `now`. */
 function formatExpiresIn(expiresAt: string, now: Date): string {
   const diffDays = Math.round((new Date(expiresAt).getTime() - now.getTime()) / DAY_MS);
-  if (diffDays <= 0) return "today";
+  // Deletion is a background sweep that can lag eligibility -- a past expiresAt is a
+  // real state ("eligible, not yet swept"), not the same as expiring today.
+  if (diffDays < 0) return "expired";
+  if (diffDays === 0) return "today";
   if (diffDays === 1) return "1 day";
   return `${diffDays} days`;
 }

--- a/frontend/app/components/admin/backups/mockBackups.ts
+++ b/frontend/app/components/admin/backups/mockBackups.ts
@@ -1,0 +1,283 @@
+// Deterministic GFS-shaped fixtures for the Backups admin tab. UI-only in this PR — every
+// generator takes an explicit `now: Date` argument rather than reading Date.now()/Math.random()
+// at call time, so SSR and tests render the exact same fixture on every run (the repo also bans
+// local-timezone Date APIs via ESLint — all construction below is UTC-anchored via Date.UTC).
+import type {
+  ActivityConclusion,
+  ActivityEvent,
+  ActivityTrigger,
+  BackupFreshness,
+  BackupHealth,
+  BackupListRow,
+  BackupMeta,
+  BackupReplica,
+  BackupReplicaStatus,
+  BackupSource,
+  BackupTier,
+} from "../../../../types/backups";
+import { ALL_BACKUP_REPLICAS } from "../../../../types/backups";
+
+// The workflow's actual cron: `17 1,7,13,19 * * *` UTC — four runs/day, 6h apart.
+const CRON_HOURS_UTC = [1, 7, 13, 19];
+const HOUR_MS = 60 * 60 * 1000;
+const DAY_MS = 24 * HOUR_MS;
+
+const DAILY_EXPIRY_DAYS = 21;
+const MONTHLY_EXPIRY_DAYS = 407;
+
+const GCS_WORKING_BUCKET = "gs://icr-db-backups-prod";
+const GCS_ARCHIVE_BUCKET = "gs://icr-db-backups-archive";
+const R2_BUCKET = "icr-db-backup-r2";
+
+export const BACKUP_BUCKETS = {
+  "gcs-working": GCS_WORKING_BUCKET,
+  "gcs-archive": GCS_ARCHIVE_BUCKET,
+  r2: R2_BUCKET,
+} satisfies Record<BackupReplica, string>;
+
+/** Small pseudo-random generator seeded by index — deterministic across runs, unlike Math.random(). */
+function seededFraction(seed: number): number {
+  const x = Math.sin(seed * 12.9898) * 43758.5453;
+  return x - Math.floor(x);
+}
+
+function hexDigits(seed: number, length: number): string {
+  let out = "";
+  for (let i = 0; i < length; i += 1) {
+    out += Math.floor(seededFraction(seed * 97 + i) * 16).toString(16);
+  }
+  return out;
+}
+
+function pad(n: number, width: number): string {
+  return String(n).padStart(width, "0");
+}
+
+/** `yyyymmddThhmmssZ`, the timestamp format baked into every artifact filename. */
+function formatArtifactTimestamp(date: Date): string {
+  return (
+    `${date.getUTCFullYear()}${pad(date.getUTCMonth() + 1, 2)}${pad(date.getUTCDate(), 2)}` +
+    `T${pad(date.getUTCHours(), 2)}${pad(date.getUTCMinutes(), 2)}${pad(date.getUTCSeconds(), 2)}Z`
+  );
+}
+
+function backupId(date: Date): string {
+  return `backup-${formatArtifactTimestamp(date)}`;
+}
+
+export function artifactFileName(row: Pick<BackupMeta, "createdAt">): string {
+  return `${backupId(new Date(row.createdAt))}.dump.age`;
+}
+
+/** Mirrors the real GFS deletion rule: daily deletes at 21d, monthly at 407d, permanent never. */
+export function computeExpiresAt(tier: BackupTier, createdAt: string): string | null {
+  if (tier === "permanent") return null;
+  const days = tier === "daily" ? DAILY_EXPIRY_DAYS : MONTHLY_EXPIRY_DAYS;
+  return new Date(new Date(createdAt).getTime() + days * DAY_MS).toISOString();
+}
+
+/** Most recent cron slot at or before `from`, per `17 1,7,13,19 * * *` UTC. */
+function latestCronSlotAtOrBefore(from: Date): Date {
+  const d = new Date(Date.UTC(from.getUTCFullYear(), from.getUTCMonth(), from.getUTCDate(), 0, 17, 0));
+  let best: Date | null = null;
+  for (const h of CRON_HOURS_UTC) {
+    const candidate = new Date(Date.UTC(from.getUTCFullYear(), from.getUTCMonth(), from.getUTCDate(), h, 17, 0));
+    if (candidate.getTime() <= from.getTime() && (!best || candidate.getTime() > best.getTime())) {
+      best = candidate;
+    }
+  }
+  if (best) return best;
+  // Every slot today is still ahead of `from` — fall back to yesterday's last (19:17) slot.
+  const yesterday = new Date(d.getTime() - DAY_MS);
+  return new Date(Date.UTC(yesterday.getUTCFullYear(), yesterday.getUTCMonth(), yesterday.getUTCDate(), 19, 17, 0));
+}
+
+function stepBackOneCronSlot(from: Date): Date {
+  return latestCronSlotAtOrBefore(new Date(from.getTime() - 1));
+}
+
+interface BuildRowOptions {
+  index: number;
+  createdAt: Date;
+  tier: BackupTier;
+  source?: BackupSource;
+  verified?: boolean;
+  replicas?: BackupReplica[];
+}
+
+const SAMPLE_ROW_COUNTS: Record<string, number> = {
+  meetings: 812,
+  users: 46,
+  suspensions: 3,
+  conflicts: 1,
+};
+
+function buildRow({ index, createdAt, tier, source = "automatic", verified = true, replicas = [...ALL_BACKUP_REPLICAS] }: BuildRowOptions): BackupListRow {
+  const createdAtIso = createdAt.toISOString();
+  const id = backupId(createdAt);
+  const triggeredBy = source === "manual" ? "admin@ithacarecovery.org" : null;
+  // ~3-8 MB, deterministic per row rather than a fixed constant, so the Size column isn't
+  // visually identical across every fixture row.
+  const sizeBytes = Math.round((3 + seededFraction(index) * 5) * 1024 * 1024);
+
+  const meta: BackupMeta = {
+    id,
+    createdAt: createdAtIso,
+    tier,
+    source,
+    triggeredBy,
+    reason: source === "manual" ? "Pre-deploy safety snapshot" : null,
+    sizeBytes,
+    sha256: hexDigits(index, 64),
+    pgVersion: "16.4",
+    appVersion: "2026.8.1",
+    gitSha: hexDigits(index + 1000, 7),
+    ageRecipients: [`age1${hexDigits(index + 2000, 58)}`, `age1${hexDigits(index + 3000, 58)}`],
+    rowCounts: SAMPLE_ROW_COUNTS,
+    verified,
+    verificationMode: "structural",
+    verifiedAt: verified ? new Date(createdAt.getTime() + 15 * 60 * 1000).toISOString() : null,
+  };
+
+  return {
+    ...meta,
+    replicas,
+    expiresAt: computeExpiresAt(tier, createdAtIso),
+  };
+}
+
+/**
+ * GFS-shaped snapshot inventory: ~14 daily rows (4/day cadence), 13 monthly rows, 1 permanent
+ * row, plus the required edge cases — one unverified row, one single-replica row, and one row
+ * missing from exactly one of the three storage targets.
+ */
+export function generateMockBackupRows(now: Date): BackupListRow[] {
+  const rows: BackupListRow[] = [];
+
+  // Daily tier: walk backward one cron slot (6h) at a time from the most recent run.
+  let cursor = latestCronSlotAtOrBefore(now);
+  for (let i = 0; i < 14; i += 1) {
+    let replicas: BackupReplica[] = [...ALL_BACKUP_REPLICAS];
+    let verified = true;
+    if (i === 3) {
+      // Required edge case: unverified row (structural check hasn't landed yet for this run).
+      verified = false;
+    }
+    if (i === 6) {
+      // Required edge case: single-replica row (only the working bucket got the upload before
+      // a transient archive/R2 failure).
+      replicas = ["gcs-working"];
+    }
+    if (i === 9) {
+      // Required edge case: missing from exactly one of the three targets.
+      replicas = ["gcs-working", "gcs-archive"];
+    }
+    rows.push(buildRow({ index: i, createdAt: cursor, tier: "daily", source: i === 5 ? "manual" : "automatic", verified, replicas }));
+    cursor = stepBackOneCronSlot(cursor);
+  }
+
+  // Monthly tier: one row roughly every 30 days, continuing further back than the dailies.
+  let monthlyCursor = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1, 1, 17, 0));
+  if (monthlyCursor.getTime() > now.getTime() - 30 * DAY_MS) {
+    monthlyCursor = new Date(monthlyCursor.getTime() - 30 * DAY_MS);
+  }
+  for (let i = 0; i < 13; i += 1) {
+    rows.push(buildRow({ index: i + 100, createdAt: monthlyCursor, tier: "monthly" }));
+    monthlyCursor = new Date(monthlyCursor.getTime() - 30 * DAY_MS);
+  }
+
+  // Permanent tier: a single manually-pinned row, oldest of all.
+  const permanentAt = new Date(monthlyCursor.getTime() - 60 * DAY_MS);
+  rows.push(
+    buildRow({
+      index: 999,
+      createdAt: permanentAt,
+      tier: "permanent",
+      source: "manual",
+    }),
+  );
+
+  return rows.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+}
+
+export function freshnessFor(lastSuccessfulBackupAt: string, now: Date): BackupFreshness {
+  const ageHours = (now.getTime() - new Date(lastSuccessfulBackupAt).getTime()) / HOUR_MS;
+  if (ageHours >= 72) return "error";
+  if (ageHours >= 26) return "warn";
+  return "ok";
+}
+
+/** Next cron fire time strictly after `now`, per `17 1,7,13,19 * * *` UTC. */
+export function nextScheduledRunAfter(now: Date): string {
+  let candidate = new Date(latestCronSlotAtOrBefore(now).getTime());
+  while (candidate.getTime() <= now.getTime()) {
+    candidate = new Date(candidate.getTime() + 6 * HOUR_MS);
+  }
+  return candidate.toISOString();
+}
+
+const FREE_TIER_LIMITS = {
+  // GCS Standard free tier: 5 GB-months regional storage.
+  gcsWorkingBytes: 5 * 1024 * 1024 * 1024,
+  gcsArchiveBytes: 5 * 1024 * 1024 * 1024,
+  // R2's free tier: 10 GB-months.
+  r2Bytes: 10 * 1024 * 1024 * 1024,
+};
+
+/** Derives BackupHealth from a fixture row set — mirrors how the real API composes it from
+ * a GCS/R2 listing plus the latest workflow run, so Wave 1 components see realistic shapes. */
+export function generateMockBackupHealth(now: Date, rows: BackupListRow[] = generateMockBackupRows(now)): BackupHealth {
+  const latest = rows[0];
+  const lastSuccessfulBackupAt = latest ? latest.createdAt : null;
+
+  const replicaStatus: BackupReplicaStatus[] = ALL_BACKUP_REPLICAS.map((replica) => ({
+    replica,
+    objectCount: rows.filter((r) => r.replicas.includes(replica)).length,
+    hasLatest: latest ? latest.replicas.includes(replica) : false,
+  }));
+
+  const totals = rows.reduce(
+    (acc, r) => ({
+      objectCount: acc.objectCount + 1,
+      totalSizeBytes: acc.totalSizeBytes + r.sizeBytes,
+    }),
+    { objectCount: 0, totalSizeBytes: 0 },
+  );
+
+  return {
+    lastSuccessfulBackupAt,
+    freshness: lastSuccessfulBackupAt ? freshnessFor(lastSuccessfulBackupAt, now) : "error",
+    // No quarterly restore drill has run yet — deliberately null, not a fixture bug.
+    lastVerifiedRestoreAt: null,
+    nextScheduledRunAt: nextScheduledRunAfter(now),
+    replicaStatus,
+    totals,
+    freeTierLimits: FREE_TIER_LIMITS,
+  };
+}
+
+const ACTIVITY_ACTORS = ["github-actions[bot]", "admin@ithacarecovery.org"];
+
+/** Recent Activity fixture, shaped like `GET /repos/.../actions/workflows/backup-db.yml/runs`. */
+export function generateMockActivityEvents(now: Date, count = 10): ActivityEvent[] {
+  const events: ActivityEvent[] = [];
+  let cursor = latestCronSlotAtOrBefore(now);
+  for (let i = 0; i < count; i += 1) {
+    const isManual = i === 2;
+    const trigger: ActivityTrigger = isManual ? "workflow_dispatch" : "schedule";
+    // One deterministic failure in the middle of the window so the empty/degraded state is
+    // exercised without every row reading as uniformly healthy.
+    const conclusion: ActivityConclusion = i === 4 ? "failure" : "success";
+    events.push({
+      id: `run-${formatArtifactTimestamp(cursor)}`,
+      trigger,
+      actor: isManual ? ACTIVITY_ACTORS[1] : ACTIVITY_ACTORS[0],
+      conclusion,
+      startedAt: cursor.toISOString(),
+      durationSeconds: Math.round(40 + seededFraction(i + 500) * 90),
+      reason: isManual ? "Pre-deploy safety snapshot" : null,
+    });
+    cursor = stepBackOneCronSlot(cursor);
+  }
+  return events;
+}

--- a/frontend/app/components/admin/diagnostics/SystemStatusCard.tsx
+++ b/frontend/app/components/admin/diagnostics/SystemStatusCard.tsx
@@ -6,7 +6,7 @@ import Icon from "../../ui/displays/Icon";
 import Card from "../shared/Card";
 import TopLoadingBar from "../../ui/displays/TopLoadingBar";
 import DiagnosticsCardError from "./DiagnosticsCardError";
-import { formatETLongDate } from "../../../../util/date/timeUtils";
+import { formatETLongDateTime } from "../../../../util/date/timeUtils";
 import styles from "./DiagnosticsTab.module.scss";
 
 interface SystemStatusCardProps {
@@ -175,7 +175,7 @@ const SystemStatusCard: React.FC<SystemStatusCardProps> = ({ email, role }) => {
           <span className={styles.statusValue}>
             v{data.application.version}
             {data.application.deployedAt
-              ? ` · deployed ${formatETLongDate(new Date(data.application.deployedAt))}`
+              ? ` · deployed ${formatETLongDateTime(new Date(data.application.deployedAt))}`
               : ""}
           </span>
         </div>

--- a/frontend/app/components/admin/diagnostics/SystemStatusCard.tsx
+++ b/frontend/app/components/admin/diagnostics/SystemStatusCard.tsx
@@ -6,6 +6,7 @@ import Icon from "../../ui/displays/Icon";
 import Card from "../shared/Card";
 import TopLoadingBar from "../../ui/displays/TopLoadingBar";
 import DiagnosticsCardError from "./DiagnosticsCardError";
+import { formatETLongDate } from "../../../../util/date/timeUtils";
 import styles from "./DiagnosticsTab.module.scss";
 
 interface SystemStatusCardProps {
@@ -22,6 +23,7 @@ interface SystemStatusData {
     hostPool: Record<string, { ok: boolean; licensed: boolean | null }>;
   };
   session: { email: string | null; role: Role | null };
+  application: { version: string; deployedAt: string | null };
 }
 
 const roleLabel: Record<string, string> = {
@@ -164,6 +166,19 @@ const SystemStatusCard: React.FC<SystemStatusCardProps> = ({ email, role }) => {
           <span className={styles.statusValue}>{email}</span>
         </div>
         <div className={styles.statusDetail}>{roleLabel[role] ?? role}</div>
+      </div>
+
+      <div className={styles.statusBlock}>
+        <div className={styles.statusRow}>
+          <span className={`${styles.dot} ${styles.dotOk}`} />
+          <span className={styles.statusLabel}>Application</span>
+          <span className={styles.statusValue}>
+            v{data.application.version}
+            {data.application.deployedAt
+              ? ` · deployed ${formatETLongDate(new Date(data.application.deployedAt))}`
+              : ""}
+          </span>
+        </div>
       </div>
     </Card>
   );

--- a/frontend/app/components/ui/buttons/SolidButton.module.scss
+++ b/frontend/app/components/ui/buttons/SolidButton.module.scss
@@ -1,0 +1,57 @@
+@import '../../../../styles/Variables.module';
+
+.solidButton {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    padding: 10px 20px;
+    border: none;
+    border-radius: $radius-md;
+    font-size: 14px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background-color 0.2s, opacity 0.2s;
+
+    &:disabled {
+        cursor: not-allowed;
+        opacity: 0.6;
+    }
+}
+
+.primary {
+    background-color: $brand-pink-color;
+    color: $white-color;
+
+    &:hover:not(:disabled) {
+        background-color: $brand-pink-secondary;
+    }
+}
+
+.danger {
+    background-color: $danger-color;
+    color: $white-color;
+
+    &:hover:not(:disabled) {
+        opacity: 0.85;
+    }
+}
+
+.label {
+    white-space: nowrap;
+}
+
+.spinner {
+    width: 14px;
+    height: 14px;
+    border: 2px solid rgb(255 255 255 / 50%);
+    border-top-color: $white-color;
+    border-radius: 50%;
+    animation: spin 0.6s linear infinite;
+}
+
+@keyframes spin {
+    to {
+        transform: rotate(360deg);
+    }
+}

--- a/frontend/app/components/ui/buttons/SolidButton.tsx
+++ b/frontend/app/components/ui/buttons/SolidButton.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import React from "react";
+import styles from "./SolidButton.module.scss";
+
+interface SolidButtonProps {
+    label: string;
+    onClick?: () => void;
+    variant?: "primary" | "danger";
+    loading?: boolean;
+    disabled?: boolean;
+    type?: "button" | "submit";
+    className?: string;
+}
+
+const SolidButton: React.FC<SolidButtonProps> = ({
+    label,
+    onClick,
+    variant = "primary",
+    loading = false,
+    disabled = false,
+    type = "button",
+    className,
+}) => {
+    const variantClass = variant === "danger" ? styles.danger : styles.primary;
+
+    // A mouse click leaves the button focused, keeping its focus ring showing after the
+    // interaction is done. e.detail is 0 for a "click" synthesized by keyboard activation
+    // (Enter/Space) and >0 for a real pointer click, so this only drops focus for the mouse
+    // case -- tabbing to the button still shows a focus ring until the user tabs away.
+    const handleClick: React.MouseEventHandler<HTMLButtonElement> = (e) => {
+        if (e.detail > 0) {
+            e.currentTarget.blur();
+        }
+        onClick?.();
+    };
+
+    return (
+        <button
+            type={type}
+            className={[styles.solidButton, variantClass, loading ? styles.loading : "", className]
+                .filter(Boolean)
+                .join(" ")}
+            onClick={handleClick}
+            disabled={disabled || loading}
+            aria-busy={loading}
+        >
+            {loading && <span className={styles.spinner} aria-hidden="true" />}
+            <span className={styles.label}>{label}</span>
+        </button>
+    );
+};
+
+export default SolidButton;

--- a/frontend/app/components/ui/buttons/SolidButton.tsx
+++ b/frontend/app/components/ui/buttons/SolidButton.tsx
@@ -38,7 +38,7 @@ const SolidButton: React.FC<SolidButtonProps> = ({
     return (
         <button
             type={type}
-            className={[styles.solidButton, variantClass, loading ? styles.loading : "", className]
+            className={[styles.solidButton, variantClass, className]
                 .filter(Boolean)
                 .join(" ")}
             onClick={handleClick}

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -1,5 +1,11 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  // Stamped once at build time (not per-request) -- powers the Diagnostics Application row's
+  // "deployed {date}" display. Evaluated here in config, which only runs at build, so this is
+  // exempt from the local-timezone Date rule that applies to runtime app code.
+  env: {
+    NEXT_PUBLIC_BUILD_DATE: new Date().toISOString(),
+  },
   // Lets a phone on the same LAN connect to the dev server's HMR websocket -- Next.js blocks
   // cross-origin dev requests by default. Set DEV_LAN_ORIGIN in .env.local (gitignored) to your
   // machine's LAN IP; unset in prod/CI so this is a no-op there.

--- a/frontend/tests/component/BackupsTab.test.tsx
+++ b/frontend/tests/component/BackupsTab.test.tsx
@@ -1,0 +1,169 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import BackupsTab from "../../app/components/admin/backups/BackupsTab";
+import BackupHealthCard from "../../app/components/admin/backups/BackupHealthCard";
+import { ToastProvider } from "../../app/components/shared/ToastProvider";
+import {
+  freshnessFor,
+  generateMockBackupHealth,
+  generateMockBackupRows,
+} from "../../app/components/admin/backups/mockBackups";
+import type { BackupHealth, BackupListRow } from "../../types/backups";
+
+// BackupsTab seeds its own `now` via `useState(() => new Date())` -- pin the system clock so
+// every card (freshness pill, "Expires in", next-run) renders deterministically under TZ=UTC.
+const FIXED_NOW = new Date("2026-08-15T12:00:00Z");
+
+const renderTab = () =>
+  render(
+    <ToastProvider>
+      <BackupsTab />
+    </ToastProvider>
+  );
+
+beforeEach(() => {
+  jest.useFakeTimers().setSystemTime(FIXED_NOW);
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+describe("BackupsTab", () => {
+  it("renders all four cards with the mock fixture", () => {
+    renderTab();
+    expect(screen.getByText("Backup Health")).toBeInTheDocument();
+    expect(screen.getByText(/^Snapshots \(\d+\)$/)).toBeInTheDocument();
+    expect(screen.getByText("Restore Runbook")).toBeInTheDocument();
+    expect(screen.getByText("Recent Activity")).toBeInTheDocument();
+  });
+
+  it("shows the unverified row with the verifiedNo treatment (index 3 of the fixture)", () => {
+    renderTab();
+    const unverifiedBadges = screen.getAllByText("Unverified");
+    expect(unverifiedBadges.length).toBeGreaterThan(0);
+    // The fixture guarantees exactly one unverified row among the dailies.
+    expect(unverifiedBadges).toHaveLength(1);
+  });
+
+  it("renders a missing replica dot for the single-replica row (index 6 of the fixture)", () => {
+    const rows = generateMockBackupRows(FIXED_NOW);
+    const singleReplicaRow = rows.find((row) => row.replicas.length === 1);
+    expect(singleReplicaRow).toBeDefined();
+
+    renderTab();
+    // The single-replica row contributes 2 "Missing from" dots, the two-replica row
+    // contributes 1 -- both are on the first (default) page alongside the fixture's other rows.
+    const missingDots = screen.getAllByTitle(/^Missing from /);
+    expect(missingDots).toHaveLength(3);
+  });
+
+  it("fixture contains both a single-replica and a two-replica (one-missing) row", () => {
+    const rows = generateMockBackupRows(FIXED_NOW);
+    const replicaCounts = rows.map((row) => row.replicas.length);
+    expect(replicaCounts).toContain(1);
+    expect(replicaCounts).toContain(2);
+  });
+
+  it("shows 'never' for the permanent row's expiry", () => {
+    const rows = generateMockBackupRows(FIXED_NOW);
+    const permanentRow = rows.find((row) => row.tier === "permanent");
+    expect(permanentRow).toBeDefined();
+    expect(permanentRow!.expiresAt).toBeNull();
+
+    renderTab();
+    // The permanent row is the oldest of 28 fixture rows (10/page) -- page to the last page
+    // where it lives before asserting its "never" expiry.
+    fireEvent.click(screen.getByLabelText(`Page ${Math.ceil(rows.length / 10)}`));
+    expect(screen.getByText("never")).toBeInTheDocument();
+  });
+
+  it("selecting a snapshot populates the Restore Runbook command with its artifact filename", () => {
+    renderTab();
+    expect(
+      screen.getByText("Select a snapshot above to generate its restore command.")
+    ).toBeInTheDocument();
+
+    const rows = generateMockBackupRows(FIXED_NOW);
+    const firstRow = rows[0];
+    const checkboxes = screen.getAllByLabelText(/Select snapshot from /i);
+    fireEvent.click(checkboxes[0]);
+
+    const commandBox = screen.getByText(new RegExp(`${firstRow.id}\\.dump\\.age`));
+    expect(commandBox).toBeInTheDocument();
+  });
+
+  it("clicking a selected row's checkbox again unselects it", () => {
+    renderTab();
+    const checkboxes = screen.getAllByLabelText(/Select snapshot from /i);
+
+    fireEvent.click(checkboxes[0]);
+    expect(
+      screen.queryByText("Select a snapshot above to generate its restore command.")
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(checkboxes[0]);
+    expect(
+      screen.getByText("Select a snapshot above to generate its restore command.")
+    ).toBeInTheDocument();
+  });
+
+  it("disables Back Up Now while creating/lockedBy is set, and fires the dispatched toast", () => {
+    renderTab();
+    const button = screen.getByRole("button", { name: "Back Up Now" });
+    expect(button).not.toBeDisabled();
+
+    fireEvent.click(button);
+
+    expect(button).toBeDisabled();
+    expect(button).toHaveAttribute("aria-busy", "true");
+    expect(
+      screen.getByText("Backup dispatched — runs appear in Recent Activity")
+    ).toBeInTheDocument();
+  });
+
+  it("Download button is labeled 'Download (encrypted)' and fires the stub toast", () => {
+    renderTab();
+    const downloadButtons = screen.getAllByText("Download (encrypted)");
+    expect(downloadButtons.length).toBeGreaterThan(0);
+
+    fireEvent.click(downloadButtons[0]);
+
+    expect(
+      screen.getByText("Signed-URL download arrives with the API wiring PR")
+    ).toBeInTheDocument();
+  });
+});
+
+describe("BackupHealthCard freshness pill", () => {
+  const buildHealth = (ageHours: number): BackupHealth => {
+    const lastSuccessfulBackupAt = new Date(
+      FIXED_NOW.getTime() - ageHours * 60 * 60 * 1000
+    ).toISOString();
+    return {
+      ...generateMockBackupHealth(FIXED_NOW, [] as BackupListRow[]),
+      lastSuccessfulBackupAt,
+      freshness: freshnessFor(lastSuccessfulBackupAt, FIXED_NOW),
+    };
+  };
+
+  it("renders 'Healthy' just under the 26h warn boundary", () => {
+    render(<BackupHealthCard health={buildHealth(25.9)} now={FIXED_NOW} />);
+    expect(screen.getByText("Healthy")).toBeInTheDocument();
+  });
+
+  it("renders 'Aging' at exactly the 26h warn boundary", () => {
+    render(<BackupHealthCard health={buildHealth(26)} now={FIXED_NOW} />);
+    expect(screen.getByText("Aging")).toBeInTheDocument();
+  });
+
+  it("renders 'Aging' just under the 72h error boundary", () => {
+    render(<BackupHealthCard health={buildHealth(71.9)} now={FIXED_NOW} />);
+    expect(screen.getByText("Aging")).toBeInTheDocument();
+  });
+
+  it("renders 'Stale' at exactly the 72h error boundary", () => {
+    render(<BackupHealthCard health={buildHealth(72)} now={FIXED_NOW} />);
+    expect(screen.getByText("Stale")).toBeInTheDocument();
+  });
+});

--- a/frontend/tests/e2e/18-backups-tab.spec.ts
+++ b/frontend/tests/e2e/18-backups-tab.spec.ts
@@ -1,0 +1,55 @@
+import { test, expect } from "./support/fixtures";
+import { loginAs } from "./support/auth";
+
+// Backups admin tab (see ithaca-recovery-backups-admin-tab-plan.md). UI-only in this PR --
+// mock-data-driven, gated to non-production builds via AdminShell's NODE_ENV guard (`yarn dev`
+// runs with NODE_ENV=development, which is what CI's e2e pass exercises). The component test
+// carries case-by-case detail (freshness thresholds, verified/replica edge cases, runbook
+// command); this spec only covers visibility and the one write action.
+
+test.describe("backups tab", () => {
+  test("Super Admin sees the Backups tab in dev, with all four cards", async ({ superAdminPage }) => {
+    const { page } = superAdminPage;
+    await page.goto("/admin");
+    await expect(page.getByTestId("admin-tab-backups")).toBeEnabled();
+    await page.getByTestId("admin-tab-backups").click();
+
+    await expect(page.getByText("Backup Health")).toBeVisible();
+    await expect(page.getByText(/^Snapshots \(\d+\)$/)).toBeVisible();
+    await expect(page.getByText("Restore Runbook")).toBeVisible();
+    await expect(page.getByTestId("backups-recent-activity-panel").getByText("Recent Activity")).toBeVisible();
+  });
+
+  // Matches the shell's established superAdminOnly treatment (see 1.8: Users/Export):
+  // the tab renders visible-but-locked for a plain Admin, not absent.
+  test("a plain Admin sees the Backups tab locked", async ({ adminPage }) => {
+    const { page } = adminPage;
+    await page.goto("/admin");
+    await expect(page.getByTestId("admin-tab-backups")).toBeDisabled();
+  });
+
+  test("an unauthenticated visitor does not see the Backups tab (redirected off /admin entirely)", async ({
+    page,
+  }) => {
+    await page.goto("/admin");
+    await expect(page.getByTestId("admin-tab-backups")).toHaveCount(0);
+  });
+
+  test("a signed-in non-admin does not see the Backups tab", async ({ page, context }) => {
+    await loginAs(context, "not-an-admin@test.icr");
+    await page.goto("/admin");
+    await expect(page.getByTestId("admin-tab-backups")).toHaveCount(0);
+  });
+
+  test("Back Up Now dispatches and shows its toast", async ({ superAdminPage }) => {
+    const { page } = superAdminPage;
+    await page.goto("/admin");
+    await page.getByTestId("admin-tab-backups").click();
+
+    const backUpButton = page.getByRole("button", { name: "Back Up Now" });
+    await backUpButton.click();
+
+    await expect(backUpButton).toBeDisabled();
+    await expect(page.getByText("Backup dispatched — runs appear in Recent Activity")).toBeVisible();
+  });
+});

--- a/frontend/types/backups.ts
+++ b/frontend/types/backups.ts
@@ -1,0 +1,112 @@
+// Mirrors the backup feature's meta.json sidecar (see
+// ithaca-recovery-backup-feature-plan.md) plus the response shapes the Backups admin tab
+// consumes. UI-only in this PR — shapes are consumed by mockBackups.ts today and by the
+// real /api/admin/backups* routes in the follow-up PR, so keep them in lockstep with the
+// sidecar the backup workflow actually writes, not with the older design brief wording.
+
+/** GFS retention tier. Only three tiers exist — no weekly, no yearly. */
+export type BackupTier = "daily" | "monthly" | "permanent";
+
+/** How a backup run was triggered. */
+export type BackupSource = "automatic" | "manual";
+
+/** Verification is always structural today (schema/row-count checks in a scratch container). */
+export type VerificationMode = "structural";
+
+/**
+ * Shape of the `<id>.meta.json` sidecar written next to every `.dump.age` artifact.
+ * INVARIANT: no `replicas` field here — a sidecar is written before upload to any storage
+ * target, so it cannot honestly claim replica presence. Replica presence is computed
+ * server-side from per-target listings and lives on {@link BackupListRow} instead.
+ */
+export interface BackupMeta {
+  id: string;
+  createdAt: string;
+  tier: BackupTier;
+  source: BackupSource;
+  triggeredBy: string | null;
+  reason: string | null;
+  sizeBytes: number;
+  sha256: string;
+  pgVersion: string;
+  appVersion: string;
+  gitSha: string;
+  ageRecipients: [string, string];
+  rowCounts: Record<string, number>;
+  verified: boolean;
+  verificationMode: VerificationMode;
+  verifiedAt: string | null;
+}
+
+/** One of the three storage targets a backup artifact is replicated to. */
+export type BackupReplica = "gcs-working" | "gcs-archive" | "r2";
+
+/** All three replica targets, in the order the Snapshots table displays them. */
+export const ALL_BACKUP_REPLICAS: readonly BackupReplica[] = ["gcs-working", "gcs-archive", "r2"];
+
+/**
+ * One row of the Snapshots table: the sidecar plus server-computed fields that can't live
+ * in the sidecar itself (replica presence, derived expiry).
+ */
+export interface BackupListRow extends BackupMeta {
+  /** Which of the three storage targets currently hold this artifact's object. */
+  replicas: BackupReplica[];
+  /** ISO timestamp this row is eligible for GFS deletion, or null for the permanent tier. */
+  expiresAt: string | null;
+}
+
+export interface BackupListResponse {
+  rows: BackupListRow[];
+  total: number;
+}
+
+/** Freshness state of the most recent successful backup, thresholded off its age. */
+export type BackupFreshness = "ok" | "warn" | "error";
+
+export interface BackupReplicaStatus {
+  replica: BackupReplica;
+  /** Object count currently visible in this target's listing. */
+  objectCount: number;
+  /** True if the most recent backup row is present in this target. */
+  hasLatest: boolean;
+}
+
+export interface BackupHealth {
+  lastSuccessfulBackupAt: string | null;
+  freshness: BackupFreshness;
+  /** Null until a quarterly restore drill has actually run once. */
+  lastVerifiedRestoreAt: string | null;
+  /** Next cron fire time, derived from `17 1,7,13,19 * * *` (UTC). */
+  nextScheduledRunAt: string;
+  replicaStatus: BackupReplicaStatus[];
+  totals: {
+    objectCount: number;
+    totalSizeBytes: number;
+  };
+  /** Free-tier ceilings the totals above are measured against, for headroom display. */
+  freeTierLimits: {
+    gcsWorkingBytes: number;
+    gcsArchiveBytes: number;
+    r2Bytes: number;
+  };
+}
+
+/** How a `backup-db.yml` run was triggered — mirrors the GitHub Actions runs API. */
+export type ActivityTrigger = "schedule" | "workflow_dispatch";
+
+export type ActivityConclusion = "success" | "failure" | "in_progress";
+
+/** One row of the Recent Activity card, shaped like a GitHub Actions workflow run. */
+export interface ActivityEvent {
+  id: string;
+  trigger: ActivityTrigger;
+  actor: string;
+  conclusion: ActivityConclusion;
+  startedAt: string;
+  durationSeconds: number;
+  reason: string | null;
+}
+
+export interface ActivityListResponse {
+  events: ActivityEvent[];
+}

--- a/frontend/util/date/timeUtils.ts
+++ b/frontend/util/date/timeUtils.ts
@@ -184,6 +184,19 @@ const etLongDateFmt = new Intl.DateTimeFormat('en-US', {
 /** ET long-form prose date (e.g. "August 14, 2026") for a given instant. */
 export const formatETLongDate = (date: Date): string => etLongDateFmt.format(date);
 
+// "2:05 PM" -- pinned ET, for pairing with formatETLongDate where same-day rows would
+// otherwise render byte-identical (e.g. the Backups Snapshots table's Created column).
+const etProseTimeFmt = new Intl.DateTimeFormat('en-US', {
+  timeZone: 'America/New_York', hour: 'numeric', minute: '2-digit', hour12: true,
+});
+
+/** ET time-of-day (e.g. "2:05 PM") for a given instant. */
+export const formatETTime = (date: Date): string => etProseTimeFmt.format(date);
+
+/** ET long-form prose date + time (e.g. "August 14, 2026, 2:05 PM") for a given instant. */
+export const formatETLongDateTime = (date: Date): string =>
+  `${formatETLongDate(date)}, ${formatETTime(date)}`;
+
 /** ET day-of-month (1-31) for a given instant. */
 export const getETDayOfMonth = (date: Date): number => Number(formatETDateString(date).slice(-2));
 


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a Backups administration tab for eligible non-production Super Admins.
  - Added backup health, snapshot, restore guidance, and recent activity views.
  - Added snapshot selection, pagination, status indicators, copyable restore commands, and backup/download feedback.
  - Added application version and deployment date to system diagnostics.
  - Added consistent loading, disabled, primary, and danger button styles.

- **Bug Fixes**
  - Improved date and time display consistency using Eastern Time formatting.

- **Tests**
  - Added component and end-to-end coverage for backup visibility, interactions, statuses, and notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

**Companion to #433** (the backup pipeline) — not stacked (zero file overlap), but best merged after it: the Restore Runbook card points at `docs/02-handoff/backups-and-recovery.md`'s break-glass section and `frontend/scripts/restore-db.sh`, both of which #433 introduces.

## Description
- **`app/components/admin/backups/`** (new feature area): Super-Admin **Backups** tab with four cards — Backup Health (freshness pill with 26h/72h warn/error thresholds, last verified restore, next cron run, per-target replica status, storage-vs-free-tier headroom), Snapshots (9 columns incl. Tier/Verified/Replicas/Expires-in, single-select rows, pagination, "Download (encrypted)" with the offline-key tooltip), Restore Runbook (prerequisites + a copy-paste `restore-db.sh` invocation for the selected snapshot — deliberately **no** in-app restore or upload: a Vercel route can't decrypt an offline-key backup, and the ~4.5 MB body limit blocks uploads regardless), and Recent Activity (shaped on GitHub Actions run history, which is the audit log — no new audit table).
- **UI-only with mock data**: `mockBackups.ts` generates a deterministic GFS-shaped fixture (daily/monthly/permanent tiers, unverified + missing-replica edge cases) matching the backup pipeline's `meta.json` sidecar contract; every mock seam carries a `// TODO(backups-api):` naming its future endpoint (list/health/activity/dispatch/download — fully specified in the plan). SSR-safe: one `now` anchor threads through all cards, no render-time `Date.now()`.
- **`AdminShell.tsx`**: `backups` TabKey between Users and Export, `superAdminOnly` (visible-but-locked for plain Admins, same treatment as Users/Export), and the `allTabs` entry exists only when `NODE_ENV !== "production"` — the tab is absent from production builds until the API-wiring PR flips it on. No feature-flag plumbing remains in the codebase, so this one-line guard is the gate.
- **`ui/buttons/SolidButton`** (new atom): filled primary/danger button with `loading`/`aria-busy` — `TextButton`/`IconButton`/`CheckButton` are all non-filled or icon-only, none fit a primary action button.
- **Diagnostics Application row** (`SystemStatusCard.tsx` + `system-status/route.ts` + `next.config.mjs`): `v2026.8.x · deployed {date}` from `package.json` + build-time `NEXT_PUBLIC_BUILD_DATE`. Also corrected a comment in the route that claimed row order derives from payload key order (the card's top-level rows are hardcoded JSX; only the nested maps render via `Object.entries`).
- **`util/date/timeUtils.ts`**: added `formatETTime`/`formatETLongDateTime` (ET-pinned date+time) so 4-runs-per-day snapshot rows have distinct display text and unique accessible names.

**For reviewer ratification** (invented locally, no spec source): the headroom bar's 70%/90% warn/error fractions and its `Math.min`-of-three-ceilings aggregation (BackupHealthCard); `NEXT_PUBLIC_BUILD_DATE` is build-time, labeled "deployed" (minutes apart on Vercel); the Backups subtree remains in the production bundle (unreachable — the tab entry and render gate both require dev; `next/dynamic` could remove it if shipping mock fixtures to prod matters).

## Testing
- [x] `yarn test:all` — lint/lint:css/typecheck clean; 213/213 unit, 220/220 component (incl. 13 new `BackupsTab.test.tsx` cases: freshness boundaries exercised through the real exported `freshnessFor`, missing-replica dots asserted by accessible title, checkbox toggle/unselect, Back Up Now lock, download stub), 93/93 integration, 103/103 e2e (incl. new `18-backups-tab.spec.ts`: locked-for-Admin / absent-unauthenticated / cards render / dispatch toast, disabled-state asserted before the toast to avoid racing the mock lock).
- [x] Independent high-effort review of the full tree pre-PR; 10 substantive findings fixed (unrunnable runbook command missing its target URL, SSR hydration mismatches from render-time `Date.now()`, a checkbox that couldn't unselect, two tests that asserted nothing, an e2e timing race, a false INVARIANT comment, unguarded clipboard write, identical accessible names on same-day rows).
- [ ] Manual `/admin` walkthrough as Super Admin + plain Admin (deferred to review — mock data renders identically under both, and the e2e spec covers the gating).

## Area(s) Touched
**Product areas**
- [x] admin — /admin shell (Diagnostics, Users, Import, Export tabs)
- [x] ui/ux — frontend layout/styling not tied to a specific integration

**Engineering**
- [x] testing — test suite (Jest/Playwright) changes

## Pre-merge Checklist
- [x] Code follows current formatting conventions and passes lint (`yarn lint`).
- [x] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
- [x] All test suites pass, both run locally and green in GitHub CI. **Do not merge if any test suite is failing.**
- [x] A test suite was added or updated for the feature/fix in this PR. **Double-check this if you change a feature and did not update the test suites**. — New behavior only (no existing behavior altered); 1.8/1.9's tab-count assertions verified still green with the fifth tab present in dev.
- [x] Only files relevant to this change are committed — no stray or unrelated files.
- [x] If this branch has a merge conflict with master, master was merged into this branch first (not the other way around).
- [x] The rest of this PR description (Description, Testing) is filled out, not left as template placeholders.
