### PR TITLE
fix(backup): use gzip compression method name pg_dump actually accepts

### DIFF
--- a/.github/scripts/backup-db.sh
+++ b/.github/scripts/backup-db.sh
@@ -58,7 +58,7 @@ trap cleanup EXIT
 
 pg_dump "$DATABASE_URL_UNPOOLED" \
   --format=custom \
-  --compress=zlib:6 \
+  --compress=gzip:6 \
   --no-owner \
   --no-privileges \
   --file="$dump_file"


### PR DESCRIPTION
## Description
- **`.github/scripts/backup-db.sh`**: `--compress=zlib:6` → `--compress=gzip:6`. pg_dump 17's `--compress` method syntax accepts `gzip`/`lz4`/`zstd`/`none` — `zlib` was never a valid method name (the older numeric-only `-Z 6` form was where the zlib association came from). Same deflate compression either way; the portability rationale (every pg_restore reads it) is unchanged.

Caught by the first real dispatch after the age key ceremony ([run 31935502998](https://github.com/cornellh4i/ithaca-recovery/actions/runs/31935502998)) — the run failed at the dump step before reaching verification/encryption/upload. I'll re-dispatch after merge to confirm the full pipeline end-to-end; issue #435 stays open until a run is green.

## Testing
- [x] shellcheck clean.
- [ ] Real `workflow_dispatch` after merge is the actual test — the failure was only reachable live.

## Area(s) Touched
**Engineering**
- [x] github-actions — workflows, Dependabot config, other .github/ CI tooling

## Pre-merge Checklist
- [x] Code follows current formatting conventions and passes lint (`yarn lint`).
- [x] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
- [x] All test suites pass, both run locally and green in GitHub CI. **Do not merge if any test suite is failing.**
- [x] A test suite was added or updated for the feature/fix in this PR. **Double-check this if you change a feature and did not update the test suites**. — N/A: one-word flag fix in a bash script; the verifying test is the post-merge dispatch.
- [x] Only files relevant to this change are committed — no stray or unrelated files.
- [x] If this branch has a merge conflict with master, master was merged into this branch first (not the other way around).
- [x] The rest of this PR description (Description, Testing) is filled out, not left as template placeholders.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated PostgreSQL database backups to use gzip compression at level 6.
  * Backup contents and functionality remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->