### PR TITLE
refactor(admin): redesign Backups tab around risk-first UX

### DIFF
--- a/frontend/app/components/admin/backups/BackupHealthCard.tsx
+++ b/frontend/app/components/admin/backups/BackupHealthCard.tsx
@@ -93,7 +93,10 @@ const BackupHealthCard: React.FC<BackupHealthCardProps> = ({ health, now }) => {
               Backups are running, but an untested backup is an unproven one. The quarterly restore drill is pending.
             </p>
           </div>
-          <a className={styles.warningBannerAction} href="/docs/02-handoff/backups-and-recovery">
+          <a
+            className={styles.warningBannerAction}
+            href="/docs/02-handoff/backups-and-recovery#verification-restore-drills"
+          >
             Restore drill runbook
           </a>
         </div>

--- a/frontend/app/components/admin/backups/BackupHealthCard.tsx
+++ b/frontend/app/components/admin/backups/BackupHealthCard.tsx
@@ -4,7 +4,8 @@ import React from "react";
 import Icon from "../../ui/displays/Icon";
 import Card from "../shared/Card";
 import type { BackupHealth, BackupReplica } from "../../../../types/backups";
-import { convertUTCToET } from "../../../../util/date/timeUtils";
+import { formatETTime } from "../../../../util/date/timeUtils";
+import { formatBytes } from "../../../../util/format/bytes";
 import styles from "./BackupsTab.module.scss";
 
 interface BackupHealthCardProps {
@@ -14,51 +15,43 @@ interface BackupHealthCardProps {
 }
 
 const REPLICA_LABEL: Record<BackupReplica, string> = {
-  "gcs-working": "GCS (working)",
-  "gcs-archive": "GCS (archive)",
+  "gcs-working": "GCS working",
+  "gcs-archive": "GCS archive",
   r2: "Cloudflare R2",
 };
 
-const FRESHNESS_LABEL: Record<BackupHealth["freshness"], string> = {
-  ok: "Healthy",
-  warn: "Aging",
-  error: "Stale",
-};
-
-const freshnessPillClass: Record<BackupHealth["freshness"], string> = {
-  ok: styles.freshnessOk,
-  warn: styles.freshnessWarn,
-  error: styles.freshnessError,
-};
-
-// Coarse relative age ("3h ago", "2d ago") -- getTime() diffs against the passed-in `now`
+// Coarse relative age ("9m ago", "3h ago") -- getTime() diffs against the passed-in `now`
 // only, no Date.now() (would mismatch between server render and client hydration) and no
 // local-timezone Date accessors (banned by the repo's ESLint rule).
 const formatRelativeAge = (sinceIso: string, now: Date): string => {
   const diffMs = Math.max(0, now.getTime() - new Date(sinceIso).getTime());
-  const diffHours = Math.floor(diffMs / (60 * 60 * 1000));
-  if (diffHours < 1) return "just now";
+  const diffMinutes = Math.floor(diffMs / (60 * 1000));
+  if (diffMinutes < 60) return diffMinutes <= 0 ? "just now" : `${diffMinutes}m ago`;
+  const diffHours = Math.floor(diffMinutes / 60);
   if (diffHours < 24) return `${diffHours}h ago`;
   const diffDays = Math.floor(diffHours / 24);
   return `${diffDays}d ago`;
 };
 
-const formatBytes = (bytes: number): string => {
-  if (bytes === 0) return "0 B";
-  const units = ["B", "KB", "MB", "GB", "TB"];
-  const exp = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
-  const value = bytes / 1024 ** exp;
-  return `${value >= 10 || exp === 0 ? Math.round(value) : value.toFixed(1)} ${units[exp]}`;
+// Countdown to the next scheduled run ("in 5h 51m"; "in 12m" once under an hour).
+const formatCountdown = (untilIso: string, now: Date): string => {
+  const diffMs = Math.max(0, new Date(untilIso).getTime() - now.getTime());
+  const diffMinutes = Math.round(diffMs / (60 * 1000));
+  const hours = Math.floor(diffMinutes / 60);
+  const minutes = diffMinutes % 60;
+  if (hours === 0) return `in ${minutes}m`;
+  return `in ${hours}h ${minutes}m`;
 };
 
-// Headroom bar switches to warn/error fill once usage crosses these fractions of the free-tier
-// ceiling -- matches the freshness pill's own two-threshold shape for visual consistency.
-const HEADROOM_WARN_FRACTION = 0.7;
-const HEADROOM_ERROR_FRACTION = 0.9;
+// Headroom bar switches to warn/error fill once REMAINING capacity drops below these
+// fractions of the free-tier ceiling (i.e. usage crosses 70%/90%) -- matches the old
+// pill's two-threshold shape for visual consistency.
+const HEADROOM_WARN_USED_FRACTION = 0.7;
+const HEADROOM_ERROR_USED_FRACTION = 0.9;
 
-const headroomFillClass = (fraction: number): string => {
-  if (fraction >= HEADROOM_ERROR_FRACTION) return `${styles.headroomFill} ${styles.headroomFillError}`;
-  if (fraction >= HEADROOM_WARN_FRACTION) return `${styles.headroomFill} ${styles.headroomFillWarn}`;
+const headroomFillClass = (usedFraction: number): string => {
+  if (usedFraction >= HEADROOM_ERROR_USED_FRACTION) return `${styles.headroomFill} ${styles.headroomFillError}`;
+  if (usedFraction >= HEADROOM_WARN_USED_FRACTION) return `${styles.headroomFill} ${styles.headroomFillWarn}`;
   return styles.headroomFill;
 };
 
@@ -71,9 +64,16 @@ const BackupHealthCard: React.FC<BackupHealthCardProps> = ({ health, now }) => {
     health.freeTierLimits.gcsArchiveBytes,
     health.freeTierLimits.r2Bytes,
   );
-  const headroomFraction = tightestLimitBytes > 0
+  const usedFraction = tightestLimitBytes > 0
     ? Math.min(1, health.totals.totalSizeBytes / tightestLimitBytes)
     : 0;
+  const remainingFraction = 1 - usedFraction;
+  const remainingBytes = Math.max(0, tightestLimitBytes - health.totals.totalSizeBytes);
+
+  const latestCount = health.replicaStatus.filter((s) => s.hasLatest).length;
+  const replicasSummary = latestCount === health.replicaStatus.length
+    ? "All three hold the latest snapshot"
+    : `${latestCount} of ${health.replicaStatus.length} hold the latest snapshot`;
 
   return (
     <Card accent="systemStatus">
@@ -82,66 +82,87 @@ const BackupHealthCard: React.FC<BackupHealthCardProps> = ({ health, now }) => {
         Backup Health
       </div>
 
-      <div className={styles.healthGrid}>
-        <div className={styles.healthRow}>
-          <span className={styles.healthLabel}>Last successful backup</span>
-          <span className={styles.healthValue}>
-            {health.lastSuccessfulBackupAt ? (
-              <>
-                {formatRelativeAge(health.lastSuccessfulBackupAt, now)}
-                {" "}
-                <span className={`${styles.freshnessPill} ${freshnessPillClass[health.freshness]}`}>
-                  {FRESHNESS_LABEL[health.freshness]}
-                </span>
-              </>
-            ) : (
-              <span className={styles.emptyState}>No successful backup yet</span>
-            )}
-          </span>
+      {health.lastVerifiedRestoreAt === null && (
+        <div className={styles.warningBanner}>
+          <div className={styles.warningBannerIcon}>
+            <Icon name="warning-amber" />
+          </div>
+          <div className={styles.warningBannerBody}>
+            <p className={styles.warningBannerTitle}>No restore has ever been verified</p>
+            <p className={styles.warningBannerText}>
+              Backups are running, but an untested backup is an unproven one. The quarterly restore drill is pending.
+            </p>
+          </div>
+          <a className={styles.warningBannerAction} href="/docs/02-handoff/backups-and-recovery">
+            Restore drill runbook
+          </a>
         </div>
+      )}
 
-        <div className={styles.healthRow}>
-          <span className={styles.healthLabel}>Last verified restore</span>
-          <span className={styles.healthValue}>
-            {health.lastVerifiedRestoreAt
-              ? `${formatRelativeAge(health.lastVerifiedRestoreAt, now)} (${convertUTCToET(health.lastVerifiedRestoreAt)} ET)`
-              : "Never — quarterly drill pending"}
-          </span>
+      <div className={styles.statRow}>
+        <div className={styles.statCell}>
+          <div
+            className={`${styles.statValue} ${
+              health.freshness === "error"
+                ? styles.statValueError
+                : health.freshness === "warn"
+                  ? styles.statValueWarn
+                  : ""
+            }`}
+          >
+            {health.lastSuccessfulBackupAt ? formatRelativeAge(health.lastSuccessfulBackupAt, now) : "None yet"}
+          </div>
+          <div className={styles.statCaption}>Last successful backup</div>
         </div>
-
-        <div className={styles.healthRow}>
-          <span className={styles.healthLabel}>Next scheduled run</span>
-          <span className={styles.healthValue}>{convertUTCToET(health.nextScheduledRunAt)} ET</span>
-        </div>
-
-        <div className={styles.healthRow}>
-          <span className={styles.healthLabel}>Replica status</span>
-          <div className={`${styles.healthValue} ${styles.replicaStatusList}`}>
-            {health.replicaStatus.map((status) => (
-              <div key={status.replica} className={styles.replicaStatusRow}>
-                <span className={styles.replicaStatusName}>{REPLICA_LABEL[status.replica]}</span>
-                <span>
-                  {status.hasLatest ? "Latest present" : "Missing latest"} · {status.objectCount} objects
-                </span>
-              </div>
-            ))}
+        <div className={styles.statCell}>
+          <div className={styles.statValue}>{formatCountdown(health.nextScheduledRunAt, now)}</div>
+          <div className={styles.statCaption}>
+            Next run · {formatETTime(new Date(health.nextScheduledRunAt))} ET
           </div>
         </div>
-
-        <div className={styles.healthRow}>
-          <span className={styles.healthLabel}>Storage vs. free tier</span>
-          <span className={styles.healthValue}>
-            {formatBytes(health.totals.totalSizeBytes)} · {health.totals.objectCount} objects
-          </span>
+        <div className={styles.statCell}>
+          <div className={styles.statValue}>{health.totals.objectCount}</div>
+          <div className={styles.statCaption}>Snapshots retained</div>
         </div>
       </div>
 
-      <div className={styles.headroomBar}>
-        <div className={headroomFillClass(headroomFraction)} style={{ width: `${headroomFraction * 100}%` }} />
-      </div>
-      <div className={styles.headroomCaption}>
-        {formatBytes(health.totals.totalSizeBytes)} of {formatBytes(tightestLimitBytes)} free-tier headroom used
-        (tightest of the three storage targets)
+      <div className={styles.replicasPanel}>
+        <div className={styles.replicasHeader}>
+          <span className={styles.replicasLabel}>REPLICAS</span>
+          <span className={styles.replicasSummary}>{replicasSummary}</span>
+        </div>
+
+        <div className={styles.replicaTiles}>
+          {health.replicaStatus.map((status) => (
+            <div key={status.replica} className={styles.replicaTile}>
+              <span className={styles.replicaTileName}>
+                <span
+                  className={`${styles.replicaTileDot} ${status.hasLatest ? styles.replicaTileDotOk : styles.replicaTileDotStale}`}
+                />
+                {REPLICA_LABEL[status.replica]}
+              </span>
+              <span className={styles.replicaTileCaption}>
+                {status.objectCount} objects · {status.hasLatest ? "current" : "stale"}
+              </span>
+            </div>
+          ))}
+        </div>
+
+        <div>
+          <div className={styles.headroomRow}>
+            <span className={styles.headroomLabel}>Free-tier headroom</span>
+            <span className={styles.headroomRemaining}>
+              {formatBytes(remainingBytes)} of {formatBytes(tightestLimitBytes)} left
+            </span>
+          </div>
+          <div className={styles.headroomBar}>
+            <div className={headroomFillClass(usedFraction)} style={{ width: `${remainingFraction * 100}%` }} />
+          </div>
+          <div className={styles.headroomCaption}>
+            {formatBytes(health.totals.totalSizeBytes)} used across {health.totals.objectCount} objects, measured
+            on the tightest of the three storage targets.
+          </div>
+        </div>
       </div>
     </Card>
   );

--- a/frontend/app/components/admin/backups/BackupsTab.module.scss
+++ b/frontend/app/components/admin/backups/BackupsTab.module.scss
@@ -8,6 +8,28 @@
   box-sizing: border-box;
 }
 
+// Tab-level title + Back Up Now, matching the admin area's small header-corner-button idiom
+// (see UsersTab/ExportTab's CardHeader) -- Back Up Now isn't scoped to a single card, so this
+// sits above the cards instead of inside one.
+.tabHeaderRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.tabHeaderTitle {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 700;
+  color: $black-color;
+}
+
+.backUpNowButton {
+  padding: 6px 14px;
+  font-size: 13px;
+}
+
 .panelHeader {
   display: flex;
   align-items: center;
@@ -37,114 +59,7 @@
   font-size: 14px;
 }
 
-.errorState {
-  color: $danger-color;
-  font-size: 14px;
-}
-
-// A `backup-db.yml` run in progress (concurrency: db-backup) locks out a second dispatch --
-// shown across Backup Health and Snapshots so the constraint is visible wherever a write
-// action might otherwise be attempted.
-.lockedBanner {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  background: $info-bg-color;
-  color: $info-text-color;
-  border-radius: $radius-sm;
-  padding: 8px 12px;
-  font-size: 13px;
-  margin-bottom: 12px;
-}
-
 /* ---------- Backup Health card ---------- */
-
-.healthGrid {
-  display: flex;
-  flex-direction: column;
-  gap: 14px;
-}
-
-.healthRow {
-  display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  gap: 12px;
-  padding-bottom: 12px;
-  border-bottom: 1px solid $grey-lightest-color;
-
-  &:last-child {
-    padding-bottom: 0;
-    border-bottom: none;
-  }
-
-  @media (width <= $breakpoint-phone) {
-    flex-direction: column;
-    gap: 2px;
-  }
-}
-
-.healthLabel {
-  font-weight: 600;
-  color: $black-color;
-  font-size: 14px;
-}
-
-.healthValue {
-  color: #555;
-  font-size: 14px;
-  text-align: right;
-
-  @media (width <= $breakpoint-phone) {
-    text-align: left;
-  }
-}
-
-// Freshness pill on the "last successful backup" row -- ok (<26h), warn (>=26h), error (>=72h).
-.freshnessPill {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  padding: 3px 10px;
-  border-radius: 999px;
-  font-size: 12px;
-  font-weight: 600;
-}
-
-.freshnessOk {
-  background: $success-bg-color;
-  color: $success-text-color;
-}
-
-.freshnessWarn {
-  background: $warning-bg-color;
-  color: $warning-text-color;
-}
-
-.freshnessError {
-  background: $danger-bg-color;
-  color: $danger-color;
-}
-
-.replicaStatusList {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-
-.replicaStatusRow {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  font-size: 13px;
-  color: #555;
-}
-
-.replicaStatusName {
-  font-family: 'Source Sans Pro', sans-serif;
-  color: $black-color;
-}
 
 // Storage-vs-free-tier headroom bar (Backup Health's totals row).
 .headroomBar {
@@ -218,16 +133,8 @@
   }
 }
 
-.row:hover {
-  background: $grey-lightest-color;
-}
-
 .rowSelected {
   background: $info-bg-color;
-}
-
-.checkboxCell {
-  width: 32px;
 }
 
 .dateCell {
@@ -235,19 +142,8 @@
   color: #555;
 }
 
-.sourceBadge {
-  font-size: 12px;
-  color: $medium-grey-color;
-}
-
 .sizeCell {
   color: #555;
-  white-space: nowrap;
-}
-
-.versionCell {
-  color: $medium-grey-color;
-  font-size: 13px;
   white-space: nowrap;
 }
 
@@ -303,49 +199,6 @@
 
 .verifiedNo {
   color: $warning-text-color;
-}
-
-// Replicas column -- three dots, one per storage target, in a fixed gcs-working / gcs-archive /
-// r2 order so a viewer can learn the column's meaning once and read every row the same way.
-.replicaDots {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-}
-
-.replicaDot {
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  background: $success-text-color;
-}
-
-.replicaDotMissing {
-  background: $light-grey-color;
-}
-
-.downloadButton {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  background: #fff;
-  border: 1px solid $grey-border-color;
-  border-radius: 6px;
-  padding: 6px 12px;
-  color: $black-color;
-  font-size: 13px;
-  font-family: 'Source Sans Pro', sans-serif;
-  cursor: pointer;
-  white-space: nowrap;
-
-  &:hover:not(:disabled) {
-    border-color: $medium-grey-color;
-  }
-
-  &:disabled {
-    cursor: default;
-    opacity: 0.6;
-  }
 }
 
 .paginationBar {
@@ -418,46 +271,6 @@
   gap: 8px;
 }
 
-.runbookCommandBox {
-  position: relative;
-  background: $navy-color;
-  border-radius: $radius-sm;
-  padding: 12px 44px 12px 14px;
-}
-
-.runbookCommand {
-  font-family: Menlo, Monaco, monospace;
-  font-size: 13px;
-  color: #fff;
-  overflow-x: auto;
-  white-space: pre;
-  margin: 0;
-}
-
-.copyButton {
-  position: absolute;
-  top: 10px;
-  right: 10px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  background: rgb(255 255 255 / 10%);
-  border: 1px solid rgb(255 255 255 / 25%);
-  border-radius: $radius-sm;
-  color: #fff;
-  cursor: pointer;
-  padding: 4px 6px;
-
-  &:hover {
-    background: rgb(255 255 255 / 20%);
-  }
-}
-
-.copyButtonCopied {
-  background: $success-text-color;
-  border-color: $success-text-color;
-}
-
 .runbookNoSelection {
   color: $medium-grey-color;
   font-size: 14px;
@@ -483,26 +296,6 @@
   }
 }
 
-.activityConclusionDot {
-  width: 9px;
-  height: 9px;
-  border-radius: 50%;
-  flex-shrink: 0;
-  margin-top: 5px;
-}
-
-.activityConclusionSuccess {
-  background: $success-text-color;
-}
-
-.activityConclusionFailure {
-  background: $danger-color;
-}
-
-.activityConclusionInProgress {
-  background: $warning-text-color;
-}
-
 .activityBody {
   flex: 1;
   min-width: 0;
@@ -520,9 +313,331 @@
   margin-top: 2px;
 }
 
-.activityTriggerBadge {
+/* =================================================================================
+ * Redesign (2026-08-16 design review) -- new classes below. Legacy classes above are
+ * kept alongside these until the compose pass removes whichever ones the rebuilt TSX
+ * stops referencing; nothing above was deleted in this pass. Every section reuses
+ * Variables.module tokens (warning/success/danger/info palettes, $radius-*,
+ * $grey-lightest-color/$grey-border-color) so the tab reads as native to this admin
+ * area rather than a new design language.
+ * ================================================================================= */
+
+/* ---------- Warning banner (top of tab) ---------- */
+
+/* Same shape as FormValidationBanner.module.scss's .banner/.iconCircle/.body/.title,
+ * recolored to the warning palette (that component is danger-only) and given a
+ * right-aligned text-link action slot. */
+
+.warningBanner {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  width: 100%;
+  box-sizing: border-box;
+  padding: 12px 16px;
+  border-radius: $radius-md;
+  background-color: $warning-bg-color;
+  font-family: 'Source Sans Pro', sans-serif;
+
+  @media (width <= $breakpoint-phone) {
+    flex-wrap: wrap;
+  }
+}
+
+.warningBannerIcon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  background-color: #fff;
+  color: $warning-text-color;
+  flex-shrink: 0;
+
+  svg {
+    width: 16px !important;
+    height: 16px !important;
+  }
+}
+
+.warningBannerBody {
+  flex: 1;
+  min-width: 0;
+}
+
+.warningBannerTitle {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 600;
+  color: $black-color;
+}
+
+.warningBannerText {
+  margin: 2px 0 0;
+  font-size: 13px;
+  line-height: 1.5;
+  color: #444;
+}
+
+.warningBannerAction {
+  flex-shrink: 0;
+  align-self: center;
+  background: none;
+  border: none;
+  padding: 0;
+  color: $link-color;
+  font-size: 13px;
+  font-weight: 600;
+  font-family: 'Source Sans Pro', sans-serif;
+  cursor: pointer;
+  white-space: nowrap;
+
+  &:hover {
+    text-decoration: underline;
+  }
+
+  @media (width <= $breakpoint-phone) {
+    align-self: flex-start;
+    margin-left: 36px;
+  }
+}
+
+/* ---------- 3-up stat row ---------- */
+
+.statRow {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+}
+
+.statCell {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 12px;
+  text-align: center;
+  border-left: 1px solid $grey-lightest-color;
+
+  &:first-child {
+    border-left: none;
+  }
+
+  @media (width <= $breakpoint-phone) {
+    padding: 4px 6px;
+  }
+}
+
+.statValue {
+  font-size: 24px;
+  font-weight: 700;
+  color: $black-color;
+  line-height: 1.2;
+}
+
+// Staleness signal for "Last successful backup" -- carries the freshness pill's old warn/error
+// meaning now that the pill itself is gone, without adding a second element back in.
+.statValueWarn {
+  color: $warning-text-color;
+}
+
+.statValueError {
+  color: $danger-color;
+}
+
+.statCaption {
+  font-size: 12px;
+  color: $medium-grey-color;
+}
+
+/* ---------- Replicas panel ---------- */
+
+.replicasPanel {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.replicasHeader {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.replicasLabel {
+  font-size: 12px;
+  font-weight: 700;
+  color: $medium-grey-color;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.replicasSummary {
+  font-size: 13px;
+  color: #555;
+  text-align: right;
+}
+
+.replicaTiles {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 12px;
+
+  @media (width <= $breakpoint-phone) {
+    grid-template-columns: 1fr;
+  }
+}
+
+.replicaTile {
+  border: 1px solid $grey-border-color;
+  border-radius: $radius-sm;
+  padding: 10px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.replicaTileDot {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  display: inline-block;
+}
+
+.replicaTileDotOk {
+  background: $success-text-color;
+}
+
+.replicaTileDotStale {
+  background: $warning-text-color;
+}
+
+.replicaTileName {
+  font-weight: 600;
+  color: $black-color;
+  font-size: 13px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.replicaTileCaption {
+  font-size: 12px;
+  color: $medium-grey-color;
+}
+
+// Free-tier headroom bar, redesigned: labeled row above the bar (left label, right bold
+// remaining-of-total), and the fill now represents REMAINING capacity, not consumed --
+// mostly-full reads as healthy, matching the "headroom" framing in the row label.
+.headroomRow {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  margin-top: 4px;
+}
+
+.headroomLabel {
+  font-size: 13px;
+  color: #555;
+}
+
+.headroomRemaining {
+  font-size: 13px;
+  font-weight: 700;
+  color: $black-color;
+  white-space: nowrap;
+}
+
+/* ---------- Snapshots card: header + filter chips ---------- */
+
+.filterChips {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.filterChip {
   display: inline-flex;
   align-items: center;
+  background: #fff;
+  border: 1px solid $grey-border-color;
+  border-radius: 999px;
+  padding: 4px 12px;
+  color: $black-color;
+  font-size: 12px;
+  font-weight: 600;
+  font-family: 'Source Sans Pro', sans-serif;
+  cursor: pointer;
+  white-space: nowrap;
+
+  &:hover:not(:disabled) {
+    border-color: $medium-grey-color;
+  }
+}
+
+.filterChipActive {
+  background: $navy-color;
+  border-color: $navy-color;
+  color: #fff;
+}
+
+// Amber variant for the Unverified chip when its count > 0 -- draws the eye without
+// requiring it to also be the active chip.
+.filterChipAttention {
+  background: $warning-bg-color;
+  border-color: $warning-text-color;
+  color: $warning-text-color;
+}
+
+/* ---------- Snapshots card: table rows ---------- */
+
+.row {
+  cursor: pointer;
+
+  &:hover {
+    background: $grey-lightest-color;
+  }
+}
+
+// Quiet text-link button, discoverable + keyboard-focusable alternative to re-clicking the
+// selected row to unselect it.
+.clearSelectionButton {
+  margin-left: auto;
+  background: none;
+  border: none;
+  padding: 0;
+  color: $link-color;
+  font-size: 13px;
+  font-weight: 600;
+  font-family: 'Source Sans Pro', sans-serif;
+  cursor: pointer;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
+.rowUnverified {
+  background: $warning-bg-color;
+
+  &:hover {
+    background: $warning-bg-color;
+  }
+}
+
+.radioCell {
+  width: 28px;
+}
+
+.sourceChip {
+  display: inline-flex;
+  align-items: center;
+  margin-left: 6px;
   padding: 1px 8px;
   border-radius: 999px;
   font-size: 11px;
@@ -531,4 +646,157 @@
   color: $medium-grey-color;
   text-transform: uppercase;
   letter-spacing: 0.02em;
+}
+
+.replicaCount {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  color: #555;
+
+  &::before {
+    content: '';
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: $success-text-color;
+  }
+}
+
+.replicaCountDegraded {
+  color: $warning-text-color;
+
+  &::before {
+    background: $warning-text-color;
+  }
+}
+
+.expiresExpired {
+  color: $danger-color;
+}
+
+.downloadIconButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  background: #fff;
+  border: 1px solid $grey-border-color;
+  border-radius: 6px;
+  color: $black-color;
+  cursor: pointer;
+
+  svg {
+    width: 16px !important;
+    height: 16px !important;
+  }
+
+  &:hover:not(:disabled) {
+    border-color: $medium-grey-color;
+  }
+
+  &:disabled {
+    cursor: default;
+    opacity: 0.6;
+  }
+}
+
+/* ---------- Restore Runbook card: dark command box ---------- */
+
+.commandBox {
+  position: relative;
+  background: #14161B;
+  border-radius: $radius-sm;
+  padding: 30px 44px 14px 14px;
+}
+
+.commandBoxHeader {
+  position: absolute;
+  top: 10px;
+  left: 14px;
+  font-size: 10px;
+  font-weight: 700;
+  color: rgb(255 255 255 / 55%);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.commandBoxCode {
+  font-family: Menlo, Monaco, monospace;
+  font-size: 13px;
+  color: #F2F2F2;
+
+  /* Wrap, don't scroll: an operator mid-incident must see the whole command at
+     once -- a horizontally-scrolled tail is how a flag gets missed. */
+  white-space: pre-wrap;
+  word-break: break-all;
+  margin: 0;
+}
+
+.commandCopyButton {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: rgb(255 255 255 / 8%);
+  border: 1px solid rgb(255 255 255 / 20%);
+  border-radius: $radius-sm;
+  color: rgb(255 255 255 / 80%);
+  cursor: pointer;
+  padding: 4px 6px;
+
+  svg {
+    width: 14px !important;
+    height: 14px !important;
+  }
+
+  &:hover {
+    background: rgb(255 255 255 / 18%);
+    color: #fff;
+  }
+
+  &:focus-visible {
+    outline: 2px solid #fff;
+    outline-offset: 2px;
+  }
+}
+
+.commandCopyButtonCopied {
+  background: $success-text-color;
+  border-color: $success-text-color;
+  color: #fff;
+}
+
+/* ---------- Notable Activity card ---------- */
+
+.activityDot {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  margin-top: 5px;
+  background: $success-text-color;
+}
+
+.activityDotFailure {
+  background: $danger-color;
+}
+
+.activityDotNeutral {
+  background: $medium-grey-color;
+}
+
+.activityTitleFailure {
+  color: $danger-color;
+}
+
+.activitySummaryLine {
+  font-size: 13px;
+  color: $medium-grey-color;
+  padding-top: 10px;
+  border-top: 1px solid $grey-lightest-color;
 }

--- a/frontend/app/components/admin/backups/BackupsTab.module.scss
+++ b/frontend/app/components/admin/backups/BackupsTab.module.scss
@@ -8,21 +8,15 @@
   box-sizing: border-box;
 }
 
-// Tab-level title + Back Up Now, matching the admin area's small header-corner-button idiom
-// (see UsersTab/ExportTab's CardHeader) -- Back Up Now isn't scoped to a single card, so this
-// sits above the cards instead of inside one.
+// Back Up Now, matching the admin area's small header-corner-button idiom (see UsersTab/
+// ExportTab's CardHeader) -- it isn't scoped to a single card, so this sits above the cards
+// instead of inside one. Left-aligned: the admin shell's active tab label already says
+// "Backups", so there's no title here to push it to the right of.
 .tabHeaderRow {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: flex-start;
   gap: 12px;
-}
-
-.tabHeaderTitle {
-  margin: 0;
-  font-size: 18px;
-  font-weight: 700;
-  color: $black-color;
 }
 
 .backUpNowButton {
@@ -274,6 +268,17 @@
 .runbookNoSelection {
   color: $medium-grey-color;
   font-size: 14px;
+}
+
+// Inline text link, matching the .warningBannerAction / .clearSelectionButton idiom elsewhere
+// in this tab -- for an actual <a> rather than a button.
+.docsLink {
+  color: $link-color;
+  font-weight: 600;
+
+  &:hover {
+    text-decoration: underline;
+  }
 }
 
 /* ---------- Recent Activity card ---------- */

--- a/frontend/app/components/admin/backups/BackupsTab.module.scss
+++ b/frontend/app/components/admin/backups/BackupsTab.module.scss
@@ -677,6 +677,122 @@
   }
 }
 
+/* ---------- Verified header legend (mirrors UsersTab.module.scss's role legend) ---------- */
+
+.thLabel {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+}
+
+.legendAnchor {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+
+.infoButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  color: $medium-grey-color;
+
+  &:hover {
+    color: $black-color;
+  }
+}
+
+// position: fixed, not absolute -- portaled to document.body (see SnapshotsCard.tsx), so it's
+// no longer a descendant of the scrollable .tableWrapper (which would otherwise clip it once
+// the table goes wider than the viewport). top/left/width come from an inline style computed
+// in JS from the icon's actual on-screen position, already clamped there to stay in-viewport.
+.legendPopover {
+  position: fixed;
+  background: #fff;
+  border: 1px solid $grey-border-color;
+  border-radius: $radius-sm;
+  box-shadow: 0 4px 12px rgb(0 0 0 / 15%);
+  padding: 14px 16px;
+  z-index: $z-index-dropdown;
+  box-sizing: border-box;
+  font-weight: 400;
+  text-transform: none;
+}
+
+.legendPopoverTitle {
+  font-size: 13px;
+  font-weight: 600;
+  color: $black-color;
+  margin-bottom: 10px;
+}
+
+.legendTable {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 10px 14px;
+  align-items: center;
+}
+
+.legendPillCell {
+  display: flex;
+}
+
+.legendDescCell {
+  font-size: 13px;
+  color: #555;
+  line-height: 1.4;
+  min-width: 0;
+  overflow-wrap: break-word;
+}
+
+/* ---------- Replica count hover tooltip (mirrors AdminShell.module.scss's locked-tab tooltip) ---------- */
+
+.replicaTooltipAnchor {
+  position: relative;
+  display: inline-flex;
+
+  &:hover .replicaTooltip,
+  &:focus-within .replicaTooltip {
+    opacity: 1;
+    visibility: visible;
+  }
+}
+
+.replicaTooltip {
+  position: absolute;
+  bottom: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  margin-bottom: 6px;
+  padding: 6px 10px;
+  border-radius: 4px;
+  background-color: $black-color;
+  color: #fff;
+  font-size: 12px;
+  width: max-content;
+  max-width: 220px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.15s ease;
+  pointer-events: none;
+  z-index: $z-index-dropdown;
+}
+
+.replicaTooltipLinePresent {
+  color: #fff;
+}
+
+.replicaTooltipLineMissing {
+  color: $warning-text-color;
+}
+
 .expiresExpired {
   color: $danger-color;
 }

--- a/frontend/app/components/admin/backups/BackupsTab.tsx
+++ b/frontend/app/components/admin/backups/BackupsTab.tsx
@@ -93,7 +93,6 @@ const BackupsTab: React.FC = () => {
   return (
     <div className={styles.container}>
       <div className={styles.tabHeaderRow}>
-        <h2 className={styles.tabHeaderTitle}>Backups</h2>
         <SolidButton
           label="Back Up Now"
           onClick={handleBackUpNow}

--- a/frontend/app/components/admin/backups/BackupsTab.tsx
+++ b/frontend/app/components/admin/backups/BackupsTab.tsx
@@ -2,12 +2,13 @@
 
 import React, { useState } from "react";
 import BackupHealthCard from "./BackupHealthCard";
-import SnapshotsCard from "./SnapshotsCard";
+import SnapshotsCard, { matchesFilter } from "./SnapshotsCard";
 import RestoreRunbookCard from "./RestoreRunbookCard";
 import RecentActivityCard from "./RecentActivityCard";
 import SolidButton from "../../ui/buttons/SolidButton";
 import { generateMockActivityEvents, generateMockBackupHealth, generateMockBackupRows } from "./mockBackups";
 import { useToast } from "../../shared/ToastProvider";
+import type { BackupTierFilter } from "../../../../types/backups";
 import styles from "./BackupsTab.module.scss";
 
 // Mock dispatch takes this long before the transient lock clears -- long enough to read the
@@ -36,6 +37,18 @@ const BackupsTab: React.FC = () => {
 
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [page, setPage] = useState(0);
+  const [filter, setFilter] = useState<BackupTierFilter>("all");
+
+  const handleFilterChange = (next: BackupTierFilter) => {
+    setFilter(next);
+    setPage(0);
+    // Prevents the Restore Runbook command box from pointing at a row that's now hidden
+    // behind the new filter -- an invisible selection is worse than none.
+    const selectedRow = rows.find((row) => row.id === selectedId);
+    if (selectedRow && !matchesFilter(selectedRow, next)) {
+      setSelectedId(null);
+    }
+  };
 
   // Mirrors the real `concurrency: db-backup` guard: Back Up Now is disabled while a run is
   // "in flight" so a double-click can't double-dispatch, same invariant the real
@@ -46,6 +59,9 @@ const BackupsTab: React.FC = () => {
   const { showToast } = useToast();
 
   const selectedRow = rows.find((row) => row.id === selectedId) ?? null;
+  // Rows are sorted newest-first by generateMockBackupRows -- the newest row's appVersion is
+  // the deployed app version the Snapshots subhead reports.
+  const latestAppVersion = rows[0]?.appVersion ?? "unknown";
 
   const handleBackUpNow = () => {
     if (lockedBy) return;
@@ -76,24 +92,31 @@ const BackupsTab: React.FC = () => {
 
   return (
     <div className={styles.container}>
-      <SolidButton
-        label="Back Up Now"
-        onClick={handleBackUpNow}
-        loading={creating}
-        disabled={!!lockedBy}
-      />
+      <div className={styles.tabHeaderRow}>
+        <h2 className={styles.tabHeaderTitle}>Backups</h2>
+        <SolidButton
+          label="Back Up Now"
+          onClick={handleBackUpNow}
+          loading={creating}
+          disabled={!!lockedBy}
+          className={styles.backUpNowButton}
+        />
+      </div>
 
       <BackupHealthCard health={health} now={now} />
       <SnapshotsCard
         rows={rows}
+        filter={filter}
+        onFilterChange={handleFilterChange}
         selectedId={selectedId}
         onSelect={(id) => setSelectedId((prev) => (prev === id ? null : id))}
         page={page}
         onPageChange={setPage}
         onDownload={handleDownload}
         now={now}
+        latestAppVersion={latestAppVersion}
       />
-      <RestoreRunbookCard selected={selectedRow} />
+      <RestoreRunbookCard selected={selectedRow} now={now} />
       <RecentActivityCard events={activity} now={now} />
     </div>
   );

--- a/frontend/app/components/admin/backups/RecentActivityCard.tsx
+++ b/frontend/app/components/admin/backups/RecentActivityCard.tsx
@@ -12,74 +12,97 @@ interface RecentActivityCardProps {
   now: Date;
 }
 
-const CONCLUSION_DOT_CLASS: Record<ActivityConclusion, string> = {
-  success: styles.activityConclusionSuccess,
-  failure: styles.activityConclusionFailure,
-  in_progress: styles.activityConclusionInProgress,
-};
-
 const CONCLUSION_LABEL: Record<ActivityConclusion, string> = {
   success: "succeeded",
   failure: "failed",
   in_progress: "in progress",
 };
 
+// Only the exceptional rows earn a place here: failures, manual runs, and in-flight runs.
+// Routine scheduled successes are summarized as a count instead (see activitySummaryLine).
+const isNotable = (event: ActivityEvent): boolean =>
+  event.conclusion === "failure" || event.trigger === "workflow_dispatch" || event.conclusion === "in_progress";
+
+/** Count of routine (non-manual, successful) runs -- the "N routine runs succeeded" summary line. */
+const countRoutineSuccesses = (events: ActivityEvent[]): number =>
+  events.filter((e) => e.trigger === "schedule" && e.conclusion === "success").length;
+
 // GitHub Actions run history IS the audit log for this feature (no separate audit table --
 // see the backups admin tab plan, Part 1). This card is purely presentational: F7 owns the
 // fetch and passes rows shaped like `GET .../actions/workflows/backup-db.yml/runs`.
-const RecentActivityCard: React.FC<RecentActivityCardProps> = ({ events, now }) => (
-  <Card data-testid="backups-recent-activity-panel">
-    <div className={styles.panelHeader}>
-      <Icon name="clock" className={styles.panelIcon} />
-      Recent Activity
-    </div>
-    {events.length === 0 ? (
-      <div className={styles.emptyState}>No backup runs recorded yet.</div>
-    ) : (
-      <ul className={styles.activityList}>
-        {events.map((event) => (
-          <li key={event.id} className={styles.activityRow}>
-            <span
-              className={`${styles.activityConclusionDot} ${CONCLUSION_DOT_CLASS[event.conclusion]}`}
-              aria-hidden="true"
-            />
-            <div className={styles.activityBody}>
-              <div className={styles.activityTitle}>
-                {activityTitle(event)}{" "}
-                <span className={styles.activityTriggerBadge}>{event.trigger === "schedule" ? "Scheduled" : "Manual"}</span>
-              </div>
-              <div className={styles.activityMeta}>
-                {event.actor} · {formatRelativeTime(event.startedAt, now)} · {formatDuration(event.durationSeconds)}
-                {" · "}
-                {CONCLUSION_LABEL[event.conclusion]}
-              </div>
-            </div>
-          </li>
-        ))}
-      </ul>
-    )}
-  </Card>
-);
+const RecentActivityCard: React.FC<RecentActivityCardProps> = ({ events, now }) => {
+  const notableEvents = events.filter(isNotable);
+  const routineSuccessCount = countRoutineSuccesses(events);
 
-// "Scheduled backup" for cron-triggered runs, "Manual backup — <reason>" for workflow_dispatch
-// runs that carried an operator-supplied reason (see BackupMeta.reason in types/backups.ts).
-const activityTitle = (event: ActivityEvent): string => {
-  const base = event.trigger === "schedule" ? "Scheduled backup" : "Manual backup";
-  return event.trigger === "workflow_dispatch" && event.reason ? `${base} — ${event.reason}` : base;
+  return (
+    <Card data-testid="backups-recent-activity-panel">
+      <div className={styles.panelHeader}>
+        <Icon name="clock" className={styles.panelIcon} />
+        Notable Activity
+      </div>
+      <div className={styles.activitySummaryLine}>
+        Failures, manual runs, and runs in progress.
+        {routineSuccessCount > 0 && ` ${routineSuccessCount} routine scheduled successes not shown.`}
+      </div>
+      {/* TODO(backups-api): link to a full-history view once the API wiring lands. */}
+      {notableEvents.length === 0 ? (
+        <div className={styles.emptyState}>No failures, manual runs, or runs in progress recorded.</div>
+      ) : (
+        <ul className={styles.activityList}>
+          {notableEvents.map((event) => (
+            <li key={event.id} className={styles.activityRow}>
+              <span
+                className={`${styles.activityDot} ${event.conclusion === "failure" ? styles.activityDotFailure : styles.activityDotNeutral}`}
+                aria-hidden="true"
+              />
+              <div className={styles.activityBody}>
+                <div className={`${styles.activityTitle} ${event.conclusion === "failure" ? styles.activityTitleFailure : ""}`}>
+                  {activityTitle(event)}
+                </div>
+                <div className={styles.activityMeta}>{activityMeta(event, now)}</div>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </Card>
+  );
 };
 
-// Coarse relative time (minutes/hours/days) -- getTime() diffs against the passed-in `now`
-// only, no Date.now() (would mismatch between server render and client hydration) and no
-// local-timezone Date accessors (banned by the repo's ESLint rule).
-const formatRelativeTime = (isoTimestamp: string, now: Date): string => {
-  const deltaMs = now.getTime() - new Date(isoTimestamp).getTime();
+const activityTitle = (event: ActivityEvent): string => {
+  if (event.conclusion === "in_progress") return "Backup in progress";
+  if (event.trigger === "workflow_dispatch") {
+    return event.reason ? `Manual backup — ${event.reason}` : "Manual backup";
+  }
+  return "Scheduled backup failed";
+};
+
+const activityMeta = (event: ActivityEvent, now: Date): string => {
+  const parts = [event.actor, formatRelativeOrAbsoluteTime(event.startedAt, now)];
+  if (event.conclusion !== "in_progress") {
+    parts.push(`ran ${formatDuration(event.durationSeconds)}`);
+  }
+  parts.push(CONCLUSION_LABEL[event.conclusion]);
+  return parts.join(" · ");
+};
+
+// Coarse relative time under 24h; absolute Eastern-time timestamp beyond that -- getTime()
+// diffs against the passed-in `now` only, no Date.now() (would mismatch between server render
+// and client hydration) and no local-timezone Date accessors (banned by the repo's ESLint rule).
+const formatRelativeOrAbsoluteTime = (isoTimestamp: string, now: Date): string => {
+  const startedAt = new Date(isoTimestamp);
+  const deltaMs = now.getTime() - startedAt.getTime();
   const deltaMinutes = Math.round(deltaMs / 60_000);
-  if (deltaMinutes < 1) return "just now";
-  if (deltaMinutes < 60) return `${deltaMinutes}m ago`;
+  if (deltaMinutes < 60) return deltaMinutes < 1 ? "just now" : `${deltaMinutes}m ago`;
   const deltaHours = Math.round(deltaMinutes / 60);
   if (deltaHours < 24) return `${deltaHours}h ago`;
-  const deltaDays = Math.round(deltaHours / 24);
-  return `${deltaDays}d ago`;
+  return `${new Intl.DateTimeFormat("en-US", {
+    timeZone: "America/New_York",
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(startedAt)} ET`;
 };
 
 const formatDuration = (durationSeconds: number): string => {

--- a/frontend/app/components/admin/backups/RecentActivityCard.tsx
+++ b/frontend/app/components/admin/backups/RecentActivityCard.tsx
@@ -35,7 +35,7 @@ const RecentActivityCard: React.FC<RecentActivityCardProps> = ({ events, now }) 
   const routineSuccessCount = countRoutineSuccesses(events);
 
   return (
-    <Card data-testid="backups-recent-activity-panel">
+    <Card accent="syncIssues" data-testid="backups-recent-activity-panel">
       <div className={styles.panelHeader}>
         <Icon name="clock" className={styles.panelIcon} />
         Notable Activity

--- a/frontend/app/components/admin/backups/RestoreRunbookCard.tsx
+++ b/frontend/app/components/admin/backups/RestoreRunbookCard.tsx
@@ -69,7 +69,7 @@ export default function RestoreRunbookCard({ selected, now }: RestoreRunbookCard
   };
 
   return (
-    <Card>
+    <Card accent="suspended">
       <div className={styles.panelHeader}>Restore Runbook</div>
       <div className={styles.panelSubhead}>
         Restoring is a deliberate, out-of-band operation — never a button in this app.
@@ -92,7 +92,14 @@ export default function RestoreRunbookCard({ selected, now }: RestoreRunbookCard
       </ul>
 
       <div className={styles.panelSubhead}>
-        Full steps: docs/02-handoff/backups-and-recovery.md (break-glass runbook).
+        Full steps:{" "}
+        <a
+          className={styles.docsLink}
+          href="/docs/02-handoff/backups-and-recovery#the-break-glass-restore-runbook"
+        >
+          Backups and Recovery
+        </a>
+        .
       </div>
 
       {selected && command ? (

--- a/frontend/app/components/admin/backups/RestoreRunbookCard.tsx
+++ b/frontend/app/components/admin/backups/RestoreRunbookCard.tsx
@@ -2,12 +2,35 @@
 
 import { useState } from "react";
 import type { BackupListRow } from "../../../../types/backups";
+import { formatETDateString, formatETLongDateTime, formatETTime } from "../../../../util/date/timeUtils";
 import Card from "../shared/Card";
+import Icon from "../../ui/displays/Icon";
 import styles from "./BackupsTab.module.scss";
 
 export interface RestoreRunbookCardProps {
   /** The currently selected Snapshots row, or null when nothing is selected. */
   selected: BackupListRow | null;
+  /** Reference instant for the command box's created-label -- passed in, never read from Date.now() here. */
+  now: Date;
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const HOURS_48_MS = 48 * 60 * 60 * 1000;
+
+// Mirrors SnapshotsCard's Created-column label so the command box's header reads the same
+// way the row it was generated from does ("Today, 3:17 AM" etc.) -- kept local rather than
+// imported since SnapshotsCard doesn't export it and this is presentational-only.
+function formatCreatedLabel(createdAt: string, now: Date): string {
+  const created = new Date(createdAt);
+  const diffMs = now.getTime() - created.getTime();
+  if (diffMs >= 0 && diffMs < HOURS_48_MS) {
+    const createdDay = formatETDateString(created);
+    const nowDay = formatETDateString(now);
+    const yesterday = formatETDateString(new Date(now.getTime() - DAY_MS));
+    if (createdDay === nowDay) return `Today, ${formatETTime(created)}`;
+    if (createdDay === yesterday) return `Yesterday, ${formatETTime(created)}`;
+  }
+  return formatETLongDateTime(created);
 }
 
 /**
@@ -16,7 +39,7 @@ export interface RestoreRunbookCardProps {
  * route cannot decrypt an offline-key `.dump.age` artifact. This card only surfaces the
  * prerequisites and a copy-pasteable `restore-db.sh` invocation for a human to run out-of-band.
  */
-export default function RestoreRunbookCard({ selected }: RestoreRunbookCardProps) {
+export default function RestoreRunbookCard({ selected, now }: RestoreRunbookCardProps) {
   const [copied, setCopied] = useState(false);
   const [copyFailed, setCopyFailed] = useState(false);
 
@@ -28,6 +51,7 @@ export default function RestoreRunbookCard({ selected }: RestoreRunbookCardProps
   const command = selected
     ? `AGE_IDENTITY_FILE=/path/to/key RESTORE_TARGET_URL=<neon-branch-url> ./frontend/scripts/restore-db.sh ./${selected.id}.dump.age`
     : null;
+  const createdLabel = selected ? formatCreatedLabel(selected.createdAt, now) : null;
 
   const handleCopy = async () => {
     if (!command) return;
@@ -48,9 +72,10 @@ export default function RestoreRunbookCard({ selected }: RestoreRunbookCardProps
     <Card>
       <div className={styles.panelHeader}>Restore Runbook</div>
       <div className={styles.panelSubhead}>
-        Restoring is a deliberate, out-of-band operation — not a button in this app.
+        Restoring is a deliberate, out-of-band operation — never a button in this app.
       </div>
 
+      <div className={styles.panelSubhead}>BEFORE YOU START, YOU NEED</div>
       <ul className={styles.runbookPrereqs}>
         <li className={styles.runbookPrereq}>
           <span>1.</span>
@@ -71,16 +96,17 @@ export default function RestoreRunbookCard({ selected }: RestoreRunbookCardProps
       </div>
 
       {selected && command ? (
-        <div className={styles.runbookCommandBox}>
-          <pre className={styles.runbookCommand}>{command}</pre>
+        <div className={styles.commandBox}>
+          <div className={styles.commandBoxHeader}>Command for the selected snapshot · {createdLabel}</div>
+          <pre className={styles.commandBoxCode}>{command}</pre>
           <button
             type="button"
-            className={`${styles.copyButton} ${copied ? styles.copyButtonCopied : ""}`}
+            className={`${styles.commandCopyButton} ${copied ? styles.commandCopyButtonCopied : ""}`}
             onClick={handleCopy}
-            aria-label="Copy restore command"
+            aria-label="Copy command"
             title={copyFailed ? "Copy failed — select the text manually" : undefined}
           >
-            {copied ? "Copied" : copyFailed ? "Copy failed" : "Copy"}
+            <Icon name={copied ? "check" : "copy"} size="sm" />
           </button>
         </div>
       ) : (

--- a/frontend/app/components/admin/backups/SnapshotsCard.tsx
+++ b/frontend/app/components/admin/backups/SnapshotsCard.tsx
@@ -4,9 +4,10 @@ import React from "react";
 import Icon from "../../ui/displays/Icon";
 import Card from "../shared/Card";
 import CardHeader from "../shared/CardHeader";
-import type { BackupListRow, BackupReplica, BackupTier } from "../../../../types/backups";
+import type { BackupListRow, BackupReplica, BackupTier, BackupTierFilter } from "../../../../types/backups";
 import { ALL_BACKUP_REPLICAS } from "../../../../types/backups";
-import { formatETLongDateTime } from "../../../../util/date/timeUtils";
+import { formatETDateString, formatETLongDateTime, formatETTime } from "../../../../util/date/timeUtils";
+import { formatBytes } from "../../../../util/format/bytes";
 import styles from "./BackupsTab.module.scss";
 
 const TIER_LABEL: Record<BackupTier, string> = {
@@ -27,49 +28,82 @@ const REPLICA_LABEL: Record<BackupReplica, string> = {
   r2: "Cloudflare R2",
 };
 
-const SOURCE_LABEL: Record<BackupListRow["source"], string> = {
-  automatic: "Automatic",
-  manual: "Manual",
+const FILTER_LABEL: Record<BackupTierFilter, string> = {
+  all: "All",
+  daily: "Daily",
+  monthly: "Monthly",
+  permanent: "Permanent",
+  unverified: "Unverified",
 };
 
-const DAY_MS = 24 * 60 * 60 * 1000;
+const FILTER_ORDER: BackupTierFilter[] = ["all", "daily", "monthly", "permanent", "unverified"];
 
+const DAY_MS = 24 * 60 * 60 * 1000;
+const MONTH_MS = 30 * DAY_MS;
+const HOURS_48_MS = 48 * 60 * 60 * 1000;
+
+const DOWNLOAD_ARIA_LABEL = "Download (encrypted) — requires an offline age key";
 const DOWNLOAD_TOOLTIP =
   "Downloads the encrypted .dump.age artifact. Requires the offline age private key to decrypt -- unusable on its own.";
 
-/** Human-readable size (e.g. "4.2 MB", "512 KB") -- no shared formatter exists yet in util/. */
-function formatSize(bytes: number): string {
-  if (bytes < 1024) return `${bytes} B`;
-  const kb = bytes / 1024;
-  if (kb < 1024) return `${kb.toFixed(1)} KB`;
-  const mb = kb / 1024;
-  if (mb < 1024) return `${mb.toFixed(1)} MB`;
-  return `${(mb / 1024).toFixed(2)} GB`;
+/**
+ * "Today, 3:17 AM" / "Yesterday, 9:17 PM" for rows within the last 48h (ET calendar-day
+ * comparison, not a raw ms cutoff, so the boundary lines up with what "Yesterday" means to
+ * a reader); otherwise falls back to the absolute ET long date + time.
+ */
+function formatCreatedAt(createdAt: string, now: Date): string {
+  const created = new Date(createdAt);
+  const diffMs = now.getTime() - created.getTime();
+  if (diffMs >= 0 && diffMs < HOURS_48_MS) {
+    const createdDay = formatETDateString(created);
+    const nowDay = formatETDateString(now);
+    const yesterday = formatETDateString(new Date(now.getTime() - DAY_MS));
+    if (createdDay === nowDay) return `Today, ${formatETTime(created)}`;
+    if (createdDay === yesterday) return `Yesterday, ${formatETTime(created)}`;
+  }
+  return formatETLongDateTime(created);
 }
 
-/** "N days" / "today" / "N days ago" for an expiry instant, relative to `now`. */
-function formatExpiresIn(expiresAt: string, now: Date): string {
-  const diffDays = Math.round((new Date(expiresAt).getTime() - now.getTime()) / DAY_MS);
-  // Deletion is a background sweep that can lag eligibility -- a past expiresAt is a
-  // real state ("eligible, not yet swept"), not the same as expiring today.
-  if (diffDays < 0) return "expired";
-  if (diffDays === 0) return "today";
-  if (diffDays === 1) return "1 day";
-  return `${diffDays} days`;
+/** "in 21d" / "in 11mo" / "Never" / "expired", relative to `now`. */
+function formatExpiresIn(expiresAt: string | null, now: Date): string {
+  if (!expiresAt) return "Never";
+  const diffMs = new Date(expiresAt).getTime() - now.getTime();
+  if (diffMs < 0) return "expired";
+  const diffDays = Math.round(diffMs / DAY_MS);
+  if (diffMs < MONTH_MS) return `in ${diffDays}d`;
+  const diffMonths = Math.round(diffMs / MONTH_MS);
+  return `in ${diffMonths}mo`;
+}
+
+function missingReplicaTitle(row: BackupListRow): string {
+  const missing = ALL_BACKUP_REPLICAS.filter((r) => !row.replicas.includes(r));
+  return `Missing from ${missing.map((r) => REPLICA_LABEL[r]).join(", ")}`;
+}
+
+export function matchesFilter(row: BackupListRow, filter: BackupTierFilter): boolean {
+  if (filter === "all") return true;
+  if (filter === "unverified") return !row.verified;
+  return row.tier === filter;
 }
 
 const PAGE_SIZE = 10;
 
 interface SnapshotsCardProps {
+  /** Full, unfiltered row set -- this component owns filtering and pagination internally so
+   * the parent doesn't need to recompute a filtered/paginated slice on every render just to
+   * hand this table what it would otherwise derive itself; the parent only owns which filter
+   * is active (for other cards / URL state) and the current page number. */
   rows: BackupListRow[];
-  /** Single-select: which row id (if any) drives the Restore Runbook card below. */
+  filter: BackupTierFilter;
+  onFilterChange: (filter: BackupTierFilter) => void;
   selectedId: string | null;
   onSelect: (id: string) => void;
   page: number;
   onPageChange: (page: number) => void;
   onDownload: (id: string) => void;
-  /** Reference instant for "Expires in" -- passed in, never read from Date.now() here. */
+  /** Reference instant for relative date/expiry math -- passed in, never read from Date.now() here. */
   now: Date;
+  latestAppVersion: string;
 }
 
 interface SnapshotRowProps {
@@ -80,107 +114,157 @@ interface SnapshotRowProps {
   now: Date;
 }
 
-const SnapshotRow: React.FC<SnapshotRowProps> = ({ row, selected, onSelect, onDownload, now }) => (
-  <tr
-    className={`${styles.row} ${selected ? styles.rowSelected : ""}`}
-    onClick={() => onSelect(row.id)}
-  >
-    <td className={styles.checkboxCell} onClick={(e) => e.stopPropagation()}>
-      <input
-        type="checkbox"
-        checked={selected}
-        aria-label={`Select snapshot from ${formatETLongDateTime(new Date(row.createdAt))}`}
-        onChange={() => onSelect(row.id)}
-      />
-    </td>
-    <td className={styles.dateCell}>{formatETLongDateTime(new Date(row.createdAt))}</td>
-    <td>
-      <span className={`${styles.tierPill} ${TIER_CLASS[row.tier]}`}>{TIER_LABEL[row.tier]}</span>
-    </td>
-    <td className={styles.sourceBadge}>{SOURCE_LABEL[row.source]}</td>
-    <td className={styles.sizeCell}>{formatSize(row.sizeBytes)}</td>
-    <td className={styles.versionCell}>{row.appVersion}</td>
-    <td>
-      <span className={`${styles.verifiedIndicator} ${row.verified ? styles.verifiedYes : styles.verifiedNo}`}>
-        <Icon name={row.verified ? "check" : "warning-circle"} size={14} />
-        {row.verified ? "Verified" : "Unverified"}
-      </span>
-    </td>
-    <td>
-      <span className={styles.replicaDots}>
-        {ALL_BACKUP_REPLICAS.map((replica) => {
-          const present = row.replicas.includes(replica);
-          return (
-            <span
-              key={replica}
-              className={`${styles.replicaDot} ${present ? "" : styles.replicaDotMissing}`}
-              title={present ? `Present in ${REPLICA_LABEL[replica]}` : `Missing from ${REPLICA_LABEL[replica]}`}
-            />
-          );
-        })}
-      </span>
-    </td>
-    <td className={styles.expiresCell}>
-      {row.expiresAt ? (
-        formatExpiresIn(row.expiresAt, now)
-      ) : (
-        <span className={styles.expiresNever}>never</span>
-      )}
-    </td>
-    <td onClick={(e) => e.stopPropagation()}>
-      <button
-        className={styles.downloadButton}
-        title={DOWNLOAD_TOOLTIP}
-        aria-label={`Download encrypted snapshot from ${formatETLongDateTime(new Date(row.createdAt))}`}
-        onClick={() => onDownload(row.id)}
-      >
-        <Icon name="backup" size={14} />
-        Download (encrypted)
-      </button>
-    </td>
-  </tr>
-);
+const SnapshotRow: React.FC<SnapshotRowProps> = ({ row, selected, onSelect, onDownload, now }) => {
+  const createdLabel = formatCreatedAt(row.createdAt, now);
+  const accessibleName = `${createdLabel} snapshot`;
+  const replicaCount = row.replicas.length;
+  const degraded = replicaCount < ALL_BACKUP_REPLICAS.length;
+
+  return (
+    <tr
+      className={`${styles.row} ${selected ? styles.rowSelected : ""} ${row.verified ? "" : styles.rowUnverified}`}
+      onClick={() => onSelect(row.id)}
+    >
+      <td className={styles.radioCell} onClick={(e) => e.stopPropagation()}>
+        <input
+          type="radio"
+          name="snapshot-select"
+          checked={selected}
+          aria-label={`Select ${accessibleName}`}
+          onChange={() => onSelect(row.id)}
+        />
+      </td>
+      <td className={styles.dateCell}>
+        {createdLabel}
+        {row.source === "manual" && <span className={styles.sourceChip}>Manual</span>}
+      </td>
+      <td>
+        <span className={`${styles.tierPill} ${TIER_CLASS[row.tier]}`}>{TIER_LABEL[row.tier]}</span>
+      </td>
+      <td className={styles.sizeCell}>{formatBytes(row.sizeBytes)}</td>
+      <td>
+        <span className={`${styles.verifiedIndicator} ${row.verified ? styles.verifiedYes : styles.verifiedNo}`}>
+          {row.verified ? "✓ Verified" : "⚠ Unverified"}
+        </span>
+      </td>
+      <td>
+        <span
+          className={`${styles.replicaCount} ${degraded ? styles.replicaCountDegraded : ""}`}
+          title={degraded ? missingReplicaTitle(row) : undefined}
+        >
+          {replicaCount} of {ALL_BACKUP_REPLICAS.length}
+        </span>
+      </td>
+      <td className={styles.expiresCell}>
+        {row.expiresAt === null ? (
+          <span className={styles.expiresNever}>Never</span>
+        ) : new Date(row.expiresAt).getTime() < now.getTime() ? (
+          <span className={styles.expiresExpired}>{formatExpiresIn(row.expiresAt, now)}</span>
+        ) : (
+          formatExpiresIn(row.expiresAt, now)
+        )}
+      </td>
+      <td onClick={(e) => e.stopPropagation()}>
+        <button
+          className={styles.downloadIconButton}
+          title={DOWNLOAD_TOOLTIP}
+          aria-label={`${DOWNLOAD_ARIA_LABEL} (${accessibleName})`}
+          onClick={() => onDownload(row.id)}
+        >
+          <Icon name="download" size={14} />
+        </button>
+      </td>
+    </tr>
+  );
+};
 
 /**
- * Snapshots table -- pure presentational, all state (rows/selection/paging) owned by the
- * parent tab. Single-select checkbox drives the Restore Runbook card; onDownload fires a
- * stub handler in this PR (no real file transfer -- see the tooltip and label wording).
+ * Snapshots table -- pure presentational, but owns filtering + pagination internally (see
+ * the `rows` prop doc): the parent hands down the full unfiltered row set and only tracks
+ * which filter/page is active, rather than recomputing a derived slice itself. Single-select
+ * radio drives the Restore Runbook card below; onDownload fires a stub handler in this PR
+ * (no real file transfer -- see the tooltip and aria-label wording).
  */
 const SnapshotsCard: React.FC<SnapshotsCardProps> = ({
   rows,
+  filter,
+  onFilterChange,
   selectedId,
   onSelect,
   page,
   onPageChange,
   onDownload,
   now,
+  latestAppVersion,
 }) => {
-  const totalPages = Math.max(1, Math.ceil(rows.length / PAGE_SIZE));
+  const filteredRows = rows.filter((row) => matchesFilter(row, filter));
+  const totalPages = Math.max(1, Math.ceil(filteredRows.length / PAGE_SIZE));
   const clampedPage = Math.min(page, totalPages - 1);
-  const pageRows = rows.slice(clampedPage * PAGE_SIZE, clampedPage * PAGE_SIZE + PAGE_SIZE);
-  const rangeStart = rows.length === 0 ? 0 : clampedPage * PAGE_SIZE + 1;
-  const rangeEnd = Math.min(rows.length, clampedPage * PAGE_SIZE + PAGE_SIZE);
+  const pageRows = filteredRows.slice(clampedPage * PAGE_SIZE, clampedPage * PAGE_SIZE + PAGE_SIZE);
+  const rangeStart = filteredRows.length === 0 ? 0 : clampedPage * PAGE_SIZE + 1;
+  const rangeEnd = Math.min(filteredRows.length, clampedPage * PAGE_SIZE + PAGE_SIZE);
+
+  const unverifiedCount = rows.filter((row) => !row.verified).length;
+  const filterCounts: Record<BackupTierFilter, number> = {
+    all: rows.length,
+    daily: rows.filter((r) => r.tier === "daily").length,
+    monthly: rows.filter((r) => r.tier === "monthly").length,
+    permanent: rows.filter((r) => r.tier === "permanent").length,
+    unverified: unverifiedCount,
+  };
 
   return (
     <Card>
-      <CardHeader icon={<Icon name="backup" size={16} />} title={`Snapshots (${rows.length})`} />
-      {rows.length === 0 ? (
-        <div className={styles.emptyState}>No snapshots yet.</div>
+      <div className={styles.panelHeader}>
+        <Icon name="backup" size={16} className={styles.panelIcon} />
+        Snapshots
+        {selectedId && (
+          <button
+            type="button"
+            className={styles.clearSelectionButton}
+            onClick={() => onSelect(selectedId)}
+          >
+            Clear selection
+          </button>
+        )}
+      </div>
+      <div className={styles.panelSubhead}>
+        {filteredRows.length} of {rows.length} snapshots · app version {latestAppVersion}
+      </div>
+      <div className={styles.filterChips}>
+        {FILTER_ORDER.map((f) => {
+          const count = filterCounts[f];
+          const attention = f === "unverified" && count > 0;
+          return (
+            <button
+              key={f}
+              type="button"
+              className={`${styles.filterChip} ${
+                filter === f ? styles.filterChipActive : attention ? styles.filterChipAttention : ""
+              }`}
+              aria-pressed={filter === f}
+              onClick={() => onFilterChange(f)}
+            >
+              {FILTER_LABEL[f]} {count}
+            </button>
+          );
+        })}
+      </div>
+      {filteredRows.length === 0 ? (
+        <div className={styles.emptyState}>No snapshots match this filter.</div>
       ) : (
         <>
           <div className={styles.tableWrapper}>
             <table className={styles.table}>
               <thead>
                 <tr>
-                  <th className={styles.checkboxCell}></th>
+                  <th className={styles.radioCell}></th>
                   <th>Created</th>
                   <th>Tier</th>
-                  <th>Source</th>
                   <th>Size</th>
-                  <th>App version</th>
                   <th>Verified</th>
                   <th>Replicas</th>
-                  <th>Expires in</th>
+                  <th>Expires</th>
                   <th>Download</th>
                 </tr>
               </thead>
@@ -200,7 +284,7 @@ const SnapshotsCard: React.FC<SnapshotsCardProps> = ({
           </div>
           <div className={styles.paginationBar}>
             <div className={styles.paginationInfo}>
-              {rangeStart}-{rangeEnd} of {rows.length}
+              {rangeStart}-{rangeEnd} of {filteredRows.length}
             </div>
             <div className={styles.paginationControls}>
               <button

--- a/frontend/app/components/admin/backups/SnapshotsCard.tsx
+++ b/frontend/app/components/admin/backups/SnapshotsCard.tsx
@@ -75,9 +75,17 @@ function formatExpiresIn(expiresAt: string | null, now: Date): string {
   return `in ${diffMonths}mo`;
 }
 
-function missingReplicaTitle(row: BackupListRow): string {
-  const missing = ALL_BACKUP_REPLICAS.filter((r) => !row.replicas.includes(r));
-  return `Missing from ${missing.map((r) => REPLICA_LABEL[r]).join(", ")}`;
+const VERIFIED_TOOLTIP =
+  "Verified: restored into a scratch database and structurally checked during the backup run";
+const UNVERIFIED_TOOLTIP =
+  "Unverified: no verification record exists — likely created outside the backup workflow. Prefer a Verified snapshot in an incident";
+
+/** Per-replica present/missing breakdown for the replica count's hover title -- every row gets
+ * this, not just degraded ones, so "3 of 3" is still legible on hover as which three. */
+function replicaStatusTitle(row: BackupListRow): string {
+  return ALL_BACKUP_REPLICAS.map(
+    (r) => `${REPLICA_LABEL[r]}: ${row.replicas.includes(r) ? "present" : "missing"}`
+  ).join("\n");
 }
 
 export function matchesFilter(row: BackupListRow, filter: BackupTierFilter): boolean {
@@ -143,14 +151,18 @@ const SnapshotRow: React.FC<SnapshotRowProps> = ({ row, selected, onSelect, onDo
       </td>
       <td className={styles.sizeCell}>{formatBytes(row.sizeBytes)}</td>
       <td>
-        <span className={`${styles.verifiedIndicator} ${row.verified ? styles.verifiedYes : styles.verifiedNo}`}>
-          {row.verified ? "✓ Verified" : "⚠ Unverified"}
+        <span
+          className={`${styles.verifiedIndicator} ${row.verified ? styles.verifiedYes : styles.verifiedNo}`}
+          title={row.verified ? VERIFIED_TOOLTIP : UNVERIFIED_TOOLTIP}
+          aria-label={row.verified ? "Verified" : "Unverified"}
+        >
+          <Icon name={row.verified ? "check-circle" : "error-outline"} size={16} />
         </span>
       </td>
       <td>
         <span
           className={`${styles.replicaCount} ${degraded ? styles.replicaCountDegraded : ""}`}
-          title={degraded ? missingReplicaTitle(row) : undefined}
+          title={replicaStatusTitle(row)}
         >
           {replicaCount} of {ALL_BACKUP_REPLICAS.length}
         </span>
@@ -214,7 +226,7 @@ const SnapshotsCard: React.FC<SnapshotsCardProps> = ({
   };
 
   return (
-    <Card>
+    <Card accent="meetingCounts">
       <div className={styles.panelHeader}>
         <Icon name="backup" size={16} className={styles.panelIcon} />
         Snapshots

--- a/frontend/app/components/admin/backups/SnapshotsCard.tsx
+++ b/frontend/app/components/admin/backups/SnapshotsCard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import React from "react";
+import React, { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import Icon from "../../ui/displays/Icon";
 import Card from "../shared/Card";
 import CardHeader from "../shared/CardHeader";
@@ -80,12 +81,35 @@ const VERIFIED_TOOLTIP =
 const UNVERIFIED_TOOLTIP =
   "Unverified: no verification record exists — likely created outside the backup workflow. Prefer a Verified snapshot in an incident";
 
-/** Per-replica present/missing breakdown for the replica count's hover title -- every row gets
- * this, not just degraded ones, so "3 of 3" is still legible on hover as which three. */
-function replicaStatusTitle(row: BackupListRow): string {
-  return ALL_BACKUP_REPLICAS.map(
-    (r) => `${REPLICA_LABEL[r]}: ${row.replicas.includes(r) ? "present" : "missing"}`
-  ).join("\n");
+interface VerifiedLegendEntry {
+  icon: "check-circle" | "error-outline";
+  colorClass: string;
+  label: string;
+  description: string;
+}
+
+const VERIFIED_LEGEND: VerifiedLegendEntry[] = [
+  {
+    icon: "check-circle",
+    colorClass: "verifiedYes",
+    label: "Verified",
+    description: "restored into a scratch database and structurally checked during its backup run",
+  },
+  {
+    icon: "error-outline",
+    colorClass: "verifiedNo",
+    label: "Unverified",
+    description: "no verification record exists; likely created outside the backup workflow. Prefer a Verified snapshot in an incident",
+  },
+];
+
+/** Per-replica present/missing breakdown for the replica count's hover tooltip -- every row
+ * gets this, not just degraded ones, so "3 of 3" is still legible on hover as which three. */
+function replicaStatusList(row: BackupListRow): { label: string; present: boolean }[] {
+  return ALL_BACKUP_REPLICAS.map((r) => ({
+    label: REPLICA_LABEL[r],
+    present: row.replicas.includes(r),
+  }));
 }
 
 export function matchesFilter(row: BackupListRow, filter: BackupTierFilter): boolean {
@@ -160,11 +184,23 @@ const SnapshotRow: React.FC<SnapshotRowProps> = ({ row, selected, onSelect, onDo
         </span>
       </td>
       <td>
-        <span
-          className={`${styles.replicaCount} ${degraded ? styles.replicaCountDegraded : ""}`}
-          title={replicaStatusTitle(row)}
-        >
-          {replicaCount} of {ALL_BACKUP_REPLICAS.length}
+        <span className={styles.replicaTooltipAnchor}>
+          <span
+            className={`${styles.replicaCount} ${degraded ? styles.replicaCountDegraded : ""}`}
+            tabIndex={0}
+          >
+            {replicaCount} of {ALL_BACKUP_REPLICAS.length}
+          </span>
+          <span className={styles.replicaTooltip} role="tooltip">
+            {replicaStatusList(row).map(({ label, present }) => (
+              <span
+                key={label}
+                className={present ? styles.replicaTooltipLinePresent : styles.replicaTooltipLineMissing}
+              >
+                {label}: {present ? "present" : "missing"}
+              </span>
+            ))}
+          </span>
         </span>
       </td>
       <td className={styles.expiresCell}>
@@ -209,6 +245,46 @@ const SnapshotsCard: React.FC<SnapshotsCardProps> = ({
   now,
   latestAppVersion,
 }) => {
+  const [legendOpen, setLegendOpen] = useState(false);
+  const [legendPosition, setLegendPosition] = useState<{ top: number; left: number; width: number } | null>(null);
+  const infoButtonRef = useRef<HTMLButtonElement>(null);
+
+  // Same pattern as UsersTab.tsx's role legend: portaled to document.body so it renders above
+  // the table's own horizontal-scroll clipping, closed on outside click via its own data
+  // attribute (it's no longer a DOM descendant of the anchor once portaled).
+  useEffect(() => {
+    if (!legendOpen) return;
+    const handleClickOutside = (event: MouseEvent) => {
+      const target = event.target as HTMLElement;
+      if (!target.closest("[data-verified-legend]") && !target.closest("[data-verified-legend-popup]")) {
+        setLegendOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [legendOpen]);
+
+  useEffect(() => {
+    if (!legendOpen) return;
+
+    const updatePosition = () => {
+      const rect = infoButtonRef.current?.getBoundingClientRect();
+      if (!rect) return;
+      const margin = 16;
+      const width = Math.min(320, window.innerWidth - margin * 2);
+      const left = Math.max(margin, Math.min(rect.right - width, window.innerWidth - width - margin));
+      setLegendPosition({ top: rect.bottom + 6, left, width });
+    };
+
+    updatePosition();
+    window.addEventListener("scroll", updatePosition, true);
+    window.addEventListener("resize", updatePosition);
+    return () => {
+      window.removeEventListener("scroll", updatePosition, true);
+      window.removeEventListener("resize", updatePosition);
+    };
+  }, [legendOpen]);
+
   const filteredRows = rows.filter((row) => matchesFilter(row, filter));
   const totalPages = Math.max(1, Math.ceil(filteredRows.length / PAGE_SIZE));
   const clampedPage = Math.min(page, totalPages - 1);
@@ -274,12 +350,47 @@ const SnapshotsCard: React.FC<SnapshotsCardProps> = ({
                   <th>Created</th>
                   <th>Tier</th>
                   <th>Size</th>
-                  <th title="Whether this artifact was restored into a scratch database and structurally checked during its backup run — hover a row's icon for detail">
-                    Verified
+                  <th>
+                    <span className={styles.thLabel}>
+                      Verified
+                      <div className={styles.legendAnchor} data-verified-legend>
+                        <button
+                          ref={infoButtonRef}
+                          type="button"
+                          className={styles.infoButton}
+                          aria-label="What does Verified mean?"
+                          aria-expanded={legendOpen}
+                          onClick={() => setLegendOpen((open) => !open)}
+                        >
+                          <Icon name="warning-circle" size={20} />
+                        </button>
+                        {legendOpen && legendPosition && createPortal(
+                          <div
+                            className={styles.legendPopover}
+                            style={{ top: legendPosition.top, left: legendPosition.left, width: legendPosition.width }}
+                            data-verified-legend-popup="true"
+                          >
+                            <div className={styles.legendPopoverTitle}>Verified</div>
+                            <div className={styles.legendTable}>
+                              {VERIFIED_LEGEND.map((entry) => (
+                                <React.Fragment key={entry.label}>
+                                  <div className={styles.legendPillCell}>
+                                    <span className={`${styles.verifiedIndicator} ${styles[entry.colorClass]}`}>
+                                      <Icon name={entry.icon} size={16} />
+                                      {entry.label}
+                                    </span>
+                                  </div>
+                                  <div className={styles.legendDescCell}>{entry.description}</div>
+                                </React.Fragment>
+                              ))}
+                            </div>
+                          </div>,
+                          document.body,
+                        )}
+                      </div>
+                    </span>
                   </th>
-                  <th title="How many of the three storage targets (GCS working, GCS archive, Cloudflare R2) hold this artifact — hover a row's count for the per-target breakdown">
-                    Replicas
-                  </th>
+                  <th>Replicas</th>
                   <th>Expires</th>
                   <th>Download</th>
                 </tr>

--- a/frontend/app/components/admin/backups/SnapshotsCard.tsx
+++ b/frontend/app/components/admin/backups/SnapshotsCard.tsx
@@ -274,8 +274,12 @@ const SnapshotsCard: React.FC<SnapshotsCardProps> = ({
                   <th>Created</th>
                   <th>Tier</th>
                   <th>Size</th>
-                  <th>Verified</th>
-                  <th>Replicas</th>
+                  <th title="Whether this artifact was restored into a scratch database and structurally checked during its backup run — hover a row's icon for detail">
+                    Verified
+                  </th>
+                  <th title="How many of the three storage targets (GCS working, GCS archive, Cloudflare R2) hold this artifact — hover a row's count for the per-target breakdown">
+                    Replicas
+                  </th>
                   <th>Expires</th>
                   <th>Download</th>
                 </tr>

--- a/frontend/app/components/ui/displays/Icon.tsx
+++ b/frontend/app/components/ui/displays/Icon.tsx
@@ -44,6 +44,8 @@ import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 import LockOutlinedIcon from "@mui/icons-material/LockOutlined";
 import ErrorOutlineIcon from "@mui/icons-material/ErrorOutline";
 import WarningAmberIcon from "@mui/icons-material/WarningAmber";
+import ContentCopyIcon from "@mui/icons-material/ContentCopy";
+import FileDownloadOutlinedIcon from "@mui/icons-material/FileDownloadOutlined";
 import type { SvgIconComponent } from "@mui/icons-material";
 
 // Brand logos with no faithful @mui/icons-material equivalent (multi-color marks with no
@@ -120,6 +122,8 @@ const MUI_ICONS = {
     // Distinct outlined glyph from `warning` (WarningIcon, filled) -- see Toast's info/warning
     // variants.
     "warning-amber": WarningAmberIcon,
+    copy: ContentCopyIcon,
+    download: FileDownloadOutlinedIcon,
 } satisfies Record<string, SvgIconComponent>;
 
 export type IconName = keyof typeof LOCAL_ICONS | keyof typeof MUI_ICONS;

--- a/frontend/tests/component/BackupsTab.test.tsx
+++ b/frontend/tests/component/BackupsTab.test.tsx
@@ -40,7 +40,7 @@ describe("BackupsTab", () => {
     expect(unverifiedBadges).toHaveLength(1);
   });
 
-  it("shows a per-target present/missing title for the single-replica and two-replica rows (indices 6 and 9)", () => {
+  it("shows a per-target present/missing tooltip for the single-replica and two-replica rows (indices 6 and 9)", () => {
     const rows = generateMockBackupRows(FIXED_NOW);
     const singleReplicaRow = rows.find((row) => row.replicas.length === 1);
     const twoReplicaRow = rows.find((row) => row.replicas.length === 2);
@@ -48,17 +48,18 @@ describe("BackupsTab", () => {
     expect(twoReplicaRow).toBeDefined();
 
     renderTab();
-    expect(screen.getByText("1 of 3", { selector: `[title*="missing"]` })).toBeInTheDocument();
-    expect(screen.getByText("2 of 3", { selector: `[title*="missing"]` })).toBeInTheDocument();
+    // Tooltip content sits permanently in the DOM (CSS-hidden until hover/focus), so it's
+    // queryable directly rather than via a native `title` attribute.
+    expect(screen.getAllByText(/missing/).length).toBeGreaterThan(0);
   });
 
-  it("gives every replica cell a hover title, including fully-replicated rows", () => {
+  it("gives every replica cell a hover tooltip, including fully-replicated rows", () => {
     const rows = generateMockBackupRows(FIXED_NOW);
     const fullReplicaRow = rows.find((row) => row.replicas.length === 3);
     expect(fullReplicaRow).toBeDefined();
 
     renderTab();
-    expect(screen.getAllByText("3 of 3", { selector: `[title*="present"]` }).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/present/).length).toBeGreaterThan(0);
   });
 
   it("fixture contains both a single-replica and a two-replica (one-missing) row", () => {
@@ -186,6 +187,19 @@ describe("BackupsTab", () => {
     expect(
       screen.getByText("Signed-URL download arrives with the API wiring PR")
     ).toBeInTheDocument();
+  });
+
+  it("clicking the Verified header info button shows the legend, and clicking outside closes it", () => {
+    renderTab();
+
+    expect(screen.queryByText(/restored into a scratch database/)).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "What does Verified mean?" }));
+    expect(screen.getByText(/restored into a scratch database/)).toBeInTheDocument();
+    expect(screen.getByText(/no verification record exists/)).toBeInTheDocument();
+
+    fireEvent.mouseDown(document.body);
+    expect(screen.queryByText(/restored into a scratch database/)).not.toBeInTheDocument();
   });
 
   it("Notable Activity lists the failure and manual run but not routine successes, and shows the count line", () => {

--- a/frontend/tests/component/BackupsTab.test.tsx
+++ b/frontend/tests/component/BackupsTab.test.tsx
@@ -3,15 +3,10 @@ import { render, screen, fireEvent } from "@testing-library/react";
 import BackupsTab from "../../app/components/admin/backups/BackupsTab";
 import BackupHealthCard from "../../app/components/admin/backups/BackupHealthCard";
 import { ToastProvider } from "../../app/components/shared/ToastProvider";
-import {
-  freshnessFor,
-  generateMockBackupHealth,
-  generateMockBackupRows,
-} from "../../app/components/admin/backups/mockBackups";
-import type { BackupHealth, BackupListRow } from "../../types/backups";
+import { generateMockBackupHealth, generateMockBackupRows } from "../../app/components/admin/backups/mockBackups";
 
 // BackupsTab seeds its own `now` via `useState(() => new Date())` -- pin the system clock so
-// every card (freshness pill, "Expires in", next-run) renders deterministically under TZ=UTC.
+// every card ("Expires in", next-run, relative-age labels) renders deterministically under TZ=UTC.
 const FIXED_NOW = new Date("2026-08-15T12:00:00Z");
 
 const renderTab = () =>
@@ -33,29 +28,28 @@ describe("BackupsTab", () => {
   it("renders all four cards with the mock fixture", () => {
     renderTab();
     expect(screen.getByText("Backup Health")).toBeInTheDocument();
-    expect(screen.getByText(/^Snapshots \(\d+\)$/)).toBeInTheDocument();
+    expect(screen.getByText("Snapshots")).toBeInTheDocument();
     expect(screen.getByText("Restore Runbook")).toBeInTheDocument();
-    expect(screen.getByText("Recent Activity")).toBeInTheDocument();
+    expect(screen.getByText("Notable Activity")).toBeInTheDocument();
   });
 
-  it("shows the unverified row with the verifiedNo treatment (index 3 of the fixture)", () => {
+  it("shows the unverified row with the Unverified treatment (index 3 of the fixture)", () => {
     renderTab();
-    const unverifiedBadges = screen.getAllByText("Unverified");
-    expect(unverifiedBadges.length).toBeGreaterThan(0);
+    const unverifiedBadges = screen.getAllByText("⚠ Unverified");
     // The fixture guarantees exactly one unverified row among the dailies.
     expect(unverifiedBadges).toHaveLength(1);
   });
 
-  it("renders a missing replica dot for the single-replica row (index 6 of the fixture)", () => {
+  it("shows a 'Missing from' title for the single-replica and two-replica rows (indices 6 and 9)", () => {
     const rows = generateMockBackupRows(FIXED_NOW);
     const singleReplicaRow = rows.find((row) => row.replicas.length === 1);
+    const twoReplicaRow = rows.find((row) => row.replicas.length === 2);
     expect(singleReplicaRow).toBeDefined();
+    expect(twoReplicaRow).toBeDefined();
 
     renderTab();
-    // The single-replica row contributes 2 "Missing from" dots, the two-replica row
-    // contributes 1 -- both are on the first (default) page alongside the fixture's other rows.
-    const missingDots = screen.getAllByTitle(/^Missing from /);
-    expect(missingDots).toHaveLength(3);
+    expect(screen.getByText("1 of 3", { selector: `[title^="Missing from"]` })).toBeInTheDocument();
+    expect(screen.getByText("2 of 3", { selector: `[title^="Missing from"]` })).toBeInTheDocument();
   });
 
   it("fixture contains both a single-replica and a two-replica (one-missing) row", () => {
@@ -65,17 +59,16 @@ describe("BackupsTab", () => {
     expect(replicaCounts).toContain(2);
   });
 
-  it("shows 'never' for the permanent row's expiry", () => {
+  it("shows 'Never' for the permanent row's expiry", () => {
     const rows = generateMockBackupRows(FIXED_NOW);
     const permanentRow = rows.find((row) => row.tier === "permanent");
     expect(permanentRow).toBeDefined();
     expect(permanentRow!.expiresAt).toBeNull();
 
     renderTab();
-    // The permanent row is the oldest of 28 fixture rows (10/page) -- page to the last page
-    // where it lives before asserting its "never" expiry.
-    fireEvent.click(screen.getByLabelText(`Page ${Math.ceil(rows.length / 10)}`));
-    expect(screen.getByText("never")).toBeInTheDocument();
+    // Filter down to the Permanent tier so the single permanent row lands on page 1.
+    fireEvent.click(screen.getByRole("button", { name: /^Permanent \d+$/ }));
+    expect(screen.getByText("Never")).toBeInTheDocument();
   });
 
   it("selecting a snapshot populates the Restore Runbook command with its artifact filename", () => {
@@ -86,23 +79,75 @@ describe("BackupsTab", () => {
 
     const rows = generateMockBackupRows(FIXED_NOW);
     const firstRow = rows[0];
-    const checkboxes = screen.getAllByLabelText(/Select snapshot from /i);
-    fireEvent.click(checkboxes[0]);
+    const radios = screen.getAllByRole("radio");
+    fireEvent.click(radios[0]);
 
     const commandBox = screen.getByText(new RegExp(`${firstRow.id}\\.dump\\.age`));
     expect(commandBox).toBeInTheDocument();
+    expect(screen.getByText(/command for the selected snapshot/i)).toBeInTheDocument();
   });
 
-  it("clicking a selected row's checkbox again unselects it", () => {
+  it("clicking a selected row again unselects it", () => {
     renderTab();
-    const checkboxes = screen.getAllByLabelText(/Select snapshot from /i);
+    // Radio inputs don't fire a native change event on a second click while already checked --
+    // click the row itself (the tr's onClick, not the radio's onChange) to exercise the toggle.
+    const dataRows = screen.getAllByRole("row").slice(1);
 
-    fireEvent.click(checkboxes[0]);
+    fireEvent.click(dataRows[0]);
     expect(
       screen.queryByText("Select a snapshot above to generate its restore command.")
     ).not.toBeInTheDocument();
 
-    fireEvent.click(checkboxes[0]);
+    fireEvent.click(dataRows[0]);
+    expect(
+      screen.getByText("Select a snapshot above to generate its restore command.")
+    ).toBeInTheDocument();
+  });
+
+  it("the runbook's copy button has an accessible 'Copy command' label", () => {
+    renderTab();
+    const radios = screen.getAllByRole("radio");
+    fireEvent.click(radios[0]);
+
+    expect(screen.getByRole("button", { name: "Copy command" })).toBeInTheDocument();
+  });
+
+  it("the Snapshots filter chips filter the table (Unverified, then Monthly)", () => {
+    const rows = generateMockBackupRows(FIXED_NOW);
+    const unverifiedCount = rows.filter((r) => !r.verified).length;
+    const monthlyCount = rows.filter((r) => r.tier === "monthly").length;
+
+    renderTab();
+
+    fireEvent.click(screen.getByRole("button", { name: `Unverified ${unverifiedCount}` }));
+    expect(screen.getAllByText("⚠ Unverified")).toHaveLength(unverifiedCount);
+
+    fireEvent.click(screen.getByRole("button", { name: `Monthly ${monthlyCount}` }));
+    expect(screen.getAllByText("Monthly", { selector: "span" }).length).toBeGreaterThan(0);
+    expect(screen.queryByText("⚠ Unverified")).not.toBeInTheDocument();
+  });
+
+  it("changing the filter resets pagination back to page 1", () => {
+    renderTab();
+    // All tier has 28 rows (14 daily + 13 monthly + 1 permanent) -- enough for page 2 to exist.
+    fireEvent.click(screen.getByRole("button", { name: "Page 2" }));
+    expect(screen.getByText(/^11-20 of/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /^Monthly \d+$/ }));
+    expect(screen.getByText(/^1-10 of 13$/)).toBeInTheDocument();
+  });
+
+  it("clears the snapshot selection when the active filter no longer matches it", () => {
+    renderTab();
+
+    fireEvent.click(screen.getByRole("button", { name: /^Daily \d+$/ }));
+    const radios = screen.getAllByRole("radio");
+    fireEvent.click(radios[0]);
+    expect(
+      screen.queryByText("Select a snapshot above to generate its restore command.")
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /^Monthly \d+$/ }));
     expect(
       screen.getByText("Select a snapshot above to generate its restore command.")
     ).toBeInTheDocument();
@@ -122,9 +167,9 @@ describe("BackupsTab", () => {
     ).toBeInTheDocument();
   });
 
-  it("Download button is labeled 'Download (encrypted)' and fires the stub toast", () => {
+  it("the download button's aria-label still contains 'Download (encrypted)' and fires the stub toast", () => {
     renderTab();
-    const downloadButtons = screen.getAllByText("Download (encrypted)");
+    const downloadButtons = screen.getAllByLabelText(/Download \(encrypted\)/);
     expect(downloadButtons.length).toBeGreaterThan(0);
 
     fireEvent.click(downloadButtons[0]);
@@ -133,37 +178,56 @@ describe("BackupsTab", () => {
       screen.getByText("Signed-URL download arrives with the API wiring PR")
     ).toBeInTheDocument();
   });
+
+  it("Notable Activity lists the failure and manual run but not routine successes, and shows the count line", () => {
+    renderTab();
+    const panel = screen.getByTestId("backups-recent-activity-panel");
+
+    expect(screen.getByText("Scheduled backup failed")).toBeInTheDocument();
+    expect(screen.getByText(/^Manual backup/)).toBeInTheDocument();
+    expect(panel).toHaveTextContent(/\d+ routine scheduled successes not shown\./);
+  });
 });
 
-describe("BackupHealthCard freshness pill", () => {
-  const buildHealth = (ageHours: number): BackupHealth => {
-    const lastSuccessfulBackupAt = new Date(
-      FIXED_NOW.getTime() - ageHours * 60 * 60 * 1000
-    ).toISOString();
-    return {
-      ...generateMockBackupHealth(FIXED_NOW, [] as BackupListRow[]),
-      lastSuccessfulBackupAt,
-      freshness: freshnessFor(lastSuccessfulBackupAt, FIXED_NOW),
+describe("BackupHealthCard warning banner", () => {
+  it("renders the no-verified-restore banner when lastVerifiedRestoreAt is null", () => {
+    const rows = generateMockBackupRows(FIXED_NOW);
+    const health = { ...generateMockBackupHealth(FIXED_NOW, rows), lastVerifiedRestoreAt: null };
+    render(<BackupHealthCard health={health} now={FIXED_NOW} />);
+    expect(screen.getByText("No restore has ever been verified")).toBeInTheDocument();
+  });
+
+  it("does not render the banner when lastVerifiedRestoreAt is set", () => {
+    const rows = generateMockBackupRows(FIXED_NOW);
+    const health = {
+      ...generateMockBackupHealth(FIXED_NOW, rows),
+      lastVerifiedRestoreAt: new Date(FIXED_NOW.getTime() - 60 * 24 * 60 * 60 * 1000).toISOString(),
     };
-  };
-
-  it("renders 'Healthy' just under the 26h warn boundary", () => {
-    render(<BackupHealthCard health={buildHealth(25.9)} now={FIXED_NOW} />);
-    expect(screen.getByText("Healthy")).toBeInTheDocument();
+    render(<BackupHealthCard health={health} now={FIXED_NOW} />);
+    expect(screen.queryByText("No restore has ever been verified")).not.toBeInTheDocument();
   });
 
-  it("renders 'Aging' at exactly the 26h warn boundary", () => {
-    render(<BackupHealthCard health={buildHealth(26)} now={FIXED_NOW} />);
-    expect(screen.getByText("Aging")).toBeInTheDocument();
+  it("shows the three-stat row: last backup, next run, snapshots retained", () => {
+    const rows = generateMockBackupRows(FIXED_NOW);
+    const health = generateMockBackupHealth(FIXED_NOW, rows);
+    render(<BackupHealthCard health={health} now={FIXED_NOW} />);
+    expect(screen.getByText("Last successful backup")).toBeInTheDocument();
+    expect(screen.getByText(/^Next run/)).toBeInTheDocument();
+    expect(screen.getByText("Snapshots retained")).toBeInTheDocument();
   });
 
-  it("renders 'Aging' just under the 72h error boundary", () => {
-    render(<BackupHealthCard health={buildHealth(71.9)} now={FIXED_NOW} />);
-    expect(screen.getByText("Aging")).toBeInTheDocument();
+  it("summarizes replicas as 'All three hold the latest snapshot' when every replica is current", () => {
+    const rows = generateMockBackupRows(FIXED_NOW);
+    const health = generateMockBackupHealth(FIXED_NOW, rows);
+    render(<BackupHealthCard health={health} now={FIXED_NOW} />);
+    expect(screen.getByText("All three hold the latest snapshot")).toBeInTheDocument();
   });
 
-  it("renders 'Stale' at exactly the 72h error boundary", () => {
-    render(<BackupHealthCard health={buildHealth(72)} now={FIXED_NOW} />);
-    expect(screen.getByText("Stale")).toBeInTheDocument();
+  it("summarizes replicas as 'N of 3 hold the latest snapshot' when degraded", () => {
+    const rows = generateMockBackupRows(FIXED_NOW);
+    const health = generateMockBackupHealth(FIXED_NOW, rows);
+    health.replicaStatus[0].hasLatest = false;
+    render(<BackupHealthCard health={health} now={FIXED_NOW} />);
+    expect(screen.getByText("2 of 3 hold the latest snapshot")).toBeInTheDocument();
   });
 });

--- a/frontend/tests/component/BackupsTab.test.tsx
+++ b/frontend/tests/component/BackupsTab.test.tsx
@@ -35,12 +35,12 @@ describe("BackupsTab", () => {
 
   it("shows the unverified row with the Unverified treatment (index 3 of the fixture)", () => {
     renderTab();
-    const unverifiedBadges = screen.getAllByText("⚠ Unverified");
+    const unverifiedBadges = screen.getAllByLabelText("Unverified");
     // The fixture guarantees exactly one unverified row among the dailies.
     expect(unverifiedBadges).toHaveLength(1);
   });
 
-  it("shows a 'Missing from' title for the single-replica and two-replica rows (indices 6 and 9)", () => {
+  it("shows a per-target present/missing title for the single-replica and two-replica rows (indices 6 and 9)", () => {
     const rows = generateMockBackupRows(FIXED_NOW);
     const singleReplicaRow = rows.find((row) => row.replicas.length === 1);
     const twoReplicaRow = rows.find((row) => row.replicas.length === 2);
@@ -48,8 +48,17 @@ describe("BackupsTab", () => {
     expect(twoReplicaRow).toBeDefined();
 
     renderTab();
-    expect(screen.getByText("1 of 3", { selector: `[title^="Missing from"]` })).toBeInTheDocument();
-    expect(screen.getByText("2 of 3", { selector: `[title^="Missing from"]` })).toBeInTheDocument();
+    expect(screen.getByText("1 of 3", { selector: `[title*="missing"]` })).toBeInTheDocument();
+    expect(screen.getByText("2 of 3", { selector: `[title*="missing"]` })).toBeInTheDocument();
+  });
+
+  it("gives every replica cell a hover title, including fully-replicated rows", () => {
+    const rows = generateMockBackupRows(FIXED_NOW);
+    const fullReplicaRow = rows.find((row) => row.replicas.length === 3);
+    expect(fullReplicaRow).toBeDefined();
+
+    renderTab();
+    expect(screen.getAllByText("3 of 3", { selector: `[title*="present"]` }).length).toBeGreaterThan(0);
   });
 
   it("fixture contains both a single-replica and a two-replica (one-missing) row", () => {
@@ -120,11 +129,11 @@ describe("BackupsTab", () => {
     renderTab();
 
     fireEvent.click(screen.getByRole("button", { name: `Unverified ${unverifiedCount}` }));
-    expect(screen.getAllByText("⚠ Unverified")).toHaveLength(unverifiedCount);
+    expect(screen.getAllByLabelText("Unverified")).toHaveLength(unverifiedCount);
 
     fireEvent.click(screen.getByRole("button", { name: `Monthly ${monthlyCount}` }));
     expect(screen.getAllByText("Monthly", { selector: "span" }).length).toBeGreaterThan(0);
-    expect(screen.queryByText("⚠ Unverified")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Unverified")).not.toBeInTheDocument();
   });
 
   it("changing the filter resets pagination back to page 1", () => {

--- a/frontend/tests/e2e/18-backups-tab.spec.ts
+++ b/frontend/tests/e2e/18-backups-tab.spec.ts
@@ -15,9 +15,9 @@ test.describe("backups tab", () => {
     await page.getByTestId("admin-tab-backups").click();
 
     await expect(page.getByText("Backup Health")).toBeVisible();
-    await expect(page.getByText(/^Snapshots \(\d+\)$/)).toBeVisible();
+    await expect(page.getByText("Snapshots", { exact: true })).toBeVisible();
     await expect(page.getByText("Restore Runbook")).toBeVisible();
-    await expect(page.getByTestId("backups-recent-activity-panel").getByText("Recent Activity")).toBeVisible();
+    await expect(page.getByTestId("backups-recent-activity-panel").getByText("Notable Activity")).toBeVisible();
   });
 
   // Matches the shell's established superAdminOnly treatment (see 1.8: Users/Export):

--- a/frontend/types/backups.ts
+++ b/frontend/types/backups.ts
@@ -7,6 +7,9 @@
 /** GFS retention tier. Only three tiers exist — no weekly, no yearly. */
 export type BackupTier = "daily" | "monthly" | "permanent";
 
+/** Snapshots table filter chip value — the three GFS tiers plus "all" and the "unverified" cross-cut. */
+export type BackupTierFilter = "all" | BackupTier | "unverified";
+
 /** How a backup run was triggered. */
 export type BackupSource = "automatic" | "manual";
 

--- a/frontend/util/format/bytes.ts
+++ b/frontend/util/format/bytes.ts
@@ -1,0 +1,14 @@
+/**
+ * Human-readable byte size (e.g. "4.2 MB", "512 KB", "1.03 GB"). Shared by every Backups
+ * admin tab card so the same size reads identically across Backup Health and Snapshots.
+ * @param bytes - Raw byte count.
+ * @returns A size string with one of B/KB/MB/GB units.
+ */
+export function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  const kb = bytes / 1024;
+  if (kb < 1024) return `${kb.toFixed(1)} KB`;
+  const mb = kb / 1024;
+  if (mb < 1024) return `${mb.toFixed(1)} MB`;
+  return `${(mb / 1024).toFixed(2)} GB`;
+}


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redesigned the backups dashboard with health warnings, summary statistics, replica details, and storage headroom information.
  * Added backup-tier and verification filters, improved pagination, and clearer snapshot details.
  * Added “Back Up Now,” download, copy, and restore-runbook actions.
  * Enhanced activity reporting to highlight failures, manual runs, and in-progress backups.
  * Added clearer relative and Eastern-time timestamps, expiration details, and formatted storage sizes.
* **Bug Fixes**
  * Improved capacity indicators and restore-verification messaging.
  * Updated responsive layouts, accessibility labels, and status presentation across backup views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Visual/UX redesign of the Backups admin tab (shipped in #434), following a design review whose center of gravity is: **the risk leads, not the button**. Design source: the "Ithaca Recovery Design System" artifact (current-vs-redesigned comparison); fidelity verified against it in a live browser walkthrough.

## Description
- **`BackupHealthCard.tsx`**: the four label/value rows become — a **warning banner** when no restore has ever been verified (the page's actual risk; its action links to the runbook docs rather than pretending a drill can run in-app), a **3-up stat row** (last backup relative age with warn/error color when stale, next-run countdown, snapshots retained), and a named **REPLICAS panel** (three tiles + "All three hold the latest snapshot" summary) with the free-tier bar **inverted to show remaining space** — a 3%-used green sliver previously read as "3% healthy".
- **`SnapshotsCard.tsx`**: filter chips (All/Daily/Monthly/Permanent/Unverified, the last with attention styling when non-zero); rows become **single-select radios** with a visible "Clear selection" control; constant columns (Source, App version) move into the subtitle and a per-row "Manual" chip; replica dots become legend-style "3 of 3" text so a degraded row states its own problem; ten labeled download buttons collapse to one per-row icon (new `download` glyph registered); subhead shows "{filtered} of {total} snapshots".
- **`RestoreRunbookCard.tsx`**: the command renders in a **dark command box** with an uppercase snapshot-context header and a **copy icon button pinned top-right** (focus-visible outline on the dark surface; clipboard failure fallback kept); command wraps rather than scrolls — an operator mid-incident must see the whole command. Command contract unchanged (`AGE_IDENTITY_FILE=… RESTORE_TARGET_URL=… ./frontend/scripts/restore-db.sh …`).
- **`RecentActivityCard.tsx`** → "Notable Activity": lists only failures, manual runs, and in-progress runs; routine scheduled successes become a count line. No "View all" link until the API-wiring PR gives it a destination.
- **`BackupsTab.tsx`**: Back Up Now demotes to a compact header-corner button; filter state resets pagination and clears a selection the new filter would hide (no command box for an invisible snapshot); one `now` anchor threads through every card (no render-path `Date.now()` anywhere — SSR-safe).
- **`util/format/bytes.ts`** (new): the tab's two divergent byte formatters unified into one shared helper.
- Tests updated honestly alongside: 19 component cases (incl. filter-resets-page and selection-clears-on-filter regression cases) + the e2e spec.

Deliberate deviations from the design mock, for the record: no "Start drill" button (a drill physically requires the offline key — same reasoning that dropped Restore in #434's review); the mock's `./scripts/restore.sh --snapshot …` command replaced with the real script contract; "View all 40 runs"/"View log" links omitted until they have destinations.

## Testing
- [x] `yarn test:all` green: lint/lint:css/typecheck clean; 213/213 unit, 227→229/229 component (19 in `BackupsTab.test.tsx`), 93/93 integration, 103/103 e2e (one strict-mode locator collision found by the suite and fixed).
- [x] Live browser walkthrough as Super Admin against the design artifact — all sections match; the one visual defect found live (command overflow) fixed to wrap. A dev-overlay hydration warning was traced to a browser extension's injected attribute (`bis_skin_checked`), not app code.
- [x] Independent high-effort review of the full diff; 12 findings fixed pre-PR (highlights: the staleness signal silently lost with the freshness pill, selection surviving filter changes, a `new Date()` bypassing the shared `now` anchor, a 48-*days* constant labeled 48 hours, a production component importing the mock fixture module).

## Area(s) Touched
**Product areas**
- [x] admin — /admin shell (Diagnostics, Users, Import, Export tabs)
- [x] ui/ux — frontend layout/styling not tied to a specific integration

**Engineering**
- [x] testing — test suite (Jest/Playwright) changes

## Pre-merge Checklist
- [x] Code follows current formatting conventions and passes lint (`yarn lint`).
- [x] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
- [x] All test suites pass, both run locally and green in GitHub CI. **Do not merge if any test suite is failing.**
- [x] A test suite was added or updated for the feature/fix in this PR. **Double-check this if you change a feature and did not update the test suites**. — Rewritten alongside the UI; searched for tests asserting the old UI's contract (freshness pill labels, checkbox selection, old card titles) and updated every one.
- [x] Only files relevant to this change are committed — no stray or unrelated files.
- [x] If this branch has a merge conflict with master, master was merged into this branch first (not the other way around).
- [x] The rest of this PR description (Description, Testing) is filled out, not left as template placeholders.
