### PR TITLE
fix(backup): match pg_dump and scratch container to Neon's Postgres 18

### DIFF
--- a/.github/scripts/backup-db.sh
+++ b/.github/scripts/backup-db.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 # Required env vars:
 #   DATABASE_URL_UNPOOLED   Neon connection string with pooling off (pgbouncer breaks pg_dump's
 #                            session-level operations -- see plan's "Design decisions").
-#   SCRATCH_DATABASE_URL     Connection string for the workflow's `services: postgres:17` scratch
+#   SCRATCH_DATABASE_URL     Connection string for the workflow's `services: postgres:18` scratch
 #                            container, e.g. postgresql://postgres:postgres@localhost:5432/scratch.
 #                            Owned by this script/B1's contract; cross-check with B1's service
 #                            definition and B9.

--- a/.github/workflows/backup-db.yml
+++ b/.github/workflows/backup-db.yml
@@ -30,7 +30,7 @@ jobs:
     timeout-minutes: 10 # bounds a pg_dump stuck behind a concurrent ACCESS EXCLUSIVE lock
     services:
       postgres:
-        image: postgres:17
+        image: postgres:18
         env:
           POSTGRES_PASSWORD: postgres
         ports:
@@ -49,7 +49,7 @@ jobs:
 
       # pg_dump/pg_restore must match the scratch container's major version (17);
       # Ubuntu's default apt repo doesn't carry it, so pull from PGDG directly.
-      - name: Install postgresql-client-17 and age
+      - name: Install postgresql-client-18 and age
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends curl ca-certificates gnupg age
@@ -59,11 +59,15 @@ jobs:
           echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt $(. /etc/os-release && echo "$VERSION_CODENAME")-pgdg main" \
             | sudo tee /etc/apt/sources.list.d/pgdg.list
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends postgresql-client-17
+          sudo apt-get install -y --no-install-recommends postgresql-client-18
 
       - name: Dump, verify, encrypt
         id: backup
         run: |
+          # Explicit PATH: the runner ships an older postgresql-client and Ubuntu's
+          # pg_wrapper picked it over the PGDG 18 install, causing a server-version
+          # mismatch abort (Neon runs Postgres 18).
+          export PATH="/usr/lib/postgresql/18/bin:$PATH"
           APP_VERSION="$(node -p "require('./frontend/package.json').version")"
           export APP_VERSION
           .github/scripts/backup-db.sh


### PR DESCRIPTION
## Description
- **`.github/workflows/backup-db.yml`**: Neon production turned out to run **Postgres 18.4** (the plan assumed 17). `pg_dump` aborts on any server newer than itself — and the runner additionally resolved `pg_dump` to the preinstalled client 16 via Ubuntu's pg_wrapper despite the PGDG install. Three changes: install `postgresql-client-18`, export `PATH=/usr/lib/postgresql/18/bin:$PATH` in the dump step (explicit beats wrapper heuristics), and bump the scratch verification container to `postgres:18` so the restore-verify runs against a matching server.
- **`.github/scripts/backup-db.sh`**: comment updated to match.

Second live-run finding after #436 ([run log](https://github.com/cornellh4i/ithaca-recovery/actions/runs/31935612385)): the gzip fix got the dump started, this gets it targeting the right server version. Will re-dispatch after merge; #435 stays open until green.

## Testing
- [x] actionlint + shellcheck clean.
- [ ] Post-merge `workflow_dispatch` is the real test.

## Area(s) Touched
**Engineering**
- [x] github-actions — workflows, Dependabot config, other .github/ CI tooling

## Pre-merge Checklist
- [x] Code follows current formatting conventions and passes lint (`yarn lint`).
- [x] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
- [x] All test suites pass, both run locally and green in GitHub CI. **Do not merge if any test suite is failing.**
- [x] A test suite was added or updated for the feature/fix in this PR. **Double-check this if you change a feature and did not update the test suites**. — N/A: CI-config fix; the verifying test is the post-merge dispatch.
- [x] Only files relevant to this change are committed — no stray or unrelated files.
- [x] If this branch has a merge conflict with master, master was merged into this branch first (not the other way around).
- [x] The rest of this PR description (Description, Testing) is filled out, not left as template placeholders.