### PR TITLE
fix(backup): judge empty canary tables against the source, not assumption

### DIFF
--- a/.github/scripts/backup-db.sh
+++ b/.github/scripts/backup-db.sh
@@ -91,12 +91,15 @@ for table in "${expected_tables[@]}"; do
   fi
 done
 
-# Admin/Meeting empty would mean a restore that "succeeded" onto essentially a blank database --
-# catches a dump taken against the wrong connection string or an empty branch.
+# An empty restored canary table only means corruption if the SOURCE has rows -- production
+# launched with zero meetings, so "empty" must be judged against the live table, not assumed.
+# Still catches the real failure (dump against the wrong/blank database) whenever the source
+# is populated; Admin can never legitimately be empty (the app is unusable without one).
 for table in Admin Meeting; do
   count="$(psql "$SCRATCH_DATABASE_URL" -tAc "SELECT count(*) FROM \"${table}\";")"
-  if [[ "$count" -eq 0 ]]; then
-    echo "backup-db: restored table \"${table}\" is empty" >&2
+  source_count="$(psql "$DATABASE_URL_UNPOOLED" -tAc "SELECT count(*) FROM \"${table}\";")"
+  if [[ "$count" -eq 0 && ( "$table" == "Admin" || "$source_count" -gt 0 ) ]]; then
+    echo "backup-db: restored table \"${table}\" is empty (source has ${source_count} rows)" >&2
     exit 1
   fi
 done


### PR DESCRIPTION
## Description
- **`.github/scripts/backup-db.sh`**: the third live dispatch got past dump and restore and was stopped by the structural verification itself: `restored table "Meeting" is empty`. That's the gate working — but the assumption behind it is wrong for this production, which was migrated pre-launch with a single admin and **zero meetings** (the check was written imagining a populated database). The canary now compares the restored count against the **live source table**: empty is fatal only when the source actually has rows (wrong-connection-string/blank-branch dumps are still caught the moment production is populated), and `Admin` stays unconditionally non-empty (the app is unusable without one). The live query is the same advisory-comparison pattern the drift check already uses.

Third live-run finding, third one-step-deeper failure: #436 fixed the dump flag, #438 fixed the server version, this fixes the verification's world-model. [Run log](https://github.com/cornellh4i/ithaca-recovery/actions/runs/31941192847-ish — see latest failed run). Will re-dispatch after merge; #435 stays open until green.

## Testing
- [x] shellcheck clean.
- [ ] Post-merge dispatch is the real test.

## Area(s) Touched
**Engineering**
- [x] github-actions — workflows, Dependabot config, other .github/ CI tooling

## Pre-merge Checklist
- [x] Code follows current formatting conventions and passes lint (`yarn lint`).
- [x] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
- [x] All test suites pass, both run locally and green in GitHub CI. **Do not merge if any test suite is failing.**
- [x] A test suite was added or updated for the feature/fix in this PR. **Double-check this if you change a feature and did not update the test suites**. — N/A: bash verification logic exercised only by the live workflow.
- [x] Only files relevant to this change are committed — no stray or unrelated files.
- [x] If this branch has a merge conflict with master, master was merged into this branch first (not the other way around).
- [x] The rest of this PR description (Description, Testing) is filled out, not left as template placeholders.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database restore verification by comparing restored administrator and meeting records with the source database.
  * Added clearer failure handling for missing records and included source row counts in error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->