### PR TITLE
fix(backup): upload to GCS via raw objects.create, not gcloud storage cp

### DIFF
--- a/.github/scripts/upload-backup.sh
+++ b/.github/scripts/upload-backup.sh
@@ -50,13 +50,32 @@ if [[ "$ARTIFACT_DAY" == "01" ]]; then
   TIERS+=("monthly")
 fi
 
+# Raw JSON-API insert instead of `gcloud storage cp`: cp stats the destination
+# object first, which needs storage.objects.get -- and the CI service accounts
+# are deliberately objectCreator-only (create, never read/overwrite). The API
+# upload is a pure objects.create. ifGenerationMatch=0 makes create-only explicit:
+# the write fails with 412 rather than overwriting if the object somehow exists.
+# No Object Lock params here: immutability for GCS targets is bucket-side
+# (lifecycle on working, retention policy on archive), not per-object.
+gcs_put() {
+  local bucket="$1" object="$2" file="$3" http_code
+  http_code="$(curl -sS -o /tmp/gcs-upload-response.json -w '%{http_code}' \
+    -X POST --data-binary @"$file" \
+    -H "Authorization: Bearer $(gcloud auth print-access-token)" \
+    -H "Content-Type: application/octet-stream" \
+    "https://storage.googleapis.com/upload/storage/v1/b/${bucket}/o?uploadType=media&ifGenerationMatch=0&name=$(printf '%s' "$object" | jq -sRr @uri)")"
+  if [[ "$http_code" != 2* ]]; then
+    echo "upload-backup: GCS upload of ${object} to ${bucket} failed (HTTP ${http_code}):" >&2
+    cat /tmp/gcs-upload-response.json >&2
+    return 1
+  fi
+}
+
 upload_gcs() {
   local bucket="$1" tier="$2"
-  # No Object Lock flags here: immutability for GCS targets is bucket-side
-  # (lifecycle on working, retention policy on archive), not per-object.
-  gcloud storage cp "$ARTIFACT_PATH" "gs://${bucket}/${tier}/${ARTIFACT_NAME}"
-  gcloud storage cp "$SHA256_PATH" "gs://${bucket}/${tier}/${SHA256_NAME}"
-  gcloud storage cp "$META_PATH" "gs://${bucket}/${tier}/${META_NAME}"
+  gcs_put "$bucket" "${tier}/${ARTIFACT_NAME}" "$ARTIFACT_PATH"
+  gcs_put "$bucket" "${tier}/${SHA256_NAME}" "$SHA256_PATH"
+  gcs_put "$bucket" "${tier}/${META_NAME}" "$META_PATH"
 }
 
 # Retention is enforced by the bucket's prefix-scoped Bucket Lock rules (daily/ 14d,


### PR DESCRIPTION
## Description
- **`.github/scripts/upload-backup.sh`**: fourth live dispatch got all the way through dump → scratch-restore verification → encryption, and **the R2 upload succeeded** — the first artifact is genuinely in Cloudflare R2. Both GCS uploads then 403'd: `gcloud storage cp` stats the destination object before writing (needs `storage.objects.get`), and both service accounts are deliberately **objectCreator-only** — create, never read. Rather than widening IAM (bucket-wide read for a compromised token was explicitly rejected in the design), the upload switches to the JSON API's media insert — a pure `objects.create` — using the workflow's existing WIF token via `gcloud auth print-access-token`. `ifGenerationMatch=0` additionally makes never-overwrite an API-level precondition (412 instead of clobber), which is stronger than what `cp` provided.

Fourth live-run finding, and the failure frontier keeps moving forward: #436 dump flag → #438 server version → #439 verification world-model → this, the last mile to storage. [Failed run](https://github.com/cornellh4i/ithaca-recovery/actions/runs/31952743060). Re-dispatch after merge; #435 closes when green.

## Testing
- [x] shellcheck clean.
- [ ] Post-merge dispatch is the real test.

## Area(s) Touched
**Engineering**
- [x] github-actions — workflows, Dependabot config, other .github/ CI tooling

## Pre-merge Checklist
- [x] Code follows current formatting conventions and passes lint (`yarn lint`).
- [x] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
- [x] All test suites pass, both run locally and green in GitHub CI. **Do not merge if any test suite is failing.**
- [x] A test suite was added or updated for the feature/fix in this PR. **Double-check this if you change a feature and did not update the test suites**. — N/A: upload path exercised only by the live workflow.
- [x] Only files relevant to this change are committed — no stray or unrelated files.
- [x] If this branch has a merge conflict with master, master was merged into this branch first (not the other way around).
- [x] The rest of this PR description (Description, Testing) is filled out, not left as template placeholders.