### PR TITLE
feat(backups): keyless Vercel OIDC auth for the Backups tab, refresh loading bar

### DIFF
--- a/docs/03-development/environment-variables.md
+++ b/docs/03-development/environment-variables.md
@@ -79,7 +79,8 @@ serving fixtures.
 
 | Variable | Purpose |
 |---|---|
-| `GCS_BACKUPS_CREDENTIALS` | Base64-encoded JSON key for a **read-only** GCS service account (list + get objects only — never the create-only CI identity used by the backup workflow itself) |
+| `GCP_BACKUPS_WIF_PROVIDER` | Full Workload Identity Federation provider resource name (`projects/<number>/locations/global/workloadIdentityPools/<pool>/providers/<provider>`) trusting Vercel's OIDC issuer — no downloadable key: org policy `iam.disableServiceAccountKeyCreation` forbids one |
+| `GCP_BACKUPS_SERVICE_ACCOUNT` | Email of the **read-only** GCS service account (list + get objects only — never the create-only CI identity used by the backup workflow itself) impersonated via WIF |
 | `GCS_WORKING_BUCKET` / `GCS_ARCHIVE_BUCKET` | GCS bucket names for the working and archive copies (`icr-db-backups-prod` / `icr-db-backups-archive`) |
 | `R2_ACCOUNT_ID` / `R2_ACCESS_KEY_ID_READ` / `R2_SECRET_ACCESS_KEY_READ` / `R2_BUCKET` | Read-scoped Cloudflare R2 API token + bucket name — a separate token from the workflow's write-scoped `R2_ACCESS_KEY_ID`/`R2_SECRET_ACCESS_KEY` GitHub secrets |
 | `GITHUB_BACKUPS_PAT` | Fine-grained GitHub PAT with Actions read+write on the repo (run history + manual dispatch) |

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -38,12 +38,13 @@ ZOOM_HOSTS=
 # Backups admin tab (all optional — when unset, dev/CI serve sample data and
 # production shows the tab's "not configured" panel; see
 # docs/03-development/environment-variables.md)
-GCS_BACKUPS_CREDENTIALS=
+GCP_BACKUPS_WIF_PROVIDER=
+GCP_BACKUPS_SERVICE_ACCOUNT=
 GCS_WORKING_BUCKET=
 GCS_ARCHIVE_BUCKET=
 R2_ACCOUNT_ID=
-R2_ACCESS_KEY_ID_READ_READ=
-R2_SECRET_ACCESS_KEY_READ_READ=
+R2_ACCESS_KEY_ID_READ=
+R2_SECRET_ACCESS_KEY_READ=
 R2_BUCKET=
 GITHUB_BACKUPS_PAT=
 GITHUB_BACKUPS_REPO=

--- a/frontend/app/components/admin/backups/BackupsTab.module.scss
+++ b/frontend/app/components/admin/backups/BackupsTab.module.scss
@@ -1,6 +1,7 @@
 @import '../../../../styles/Variables.module';
 
 .container {
+  position: relative; // anchors TopLoadingBar, which positions itself absolutely against this
   display: flex;
   flex-direction: column;
   gap: 20px;

--- a/frontend/app/components/admin/backups/BackupsTab.tsx
+++ b/frontend/app/components/admin/backups/BackupsTab.tsx
@@ -7,6 +7,7 @@ import RestoreRunbookCard from "./RestoreRunbookCard";
 import RecentActivityCard from "./RecentActivityCard";
 import SolidButton from "../../ui/buttons/SolidButton";
 import DiagnosticsCardError from "../diagnostics/DiagnosticsCardError";
+import TopLoadingBar from "../../ui/displays/TopLoadingBar";
 import { useToast } from "../../shared/ToastProvider";
 import type {
   ActivityEvent,
@@ -44,6 +45,10 @@ type TabPhase = "loading" | "unconfigured" | "error" | "ready";
  */
 const BackupsTab: React.FC = () => {
   const [phase, setPhase] = useState<TabPhase>("loading");
+  // Background refetches (post-dispatch refresh, poll-completion fetchAll) sweep a TopLoadingBar
+  // over the rendered cards instead of blanking back to the initial "Loading backups…" state --
+  // same idiom as UsersTab's refetch-over-existing-rows.
+  const [refreshing, setRefreshing] = useState(false);
   const [missing, setMissing] = useState<string[]>([]);
 
   const [rows, setRows] = useState<BackupListRow[]>([]);
@@ -188,7 +193,12 @@ const BackupsTab: React.FC = () => {
           if (cancelledRef.current) return;
           const hasNewRun = envelope.data.events.some((event) => !baselineIds.has(event.id));
           if (hasNewRun) {
-            await fetchAll();
+            setRefreshing(true);
+            try {
+              await fetchAll();
+            } finally {
+              if (!cancelledRef.current) setRefreshing(false);
+            }
             if (cancelledRef.current) return;
             setCreating(false);
             setLockedBy(null);
@@ -307,6 +317,7 @@ const BackupsTab: React.FC = () => {
   // phase === "ready" -- now, health are guaranteed non-null by fetchAll's success path.
   return (
     <div className={styles.container}>
+      <TopLoadingBar active={refreshing} label="Loading backups" />
       {mode === "mock" && (
         <span className={styles.modeBadge}>Sample data — backup credentials not configured</span>
       )}

--- a/frontend/app/components/admin/diagnostics/ConflictsCard.tsx
+++ b/frontend/app/components/admin/diagnostics/ConflictsCard.tsx
@@ -51,7 +51,7 @@ const ConflictsCard: React.FC = () => {
   if (!conflicts) {
     return (
       <Card accent="conflicts" data-testid="diagnostics-conflicts-panel">
-        <TopLoadingBar active={loading} />
+        <TopLoadingBar active={loading} label="Loading conflicts" />
         Loading conflicts…
       </Card>
     );
@@ -59,7 +59,7 @@ const ConflictsCard: React.FC = () => {
 
   return (
     <Card accent="conflicts" data-testid="diagnostics-conflicts-panel">
-      <TopLoadingBar active={loading} />
+      <TopLoadingBar active={loading} label="Loading conflicts" />
       <div className={styles.panelHeader}>
         <Icon name="warning" className={`${styles.panelIcon} ${styles.panelIconConflicts}`} />
         Conflicts ({conflicts.length})

--- a/frontend/app/components/admin/diagnostics/MeetingCountsCard.tsx
+++ b/frontend/app/components/admin/diagnostics/MeetingCountsCard.tsx
@@ -53,7 +53,7 @@ const MeetingCountsCard: React.FC = () => {
   if (!data) {
     return (
       <Card accent="meetingCounts">
-        <TopLoadingBar active={loading} />
+        <TopLoadingBar active={loading} label="Loading meeting counts" />
         Loading meeting counts…
       </Card>
     );
@@ -61,7 +61,7 @@ const MeetingCountsCard: React.FC = () => {
 
   return (
     <Card accent="meetingCounts">
-      <TopLoadingBar active={loading} />
+      <TopLoadingBar active={loading} label="Loading meeting counts" />
       <div className={styles.panelHeader}>
         <Icon name="event-available" className={`${styles.panelIcon} ${styles.panelIconMeetingCounts}`} />
         Meeting Counts

--- a/frontend/app/components/admin/diagnostics/SuspendedCard.tsx
+++ b/frontend/app/components/admin/diagnostics/SuspendedCard.tsx
@@ -117,7 +117,7 @@ const SuspendedCard: React.FC = () => {
   if (!suspendedMeetings) {
     return (
       <Card accent="suspended" data-testid="diagnostics-suspended-panel">
-        <TopLoadingBar active={loading} />
+        <TopLoadingBar active={loading} label="Loading suspended meetings" />
         Loading suspended meetings…
       </Card>
     );
@@ -126,7 +126,7 @@ const SuspendedCard: React.FC = () => {
   return (
     <>
       <Card accent="suspended" data-testid="diagnostics-suspended-panel">
-        <TopLoadingBar active={loading} />
+        <TopLoadingBar active={loading} label="Loading suspended meetings" />
         <div className={styles.panelHeader}>
           <Icon name="pause" className={`${styles.panelIcon} ${styles.panelIconSuspended}`} />
           Suspended ({total})

--- a/frontend/app/components/admin/diagnostics/SyncIssuesCard.tsx
+++ b/frontend/app/components/admin/diagnostics/SyncIssuesCard.tsx
@@ -153,7 +153,7 @@ const SyncIssuesCard: React.FC = () => {
   if (!syncIssues) {
     return (
       <Card accent="syncIssues" data-testid="diagnostics-sync-issues-panel">
-        <TopLoadingBar active={loading} />
+        <TopLoadingBar active={loading} label="Loading sync issues" />
         Loading sync issues…
       </Card>
     );
@@ -161,7 +161,7 @@ const SyncIssuesCard: React.FC = () => {
 
   return (
     <Card accent="syncIssues" data-testid="diagnostics-sync-issues-panel">
-      <TopLoadingBar active={loading} />
+      <TopLoadingBar active={loading} label="Loading sync issues" />
       <div className={styles.panelHeader}>
         <Icon name="sync-error" className={`${styles.panelIcon} ${styles.panelIconSyncIssues}`} />
         Sync Issues ({total})

--- a/frontend/app/components/admin/diagnostics/SystemStatusCard.tsx
+++ b/frontend/app/components/admin/diagnostics/SystemStatusCard.tsx
@@ -67,7 +67,7 @@ const SystemStatusCard: React.FC<SystemStatusCardProps> = ({ email, role }) => {
   if (!data) {
     return (
       <Card accent="systemStatus">
-        <TopLoadingBar active={loading} />
+        <TopLoadingBar active={loading} label="Loading system status" />
         Loading system status…
       </Card>
     );
@@ -92,7 +92,7 @@ const SystemStatusCard: React.FC<SystemStatusCardProps> = ({ email, role }) => {
 
   return (
     <Card accent="systemStatus">
-      <TopLoadingBar active={loading} />
+      <TopLoadingBar active={loading} label="Loading system status" />
       <div className={styles.panelHeader}>
         <Icon name="monitor-heart" className={`${styles.panelIcon} ${styles.panelIconSystemStatus}`} />
         System Status

--- a/frontend/app/components/admin/users/UsersTab.tsx
+++ b/frontend/app/components/admin/users/UsersTab.tsx
@@ -338,7 +338,7 @@ const UsersTab: React.FC = () => {
   return (
     <div className={styles.container}>
       <Card>
-        <TopLoadingBar active={loading} />
+        <TopLoadingBar active={loading} label="Loading users" />
         <CardHeader
           icon={<Icon name="groups" size={16} />}
           title={`Users (${(admins ?? []).length})`}

--- a/frontend/app/components/calendar/desktop/WeekView.tsx
+++ b/frontend/app/components/calendar/desktop/WeekView.tsx
@@ -190,7 +190,7 @@ const WeekView: React.FC<WeekViewProps> = ({
 
     return (
         <div className={styles.outerContainer}>
-            <TopLoadingBar active={isLoading} />
+            <TopLoadingBar active={isLoading} label="Loading meetings" />
             <div
                 className={styles.viewContainer}
                 ref={viewContainerRef}

--- a/frontend/app/components/calendar/mobile/DayLandscapeView.tsx
+++ b/frontend/app/components/calendar/mobile/DayLandscapeView.tsx
@@ -455,7 +455,7 @@ const DayLandscapeView: React.FC<DayLandscapeViewProps> = ({
 
   return (
     <div className={styles.outerContainer}>
-      <TopLoadingBar active={isLoading} />
+      <TopLoadingBar active={isLoading} label="Loading meetings" />
       <div
         className={styles.scrollArea}
         ref={scrollAreaRef}

--- a/frontend/app/components/calendar/mobile/DayPortraitView.tsx
+++ b/frontend/app/components/calendar/mobile/DayPortraitView.tsx
@@ -307,7 +307,7 @@ const DayPortraitView: React.FC<DayPortraitViewProps> = ({
 
   return (
     <div className={styles.container}>
-      <TopLoadingBar active={isLoading} />
+      <TopLoadingBar active={isLoading} label="Loading meetings" />
       <WeekStrip />
       <CalendarHeader
         selectedDate={selectedDate}

--- a/frontend/app/components/calendar/mobile/MultiDayLandscapeView.tsx
+++ b/frontend/app/components/calendar/mobile/MultiDayLandscapeView.tsx
@@ -298,7 +298,7 @@ const MultiDayLandscapeView: React.FC<MultiDayLandscapeViewProps> = ({
 
   return (
     <div className={styles.outerContainer}>
-      <TopLoadingBar active={isLoading} />
+      <TopLoadingBar active={isLoading} label="Loading meetings" />
       <div
         className={styles.scrollArea}
         ref={scrollAreaRef}

--- a/frontend/app/components/docs/DocsShell.tsx
+++ b/frontend/app/components/docs/DocsShell.tsx
@@ -294,7 +294,7 @@ const DocsShell: React.FC<DocsShellProps> = ({ docsMeta, children }) => {
 
   return (
     <div className={styles.page}>
-      <TopLoadingBar active={isNavigating} />
+      <TopLoadingBar active={isNavigating} label="Loading page" />
       {/* Single instance for the whole docs session -- pagefind-modal-trigger (in the sidebar
           below) and this connect automatically by sharing Pagefind's default "instance". Both
           live here, in the layout-rendered shell, specifically so they never remount -- see this

--- a/frontend/app/components/ui/displays/TopLoadingBar.tsx
+++ b/frontend/app/components/ui/displays/TopLoadingBar.tsx
@@ -3,17 +3,19 @@ import styles from "./TopLoadingBar.module.scss";
 
 interface TopLoadingBarProps {
   active: boolean;
+  /** Accessible name; defaults to the calendar wording most call sites predate. */
+  label?: string;
 }
 
 // A thin sweeping bar along a container's top edge -- signals a background refetch (e.g.
 // paging to a new week/range) without dimming or covering the content still on screen. The
 // caller's own position: relative container is what anchors this; it's absolutely positioned
 // to span that container's full width.
-const TopLoadingBar: React.FC<TopLoadingBarProps> = ({ active }) => {
+const TopLoadingBar: React.FC<TopLoadingBarProps> = ({ active, label = "Loading meetings" }) => {
   if (!active) return null;
 
   return (
-    <div className={styles.track} role="progressbar" aria-label="Loading meetings">
+    <div className={styles.track} role="progressbar" aria-label={label}>
       <div className={styles.fill} />
     </div>
   );

--- a/frontend/app/components/ui/displays/TopLoadingBar.tsx
+++ b/frontend/app/components/ui/displays/TopLoadingBar.tsx
@@ -3,15 +3,15 @@ import styles from "./TopLoadingBar.module.scss";
 
 interface TopLoadingBarProps {
   active: boolean;
-  /** Accessible name; defaults to the calendar wording most call sites predate. */
-  label?: string;
+  /** Accessible name announced by screen readers -- name the resource actually loading. */
+  label: string;
 }
 
 // A thin sweeping bar along a container's top edge -- signals a background refetch (e.g.
 // paging to a new week/range) without dimming or covering the content still on screen. The
 // caller's own position: relative container is what anchors this; it's absolutely positioned
 // to span that container's full width.
-const TopLoadingBar: React.FC<TopLoadingBarProps> = ({ active, label = "Loading meetings" }) => {
+const TopLoadingBar: React.FC<TopLoadingBarProps> = ({ active, label }) => {
   if (!active) return null;
 
   return (

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,6 +27,8 @@
     "@mui/icons-material": "^7.3.11",
     "@mui/material": "^7.3.11",
     "@prisma/client": "6.19.3",
+    "@vercel/functions": "^3.9.3",
+    "google-auth-library": "^9.6.3",
     "googleapis": "^174.0.1",
     "marked": "^18.0.9",
     "motion": "^13.1.0",

--- a/frontend/services/backups/config.ts
+++ b/frontend/services/backups/config.ts
@@ -2,14 +2,9 @@
 // with zero credentials (mock mode) -- see the mode-resolution helpers below for what happens
 // when they're missing in each environment.
 
-export interface GcsCredentials {
-  clientEmail: string;
-  privateKey: string;
-  projectId: string;
-}
-
 export interface BackupsStorageConfig {
-  gcsCredentials: GcsCredentials;
+  gcpWifProvider: string;
+  gcpServiceAccount: string;
   gcsWorkingBucket: string;
   gcsArchiveBucket: string;
   r2AccountId: string;
@@ -24,7 +19,8 @@ export interface BackupsGithubConfig {
 }
 
 const STORAGE_VAR_NAMES = [
-  "GCS_BACKUPS_CREDENTIALS",
+  "GCP_BACKUPS_WIF_PROVIDER",
+  "GCP_BACKUPS_SERVICE_ACCOUNT",
   "GCS_WORKING_BUCKET",
   "GCS_ARCHIVE_BUCKET",
   "R2_ACCOUNT_ID",
@@ -35,25 +31,16 @@ const STORAGE_VAR_NAMES = [
 
 const GITHUB_VAR_NAMES = ["GITHUB_BACKUPS_PAT"] as const;
 
-/** True only if the value decodes as base64 -> JSON with the three fields getStorageConfig() reads. */
-function isDecodableGcsCredentials(raw: string): boolean {
-  try {
-    const decoded = JSON.parse(Buffer.from(raw, "base64").toString("utf8")) as Record<string, unknown>;
-    return [decoded.client_email, decoded.private_key, decoded.project_id].every(
-      (field) => typeof field === "string" && field.trim().length > 0,
-    );
-  } catch {
-    return false;
-  }
-}
+// Bare resource path, no `//iam.googleapis.com/` prefix (storage.ts adds it as the audience) --
+// the most likely paste error, which would otherwise pass the presence check and 500 at STS time
+// instead of 503ing with an actionable name.
+const WIF_PROVIDER_SHAPE = /^projects\/\d+\/locations\/[^/]+\/workloadIdentityPools\/[^/]+\/providers\/[^/]+$/;
 
 function missingStorageVars(): string[] {
   return STORAGE_VAR_NAMES.filter((name) => {
     const value = process.env[name];
     if (!value) return true;
-    // A present-but-undecodable value must count as missing, not pass the presence check and
-    // 500 later inside getStorageConfig()'s JSON.parse.
-    if (name === "GCS_BACKUPS_CREDENTIALS") return !isDecodableGcsCredentials(value);
+    if (name === "GCP_BACKUPS_WIF_PROVIDER") return !WIF_PROVIDER_SHAPE.test(value);
     return false;
   });
 }
@@ -101,17 +88,9 @@ export function resolveCombinedMode(): { mode: "live" } | { mode: "mock" } | { m
 }
 
 export function getStorageConfig(): BackupsStorageConfig {
-  const decoded = JSON.parse(Buffer.from(process.env.GCS_BACKUPS_CREDENTIALS as string, "base64").toString("utf8")) as {
-    client_email: string;
-    private_key: string;
-    project_id: string;
-  };
   return {
-    gcsCredentials: {
-      clientEmail: decoded.client_email,
-      privateKey: decoded.private_key,
-      projectId: decoded.project_id,
-    },
+    gcpWifProvider: process.env.GCP_BACKUPS_WIF_PROVIDER as string,
+    gcpServiceAccount: process.env.GCP_BACKUPS_SERVICE_ACCOUNT as string,
     gcsWorkingBucket: process.env.GCS_WORKING_BUCKET as string,
     gcsArchiveBucket: process.env.GCS_ARCHIVE_BUCKET as string,
     r2AccountId: process.env.R2_ACCOUNT_ID as string,

--- a/frontend/services/backups/config.ts
+++ b/frontend/services/backups/config.ts
@@ -35,12 +35,16 @@ const GITHUB_VAR_NAMES = ["GITHUB_BACKUPS_PAT"] as const;
 // the most likely paste error, which would otherwise pass the presence check and 500 at STS time
 // instead of 503ing with an actionable name.
 const WIF_PROVIDER_SHAPE = /^projects\/\d+\/locations\/[^/]+\/workloadIdentityPools\/[^/]+\/providers\/[^/]+$/;
+// A malformed SA email would build an invalid IAM impersonation URL and 500 at request time
+// instead of 503ing with an actionable name -- same rationale as the provider shape above.
+const SERVICE_ACCOUNT_SHAPE = /^[^@/\s]+@[^@/\s]+\.iam\.gserviceaccount\.com$/;
 
 function missingStorageVars(): string[] {
   return STORAGE_VAR_NAMES.filter((name) => {
     const value = process.env[name];
     if (!value) return true;
     if (name === "GCP_BACKUPS_WIF_PROVIDER") return !WIF_PROVIDER_SHAPE.test(value);
+    if (name === "GCP_BACKUPS_SERVICE_ACCOUNT") return !SERVICE_ACCOUNT_SHAPE.test(value);
     return false;
   });
 }

--- a/frontend/services/backups/storage.ts
+++ b/frontend/services/backups/storage.ts
@@ -4,10 +4,36 @@
 // computes the per-row `replicas` field the sidecar itself can never honestly claim (see
 // BackupMeta's INVARIANT comment in types/backups.ts).
 import { Storage } from "@google-cloud/storage";
+import { ExternalAccountClient } from "google-auth-library";
+import type { BaseExternalAccountClient } from "google-auth-library";
+import { getVercelOidcToken } from "@vercel/functions/oidc";
 import { ListObjectsV2Command, S3Client } from "@aws-sdk/client-s3";
 import type { BackupListRow, BackupMeta, BackupReplica, BackupTier } from "../../types/backups";
 import { ALL_BACKUP_REPLICAS, backupArtifactBaseName } from "../../types/backups";
 import { getStorageConfig } from "./config";
+
+// INVARIANT: keyless signing requires ONE physical copy of google-auth-library in
+// @google-cloud/storage's resolution path -- the direct dependency's range in package.json must
+// keep overlapping @google-cloud/storage's own, or yarn nests a second copy and an internal
+// `instanceof BaseExternalAccountClient` check fails at runtime only (no test catches it).
+//
+// GCP org policy `iam.disableServiceAccountKeyCreation` rules out a downloadable service-account
+// key entirely -- auth is Vercel OIDC -> GCP Workload Identity Federation instead. The WIF
+// provider trusts Vercel's OIDC issuer and exchanges the request's short-lived identity token for
+// an impersonated access token on GCP_BACKUPS_SERVICE_ACCOUNT; see this file's
+// `signedDownloadUrl` comment for the extra IAM role that impersonation needs for signing.
+function gcsAuthClient(provider: string, serviceAccount: string): BaseExternalAccountClient {
+  const client = ExternalAccountClient.fromJSON({
+    type: "external_account",
+    audience: `//iam.googleapis.com/${provider}`,
+    subject_token_type: "urn:ietf:params:oauth:token-type:jwt",
+    token_url: "https://sts.googleapis.com/v1/token",
+    service_account_impersonation_url: `https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/${serviceAccount}:generateAccessToken`,
+    subject_token_supplier: { getSubjectToken: () => getVercelOidcToken() },
+  });
+  if (!client) throw new Error("services/backups/storage: ExternalAccountClient.fromJSON returned null -- malformed WIF config");
+  return client;
+}
 
 const TIERS: BackupTier[] = ["daily", "monthly", "permanent"];
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -21,15 +47,25 @@ function computeExpiresAt(tier: BackupTier, createdAt: string): string | null {
   return new Date(new Date(createdAt).getTime() + days * DAY_MS).toISOString();
 }
 
+// Memoized per process, keyed on the two config values: rebuilding the ExternalAccountClient
+// per request would discard its internal STS/impersonated-token cache, paying the full
+// OIDC -> STS -> generateAccessToken exchange on every call instead of reusing a ~1h token.
+// The OIDC subject token itself stays fresh -- the supplier above is invoked per refresh, not
+// captured at construction.
+let cachedGcs: { provider: string; serviceAccount: string; storage: Storage } | null = null;
+
 function gcsClient(): Storage {
   const config = getStorageConfig();
-  return new Storage({
-    projectId: config.gcsCredentials.projectId,
-    credentials: {
-      client_email: config.gcsCredentials.clientEmail,
-      private_key: config.gcsCredentials.privateKey,
-    },
+  if (cachedGcs && cachedGcs.provider === config.gcpWifProvider && cachedGcs.serviceAccount === config.gcpServiceAccount) {
+    return cachedGcs.storage;
+  }
+  const storage = new Storage({
+    // The SA's own project doubles as the quota project for its STS exchanges.
+    projectId: config.gcpServiceAccount.split("@")[1]?.split(".")[0] ?? "icr-management-system",
+    authClient: gcsAuthClient(config.gcpWifProvider, config.gcpServiceAccount),
   });
+  cachedGcs = { provider: config.gcpWifProvider, serviceAccount: config.gcpServiceAccount, storage };
+  return storage;
 }
 
 function r2Client(): S3Client {
@@ -209,6 +245,10 @@ export async function listBackups(): Promise<{ rows: BackupListRow[]; archiveObj
   return { rows: cache.rows, archiveObjectCount, r2ObjectCount, workingObjectCount };
 }
 
+// With no private key on hand, google-auth-library signs the URL by calling IAM Credentials'
+// signBlob API through the impersonated access token -- GCP_BACKUPS_SERVICE_ACCOUNT must hold
+// roles/iam.serviceAccountTokenCreator on *itself* (not just the WIF pool's impersonation grant)
+// for that signBlob call to succeed.
 export async function signedDownloadUrl(id: string, tier: BackupTier): Promise<string> {
   const config = getStorageConfig();
   const storage = gcsClient();

--- a/frontend/tests/integration/backups-routes.test.ts
+++ b/frontend/tests/integration/backups-routes.test.ts
@@ -50,9 +50,10 @@ function setLiveEnv() {
   STORAGE_VARS.forEach((name) => {
     process.env[name] = "test-value";
   });
-  // The WIF provider var is shape-validated, not just presence-checked -- a bare "test-value"
+  // These two vars are shape-validated, not just presence-checked -- a bare "test-value"
   // would count as missing and keep every "live mode" test stuck in unconfigured.
   process.env.GCP_BACKUPS_WIF_PROVIDER = "projects/123/locations/global/workloadIdentityPools/pool/providers/provider";
+  process.env.GCP_BACKUPS_SERVICE_ACCOUNT = "backups-tab-reader@icr-management-system.iam.gserviceaccount.com";
   GITHUB_VARS.forEach((name) => {
     process.env[name] = "test-value";
   });
@@ -145,6 +146,18 @@ describe("GET /api/admin/backups", () => {
     const body = await response.json();
     expect(response.status).toBe(503);
     expect(body.missing).toContain("GCP_BACKUPS_WIF_PROVIDER");
+  });
+
+  test("treats a malformed GCP_BACKUPS_SERVICE_ACCOUNT as missing rather than 500ing", async () => {
+    mockedRequireRole.mockResolvedValue(superAdminSession);
+    setLiveEnv();
+    process.env.GCP_BACKUPS_SERVICE_ACCOUNT = "not-a-service-account";
+    jest.replaceProperty(process, "env", { ...process.env, NODE_ENV: "production" });
+    const { GET } = await import("../../app/api/admin/backups/route");
+    const response = await GET();
+    const body = await response.json();
+    expect(response.status).toBe(503);
+    expect(body.missing).toContain("GCP_BACKUPS_SERVICE_ACCOUNT");
   });
 
   test("treats a missing GCP_BACKUPS_WIF_PROVIDER as missing rather than 500ing", async () => {

--- a/frontend/tests/integration/backups-routes.test.ts
+++ b/frontend/tests/integration/backups-routes.test.ts
@@ -28,7 +28,8 @@ const mockedFetchRecentActivity = fetchRecentActivity as jest.Mock;
 const mockedDispatchBackup = dispatchBackup as jest.Mock;
 
 const STORAGE_VARS = [
-  "GCS_BACKUPS_CREDENTIALS",
+  "GCP_BACKUPS_WIF_PROVIDER",
+  "GCP_BACKUPS_SERVICE_ACCOUNT",
   "GCS_WORKING_BUCKET",
   "GCS_ARCHIVE_BUCKET",
   "R2_ACCOUNT_ID",
@@ -45,14 +46,13 @@ function clearBackupsEnv() {
   ALL_BACKUPS_VARS.forEach((name) => delete process.env[name]);
 }
 
-const VALID_GCS_CREDENTIALS = Buffer.from(
-  JSON.stringify({ client_email: "backup@icr.iam.gserviceaccount.com", private_key: "test-key", project_id: "icr-db-backups-prod" }),
-).toString("base64");
-
 function setLiveEnv() {
   STORAGE_VARS.forEach((name) => {
-    process.env[name] = name === "GCS_BACKUPS_CREDENTIALS" ? VALID_GCS_CREDENTIALS : "test-value";
+    process.env[name] = "test-value";
   });
+  // The WIF provider var is shape-validated, not just presence-checked -- a bare "test-value"
+  // would count as missing and keep every "live mode" test stuck in unconfigured.
+  process.env.GCP_BACKUPS_WIF_PROVIDER = "projects/123/locations/global/workloadIdentityPools/pool/providers/provider";
   GITHUB_VARS.forEach((name) => {
     process.env[name] = "test-value";
   });
@@ -132,19 +132,31 @@ describe("GET /api/admin/backups", () => {
     const body = await response.json();
     expect(response.status).toBe(503);
     expect(body.configured).toBe(false);
-    expect(body.missing).toEqual(expect.arrayContaining(["GCS_BACKUPS_CREDENTIALS", "R2_BUCKET"]));
+    expect(body.missing).toEqual(expect.arrayContaining(["GCP_BACKUPS_WIF_PROVIDER", "R2_BUCKET"]));
   });
 
-  test("treats an undecodable GCS_BACKUPS_CREDENTIALS value as missing rather than 500ing", async () => {
+  test("treats a malformed GCP_BACKUPS_WIF_PROVIDER (e.g. pasted with the audience prefix) as missing", async () => {
     mockedRequireRole.mockResolvedValue(superAdminSession);
     setLiveEnv();
-    process.env.GCS_BACKUPS_CREDENTIALS = "not-valid-base64-json";
+    process.env.GCP_BACKUPS_WIF_PROVIDER = "//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/pool/providers/provider";
     jest.replaceProperty(process, "env", { ...process.env, NODE_ENV: "production" });
     const { GET } = await import("../../app/api/admin/backups/route");
     const response = await GET();
     const body = await response.json();
     expect(response.status).toBe(503);
-    expect(body.missing).toContain("GCS_BACKUPS_CREDENTIALS");
+    expect(body.missing).toContain("GCP_BACKUPS_WIF_PROVIDER");
+  });
+
+  test("treats a missing GCP_BACKUPS_WIF_PROVIDER as missing rather than 500ing", async () => {
+    mockedRequireRole.mockResolvedValue(superAdminSession);
+    setLiveEnv();
+    delete process.env.GCP_BACKUPS_WIF_PROVIDER;
+    jest.replaceProperty(process, "env", { ...process.env, NODE_ENV: "production" });
+    const { GET } = await import("../../app/api/admin/backups/route");
+    const response = await GET();
+    const body = await response.json();
+    expect(response.status).toBe(503);
+    expect(body.missing).toContain("GCP_BACKUPS_WIF_PROVIDER");
   });
 
   test("never leaks a raw upstream error into the response body", async () => {

--- a/frontend/tests/integration/backups-storage.test.ts
+++ b/frontend/tests/integration/backups-storage.test.ts
@@ -32,8 +32,18 @@ jest.mock("@aws-sdk/client-s3", () => ({
   ListObjectsV2Command: jest.fn().mockImplementation((input) => ({ input })),
 }));
 
+// No real STS/IAM calls in this suite -- fromJSON just needs to return something truthy that
+// Storage's mock constructor above never inspects.
+jest.mock("google-auth-library", () => ({
+  ExternalAccountClient: { fromJSON: jest.fn().mockReturnValue({}) },
+}));
+jest.mock("@vercel/functions/oidc", () => ({
+  getVercelOidcToken: jest.fn().mockResolvedValue("test-oidc-token"),
+}));
+
 const STORAGE_VARS = {
-  GCS_BACKUPS_CREDENTIALS: Buffer.from(JSON.stringify({ client_email: "a@b.com", private_key: "key", project_id: "p" })).toString("base64"),
+  GCP_BACKUPS_WIF_PROVIDER: "projects/123/locations/global/workloadIdentityPools/pool/providers/provider",
+  GCP_BACKUPS_SERVICE_ACCOUNT: "backups-tab-reader@icr-management-system.iam.gserviceaccount.com",
   GCS_WORKING_BUCKET: WORKING_BUCKET,
   GCS_ARCHIVE_BUCKET: ARCHIVE_BUCKET,
   R2_ACCOUNT_ID: "acct",
@@ -101,6 +111,39 @@ describe("listBackups against real-shaped keys", () => {
 
     await signedDownloadUrl(rows[0].id, rows[0].tier);
     expect(mockFile).toHaveBeenCalledWith(dumpKey);
+  });
+
+  test("builds the external-account config with the exact WIF/STS/impersonation shapes", async () => {
+    filesByBucketPrefix = {
+      [WORKING_BUCKET]: { "daily/": [], "monthly/": [], "permanent/": [] },
+      [ARCHIVE_BUCKET]: { "daily/": [], "monthly/": [], "permanent/": [] },
+    };
+    mockSend.mockResolvedValue({ Contents: [] });
+
+    const { ExternalAccountClient } = jest.requireMock("google-auth-library") as {
+      ExternalAccountClient: { fromJSON: jest.Mock };
+    };
+    const { getVercelOidcToken } = jest.requireMock("@vercel/functions/oidc") as {
+      getVercelOidcToken: jest.Mock;
+    };
+    const { listBackups } = await import("../../services/backups/storage");
+    await listBackups();
+
+    // These four strings only ever fail in production -- pin them here.
+    expect(ExternalAccountClient.fromJSON).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "external_account",
+        audience: `//iam.googleapis.com/${STORAGE_VARS.GCP_BACKUPS_WIF_PROVIDER}`,
+        subject_token_type: "urn:ietf:params:oauth:token-type:jwt",
+        token_url: "https://sts.googleapis.com/v1/token",
+        service_account_impersonation_url: `https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/${STORAGE_VARS.GCP_BACKUPS_SERVICE_ACCOUNT}:generateAccessToken`,
+      }),
+    );
+
+    // The supplier must delegate per call (a token captured at construction would go stale).
+    const supplier = ExternalAccountClient.fromJSON.mock.calls[0][0].subject_token_supplier;
+    await expect(supplier.getSubjectToken()).resolves.toBe("test-oidc-token");
+    expect(getVercelOidcToken).toHaveBeenCalled();
   });
 
   test("dedupes a 1st-of-month artifact uploaded to both daily/ and monthly/, keeping the monthly row", async () => {

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2556,6 +2556,37 @@
   resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.12.2.tgz#72da0da48d72b1e87831b9c0308931d3f4669027"
   integrity sha512-nAB74NfSNKknqQ1RrYj6uz8FcXEomu/MATJZxh/x+BArzN2U3JbOYC0APYzUIGhVY3m5hRxA8VPNdPBoG8txlA==
 
+"@vercel/cli-config@0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@vercel/cli-config/-/cli-config-0.2.3.tgz#617881e9de809f70edc48905d09014633541bd9e"
+  integrity sha512-Ggh0Wmi92TUkUexmSUPkkDtvJmbjUr7IvF5T3FkSsWrXXs3GFzOujfxFpECdJZpux1JG4SWDv9BT4w++TDgD6A==
+  dependencies:
+    xdg-app-paths "5"
+    zod "4.1.11"
+
+"@vercel/cli-exec@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@vercel/cli-exec/-/cli-exec-1.0.1.tgz#5b1d1e8b2dd6909ab810d5e5ee990e6263a0f5a9"
+  integrity sha512-g9XerViJ/paZujufXYcu5XYI2vU2rtB4sgdpjUHde5RnOkdmpu0ngH46LCFGHoPXO/C+qDPSczIHIRN+8Q2YKQ==
+  dependencies:
+    execa "5.1.1"
+
+"@vercel/functions@^3.9.3":
+  version "3.9.3"
+  resolved "https://registry.yarnpkg.com/@vercel/functions/-/functions-3.9.3.tgz#2bdfc128874c135ce85fbef18dc980d21d1c3958"
+  integrity sha512-cbzTdASCZDnufrABc8oO00e/FqlqFFSdld+iGZPhrWBDHP4Pu8ESKKYIzASqYvbYYUIWujBvEa5LLCcZzm7WEw==
+  dependencies:
+    "@vercel/oidc" "3.8.4"
+
+"@vercel/oidc@3.8.4":
+  version "3.8.4"
+  resolved "https://registry.yarnpkg.com/@vercel/oidc/-/oidc-3.8.4.tgz#6598e8ac639047b0a209bc36737a4ef78f9f3572"
+  integrity sha512-FGNvVZ5pgX9FaBqkPt6VkYFZ6bWAMDzYi7nxW+1Xt+Z4fn5PuTULVwsxjKc+0uKhysyWBQmvsmM50Oh6C2/oMA==
+  dependencies:
+    "@vercel/cli-config" "0.2.3"
+    "@vercel/cli-exec" "1.0.1"
+    jose "^5.9.6"
+
 abort-controller@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/abort-controller/-/abort-controller-3.0.0.tgz#eaf54d53b62bae4138e809ca225c8439a6efb392"
@@ -3967,7 +3998,7 @@ event-target-shim@^5.0.0:
   resolved "https://registry.yarnpkg.com/event-target-shim/-/event-target-shim-5.0.1.tgz#5d4d3ebdf9583d63a5333ce2deb7480ab2b05789"
   integrity sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==
 
-execa@^5.1.1:
+execa@5.1.1, execa@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/execa/-/execa-5.1.1.tgz#f80ad9cbf4298f7bd1d4c9555c21e93741c411dd"
   integrity sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==
@@ -5505,6 +5536,11 @@ jose@^4.15.5, jose@^4.15.9:
   resolved "https://registry.yarnpkg.com/jose/-/jose-4.15.9.tgz#9b68eda29e9a0614c042fa29387196c7dd800100"
   integrity sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==
 
+jose@^5.9.6:
+  version "5.10.0"
+  resolved "https://registry.yarnpkg.com/jose/-/jose-5.10.0.tgz#c37346a099d6467c401351a9a0c2161e0f52c4be"
+  integrity sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -6131,6 +6167,11 @@ optionator@^0.9.3:
     prelude-ls "^1.2.1"
     type-check "^0.4.0"
     word-wrap "^1.2.5"
+
+os-paths@^4.0.1:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/os-paths/-/os-paths-4.4.0.tgz#2908b5bcb60cbfe3afb869292281a2a6b2f77ebe"
+  integrity sha512-wrAwOeXp1RRMFfQY8Sy7VaGVmPocaLwSFOYCGKSyo8qmJ+/yaafCl5BCA1IQZWqFSRBrKDYFeR9d/VyQzfH/jg==
 
 own-keys@^1.0.1:
   version "1.0.2"
@@ -7833,6 +7874,21 @@ ws@^8.18.0:
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.21.3.tgz#660b4faddb6a3e575c86e078126919961f4de4fc"
   integrity sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==
 
+xdg-app-paths@5:
+  version "5.5.1"
+  resolved "https://registry.yarnpkg.com/xdg-app-paths/-/xdg-app-paths-5.5.1.tgz#2d5e94218c6fc4e9b742503889dfd29bbd336b8c"
+  integrity sha512-hI3flOB4PLZIy5prbtTpirobtPE2ZtZ52szO+2mM9Efp6ErM398La+C1lIpNWDfNoQk+6Lsi6nMcCwVB7pxeMQ==
+  dependencies:
+    os-paths "^4.0.1"
+    xdg-portable "^7.2.0"
+
+xdg-portable@^7.2.0:
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/xdg-portable/-/xdg-portable-7.3.0.tgz#c6b1610de806a2ca1fe65727d5f8402c295d2e96"
+  integrity sha512-sqMMuL1rc0FmMBOzCpd0yuy9trqF2yTTVe+E9ogwCSWQCdDEtQUwrZPT6AxqtsFGRNxycgncbP/xmOOSPw5ZUw==
+  dependencies:
+    os-paths "^4.0.1"
+
 "xlsx@https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz":
   version "0.20.3"
   resolved "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz#992725af0bb69fa9733590fcb8ab4a57e10b929b"
@@ -7921,6 +7977,11 @@ yocto-queue@^0.1.0:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/zod-validation-error/-/zod-validation-error-4.0.2.tgz#bc605eba49ce0fcd598c127fee1c236be3f22918"
   integrity sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==
+
+zod@4.1.11:
+  version "4.1.11"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-4.1.11.tgz#4aab62f76cfd45e6c6166519ba31b2ea019f75f5"
+  integrity sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==
 
 "zod@^3.25.0 || ^4.0.0", zod@^4.4.3:
   version "4.4.3"


### PR DESCRIPTION
## What

Replaces the never-provisioned service-account-key auth (`GCS_BACKUPS_CREDENTIALS`) for the Backups tab's GCS access with **keyless Vercel OIDC → GCP Workload Identity Federation**, and adds the standard admin-tab loading bar for background refetches.

## Why

The 518icr.com org enforces `iam.disableServiceAccountKeyCreation` — the org itself saying keys are the wrong tool. OIDC removes the standing secret, the rotation burden, and the policy-exception ritual entirely.

## How

- New env vars (both **non-secret**): `GCP_BACKUPS_WIF_PROVIDER` (full provider resource name, shape-validated so a paste error 503s with an actionable name instead of 500ing at STS time) + `GCP_BACKUPS_SERVICE_ACCOUNT`. Every trace of `GCS_BACKUPS_CREDENTIALS` is removed.
- `services/backups/storage.ts` builds an `ExternalAccountClient` whose `subject_token_supplier` fetches the Vercel OIDC token per refresh (`@vercel/functions`), impersonating `backups-tab-reader`. Memoized per process so the STS/impersonation token cache is reused instead of re-exchanged per request.
- Signed download URLs go keyless via IAM `signBlob` — verified end-to-end against the installed `google-auth-library@9.15.1` source. INVARIANT documented: exactly one physical `google-auth-library` copy must stay in `@google-cloud/storage`'s resolution path (a nested second copy breaks an `instanceof` check at runtime only).
- A new test pins the four external-account config strings (audience, token type URN, STS URL, impersonation URL) — the parts that would otherwise only fail in production.
- `TopLoadingBar` (with a new optional `label` prop) sweeps over the cards during post-dispatch refetches, matching the Users/Diagnostics idiom; the initial load keeps its text state.

## Infrastructure (already provisioned, live)

WIF pool `vercel-backups-pool` + provider `vercel` in `icr-management-system`, trusting `https://oidc.vercel.com/icr-e15f76a6` with an attribute condition pinning the subject to `owner:icr-e15f76a6:project:ithaca-recovery:environment:production` only. `backups-tab-reader` has `workloadIdentityUser` for that single principal and `serviceAccountTokenCreator` on itself (signBlob). OIDC federation is enabled on the Vercel project.

## After merge

Set in Vercel (Production) and redeploy — no secrets involved:
```
GCP_BACKUPS_WIF_PROVIDER=projects/152224493895/locations/global/workloadIdentityPools/vercel-backups-pool/providers/vercel
GCP_BACKUPS_SERVICE_ACCOUNT=backups-tab-reader@icr-management-system.iam.gserviceaccount.com
```
Doc follow-up: `docs/02-handoff/backup-infra-setup.md` + `credentials-and-integrations.md` still describe the key-file flow (they're mid-PR on #443) — rewrite after both merge.

## Testing

Full `yarn test:all` green (107 e2e). Opus high-effort pre-push review: safe, with its four cheap findings (client memoization, projectId comment, config-shape test, import type) folded in.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Backup storage now supports keyless Google Cloud authentication through Workload Identity Federation.
  * Backup refreshes display a loading indicator while new activity is being retrieved.
  * Loading indicators now provide customizable accessible labels.

* **Bug Fixes**
  * Corrected backup and read-access storage configuration names in the environment template.

* **Documentation**
  * Updated setup guidance for the new backup authentication configuration and required permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->