### PR TITLE
fix(ui): render the DatePicker popup above modal overlays

### DIFF
--- a/frontend/app/components/ui/pickers/DatePicker.module.scss
+++ b/frontend/app/components/ui/pickers/DatePicker.module.scss
@@ -74,7 +74,13 @@
 // longer a DOM descendant of it.
 .calendar-popup {
   position: fixed;
-  z-index: 2000; // High z-index to ensure visibility above any other page content
+
+  // Must beat the confirm modals' overlays (Suspend/Resume/Delete/DeleteRecurring, all
+  // z-index: 2001) -- this popup portals to document.body as their SIBLING, so stacking is
+  // decided purely by these numbers, and any modal embedding a DatePicker would otherwise
+  // paint over its own calendar. Extend this chain (don't guess) if a higher modal tier is
+  // ever added.
+  z-index: 2002;
   background-color: white;
   box-shadow: 0 4px 12px rgb(0 0 0 / 15%);
   border-radius: 4px;

--- a/frontend/tests/e2e/14-meeting-suspension.spec.ts
+++ b/frontend/tests/e2e/14-meeting-suspension.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "./support/fixtures";
-import { seedMeeting } from "../factories/meeting";
+import { seedMeeting, seedSuspendedMeeting } from "../factories/meeting";
 import { getTestPrismaClient } from "../factories/db";
 import type { Page } from "@playwright/test";
 
@@ -129,5 +129,25 @@ test.describe("meeting suspension", () => {
     await expect(page.getByText(/permanently removed/)).toBeVisible();
     // No "Suspend instead" nudge -- suspending again would just 409 against the pending one.
     await expect(page.getByText(/Not sure\?/)).toHaveCount(0);
+  });
+
+  test("14.6 the Resume 'On' datepicker popup renders above the modal and is clickable", async ({ adminPage }) => {
+    const { page } = adminPage;
+    await seedSuspendedMeeting({ title: "Datepicker Layering" });
+    await page.goto("/admin");
+
+    const suspendedPanel = page.getByTestId("diagnostics-suspended-panel");
+    await suspendedPanel.getByRole("button", { name: "Resume" }).click();
+    const resumeModal = page.getByTestId("resume-meeting-modal");
+    await resumeModal.getByText("On", { exact: true }).click();
+    await resumeModal.locator('input[placeholder="MM/DD/YYYY"]').click();
+
+    // The popup portals to document.body as the modal overlay's SIBLING -- clicking a day cell
+    // (not just asserting DOM presence) is what proves it stacks above the overlay, since the
+    // z-index regression left it present but painted underneath and unclickable.
+    const popup = page.locator('[data-datepicker-popup="true"]');
+    await expect(popup).toBeVisible();
+    await popup.getByRole("button", { name: /15/ }).first().click();
+    await expect(resumeModal.locator('input[placeholder="MM/DD/YYYY"]')).toHaveValue(/\d{2}\/15\/\d{4}/);
   });
 });


### PR DESCRIPTION
Resolves #447

@coderabbitai summary

## Description
- **app/components/ui/pickers/DatePicker.module.scss**: the calendar popup portals to `document.body` at `z-index: 2000`, while the Suspend/Resume/Delete confirm modals' overlays sit at `2001` (deliberately, to beat ViewMeeting's `2000` anchor). As body-level siblings, stacking is decided purely by those numbers — the popup painted *between* the modal and the page, visible in the DOM but obscured and unclickable. Bumped to `2002` (verified nothing else in the tier is ≥2002) with the codebase's established "must beat X's z-index Y" comment convention so the next tier addition extends the chain instead of guessing.
- **tests/e2e/14-meeting-suspension.spec.ts**: new case 14.6 opens Diagnostics → Resume → "On", then *clicks a day cell in the popup and asserts the input updates*. Playwright's actionability hit-testing makes this a true regression guard — under the old stacking the overlay intercepts the click and the test fails; DOM-presence assertions would not have caught this.

Known pre-existing follow-up (not this PR): the modal focus trap (`useDialogBehavior`) only queries inside `contentRef`, so tabbing can escape into the portaled popup — shared by every modal embedding a DatePicker.

## Testing
- [x] `yarn test:e2e -- 14-meeting-suspension` — 5/5 including the new layering case
- [x] Full `yarn test:all` green (217 unit / 237 component / 120 integration / 111 e2e)

## Area(s) Touched
**Product areas**
- [ ] auth — sign-in, sessions, NextAuth, role-based access
- [x] admin — /admin shell (Diagnostics, Users, Import, Export tabs)
- [ ] docs — /docs Resources page (rendering, navigation, search)
- [x] ui/ux — frontend layout/styling not tied to a specific integration

**Integrations**
- [ ] google-calendar — Google Calendar sync
- [ ] zoom-api — Zoom meeting/host sync

**Engineering**
- [ ] security — auth hardening, data exposure, dependency/security scanning
- [x] testing — test suite (Jest/Playwright) changes
- [ ] github-actions — workflows, Dependabot config, other .github/ CI tooling
- [ ] cleanup — refactor or dead-code removal, no behavior change
- [ ] documentation — docs/ or README changes only

## Pre-merge Checklist
- [x] Code follows current formatting conventions and passes lint (`yarn lint`).
- [x] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
- [x] All test suites pass, both run locally and green in GitHub CI. **Do not merge if any test suite is failing.**
- [x] A test suite was added or updated for the feature/fix in this PR. **Double-check this if you change a feature and did not update the test suites**.
- [x] Only files relevant to this change are committed — no stray or unrelated files.
- [ ] If this branch has a merge conflict with master, master was merged into this branch first (not the other way around).
- [x] The rest of this PR description (Description, Testing) is filled out, not left as template placeholders.