### PR TITLE
feat(backups): per-card loading shells, honest manual-run attribution

### DIFF
--- a/frontend/app/components/admin/backups/BackupsTab.module.scss
+++ b/frontend/app/components/admin/backups/BackupsTab.module.scss
@@ -925,12 +925,6 @@
 
 /* ---------- Tab-level load states (loading / fetch error / unconfigured / mock badge) ---------- */
 
-.loadingState {
-  padding: 24px 0;
-  color: $medium-grey-color;
-  font-size: 14px;
-}
-
 // Same shape as DiagnosticsCardError's retry button (DiagnosticsTab.module.scss) --
 // duplicated locally rather than shared cross-module since this tab already owns its own
 // error surface (a single tab-wide fetch failure) instead of per-card errors.

--- a/frontend/app/components/admin/backups/BackupsTab.tsx
+++ b/frontend/app/components/admin/backups/BackupsTab.tsx
@@ -7,6 +7,7 @@ import RestoreRunbookCard from "./RestoreRunbookCard";
 import RecentActivityCard from "./RecentActivityCard";
 import SolidButton from "../../ui/buttons/SolidButton";
 import DiagnosticsCardError from "../diagnostics/DiagnosticsCardError";
+import Card from "../shared/Card";
 import TopLoadingBar from "../../ui/displays/TopLoadingBar";
 import { useToast } from "../../shared/ToastProvider";
 import type {
@@ -287,8 +288,30 @@ const BackupsTab: React.FC = () => {
     }
   };
 
+  // Per-card loading shells, mirroring the Diagnostics cards' own Card + TopLoadingBar idiom --
+  // one accent-matched skeleton per card rather than a bare tab-level line, so the tab's layout
+  // doesn't jump when data lands.
   if (phase === "loading") {
-    return <div className={styles.loadingState}>Loading backups…</div>;
+    return (
+      <div className={styles.container}>
+        <Card accent="systemStatus">
+          <TopLoadingBar active label="Loading backup health" />
+          Loading backup health…
+        </Card>
+        <Card accent="meetingCounts">
+          <TopLoadingBar active label="Loading snapshots" />
+          Loading snapshots…
+        </Card>
+        <Card accent="suspended">
+          <TopLoadingBar active label="Loading restore runbook" />
+          Loading restore runbook…
+        </Card>
+        <Card accent="syncIssues">
+          <TopLoadingBar active label="Loading activity" />
+          Loading activity…
+        </Card>
+      </div>
+    );
   }
 
   if (phase === "error") {

--- a/frontend/app/components/admin/backups/RecentActivityCard.tsx
+++ b/frontend/app/components/admin/backups/RecentActivityCard.tsx
@@ -52,9 +52,16 @@ const RecentActivityCard: React.FC<RecentActivityCardProps> = ({ events, now, un
         <>
           <div className={styles.activitySummaryLine}>
             Failures, manual runs, and runs in progress.
-            {routineSuccessCount > 0 && ` ${routineSuccessCount} routine scheduled successes not shown.`}
+            {routineSuccessCount > 0 && ` ${routineSuccessCount} routine scheduled successes not shown.`}{" "}
+            <a
+              className={styles.docsLink}
+              href="https://github.com/cornellh4i/ithaca-recovery/actions/workflows/backup-db.yml"
+              target="_blank"
+              rel="noreferrer"
+            >
+              Full history on GitHub
+            </a>
           </div>
-          {/* TODO(backups-api): link to a full-history view once the API wiring lands. */}
           {notableEvents.length === 0 ? (
             <div className={styles.emptyState}>No failures, manual runs, or runs in progress recorded.</div>
           ) : (

--- a/frontend/app/components/admin/backups/RecentActivityCard.tsx
+++ b/frontend/app/components/admin/backups/RecentActivityCard.tsx
@@ -90,7 +90,11 @@ const activityTitle = (event: ActivityEvent): string => {
 };
 
 const activityMeta = (event: ActivityEvent, now: Date): string => {
-  const parts = [event.actor, formatRelativeOrAbsoluteTime(event.startedAt, now)];
+  // Manual runs dispatch through the tab's shared PAT, so GitHub attributes every one to the
+  // PAT owner's account regardless of which admin clicked -- showing that login would misname
+  // the actor. Per-click attribution lives in the server logs, not the runs API.
+  const attribution = event.trigger === "workflow_dispatch" ? "via Backups tab" : event.actor;
+  const parts = [attribution, formatRelativeOrAbsoluteTime(event.startedAt, now)];
   if (event.conclusion !== "in_progress") {
     parts.push(`ran ${formatDuration(event.durationSeconds)}`);
   }

--- a/frontend/tests/component/BackupsTab.test.tsx
+++ b/frontend/tests/component/BackupsTab.test.tsx
@@ -445,6 +445,28 @@ describe("BackupsTab", () => {
     expect(screen.getByText(/^Manual backup/)).toBeInTheDocument();
     expect(panel).toHaveTextContent(/\d+ routine scheduled successes not shown\./);
   });
+
+  it("shows four per-card loading shells with progress bars while fetching", () => {
+    // Never-resolving fetch keeps the tab in its loading phase.
+    global.fetch = jest.fn().mockReturnValue(new Promise(() => {}));
+    render(
+      <ToastProvider>
+        <BackupsTab />
+      </ToastProvider>,
+    );
+    expect(screen.getAllByRole("progressbar")).toHaveLength(4);
+    expect(screen.getByText("Loading snapshots…")).toBeInTheDocument();
+  });
+
+  it("attributes manual runs to the Backups tab, not the PAT owner's GitHub login", async () => {
+    setupFetchMock();
+    await renderTab();
+    const panel = screen.getByTestId("backups-recent-activity-panel");
+
+    // GitHub attributes every PAT dispatch to the PAT owner regardless of which admin clicked,
+    // so the login would misname the actor on every manual run.
+    expect(panel).toHaveTextContent("via Backups tab");
+  });
 });
 
 describe("BackupHealthCard warning banner", () => {


### PR DESCRIPTION
@coderabbitai summary

## Description
- **app/components/admin/backups/RecentActivityCard.tsx**: manual runs now show "via Backups tab" instead of the run actor's GitHub login — every PAT `workflow_dispatch` is attributed to the PAT owner regardless of which admin clicked, so the login misnames the actor on every manual run. Per-click attribution stays in the server logs (the dispatch route's audit line).
- **app/components/admin/backups/BackupsTab.tsx** (+ `.module.scss`): the loading phase renders four accent-matched `Card` skeletons, each with its own labeled `TopLoadingBar`, mirroring the Diagnostics cards' idiom — replacing the bare tab-level "Loading backups…" line (and its now-dead style), so the layout doesn't jump when data lands.
- **tests/component/BackupsTab.test.tsx**: new cases for the attribution label and the four loading shells.

## Testing
- [x] `yarn test:component -- BackupsTab` — 29/29
- [x] Full `yarn test:all` green (217 unit / 239 component / 120 integration / 110 e2e)

## Area(s) Touched
**Product areas**
- [ ] auth — sign-in, sessions, NextAuth, role-based access
- [x] admin — /admin shell (Diagnostics, Users, Import, Export tabs)
- [ ] docs — /docs Resources page (rendering, navigation, search)
- [x] ui/ux — frontend layout/styling not tied to a specific integration

**Integrations**
- [ ] google-calendar — Google Calendar sync
- [ ] zoom-api — Zoom meeting/host sync

**Engineering**
- [ ] security — auth hardening, data exposure, dependency/security scanning
- [x] testing — test suite (Jest/Playwright) changes
- [ ] github-actions — workflows, Dependabot config, other .github/ CI tooling
- [ ] cleanup — refactor or dead-code removal, no behavior change
- [ ] documentation — docs/ or README changes only

## Pre-merge Checklist
- [x] Code follows current formatting conventions and passes lint (`yarn lint`).
- [x] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
- [x] All test suites pass, both run locally and green in GitHub CI. **Do not merge if any test suite is failing.**
- [x] A test suite was added or updated for the feature/fix in this PR. **Double-check this if you change a feature and did not update the test suites**.
- [x] Only files relevant to this change are committed — no stray or unrelated files.
- [ ] If this branch has a merge conflict with master, master was merged into this branch first (not the other way around).
- [x] The rest of this PR description (Description, Testing) is filled out, not left as template placeholders.