### PR TITLE
fix(signage): make week view scroll to now, scale consistently, and show loading

### DIFF
--- a/frontend/app/(signage)/signage/page.tsx
+++ b/frontend/app/(signage)/signage/page.tsx
@@ -75,6 +75,13 @@ function SignageContent() {
   // actually attaches. Storing it in state makes attachment itself a dependency change.
   const [contentEl, setContentEl] = useState<HTMLDivElement | null>(null);
   const [scale, setScale] = useState(1);
+  // Week's internal scroll-to-current-time needs a flex-column ancestor with a *bounded*
+  // height (see WeekView.module.scss's .outerContainer comment) -- contentEl is otherwise a
+  // plain unbounded block, so WeekView's own overflow:auto container never actually overflows
+  // and its scrollTop assignment silently no-ops. Only set for Week: Day's height-based scale
+  // branch below depends on contentEl growing to its full natural (unbounded) height so
+  // contentEl.scrollHeight reflects real, unclipped content size.
+  const [weekContentHeight, setWeekContentHeight] = useState<number | undefined>(undefined);
 
   // Scale the whole page (header + calendar) together as one unit.
   // Day's timeline runs horizontally, so it scales to fit height.
@@ -86,7 +93,12 @@ function SignageContent() {
       if (view === "Day") {
         if (contentEl.scrollHeight > 0) setScale(window.innerHeight / contentEl.scrollHeight);
       } else if (contentEl.scrollWidth > 0) {
-        setScale(window.innerWidth / contentEl.scrollWidth);
+        // scrollWidth reflects the natural (horizontally unclipped) width of contentEl's
+        // descendants regardless of contentEl's own height -- bounding that height below
+        // doesn't feed back into this measurement.
+        const newScale = window.innerWidth / contentEl.scrollWidth;
+        setScale(newScale);
+        if (newScale > 0) setWeekContentHeight(window.innerHeight / newScale);
       }
     };
 
@@ -138,13 +150,24 @@ function SignageContent() {
   }
 
   return (
-    <div style={{ height: "100vh", overflow: view === "Day" ? "hidden" : "auto" }}>
+    // Always hidden -- the page itself must never be the scroller (that was the bug: with
+    // Week's overflow:auto here, the page silently absorbed the scroll WeekView's own
+    // scrollToCurrentTime meant to perform). Day never needed page-level scroll either
+    // (its own timeline scrolls horizontally within contentEl).
+    <div style={{ height: "100vh", overflow: "hidden" }}>
       <div
         ref={setContentEl}
         style={{
           transform: `scale(${scale})`,
           transformOrigin: "top left",
           width: `${100 / scale}%`,
+          // Bounding contentEl to a flex column with an explicit height gives WeekView's
+          // .outerContainer (flex: 1 1 auto; min-height: 0) a real ancestor to resolve
+          // against, mirroring the main app's .primaryCalendar (page.module.scss). Day is
+          // left unbounded (height: auto) -- see recalcScale's comment above.
+          ...(view === "Week"
+            ? { display: "flex", flexDirection: "column" as const, height: weekContentHeight }
+            : undefined),
         }}
       >
         <div className={navbarStyles.navbar}>

--- a/frontend/app/(signage)/signage/page.tsx
+++ b/frontend/app/(signage)/signage/page.tsx
@@ -150,10 +150,9 @@ function SignageContent() {
   }
 
   return (
-    // Always hidden -- the page itself must never be the scroller (that was the bug: with
-    // Week's overflow:auto here, the page silently absorbed the scroll WeekView's own
-    // scrollToCurrentTime meant to perform). Day never needed page-level scroll either
-    // (its own timeline scrolls horizontally within contentEl).
+    // The page wrapper must never be the scroller: WeekView owns its own vertical scroll
+    // (scroll-to-current-time targets its internal container) and Day's timeline scrolls
+    // horizontally within contentEl, so page-level overflow stays hidden for both views.
     <div style={{ height: "100vh", overflow: "hidden" }}>
       <div
         ref={setContentEl}

--- a/frontend/app/components/calendar/desktop/DayView.module.scss
+++ b/frontend/app/components/calendar/desktop/DayView.module.scss
@@ -6,6 +6,7 @@
   flex-direction: column;
   width: 100%;
   font-family: 'Source Sans Pro', sans-serif;
+  position: relative; // anchors TopLoadingBar's absolute positioning to this view's own bounds
 
   // Fills whatever's left under CalendarNavbar in .primaryCalendar (page.module.scss), not
   // this element's full containing-block height -- `height: 100%` resolved against

--- a/frontend/app/components/calendar/desktop/DayView.tsx
+++ b/frontend/app/components/calendar/desktop/DayView.tsx
@@ -11,6 +11,7 @@ import { defaultRooms } from "../../../../util/rooms/rooms";
 import { layoutOverlappingMeetings, OverlapMeeting } from "../../../../util/meetings/meetingOverlapLayout";
 import { dateEnterMotion, type SwipeDirection } from "../../../../util/date/dateTransition";
 import { addDaysToDate } from "../../../../util/date/weekDates";
+import TopLoadingBar from "../../ui/displays/TopLoadingBar";
 
 type Meeting = OverlapMeeting;
 
@@ -229,6 +230,10 @@ const DayView: React.FC<DayViewProps> = ({
   // have actually caught up to what's requested; otherwise it can animate in the *previous*
   // day's still-cached meetings under the new date's heading for however long the fetch takes.
   const [meetingsDate, setMeetingsDate] = useState<Date>(selectedDate);
+  // Mirrors WeekView's isLoading (from useWeekMeetings) -- DayView's own fetchMeetingsByDay
+  // has no such flag, so this view previously showed an empty grid with no indication a
+  // fetch was even in flight while paging dates or refreshing.
+  const [isLoading, setIsLoading] = useState(false);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   // Guards against out-of-order responses: rapid date/filter changes can fire overlapping
   // fetches, and without this a slower-but-stale response can overwrite a newer one.
@@ -269,11 +274,13 @@ const DayView: React.FC<DayViewProps> = ({
 
     const requestId = ++fetchRequestIdRef.current;
     const requestDate = selectedDateRef.current;
+    setIsLoading(true);
     const data = await fetchMeetingsByDay(requestDate);
     if (requestId === fetchRequestIdRef.current) {
       setMeetings(data);
       setMeetingsDate(requestDate);
       updateTimePosition();
+      setIsLoading(false);
     }
   }, [updateTimePosition]);
 
@@ -342,6 +349,7 @@ const DayView: React.FC<DayViewProps> = ({
 
   return (
     <div className={styles.outerContainer}>
+      <TopLoadingBar active={isLoading} label="Loading meetings" />
       <div
         ref={scrollContainerRef}
         className={styles.viewContainer}

--- a/frontend/app/components/calendar/desktop/DayView.tsx
+++ b/frontend/app/components/calendar/desktop/DayView.tsx
@@ -230,9 +230,9 @@ const DayView: React.FC<DayViewProps> = ({
   // have actually caught up to what's requested; otherwise it can animate in the *previous*
   // day's still-cached meetings under the new date's heading for however long the fetch takes.
   const [meetingsDate, setMeetingsDate] = useState<Date>(selectedDate);
-  // Mirrors WeekView's isLoading (from useWeekMeetings) -- DayView's own fetchMeetingsByDay
-  // has no such flag, so this view previously showed an empty grid with no indication a
-  // fetch was even in flight while paging dates or refreshing.
+  // Mirrors WeekView's isLoading (from useWeekMeetings) -- fetchMeetingsByDay exposes no flag
+  // of its own, and without one the grid reads as empty while a page/refresh fetch is in
+  // flight.
   const [isLoading, setIsLoading] = useState(false);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   // Guards against out-of-order responses: rapid date/filter changes can fire overlapping

--- a/frontend/app/components/calendar/desktop/WeekView.tsx
+++ b/frontend/app/components/calendar/desktop/WeekView.tsx
@@ -194,6 +194,7 @@ const WeekView: React.FC<WeekViewProps> = ({
             <div
                 className={styles.viewContainer}
                 ref={viewContainerRef}
+                data-testid="week-view-scroll-container"
                 style={{
                     ...(scrollLocked ? { overflow: 'hidden' } : undefined),
                     visibility: initialScrollDone ? 'visible' : 'hidden',

--- a/frontend/app/components/calendar/desktop/WeekView.tsx
+++ b/frontend/app/components/calendar/desktop/WeekView.tsx
@@ -166,9 +166,11 @@ const WeekView: React.FC<WeekViewProps> = ({
                 // The latch also gates the visibility flash-guard -- if the grid genuinely
                 // fits its container (nothing to ever scroll), the observer condition never
                 // holds, so latch anyway after a beat rather than staying hidden forever.
+                // Flips only the latch (visibility guard) -- the observer stays connected so a
+                // bounded height arriving later than the fallback still gets its one scroll;
+                // the observer disconnects itself on success and cleanup covers the rest.
                 const fallbackId = window.setTimeout(() => {
                     setInitialScrollDone(true);
-                    observer.disconnect();
                 }, 2000);
                 const intervalId = setInterval(updateTimePosition, 60000);
                 return () => {
@@ -176,6 +178,10 @@ const WeekView: React.FC<WeekViewProps> = ({
                     window.clearTimeout(fallbackId);
                     clearInterval(intervalId);
                 };
+            } else {
+                // Null ref can't scroll anyway -- latch so the visibility guard never wedges
+                // the grid invisible.
+                setInitialScrollDone(true);
             }
         }
 

--- a/frontend/app/components/calendar/desktop/WeekView.tsx
+++ b/frontend/app/components/calendar/desktop/WeekView.tsx
@@ -145,8 +145,38 @@ const WeekView: React.FC<WeekViewProps> = ({
         // eslint-disable-next-line react-hooks/set-state-in-effect
         updateTimePosition();
         if (initialScrollDone === false) {
-            scrollToCurrentTime();
-            setInitialScrollDone(true);
+            const container = viewContainerRef.current;
+            if (container && container.scrollHeight > container.clientHeight) {
+                scrollToCurrentTime();
+                setInitialScrollDone(true);
+            } else if (container) {
+                // The container may not be scrollable yet: on /signage its bounded height
+                // arrives asynchronously from the page's recalcScale, after this mount-time
+                // effect -- scrolling now would silently no-op and the latch would mask it.
+                // Watch for the resize that makes it scrollable, scroll once, then latch
+                // (same retry idea as DayLandscapeView's width-measurement guard).
+                const observer = new ResizeObserver(() => {
+                    if (container.scrollHeight > container.clientHeight) {
+                        scrollToCurrentTime();
+                        setInitialScrollDone(true);
+                        observer.disconnect();
+                    }
+                });
+                observer.observe(container);
+                // The latch also gates the visibility flash-guard -- if the grid genuinely
+                // fits its container (nothing to ever scroll), the observer condition never
+                // holds, so latch anyway after a beat rather than staying hidden forever.
+                const fallbackId = window.setTimeout(() => {
+                    setInitialScrollDone(true);
+                    observer.disconnect();
+                }, 2000);
+                const intervalId = setInterval(updateTimePosition, 60000);
+                return () => {
+                    observer.disconnect();
+                    window.clearTimeout(fallbackId);
+                    clearInterval(intervalId);
+                };
+            }
         }
 
         const intervalId = setInterval(updateTimePosition, 60000);

--- a/frontend/tests/component/DayView.test.tsx
+++ b/frontend/tests/component/DayView.test.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import DayView from "../../app/components/calendar/desktop/DayView";
+import { createDefaultFilters } from "../../util/filters/meetingFilters";
+
+const etNoon = (y: number, m: number, d: number) => new Date(Date.UTC(y, m - 1, d, 16, 0));
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+const renderView = (selectedDate: Date) =>
+  render(
+    <DayView
+      filters={createDefaultFilters(true)}
+      selectedDate={selectedDate}
+      setSelectedDate={jest.fn()}
+      selectedMeetingID={null}
+      setSelectedMeetingID={jest.fn()}
+      setSelectedNewMeeting={jest.fn()}
+      setAnchorEl={jest.fn()}
+    />
+  );
+
+describe("DayView loading bar", () => {
+  // Regression coverage for #448's bundled scope addition: DayView previously had no isLoading
+  // flag at all (unlike WeekView's, which already renders TopLoadingBar via useWeekMeetings),
+  // so it showed an empty grid with no indication a fetch was in flight.
+  it("shows the loading bar while the day's meetings are being fetched, hides it once resolved", async () => {
+    let resolveFetch!: (value: { ok: true; json: () => Promise<unknown[]> }) => void;
+    global.fetch = jest.fn().mockReturnValue(
+      new Promise((resolve) => {
+        resolveFetch = resolve;
+      })
+    ) as jest.Mock;
+
+    renderView(etNoon(2026, 8, 20));
+
+    await waitFor(() => expect(screen.getByRole("progressbar")).toBeInTheDocument());
+    expect(screen.getByRole("progressbar")).toHaveAccessibleName("Loading meetings");
+
+    resolveFetch({ ok: true, json: async () => [] });
+
+    await waitFor(() => expect(screen.queryByRole("progressbar")).not.toBeInTheDocument());
+  });
+});

--- a/frontend/tests/component/DayView.test.tsx
+++ b/frontend/tests/component/DayView.test.tsx
@@ -23,9 +23,8 @@ const renderView = (selectedDate: Date) =>
   );
 
 describe("DayView loading bar", () => {
-  // Regression coverage for #448's bundled scope addition: DayView previously had no isLoading
-  // flag at all (unlike WeekView's, which already renders TopLoadingBar via useWeekMeetings),
-  // so it showed an empty grid with no indication a fetch was in flight.
+  // The loading bar is the only signal a fetch is in flight -- without it the grid reads as
+  // an empty day (regression guard for #448's bundled scope addition).
   it("shows the loading bar while the day's meetings are being fetched, hides it once resolved", async () => {
     let resolveFetch!: (value: { ok: true; json: () => Promise<unknown[]> }) => void;
     global.fetch = jest.fn().mockReturnValue(

--- a/frontend/tests/e2e/13-digital-signage.spec.ts
+++ b/frontend/tests/e2e/13-digital-signage.spec.ts
@@ -78,22 +78,25 @@ test.describe("digital signage", () => {
   // Extends 13.6 to Week -- 13.6 alone is Day-only, so a Week-specific scale regression (the
   // width-based branch, or the bounded-height wrapping added for the scroll fix below) could
   // silently reintroduce scale(1) without tripping any existing test.
-  test("13.6b /signage?view=week rescales to fit the viewport, plain and filtered", async ({ page }) => {
-    await seedMeeting({ title: "Week Scale Signage Meeting" });
+  // Week content fits a 1280px-wide viewport without downscaling (scale 1 is legitimate here,
+  // unlike Day's height-driven scale in 13.6) -- what #448's filtered-navbar symptom actually
+  // demands is that the filtered variant scales IDENTICALLY to the plain one, so equality is
+  // the assertion, not non-identity.
+  test("13.6b a filtered /signage?view=week scales identically to the plain one", async ({ page }) => {
+    await seedMeeting({ title: "Week Scale Signage Meeting", room: "Serenity Room" });
     await page.goto("/signage?view=week");
     await expect(page.getByText("Week Scale Signage Meeting")).toBeVisible();
 
     const contentDiv = page.locator('div[style*="transform"]').first();
     const transform = await contentDiv.evaluate((el) => window.getComputedStyle(el).transform);
-    expect(transform).not.toBe("matrix(1, 0, 0, 1, 0, 0)");
+    expect(transform).not.toBe("none");
 
-    await seedMeeting({ title: "Week Scale Filtered Meeting", room: "Serenity Room" });
     await page.goto("/signage?view=week&rooms=Serenity");
-    await expect(page.getByText("Week Scale Filtered Meeting")).toBeVisible();
+    await expect(page.getByText("Week Scale Signage Meeting")).toBeVisible();
 
     const filteredContentDiv = page.locator('div[style*="transform"]').first();
     const filteredTransform = await filteredContentDiv.evaluate((el) => window.getComputedStyle(el).transform);
-    expect(filteredTransform).not.toBe("matrix(1, 0, 0, 1, 0, 0)");
+    expect(filteredTransform).toBe(transform);
   });
 
   // Regression test for #448: WeekView's internal scroll container (.viewContainer) needs a

--- a/frontend/tests/e2e/13-digital-signage.spec.ts
+++ b/frontend/tests/e2e/13-digital-signage.spec.ts
@@ -89,7 +89,6 @@ test.describe("digital signage", () => {
 
     const contentDiv = page.locator('div[style*="transform"]').first();
     const transform = await contentDiv.evaluate((el) => window.getComputedStyle(el).transform);
-    expect(transform).not.toBe("none");
 
     await page.goto("/signage?view=week&rooms=Serenity");
     await expect(page.getByText("Week Scale Signage Meeting")).toBeVisible();
@@ -99,24 +98,26 @@ test.describe("digital signage", () => {
     expect(filteredTransform).toBe(transform);
   });
 
-  // Regression test for #448: WeekView's internal scroll container (.viewContainer) needs a
-  // bounded flex-column ancestor to actually overflow -- signage's contentEl used to be an
-  // unbounded plain div, so scrollHeight === clientHeight and scrollToCurrentTime's scrollTop
-  // assignment silently no-opped (the page's own overflow:auto wrapper scrolled instead, or
-  // -- once that was also removed -- nothing scrolled at all).
+  // Regression test for #448: WeekView's internal scroll container must be the element that
+  // scrolls on signage -- the page wrapper is overflow:hidden, so if the container's bounded
+  // height never resolves, scrollTop silently stays 0. Proximity (not just > 0) so the
+  // assertion still bites in the first ~100 ET minutes of the day, when the expected offset
+  // legitimately clamps to 0.
   test("13.8 /signage?view=week scrolls its internal grid to the current time", async ({ page }) => {
     await seedMeeting({ title: "Week Scroll Signage Meeting" });
     await page.goto("/signage?view=week");
+    await expect(page.getByText("Week Scroll Signage Meeting")).toBeVisible();
     const container = page.getByTestId("week-view-scroll-container");
     await expect(container).toBeVisible();
 
     const expected = expectedWeekScrollTop();
-    const scrollTop = await container.evaluate((el) => el.scrollTop);
-    if (expected > 0) {
-      expect(scrollTop).toBeGreaterThan(0);
-    } else {
-      expect(scrollTop).toBe(0);
-    }
+    // The browser clamps scrollTop to the scrollable range -- late in the ET day the raw
+    // formula exceeds it, so the expectation must clamp the same way.
+    const { scrollTop, maxScrollTop } = await container.evaluate((el) => ({
+      scrollTop: el.scrollTop,
+      maxScrollTop: el.scrollHeight - el.clientHeight,
+    }));
+    expect(Math.abs(scrollTop - Math.min(expected, maxScrollTop))).toBeLessThan(5);
   });
 
   // Same assertion as 13.8, filtered -- the filtered-navbar symptom reported alongside the
@@ -124,15 +125,17 @@ test.describe("digital signage", () => {
   test("13.9 a filtered /signage?view=week URL still scrolls its internal grid to the current time", async ({ page }) => {
     await seedMeeting({ title: "Week Scroll Filtered Meeting", room: "Serenity Room" });
     await page.goto("/signage?view=week&rooms=Serenity");
+    await expect(page.getByText("Week Scroll Filtered Meeting")).toBeVisible();
     const container = page.getByTestId("week-view-scroll-container");
     await expect(container).toBeVisible();
 
     const expected = expectedWeekScrollTop();
-    const scrollTop = await container.evaluate((el) => el.scrollTop);
-    if (expected > 0) {
-      expect(scrollTop).toBeGreaterThan(0);
-    } else {
-      expect(scrollTop).toBe(0);
-    }
+    // The browser clamps scrollTop to the scrollable range -- late in the ET day the raw
+    // formula exceeds it, so the expectation must clamp the same way.
+    const { scrollTop, maxScrollTop } = await container.evaluate((el) => ({
+      scrollTop: el.scrollTop,
+      maxScrollTop: el.scrollHeight - el.clientHeight,
+    }));
+    expect(Math.abs(scrollTop - Math.min(expected, maxScrollTop))).toBeLessThan(5);
   });
 });

--- a/frontend/tests/e2e/13-digital-signage.spec.ts
+++ b/frontend/tests/e2e/13-digital-signage.spec.ts
@@ -1,5 +1,15 @@
 import { test, expect } from "./support/fixtures";
 import { seedMeeting } from "../factories/meeting";
+import { getCurrentETMinutesSinceMidnight } from "../../util/date/timeUtils";
+
+// Mirrors WeekView.tsx's own scrollToCurrentTime formula exactly -- used to compute the
+// expected scrollTop rather than asserting a blind ">0", which would be a false negative in
+// the near-midnight window (first ~100 ET minutes) where the real formula also clamps to 0.
+const expectedWeekScrollTop = (): number => {
+  const dayHeaderOffset = 40;
+  const scrollOffset = dayHeaderOffset + getCurrentETMinutesSinceMidnight() * (120 / 60) - 240;
+  return Math.max(0, scrollOffset);
+};
 
 // Manual script §13 (Digital Signage). §13.4 (midnight ET rollover) and §13.5
 // (picking up changes within ~2 minutes) depend on real elapsed time or clock
@@ -63,5 +73,63 @@ test.describe("digital signage", () => {
     // scale(1) resolves to the identity matrix -- if the auto-fit calculation never ran, this
     // is exactly what a fresh, unscaled render would still show.
     expect(transform).not.toBe("matrix(1, 0, 0, 1, 0, 0)");
+  });
+
+  // Extends 13.6 to Week -- 13.6 alone is Day-only, so a Week-specific scale regression (the
+  // width-based branch, or the bounded-height wrapping added for the scroll fix below) could
+  // silently reintroduce scale(1) without tripping any existing test.
+  test("13.6b /signage?view=week rescales to fit the viewport, plain and filtered", async ({ page }) => {
+    await seedMeeting({ title: "Week Scale Signage Meeting" });
+    await page.goto("/signage?view=week");
+    await expect(page.getByText("Week Scale Signage Meeting")).toBeVisible();
+
+    const contentDiv = page.locator('div[style*="transform"]').first();
+    const transform = await contentDiv.evaluate((el) => window.getComputedStyle(el).transform);
+    expect(transform).not.toBe("matrix(1, 0, 0, 1, 0, 0)");
+
+    await seedMeeting({ title: "Week Scale Filtered Meeting", room: "Serenity Room" });
+    await page.goto("/signage?view=week&rooms=Serenity");
+    await expect(page.getByText("Week Scale Filtered Meeting")).toBeVisible();
+
+    const filteredContentDiv = page.locator('div[style*="transform"]').first();
+    const filteredTransform = await filteredContentDiv.evaluate((el) => window.getComputedStyle(el).transform);
+    expect(filteredTransform).not.toBe("matrix(1, 0, 0, 1, 0, 0)");
+  });
+
+  // Regression test for #448: WeekView's internal scroll container (.viewContainer) needs a
+  // bounded flex-column ancestor to actually overflow -- signage's contentEl used to be an
+  // unbounded plain div, so scrollHeight === clientHeight and scrollToCurrentTime's scrollTop
+  // assignment silently no-opped (the page's own overflow:auto wrapper scrolled instead, or
+  // -- once that was also removed -- nothing scrolled at all).
+  test("13.8 /signage?view=week scrolls its internal grid to the current time", async ({ page }) => {
+    await seedMeeting({ title: "Week Scroll Signage Meeting" });
+    await page.goto("/signage?view=week");
+    const container = page.getByTestId("week-view-scroll-container");
+    await expect(container).toBeVisible();
+
+    const expected = expectedWeekScrollTop();
+    const scrollTop = await container.evaluate((el) => el.scrollTop);
+    if (expected > 0) {
+      expect(scrollTop).toBeGreaterThan(0);
+    } else {
+      expect(scrollTop).toBe(0);
+    }
+  });
+
+  // Same assertion as 13.8, filtered -- the filtered-navbar symptom reported alongside the
+  // scroll bug suggested the filtered path might diverge from the plain one.
+  test("13.9 a filtered /signage?view=week URL still scrolls its internal grid to the current time", async ({ page }) => {
+    await seedMeeting({ title: "Week Scroll Filtered Meeting", room: "Serenity Room" });
+    await page.goto("/signage?view=week&rooms=Serenity");
+    const container = page.getByTestId("week-view-scroll-container");
+    await expect(container).toBeVisible();
+
+    const expected = expectedWeekScrollTop();
+    const scrollTop = await container.evaluate((el) => el.scrollTop);
+    if (expected > 0) {
+      expect(scrollTop).toBeGreaterThan(0);
+    } else {
+      expect(scrollTop).toBe(0);
+    }
   });
 });


### PR DESCRIPTION
Resolves #448

@coderabbitai summary

## Description
- **frontend/app/(signage)/signage/page.tsx**: WeekView's scroll container never overflowed on signage — the scaled `contentEl` gave it no bounded height, so `scrollToCurrentTime`'s `scrollTop` assignment silently no-opped and the run-once latch masked it (the page wrapper's `overflow: auto` was the thing scrolling). `contentEl` is now a bounded flex column for Week and the page wrapper stays `overflow: hidden` for both views. Day's scale measurement path is untouched (its #348 regression guard 13.6 still passes).
- **frontend/app/components/calendar/desktop/WeekView.tsx**: the scroll effect waits for real overflow via a ResizeObserver before scrolling and latching (signage's bounded height arrives asynchronously from `recalcScale`), with a 2s fallback that flips only the visibility latch — the observer stays alive so a late height still gets its scroll. Adds `data-testid` on the scroll container. Run-once semantics unchanged: a kiosk does not re-anchor at midnight rollover (known trade-off, revisit if ICR reports drift).
- **frontend/app/components/calendar/desktop/DayView.tsx**: gains `isLoading` + the required-label `TopLoadingBar`, matching WeekView — previously an in-flight fetch rendered as an empty day, on signage and the main calendar alike.
- **Tests**: e2e 13.6b (filtered week scales identically to plain — the reported navbar symptom), 13.8/13.9 (scroll proximity to the computed current-time offset, browser-clamped, plain + filtered), and a DayView loading-bar component test.

## Testing
- [x] `yarn test:e2e -- 13-digital-signage` — 8/8
- [x] Full `yarn test:all` green (217 unit / 238 component / 120 integration / 114 e2e)
- [x] Headless probe on `localhost:3000/signage?view=week`: scrollTop 2336 with the container genuinely scrollable (2921 > 584)
- [x] Opus high-effort review; its pre-merge findings folded in

## Area(s) Touched
**Product areas**
- [ ] auth — sign-in, sessions, NextAuth, role-based access
- [ ] admin — /admin shell (Diagnostics, Users, Import, Export tabs)
- [ ] docs — /docs Resources page (rendering, navigation, search)
- [x] ui/ux — frontend layout/styling not tied to a specific integration

**Integrations**
- [ ] google-calendar — Google Calendar sync
- [ ] zoom-api — Zoom meeting/host sync

**Engineering**
- [ ] security — auth hardening, data exposure, dependency/security scanning
- [x] testing — test suite (Jest/Playwright) changes
- [ ] github-actions — workflows, Dependabot config, other .github/ CI tooling
- [ ] cleanup — refactor or dead-code removal, no behavior change
- [ ] documentation — docs/ or README changes only

## Pre-merge Checklist
- [x] Code follows current formatting conventions and passes lint (`yarn lint`).
- [x] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
- [x] All test suites pass, both run locally and green in GitHub CI. **Do not merge if any test suite is failing.**
- [x] A test suite was added or updated for the feature/fix in this PR. **Double-check this if you change a feature and did not update the test suites**.
- [x] Only files relevant to this change are committed — no stray or unrelated files.
- [ ] If this branch has a merge conflict with master, master was merged into this branch first (not the other way around).
- [x] The rest of this PR description (Description, Testing) is filled out, not left as template placeholders.