### PR TITLE
feat(backups): surface restore-drill verification in the Backups tab

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules/
 package-lock.json
 package.json
 dump.rdb
+drill-verified.json

--- a/docs/01-user-guide/README.md
+++ b/docs/01-user-guide/README.md
@@ -11,6 +11,7 @@ For ICR board members using the platform day to day. Organized by what you need 
   - [Suspend and Resume a Meeting](how-to/suspend-and-resume-a-meeting.md)
   - [Navigate and Filter the Calendar](how-to/navigate-and-filter-the-calendar.md)
   - [Export Data](how-to/export-data.md)
+  - [Check Backups and Run One](how-to/check-backups-and-run-one.md)
   - [Manage Admin Users](how-to/manage-admin-users.md)
   - [Use Digital Signage](how-to/use-digital-signage.md)
   - [Retry a Failed Sync](how-to/retry-a-failed-sync.md)

--- a/docs/01-user-guide/how-to/check-backups-and-run-one.md
+++ b/docs/01-user-guide/how-to/check-backups-and-run-one.md
@@ -1,0 +1,68 @@
+# Check Backups and Run One
+
+Go to **Admin → Backups**. Super-Admin-only.
+
+This tab shows the health of the platform's automatic database backups, lets you trigger an
+extra one, and gives a break-glass runbook for restoring in an emergency. For how the backup
+system itself is built, see [Backups and Recovery](../../02-handoff/backups-and-recovery.md) —
+this page is just about using the tab.
+
+## Reading the Backup Health card
+
+The top card shows four numbers at a glance: when the last backup succeeded, when the next one
+is scheduled, how many snapshots are retained, and when a restore was last verified. Below that,
+a **Replicas** panel shows whether all three storage copies have the latest snapshot, plus how
+much free-tier storage is left.
+
+A banner appears above these numbers when something needs attention:
+
+- **"No restore has ever been verified"** — backups are running, but nobody has proven one can
+  actually be restored yet. Not an emergency, just a reminder that the quarterly drill is
+  pending.
+- **"Last verified restore was N months ago — run the quarterly drill"** — the same reminder,
+  but for a drill that's gone stale (roughly 100 days since the last one).
+
+Either banner links to the restore drill runbook section in Backups and Recovery. Who actually
+runs the drill — an H4I Maintenance Lead or ICR key holder — is covered there; this tab only
+shows whether it's due.
+
+If the "Last successful backup" number turns orange or red, a scheduled backup is overdue or
+failed — see [Troubleshooting](../reference/troubleshooting.md#backups-tab).
+
+## Running a backup on demand
+
+Click **Back Up Now** at the top of the tab. A toast confirms the run was dispatched, and it
+appears under **Notable Activity** within about a minute. The button is disabled while a run is
+already in progress — the platform only allows one backup at a time.
+
+## Downloading a snapshot
+
+In the **Snapshots** table, click the download icon on any row. This downloads the raw encrypted
+backup file — it is **not readable on its own**. Opening it requires a private decryption key
+held only by the H4I Maintenance Lead or ICR's President (see the two-key rule in
+[Backups and Recovery](../../02-handoff/backups-and-recovery.md#the-two-key-rule)). In practice,
+only download a snapshot if one of those key holders has asked you to, as part of a restore.
+
+Use the **Verified** column (hover the ⓘ next to the header for the legend) to see whether a
+snapshot has actually been proven restorable — prefer a Verified one if you're ever asked to hand
+one over. The **Replicas** column shows how many of the three storage copies hold that snapshot;
+hover it for the per-copy breakdown. Filter chips above the table (All / Daily / Monthly /
+Permanent / Unverified) narrow the list.
+
+## Restoring a backup
+
+Restoring is a deliberate, hands-on-keyboard operation performed by a key holder — never a
+button in this app. Selecting a snapshot row fills in a copy-pasteable command in the **Restore
+Runbook** card below, but running it requires an `age` private key and direct database access
+that only the Maintenance Lead or ICR President have.
+
+If you suspect data loss or corruption, don't try to fix it yourself — contact the Maintenance
+Lead (see [Support Process](../../02-handoff/support-process.md)). Full restore steps live in
+[Backups and Recovery](../../02-handoff/backups-and-recovery.md#the-break-glass-restore-runbook).
+
+## The quarterly restore drill
+
+Separately from the button above, a key holder periodically test-restores a real backup to prove
+the pipeline actually works, not just that files exist. This tab shows when that last happened
+(see the health card banners above); it doesn't run the drill for you. Who's responsible for it
+is covered in [Backups and Recovery](../../02-handoff/backups-and-recovery.md#verification-restore-drills).

--- a/docs/01-user-guide/reference/quick-reference-card.md
+++ b/docs/01-user-guide/reference/quick-reference-card.md
@@ -40,6 +40,10 @@
 1. "Export Meetings" → full XLSX backup
 2. "Export Lease CSV" → PandaDoc Bulk Send, once per year in early July
 
+**Check backups / run one** *(Admin → Backups, Super Admin only)*
+1. Backup Health card shows last backup, next run, and restore-drill status
+2. "Back Up Now" triggers an extra backup — appears in activity within ~1 minute
+
 ---
 
 **Key contacts**

--- a/docs/01-user-guide/reference/roles-and-permissions.md
+++ b/docs/01-user-guide/reference/roles-and-permissions.md
@@ -6,7 +6,7 @@ Three roles, each a superset of the one before it.
 |---|---|
 | **User** (no sign-in and basic users) | View the calendar and `/signage`.|
 | **Admin** | Everything a User can, plus: create, edit, delete, suspend, and resume meetings; retry a failed sync; view the Diagnostics tab; use the Signage tab (signage URL generator). |
-| **Super Admin** | Everything an Admin can, plus: invite/remove admins and change their roles (Users tab); use the Export tab (meetings backup, lease CSV, lease/export settings). |
+| **Super Admin** | Everything an Admin can, plus: invite/remove admins and change their roles (Users tab); use the Export tab (meetings backup, lease CSV, lease/export settings); use the Backups tab (backup health, Back Up Now, download encrypted snapshots, restore runbook). |
 
 ## How you get a role
 

--- a/docs/01-user-guide/reference/troubleshooting.md
+++ b/docs/01-user-guide/reference/troubleshooting.md
@@ -12,6 +12,15 @@
 | "Export Lease CSV" fails with no meetings to export | Confirm at least one non-deleted meeting exists (suspended meetings still count) |
 | Page behaves unexpectedly | Hard refresh: Ctrl+Shift+R (Windows) or Cmd+Shift+R (Mac). Or try a different browser |
 
+## Backups tab
+
+| Problem | What to try |
+|---|---|
+| Warning banner: "No restore has ever been verified" or "Last verified restore was N months ago" | Not an emergency — it means the quarterly restore drill is pending or overdue. See [Check Backups and Run One](../how-to/check-backups-and-run-one.md) |
+| "Backup monitoring isn't configured in this environment" panel | Backup credentials aren't set up for this environment. Contact the H4I Maintenance Lead — nothing to fix from the UI |
+| A backup run failed | A GitHub issue opens automatically to notify the H4I team — nothing else needed from you beyond reporting it per [Support Process](../../02-handoff/support-process.md) if it's urgent |
+| "Back Up Now" button is disabled/greyed out | A backup is already running — only one can run at a time. Wait for it to finish, then try again |
+
 ## Common scenarios
 
 **"I accidentally deleted a meeting."** Deleted meetings can't be recovered ([learn why](../explanation/why-some-actions-cant-be-undone.md)) and must be recreated manually. For recurring series, ensure you select **This event** instead of **All events** if you only intend to cancel a single occurrence.

--- a/docs/02-handoff/backups-and-recovery.md
+++ b/docs/02-handoff/backups-and-recovery.md
@@ -61,7 +61,10 @@ non-technical maintainer should attempt. If you suspect data loss or corruption:
 
 ## Verification: restore drills
 
-Backups are periodically test-restored to prove they actually work, not just that they exist.
+Backups are periodically test-restored to prove they actually work, not just that they exist. An
+operator runs this quarterly, restoring the newest monthly backup into a scratch database. The
+Backups admin tab's Backup Health card shows when this last happened and which key holder ran it.
+
 Mechanics: [Backup Infrastructure Setup](../03-development/backup-infra-setup.md).
 
 ## The break-glass restore runbook

--- a/docs/02-handoff/backups-and-recovery.md
+++ b/docs/02-handoff/backups-and-recovery.md
@@ -72,6 +72,9 @@ Mechanics: [Backup Infrastructure Setup](../03-development/backup-infra-setup.md
 Restoring a backup deliberately requires a human with a private key — no automated system can do
 it on its own. This keeps our data safe even if the app or its cloud accounts were compromised.
 
+One operator at a time: restores are coordinated through the Maintenance Lead so two people never
+run one concurrently — there is no technical lock preventing it.
+
 At a high level, an operator:
 
 1. Picks the right backup and confirms it's undamaged.

--- a/docs/03-development/backup-infra-setup.md
+++ b/docs/03-development/backup-infra-setup.md
@@ -436,7 +436,36 @@ see the break-glass runbook in `backups-and-recovery.md`):
 
 ---
 
-## 8. Backups admin tab: keyless GCS auth
+## 8. Restore drill verification marker
+
+`restore-drill.sh`'s final step (reachable only once decrypt, scratch restore, and the exact
+`count(*)` match have all passed) writes `drill-verified.json` to the working bucket root
+(`gs://icr-db-backups-prod/drill-verified.json`, not under `daily/`/`monthly/`/`permanent/`) and
+uploads it with the operator's own `gcloud storage cp` — the drill only ever holds read access to
+the bucket, so this is a deliberately separate, manually-authenticated write:
+
+```json
+{
+  "verifiedAt": "2026-08-16T14:34:57Z",
+  "artifactId": "20260801T071700Z",
+  "keyUsed": "A"
+}
+```
+
+No key material and no operator PII — `keyUsed` is the key *letter* (A or B), not an identity.
+The Backups admin tab's storage layer reads this object in the same cached listing pass as the
+sidecars (one extra `objects.get`, same 60s TTL); absent (no drill has run yet), malformed, or
+wrong-shape objects are all treated as "never verified" rather than erroring the listing.
+
+Since `restore-drill.sh` runs on an operator's own machine (never CI — see §7), it can't infer
+which physical key `AGE_IDENTITY_FILE` points at. `DRILL_KEY_USED=A|B` is a required env var,
+validated to exactly one of those two values, so the marker's `keyUsed` field is always accurate.
+If `gcloud` isn't installed, the script still passes — it prints the exact `gcloud storage cp`
+command for the operator to run by hand as a separate concluding step.
+
+---
+
+## 9. Backups admin tab: keyless GCS auth
 
 The Admin → Backups tab's server routes read GCS keylessly: Vercel OIDC → Workload Identity
 Federation, the same mechanism the backup workflow uses for GitHub Actions. No service-account

--- a/docs/03-development/backup-infra-setup.md
+++ b/docs/03-development/backup-infra-setup.md
@@ -460,8 +460,10 @@ wrong-shape objects are all treated as "never verified" rather than erroring the
 Since `restore-drill.sh` runs on an operator's own machine (never CI — see §7), it can't infer
 which physical key `AGE_IDENTITY_FILE` points at. `DRILL_KEY_USED=A|B` is a required env var,
 validated to exactly one of those two values, so the marker's `keyUsed` field is always accurate.
-If `gcloud` isn't installed, the script still passes — it prints the exact `gcloud storage cp`
-command for the operator to run by hand as a separate concluding step.
+A failed marker write or upload (network blip, stale `gcloud` auth, etc.) never fails the drill
+itself — the PASS/FAIL result is already printed by that point. The script instead prints the
+exact command (`jq -n ...` or `gcloud storage cp ...`) for the operator to run by hand as a
+separate concluding step.
 
 ---
 

--- a/frontend/app/api/admin/backups/health/route.ts
+++ b/frontend/app/api/admin/backups/health/route.ts
@@ -25,7 +25,7 @@ export const GET = async () => {
   }
 
   try {
-    const { rows, workingObjectCount, archiveObjectCount, r2ObjectCount } = await listBackups();
+    const { rows, workingObjectCount, archiveObjectCount, r2ObjectCount, drillMarker } = await listBackups();
     const latest = rows[0];
     const lastSuccessfulBackupAt = latest ? latest.createdAt : null;
 
@@ -48,9 +48,8 @@ export const GET = async () => {
     const health: BackupHealth = {
       lastSuccessfulBackupAt,
       freshness: lastSuccessfulBackupAt ? freshnessFor(lastSuccessfulBackupAt, now) : "error",
-      // No quarterly restore drill has run against production yet -- see
-      // docs/02-handoff/backups-and-recovery.md's "Verification: restore drills" section.
-      lastVerifiedRestoreAt: null,
+      lastVerifiedRestoreAt: drillMarker ? drillMarker.verifiedAt : null,
+      lastVerifiedRestoreKey: drillMarker ? drillMarker.keyUsed : null,
       nextScheduledRunAt: nextScheduledRunAfter(now),
       replicaStatus,
       totals,

--- a/frontend/app/components/admin/backups/BackupHealthCard.tsx
+++ b/frontend/app/components/admin/backups/BackupHealthCard.tsx
@@ -14,6 +14,11 @@ interface BackupHealthCardProps {
   now: Date;
 }
 
+// Quarterly cadence is ~91 days; 100 gives a ~9-day grace window before the banner nags an
+// operator who's about to run the drill anyway.
+const DRILL_STALE_DAYS = 100;
+const DRILL_STALE_MS = DRILL_STALE_DAYS * 24 * 60 * 60 * 1000;
+
 const REPLICA_LABEL: Record<BackupReplica, string> = {
   "gcs-working": "GCS working",
   "gcs-archive": "GCS archive",
@@ -31,6 +36,14 @@ const formatRelativeAge = (sinceIso: string, now: Date): string => {
   if (diffHours < 24) return `${diffHours}h ago`;
   const diffDays = Math.floor(diffHours / 24);
   return `${diffDays}d ago`;
+};
+
+// "3 months ago" for the stale-drill banner -- coarser than formatRelativeAge's
+// minutes/hours/days since a drill's staleness is only meaningful in month-scale terms.
+const formatMonthsAgo = (sinceIso: string, now: Date): string => {
+  const diffMs = Math.max(0, now.getTime() - new Date(sinceIso).getTime());
+  const months = Math.max(1, Math.round(diffMs / (30 * 24 * 60 * 60 * 1000)));
+  return `${months} month${months === 1 ? "" : "s"} ago`;
 };
 
 // Countdown to the next scheduled run ("in 5h 51m"; "in 12m" once under an hour).
@@ -75,6 +88,11 @@ const BackupHealthCard: React.FC<BackupHealthCardProps> = ({ health, now }) => {
     ? "All three hold the latest snapshot"
     : `${latestCount} of ${health.replicaStatus.length} hold the latest snapshot`;
 
+  const drillAgeMs = health.lastVerifiedRestoreAt
+    ? now.getTime() - new Date(health.lastVerifiedRestoreAt).getTime()
+    : null;
+  const drillIsStale = drillAgeMs !== null && drillAgeMs >= DRILL_STALE_MS;
+
   return (
     <Card accent="systemStatus">
       <div className={styles.panelHeader}>
@@ -91,6 +109,25 @@ const BackupHealthCard: React.FC<BackupHealthCardProps> = ({ health, now }) => {
             <p className={styles.warningBannerTitle}>No restore has ever been verified</p>
             <p className={styles.warningBannerText}>
               Backups are running, but an untested backup is an unproven one. The quarterly restore drill is pending.
+            </p>
+          </div>
+          <a
+            className={styles.warningBannerAction}
+            href="/docs/02-handoff/backups-and-recovery#verification-restore-drills"
+          >
+            Restore drill runbook
+          </a>
+        </div>
+      )}
+
+      {drillIsStale && health.lastVerifiedRestoreAt !== null && (
+        <div className={styles.warningBanner}>
+          <div className={styles.warningBannerIcon}>
+            <Icon name="warning-amber" />
+          </div>
+          <div className={styles.warningBannerBody}>
+            <p className={styles.warningBannerTitle}>
+              Last verified restore was {formatMonthsAgo(health.lastVerifiedRestoreAt, now)} — run the quarterly drill
             </p>
           </div>
           <a
@@ -126,6 +163,15 @@ const BackupHealthCard: React.FC<BackupHealthCardProps> = ({ health, now }) => {
         <div className={styles.statCell}>
           <div className={styles.statValue}>{health.totals.objectCount}</div>
           <div className={styles.statCaption}>Snapshots retained</div>
+        </div>
+        <div className={styles.statCell}>
+          <div className={`${styles.statValue} ${drillIsStale ? styles.statValueWarn : ""}`}>
+            {health.lastVerifiedRestoreAt ? formatRelativeAge(health.lastVerifiedRestoreAt, now) : "Never"}
+          </div>
+          <div className={styles.statCaption}>
+            Last verified restore
+            {health.lastVerifiedRestoreAt && health.lastVerifiedRestoreKey ? ` · key ${health.lastVerifiedRestoreKey}` : ""}
+          </div>
         </div>
       </div>
 

--- a/frontend/app/components/admin/backups/BackupsTab.module.scss
+++ b/frontend/app/components/admin/backups/BackupsTab.module.scss
@@ -409,7 +409,7 @@
   }
 }
 
-/* ---------- 3-up stat row ---------- */
+/* ---------- 4-up stat row ---------- */
 
 .statRow {
   display: flex;

--- a/frontend/app/components/admin/backups/RestoreRunbookCard.tsx
+++ b/frontend/app/components/admin/backups/RestoreRunbookCard.tsx
@@ -111,6 +111,14 @@ export default function RestoreRunbookCard({ selected, now }: RestoreRunbookCard
           <span>3.</span>
           <span>A scratch Neon branch connection string, unpooled — the script refuses <code>-pooler</code> URLs.</span>
         </li>
+        <li className={styles.runbookPrereq}>
+          <span>4.</span>
+          <span>
+            Confirmation that no one else is mid-restore — one operator at a time, coordinated
+            through the Maintenance Lead. There is no technical lock; two concurrent restores
+            against the same target would interleave destructively.
+          </span>
+        </li>
       </ul>
 
       <div className={styles.panelSubhead}>

--- a/frontend/app/components/admin/backups/RestoreRunbookCard.tsx
+++ b/frontend/app/components/admin/backups/RestoreRunbookCard.tsx
@@ -42,6 +42,8 @@ function formatCreatedLabel(createdAt: string, now: Date): string {
 export default function RestoreRunbookCard({ selected, now }: RestoreRunbookCardProps) {
   const [copied, setCopied] = useState(false);
   const [copyFailed, setCopyFailed] = useState(false);
+  const [drillCopied, setDrillCopied] = useState(false);
+  const [drillCopyFailed, setDrillCopyFailed] = useState(false);
 
   // Mock fixtures already set `id` to `backup-<yyyymmddThhmmssZ>`, but real rows carry the
   // sidecar's bare-timestamp `id` -- backupArtifactBaseName() normalizes either shape to the
@@ -52,6 +54,13 @@ export default function RestoreRunbookCard({ selected, now }: RestoreRunbookCard
     ? `AGE_IDENTITY_FILE=/path/to/key RESTORE_TARGET_URL=<neon-branch-url> ./frontend/scripts/restore-db.sh ./${backupArtifactBaseName(selected.id)}.dump.age`
     : null;
   const createdLabel = selected ? formatCreatedLabel(selected.createdAt, now) : null;
+
+  // Drill key letter isn't derivable from anything client-side (the operator picks whichever
+  // physical key they hold) -- <A|B> is a literal placeholder the operator fills in, same idiom
+  // as the /path/to/key and <neon-branch-url> placeholders above.
+  const drillCommand = selected
+    ? `DRILL_KEY_USED=<A|B> AGE_IDENTITY_FILE=/path/to/key ./frontend/scripts/restore-drill.sh ./${backupArtifactBaseName(selected.id)}.dump.age`
+    : null;
 
   const handleCopy = async () => {
     if (!command) return;
@@ -65,6 +74,19 @@ export default function RestoreRunbookCard({ selected, now }: RestoreRunbookCard
       // context -- keep the button un-flipped and tell the operator to select the text by hand.
       setCopied(false);
       setCopyFailed(true);
+    }
+  };
+
+  const handleDrillCopy = async () => {
+    if (!drillCommand) return;
+    try {
+      await navigator.clipboard.writeText(drillCommand);
+      setDrillCopyFailed(false);
+      setDrillCopied(true);
+      window.setTimeout(() => setDrillCopied(false), 2000);
+    } catch {
+      setDrillCopied(false);
+      setDrillCopyFailed(true);
     }
   };
 
@@ -118,6 +140,36 @@ export default function RestoreRunbookCard({ selected, now }: RestoreRunbookCard
         </div>
       ) : (
         <div className={styles.runbookNoSelection}>Select a snapshot above to generate its restore command.</div>
+      )}
+
+      <div className={styles.panelSubhead}>QUARTERLY DRILL</div>
+      <ul className={styles.runbookPrereqs}>
+        <li className={styles.runbookPrereq}>
+          <span>1.</span>
+          <span>An <code>age</code> private key (holder A or B).</span>
+        </li>
+        <li className={styles.runbookPrereq}>
+          <span>2.</span>
+          <span>A scratch Postgres database, unpooled — same rule as the restore command above.</span>
+        </li>
+      </ul>
+
+      {selected && drillCommand ? (
+        <div className={styles.commandBox}>
+          <div className={styles.commandBoxHeader}>Drill command for the selected snapshot · {createdLabel}</div>
+          <pre className={styles.commandBoxCode}>{drillCommand}</pre>
+          <button
+            type="button"
+            className={`${styles.commandCopyButton} ${drillCopied ? styles.commandCopyButtonCopied : ""}`}
+            onClick={handleDrillCopy}
+            aria-label="Copy drill command"
+            title={drillCopyFailed ? "Copy failed — select the text manually" : undefined}
+          >
+            <Icon name={drillCopied ? "check" : "copy"} size="sm" />
+          </button>
+        </div>
+      ) : (
+        <div className={styles.runbookNoSelection}>Select a snapshot above to generate its drill command.</div>
       )}
     </Card>
   );

--- a/frontend/app/components/admin/backups/RestoreRunbookCard.tsx
+++ b/frontend/app/components/admin/backups/RestoreRunbookCard.tsx
@@ -55,12 +55,13 @@ export default function RestoreRunbookCard({ selected, now }: RestoreRunbookCard
     : null;
   const createdLabel = selected ? formatCreatedLabel(selected.createdAt, now) : null;
 
-  // Drill key letter isn't derivable from anything client-side (the operator picks whichever
-  // physical key they hold) -- <A|B> is a literal placeholder the operator fills in, same idiom
-  // as the /path/to/key and <neon-branch-url> placeholders above.
-  const drillCommand = selected
-    ? `DRILL_KEY_USED=<A|B> AGE_IDENTITY_FILE=/path/to/key ./frontend/scripts/restore-drill.sh ./${backupArtifactBaseName(selected.id)}.dump.age`
-    : null;
+  // restore-drill.sh takes no positional argument -- it self-selects the newest monthly/
+  // sidecar in the bucket -- so unlike the restore command above, this one is snapshot-
+  // independent and doesn't gate on `selected`. DRILL_KEY_USED/DRILL_TARGET_URL are literal
+  // placeholders the operator fills in, same idiom as /path/to/key above.
+  const drillCommand =
+    "DRILL_KEY_USED=<A|B> DRILL_TARGET_URL=<unpooled-scratch-url> AGE_IDENTITY_FILE=/path/to/key" +
+    " ./frontend/scripts/restore-drill.sh";
 
   const handleCopy = async () => {
     if (!command) return;
@@ -151,6 +152,10 @@ export default function RestoreRunbookCard({ selected, now }: RestoreRunbookCard
       )}
 
       <div className={styles.panelSubhead}>QUARTERLY DRILL</div>
+      <div className={styles.panelSubhead}>
+        Drills the newest monthly snapshot — restore-drill.sh always self-selects it, so there is
+        nothing to select above.
+      </div>
       <ul className={styles.runbookPrereqs}>
         <li className={styles.runbookPrereq}>
           <span>1.</span>
@@ -162,23 +167,19 @@ export default function RestoreRunbookCard({ selected, now }: RestoreRunbookCard
         </li>
       </ul>
 
-      {selected && drillCommand ? (
-        <div className={styles.commandBox}>
-          <div className={styles.commandBoxHeader}>Drill command for the selected snapshot · {createdLabel}</div>
-          <pre className={styles.commandBoxCode}>{drillCommand}</pre>
-          <button
-            type="button"
-            className={`${styles.commandCopyButton} ${drillCopied ? styles.commandCopyButtonCopied : ""}`}
-            onClick={handleDrillCopy}
-            aria-label="Copy drill command"
-            title={drillCopyFailed ? "Copy failed — select the text manually" : undefined}
-          >
-            <Icon name={drillCopied ? "check" : "copy"} size="sm" />
-          </button>
-        </div>
-      ) : (
-        <div className={styles.runbookNoSelection}>Select a snapshot above to generate its drill command.</div>
-      )}
+      <div className={styles.commandBox}>
+        <div className={styles.commandBoxHeader}>Quarterly drill command</div>
+        <pre className={styles.commandBoxCode}>{drillCommand}</pre>
+        <button
+          type="button"
+          className={`${styles.commandCopyButton} ${drillCopied ? styles.commandCopyButtonCopied : ""}`}
+          onClick={handleDrillCopy}
+          aria-label="Copy drill command"
+          title={drillCopyFailed ? "Copy failed — select the text manually" : undefined}
+        >
+          <Icon name={drillCopied ? "check" : "copy"} size="sm" />
+        </button>
+      </div>
     </Card>
   );
 }

--- a/frontend/app/components/admin/backups/mockBackups.ts
+++ b/frontend/app/components/admin/backups/mockBackups.ts
@@ -247,8 +247,10 @@ export function generateMockBackupHealth(now: Date, rows: BackupListRow[] = gene
   return {
     lastSuccessfulBackupAt,
     freshness: lastSuccessfulBackupAt ? freshnessFor(lastSuccessfulBackupAt, now) : "error",
-    // No quarterly restore drill has run yet — deliberately null, not a fixture bug.
-    lastVerifiedRestoreAt: null,
+    // 120 days ago -- past DRILL_STALE_DAYS (100), so dev/mock mode renders the stale-warning
+    // state by default rather than the misleadingly-happy "just verified" one.
+    lastVerifiedRestoreAt: new Date(now.getTime() - 120 * DAY_MS).toISOString(),
+    lastVerifiedRestoreKey: "A",
     nextScheduledRunAt: nextScheduledRunAfter(now),
     replicaStatus,
     totals,

--- a/frontend/build-scripts/generate-docs-content.mjs
+++ b/frontend/build-scripts/generate-docs-content.mjs
@@ -38,6 +38,7 @@ const MANIFEST = [
   { group: "User Guide", relPath: "01-user-guide/how-to/set-up-a-recurring-meeting.md" },
   { group: "User Guide", relPath: "01-user-guide/how-to/navigate-and-filter-the-calendar.md" },
   { group: "User Guide", relPath: "01-user-guide/how-to/export-data.md" },
+  { group: "User Guide", relPath: "01-user-guide/how-to/check-backups-and-run-one.md" },
   { group: "User Guide", relPath: "01-user-guide/how-to/use-digital-signage.md" },
   { group: "User Guide", relPath: "01-user-guide/how-to/manage-admin-users.md" },
   { group: "User Guide", relPath: "01-user-guide/how-to/retry-a-failed-sync.md" },

--- a/frontend/scripts/restore-drill.sh
+++ b/frontend/scripts/restore-drill.sh
@@ -143,21 +143,24 @@ EOF
   # read access to the working bucket.
   ARTIFACT_ID="$(basename "$ARTIFACT_STEM")"
   ARTIFACT_ID="${ARTIFACT_ID#backup-}"
-  # Written to the invoking directory, not $WORKDIR -- the EXIT trap deletes $WORKDIR before
-  # the operator can read the printed fallback path below.
-  MARKER_FILE="./drill-verified.json"
-  jq -n \
+  # Absolute path, written to the invoking directory (not $WORKDIR, which the EXIT trap
+  # deletes) -- both the jq write and the printed fallback command below need a path that's
+  # still valid after $WORKDIR is gone.
+  MARKER_FILE="$(pwd)/drill-verified.json"
+
+  # A PASSED drill must exit 0 even if this bookkeeping step fails -- under set -euo pipefail,
+  # a failed jq write or gcloud upload would otherwise make a passing drill exit non-zero and
+  # look like a failure to anything checking the exit code.
+  if ! jq -n \
     --arg verifiedAt "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
     --arg artifactId "$ARTIFACT_ID" \
     --arg keyUsed "$DRILL_KEY_USED" \
-    '{verifiedAt: $verifiedAt, artifactId: $artifactId, keyUsed: $keyUsed}' > "$MARKER_FILE"
-
-  if command -v gcloud >/dev/null 2>&1; then
-    echo "Uploading drill-verified.json to gs://$GCS_BUCKET/..."
-    gcloud storage cp "$MARKER_FILE" "gs://$GCS_BUCKET/drill-verified.json"
-  else
-    echo "gcloud not found -- skipping marker upload (the drill itself still passed)." >&2
-    echo "Run this by hand once gcloud is available:" >&2
+    '{verifiedAt: $verifiedAt, artifactId: $artifactId, keyUsed: $keyUsed}' > "$MARKER_FILE"; then
+    echo "Marker write failed -- the drill still passed. Run by hand:" >&2
+    echo "  jq -n --arg verifiedAt \"\$(date -u +%Y-%m-%dT%H:%M:%SZ)\" --arg artifactId $ARTIFACT_ID" \
+      "--arg keyUsed $DRILL_KEY_USED '{verifiedAt: \$verifiedAt, artifactId: \$artifactId, keyUsed: \$keyUsed}' > $MARKER_FILE" >&2
+  elif ! gcloud storage cp "$MARKER_FILE" "gs://$GCS_BUCKET/drill-verified.json"; then
+    echo "Marker upload failed -- the drill still passed. Run by hand:" >&2
     echo "  gcloud storage cp $MARKER_FILE gs://$GCS_BUCKET/drill-verified.json" >&2
   fi
 else

--- a/frontend/scripts/restore-drill.sh
+++ b/frontend/scripts/restore-drill.sh
@@ -9,12 +9,20 @@
 # Env:
 #   AGE_IDENTITY_FILE   path to an `age` private key file (holder A or B; either suffices)
 #   DRILL_TARGET_URL    unpooled connection string for a scratch DB (new/reset each drill)
+#   DRILL_KEY_USED      which physical key AGE_IDENTITY_FILE is (A or B) -- the script can't
+#                        derive this from the key file itself, so it must be told
 #   GCS_BUCKET           bucket to pull the monthly/ artifact from (default: icr-db-backups-prod)
 set -euo pipefail
 
 : "${AGE_IDENTITY_FILE:?missing}"
 : "${DRILL_TARGET_URL:?missing}"
+: "${DRILL_KEY_USED:?missing (set to A or B -- whichever physical key AGE_IDENTITY_FILE is)}"
 GCS_BUCKET="${GCS_BUCKET:-icr-db-backups-prod}"
+
+if [[ "$DRILL_KEY_USED" != "A" && "$DRILL_KEY_USED" != "B" ]]; then
+  echo "DRILL_KEY_USED must be exactly 'A' or 'B', got: $DRILL_KEY_USED" >&2
+  exit 1
+fi
 
 if [[ ! -f "$AGE_IDENTITY_FILE" ]]; then
   echo "age identity file not found: $AGE_IDENTITY_FILE" >&2
@@ -127,6 +135,31 @@ Result:   PASS
 Tables:   $(jq '.rowCounts | length' "$WORKDIR/meta.json") checked, 0 mismatches
 ===================================
 EOF
+
+  # Final step, reachable only once every check above has passed. Writes the
+  # drill-verified.json marker the Backups admin tab reads (no key material, no operator
+  # PII — see docs/03-development/backup-infra-setup.md's marker-contract section) and
+  # uploads it with the operator's own gcloud credentials, since the drill itself only holds
+  # read access to the working bucket.
+  ARTIFACT_ID="$(basename "$ARTIFACT_STEM")"
+  ARTIFACT_ID="${ARTIFACT_ID#backup-}"
+  # Written to the invoking directory, not $WORKDIR -- the EXIT trap deletes $WORKDIR before
+  # the operator can read the printed fallback path below.
+  MARKER_FILE="./drill-verified.json"
+  jq -n \
+    --arg verifiedAt "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    --arg artifactId "$ARTIFACT_ID" \
+    --arg keyUsed "$DRILL_KEY_USED" \
+    '{verifiedAt: $verifiedAt, artifactId: $artifactId, keyUsed: $keyUsed}' > "$MARKER_FILE"
+
+  if command -v gcloud >/dev/null 2>&1; then
+    echo "Uploading drill-verified.json to gs://$GCS_BUCKET/..."
+    gcloud storage cp "$MARKER_FILE" "gs://$GCS_BUCKET/drill-verified.json"
+  else
+    echo "gcloud not found -- skipping marker upload (the drill itself still passed)." >&2
+    echo "Run this by hand once gcloud is available:" >&2
+    echo "  gcloud storage cp $MARKER_FILE gs://$GCS_BUCKET/drill-verified.json" >&2
+  fi
 else
   cat <<EOF
 

--- a/frontend/services/backups/storage.ts
+++ b/frontend/services/backups/storage.ts
@@ -134,8 +134,11 @@ async function readDrillMarker(storage: Storage, bucket: string): Promise<DrillV
     return parsed;
   } catch (error) {
     // Absent object (never drilled yet) is the overwhelmingly common case and not worth a
-    // log line -- only a present-but-corrupt marker is worth flagging.
-    const isNotFound = typeof error === "object" && error !== null && "code" in error && (error as { code: unknown }).code === 404;
+    // log line -- only a present-but-corrupt marker is worth flagging. The GCS client library
+    // has been observed surfacing 404s as a numeric error.code, a string error.code, or a
+    // numeric error.status depending on transport path, so all three are checked.
+    const errObj = typeof error === "object" && error !== null ? (error as { code?: unknown; status?: unknown }) : null;
+    const isNotFound = errObj !== null && (errObj.code === 404 || errObj.code === "404" || errObj.status === 404);
     if (!isNotFound) {
       console.error("services/backups/storage: failed to read drill-verified.json", error);
     }

--- a/frontend/services/backups/storage.ts
+++ b/frontend/services/backups/storage.ts
@@ -8,7 +8,7 @@ import { ExternalAccountClient } from "google-auth-library";
 import type { BaseExternalAccountClient } from "google-auth-library";
 import { getVercelOidcToken } from "@vercel/functions/oidc";
 import { ListObjectsV2Command, S3Client } from "@aws-sdk/client-s3";
-import type { BackupListRow, BackupMeta, BackupReplica, BackupTier } from "../../types/backups";
+import type { BackupListRow, BackupMeta, BackupReplica, BackupTier, DrillVerifiedMarker } from "../../types/backups";
 import { ALL_BACKUP_REPLICAS, backupArtifactBaseName } from "../../types/backups";
 import { getStorageConfig } from "./config";
 
@@ -108,6 +108,41 @@ async function listR2ObjectKeys(client: S3Client, bucket: string): Promise<Set<s
   return keys;
 }
 
+const DRILL_MARKER_KEY = "drill-verified.json";
+
+// A marker that's valid JSON but missing/mistyped a field must be treated as absent, not
+// thrown -- a corrupt marker must never 500 the whole listing over a health-card nicety.
+function isUsableDrillMarker(value: unknown): value is DrillVerifiedMarker {
+  if (typeof value !== "object" || value === null) return false;
+  const marker = value as Record<string, unknown>;
+  return (
+    typeof marker.verifiedAt === "string" &&
+    !Number.isNaN(new Date(marker.verifiedAt).getTime()) &&
+    typeof marker.artifactId === "string" &&
+    marker.artifactId.length > 0 &&
+    (marker.keyUsed === "A" || marker.keyUsed === "B")
+  );
+}
+
+async function readDrillMarker(storage: Storage, bucket: string): Promise<DrillVerifiedMarker | null> {
+  try {
+    const [buf] = await storage.bucket(bucket).file(DRILL_MARKER_KEY).download();
+    const parsed: unknown = JSON.parse(buf.toString("utf8"));
+    if (!isUsableDrillMarker(parsed)) {
+      throw new Error("marker JSON is missing verifiedAt/artifactId/keyUsed");
+    }
+    return parsed;
+  } catch (error) {
+    // Absent object (never drilled yet) is the overwhelmingly common case and not worth a
+    // log line -- only a present-but-corrupt marker is worth flagging.
+    const isNotFound = typeof error === "object" && error !== null && "code" in error && (error as { code: unknown }).code === 404;
+    if (!isNotFound) {
+      console.error("services/backups/storage: failed to read drill-verified.json", error);
+    }
+    return null;
+  }
+}
+
 const SIDECAR_READ_CONCURRENCY = 10;
 
 const VALID_TIERS: readonly string[] = ["daily", "monthly", "permanent"];
@@ -181,6 +216,7 @@ interface CachedListing {
   workingKeys: Set<string>;
   archiveKeys: Set<string>;
   r2Keys: Set<string>;
+  drillMarker: DrillVerifiedMarker | null;
 }
 
 let cache: CachedListing | null = null;
@@ -195,10 +231,11 @@ async function fetchListing(): Promise<CachedListing> {
   const storage = gcsClient();
   const s3 = r2Client();
 
-  const [workingKeys, archiveKeys, r2Keys] = await Promise.all([
+  const [workingKeys, archiveKeys, r2Keys, drillMarker] = await Promise.all([
     listGcsObjectKeys(storage, config.gcsWorkingBucket),
     listGcsObjectKeys(storage, config.gcsArchiveBucket),
     listR2ObjectKeys(s3, config.r2Bucket),
+    readDrillMarker(storage, config.gcsWorkingBucket),
   ]);
 
   const metas = await readGcsMetaSidecars(storage, config.gcsWorkingBucket, workingKeys);
@@ -222,7 +259,7 @@ async function fetchListing(): Promise<CachedListing> {
   const rows = dedupeRowsById(allRows);
   rows.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
 
-  return { expiresAt: Date.now() + CACHE_TTL_MS, rows, workingKeys, archiveKeys, r2Keys };
+  return { expiresAt: Date.now() + CACHE_TTL_MS, rows, workingKeys, archiveKeys, r2Keys, drillMarker };
 }
 
 /**
@@ -231,7 +268,13 @@ async function fetchListing(): Promise<CachedListing> {
  * second round of API calls -- GCS/R2 free tiers meter listing as billable Class A ops, so an
  * idly refreshing admin tab must not re-list on every request.
  */
-export async function listBackups(): Promise<{ rows: BackupListRow[]; archiveObjectCount: number; r2ObjectCount: number; workingObjectCount: number }> {
+export async function listBackups(): Promise<{
+  rows: BackupListRow[];
+  archiveObjectCount: number;
+  r2ObjectCount: number;
+  workingObjectCount: number;
+  drillMarker: DrillVerifiedMarker | null;
+}> {
   if (!cache || cache.expiresAt <= Date.now()) {
     cache = await fetchListing();
   }
@@ -242,7 +285,7 @@ export async function listBackups(): Promise<{ rows: BackupListRow[]; archiveObj
   const workingObjectCount = Array.from(cache.workingKeys).filter((k) => k.endsWith(artifactSuffix)).length;
   const archiveObjectCount = Array.from(cache.archiveKeys).filter((k) => k.endsWith(artifactSuffix)).length;
   const r2ObjectCount = Array.from(cache.r2Keys).filter((k) => k.endsWith(artifactSuffix)).length;
-  return { rows: cache.rows, archiveObjectCount, r2ObjectCount, workingObjectCount };
+  return { rows: cache.rows, archiveObjectCount, r2ObjectCount, workingObjectCount, drillMarker: cache.drillMarker };
 }
 
 // With no private key on hand, google-auth-library signs the URL by calling IAM Credentials'

--- a/frontend/tests/component/BackupsTab.test.tsx
+++ b/frontend/tests/component/BackupsTab.test.tsx
@@ -226,9 +226,9 @@ describe("BackupsTab", () => {
     const radios = screen.getAllByRole("radio");
     fireEvent.click(radios[0]);
 
-    const commandBox = screen.getByText(new RegExp(`${firstRow.id}\\.dump\\.age`));
+    const commandBox = screen.getByText(new RegExp(`restore-db\\.sh.*${firstRow.id}\\.dump\\.age`));
     expect(commandBox).toBeInTheDocument();
-    expect(screen.getByText(/command for the selected snapshot/i)).toBeInTheDocument();
+    expect(screen.getByText(/^command for the selected snapshot/i)).toBeInTheDocument();
   });
 
   it("clicking a selected row again unselects it", async () => {
@@ -254,6 +254,29 @@ describe("BackupsTab", () => {
     fireEvent.click(radios[0]);
 
     expect(screen.getByRole("button", { name: "Copy command" })).toBeInTheDocument();
+  });
+
+  it("hides the drill command box without a selection", async () => {
+    setupFetchMock();
+    await renderTab();
+    expect(
+      screen.getByText("Select a snapshot above to generate its drill command."),
+    ).toBeInTheDocument();
+  });
+
+  it("selecting a snapshot renders its drill command with a copy button", async () => {
+    setupFetchMock();
+    await renderTab();
+    const firstRow = rows[0];
+    const radios = screen.getAllByRole("radio");
+    fireEvent.click(radios[0]);
+
+    expect(
+      screen.queryByText("Select a snapshot above to generate its drill command."),
+    ).not.toBeInTheDocument();
+    const drillBox = screen.getByText(new RegExp(`DRILL_KEY_USED=<A\\|B>.*${firstRow.id}\\.dump\\.age`));
+    expect(drillBox).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Copy drill command" })).toBeInTheDocument();
   });
 
   it("the Snapshots filter chips filter the table (Unverified, then Monthly)", async () => {
@@ -502,5 +525,37 @@ describe("BackupHealthCard warning banner", () => {
     degradedHealth.replicaStatus[0].hasLatest = false;
     render(<BackupHealthCard health={degradedHealth} now={FIXED_NOW} />);
     expect(screen.getByText("2 of 3 hold the latest snapshot")).toBeInTheDocument();
+  });
+
+  it("fresh (< 100 days): shows no banner, and the stat shows date + key letter", () => {
+    const freshHealth = {
+      ...generateMockBackupHealth(FIXED_NOW, rows),
+      lastVerifiedRestoreAt: new Date(FIXED_NOW.getTime() - 30 * 24 * 60 * 60 * 1000).toISOString(),
+      lastVerifiedRestoreKey: "A" as const,
+    };
+    render(<BackupHealthCard health={freshHealth} now={FIXED_NOW} />);
+    expect(screen.queryByText("No restore has ever been verified")).not.toBeInTheDocument();
+    expect(screen.queryByText(/run the quarterly drill/)).not.toBeInTheDocument();
+    expect(screen.getByText(/Last verified restore/)).toBeInTheDocument();
+    expect(screen.getByText(/key A/)).toBeInTheDocument();
+  });
+
+  it("stale (>= 100 days): shows the stale-warning banner with a months-ago count", () => {
+    const staleHealth = {
+      ...generateMockBackupHealth(FIXED_NOW, rows),
+      lastVerifiedRestoreAt: new Date(FIXED_NOW.getTime() - 120 * 24 * 60 * 60 * 1000).toISOString(),
+      lastVerifiedRestoreKey: "B" as const,
+    };
+    render(<BackupHealthCard health={staleHealth} now={FIXED_NOW} />);
+    expect(screen.queryByText("No restore has ever been verified")).not.toBeInTheDocument();
+    expect(screen.getByText(/Last verified restore was .* months? ago — run the quarterly drill/)).toBeInTheDocument();
+  });
+
+  it("never verified: shows the never-verified banner, not the stale-warning banner", () => {
+    const neverHealth = { ...generateMockBackupHealth(FIXED_NOW, rows), lastVerifiedRestoreAt: null, lastVerifiedRestoreKey: null };
+    render(<BackupHealthCard health={neverHealth} now={FIXED_NOW} />);
+    expect(screen.getByText("No restore has ever been verified")).toBeInTheDocument();
+    expect(screen.queryByText(/run the quarterly drill/)).not.toBeInTheDocument();
+    expect(screen.getByText("Never")).toBeInTheDocument();
   });
 });

--- a/frontend/tests/component/BackupsTab.test.tsx
+++ b/frontend/tests/component/BackupsTab.test.tsx
@@ -256,27 +256,25 @@ describe("BackupsTab", () => {
     expect(screen.getByRole("button", { name: "Copy command" })).toBeInTheDocument();
   });
 
-  it("hides the drill command box without a selection", async () => {
+  it("renders the drill command without a snapshot selection", async () => {
     setupFetchMock();
     await renderTab();
-    expect(
-      screen.getByText("Select a snapshot above to generate its drill command."),
-    ).toBeInTheDocument();
+
+    // restore-drill.sh self-selects the newest monthly/ sidecar (no positional argument),
+    // so unlike the restore command, the drill command box needs no Snapshots-row selection.
+    expect(screen.getByText(/DRILL_KEY_USED=<A\|B>/)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Copy drill command" })).toBeInTheDocument();
   });
 
-  it("selecting a snapshot renders its drill command with a copy button", async () => {
+  it("the drill command carries all three required placeholders and no artifact path", async () => {
     setupFetchMock();
     await renderTab();
-    const firstRow = rows[0];
-    const radios = screen.getAllByRole("radio");
-    fireEvent.click(radios[0]);
 
-    expect(
-      screen.queryByText("Select a snapshot above to generate its drill command."),
-    ).not.toBeInTheDocument();
-    const drillBox = screen.getByText(new RegExp(`DRILL_KEY_USED=<A\\|B>.*${firstRow.id}\\.dump\\.age`));
+    const drillBox = screen.getByText(
+      /DRILL_KEY_USED=<A\|B>.*DRILL_TARGET_URL=<unpooled-scratch-url>.*AGE_IDENTITY_FILE=\/path\/to\/key.*restore-drill\.sh/,
+    );
     expect(drillBox).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Copy drill command" })).toBeInTheDocument();
+    expect(drillBox.textContent).not.toMatch(/\.dump\.age/);
   });
 
   it("the Snapshots filter chips filter the table (Unverified, then Monthly)", async () => {
@@ -494,7 +492,11 @@ describe("BackupsTab", () => {
 
 describe("BackupHealthCard warning banner", () => {
   it("renders the no-verified-restore banner when lastVerifiedRestoreAt is null", () => {
-    const bannerHealth = { ...generateMockBackupHealth(FIXED_NOW, rows), lastVerifiedRestoreAt: null };
+    const bannerHealth = {
+      ...generateMockBackupHealth(FIXED_NOW, rows),
+      lastVerifiedRestoreAt: null,
+      lastVerifiedRestoreKey: null,
+    };
     render(<BackupHealthCard health={bannerHealth} now={FIXED_NOW} />);
     expect(screen.getByText("No restore has ever been verified")).toBeInTheDocument();
   });
@@ -508,11 +510,12 @@ describe("BackupHealthCard warning banner", () => {
     expect(screen.queryByText("No restore has ever been verified")).not.toBeInTheDocument();
   });
 
-  it("shows the three-stat row: last backup, next run, snapshots retained", () => {
+  it("shows the four-stat row: last backup, next run, snapshots retained, last verified restore", () => {
     render(<BackupHealthCard health={health} now={FIXED_NOW} />);
     expect(screen.getByText("Last successful backup")).toBeInTheDocument();
     expect(screen.getByText(/^Next run/)).toBeInTheDocument();
     expect(screen.getByText("Snapshots retained")).toBeInTheDocument();
+    expect(screen.getAllByText(/^Last verified restore/).length).toBeGreaterThan(0);
   });
 
   it("summarizes replicas as 'All three hold the latest snapshot' when every replica is current", () => {

--- a/frontend/tests/integration/backups-routes.test.ts
+++ b/frontend/tests/integration/backups-routes.test.ts
@@ -279,6 +279,42 @@ describe("GET /api/admin/backups/health", () => {
     expect(body.configured).toBe(false);
     expect(body.missing.length).toBeGreaterThan(0);
   });
+
+  test("live mode reports lastVerifiedRestoreAt/Key as null when no drill has ever run", async () => {
+    mockedRequireRole.mockResolvedValue(superAdminSession);
+    setLiveEnv();
+    mockedListBackups.mockResolvedValue({
+      rows: [sampleRow],
+      workingObjectCount: 1,
+      archiveObjectCount: 1,
+      r2ObjectCount: 1,
+      drillMarker: null,
+    });
+    const { GET } = await import("../../app/api/admin/backups/health/route");
+    const response = await GET();
+    const body = await response.json();
+    expect(response.status).toBe(200);
+    expect(body.data.lastVerifiedRestoreAt).toBeNull();
+    expect(body.data.lastVerifiedRestoreKey).toBeNull();
+  });
+
+  test("live mode flows the drill marker's verifiedAt/keyUsed through to lastVerifiedRestoreAt/Key", async () => {
+    mockedRequireRole.mockResolvedValue(superAdminSession);
+    setLiveEnv();
+    mockedListBackups.mockResolvedValue({
+      rows: [sampleRow],
+      workingObjectCount: 1,
+      archiveObjectCount: 1,
+      r2ObjectCount: 1,
+      drillMarker: { verifiedAt: "2026-08-01T07:17:00.000Z", artifactId: "20260801T071700Z", keyUsed: "B" },
+    });
+    const { GET } = await import("../../app/api/admin/backups/health/route");
+    const response = await GET();
+    const body = await response.json();
+    expect(response.status).toBe(200);
+    expect(body.data.lastVerifiedRestoreAt).toBe("2026-08-01T07:17:00.000Z");
+    expect(body.data.lastVerifiedRestoreKey).toBe("B");
+  });
 });
 
 describe("GET /api/admin/backups/activity", () => {

--- a/frontend/tests/integration/backups-storage.test.ts
+++ b/frontend/tests/integration/backups-storage.test.ts
@@ -5,13 +5,26 @@ import type { BackupMeta } from "../../types/backups";
 
 let filesByBucketPrefix: Record<string, Record<string, string[]>> = {};
 let metaByKey: Record<string, BackupMeta> = {};
+// Working-bucket drill-verified.json content -- raw string so malformed-JSON cases can be
+// exercised, `undefined` means "not found" (404), matching a real never-drilled bucket.
+let markerContent: string | undefined;
 
 const WORKING_BUCKET = "icr-db-backups-prod";
 const ARCHIVE_BUCKET = "icr-db-backups-archive";
+const DRILL_MARKER_KEY = "drill-verified.json";
 
 const mockGetSignedUrl = jest.fn().mockResolvedValue(["https://storage.googleapis.com/signed-url-example"]);
 const mockFile = jest.fn((key: string) => ({
-  download: () => Promise.resolve([Buffer.from(JSON.stringify(metaByKey[key]))]),
+  download: () => {
+    if (key === DRILL_MARKER_KEY) {
+      if (markerContent === undefined) {
+        const notFound = Object.assign(new Error("not found"), { code: 404 });
+        return Promise.reject(notFound);
+      }
+      return Promise.resolve([Buffer.from(markerContent)]);
+    }
+    return Promise.resolve([Buffer.from(JSON.stringify(metaByKey[key]))]);
+  },
   getSignedUrl: mockGetSignedUrl,
 }));
 const mockBucket = jest.fn((bucketName: string) => ({
@@ -83,6 +96,7 @@ beforeEach(() => {
   mockSend.mockResolvedValue({ Contents: [] });
   filesByBucketPrefix = {};
   metaByKey = {};
+  markerContent = undefined;
 });
 
 afterEach(() => {
@@ -169,5 +183,59 @@ describe("listBackups against real-shaped keys", () => {
     const matching = rows.filter((r) => r.id === "20260815T011700Z");
     expect(matching).toHaveLength(1);
     expect(matching[0].tier).toBe("monthly");
+  });
+});
+
+describe("listBackups: drill-verified.json marker", () => {
+  beforeEach(() => {
+    filesByBucketPrefix = {
+      [WORKING_BUCKET]: { "daily/": [], "monthly/": [], "permanent/": [] },
+      [ARCHIVE_BUCKET]: { "daily/": [], "monthly/": [], "permanent/": [] },
+    };
+  });
+
+  test("absent marker resolves to null", async () => {
+    markerContent = undefined;
+    const { listBackups } = await import("../../services/backups/storage");
+    const { drillMarker } = await listBackups();
+    expect(drillMarker).toBeNull();
+  });
+
+  test("present, well-formed marker resolves to its parsed contents", async () => {
+    markerContent = JSON.stringify({
+      verifiedAt: "2026-08-01T07:17:00.000Z",
+      artifactId: "20260801T071700Z",
+      keyUsed: "A",
+    });
+    const { listBackups } = await import("../../services/backups/storage");
+    const { drillMarker } = await listBackups();
+    expect(drillMarker).toEqual({
+      verifiedAt: "2026-08-01T07:17:00.000Z",
+      artifactId: "20260801T071700Z",
+      keyUsed: "A",
+    });
+  });
+
+  test("malformed JSON is treated as absent, with one server log line", async () => {
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => undefined);
+    markerContent = "{not json";
+    const { listBackups } = await import("../../services/backups/storage");
+    const { drillMarker } = await listBackups();
+    expect(drillMarker).toBeNull();
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("failed to read drill-verified.json"),
+      expect.anything(),
+    );
+    errorSpy.mockRestore();
+  });
+
+  test("wrong-shape JSON (missing keyUsed) is treated as absent, with one server log line", async () => {
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => undefined);
+    markerContent = JSON.stringify({ verifiedAt: "2026-08-01T07:17:00.000Z", artifactId: "20260801T071700Z" });
+    const { listBackups } = await import("../../services/backups/storage");
+    const { drillMarker } = await listBackups();
+    expect(drillMarker).toBeNull();
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    errorSpy.mockRestore();
   });
 });

--- a/frontend/types/backups.ts
+++ b/frontend/types/backups.ts
@@ -69,6 +69,19 @@ export interface BackupListRow extends BackupMeta {
   expiresAt: string | null;
 }
 
+/**
+ * Shape of `drill-verified.json`, written to the working bucket root by
+ * `restore-drill.sh`'s final step once every check (decrypt, scratch restore, exact
+ * count(*) match) has passed. No key material or operator PII — only the artifact it
+ * verified, when, and which key holder ran it.
+ */
+export interface DrillVerifiedMarker {
+  verifiedAt: string;
+  /** Bare timestamp id (see {@link backupArtifactBaseName}), not the `backup-` prefixed form. */
+  artifactId: string;
+  keyUsed: "A" | "B";
+}
+
 export interface BackupListResponse {
   rows: BackupListRow[];
   total: number;
@@ -90,6 +103,8 @@ export interface BackupHealth {
   freshness: BackupFreshness;
   /** Null until a quarterly restore drill has actually run once. */
   lastVerifiedRestoreAt: string | null;
+  /** Which `age` key holder ran the most recent verified drill; null alongside a null date. */
+  lastVerifiedRestoreKey: "A" | "B" | null;
   /** Next cron fire time, derived from `17 1,7,13,19 * * *` (UTC). */
   nextScheduledRunAt: string;
   replicaStatus: BackupReplicaStatus[];


### PR DESCRIPTION
@coderabbitai summary

## Description
- **frontend/scripts/restore-drill.sh**: gains required `DRILL_KEY_USED=A|B` and a final step — reachable only after every check passes (single-key decrypt, scratch restore, exact per-table `count(*)` match) — that uploads a `drill-verified.json` marker (`{verifiedAt, artifactId, keyUsed}`, no key material or PII) to the working bucket via the operator's own gcloud. Marker bookkeeping is non-fatal: a passed drill prints the retry command instead of exiting non-zero.
- **frontend/services/backups/storage.ts** + health route + `types/backups.ts`: the marker is read in the same 60s-cached listing pass (absent/malformed → null with one log line; 404 shape-tolerant) and feeds `lastVerifiedRestoreAt` + new `lastVerifiedRestoreKey`.
- **frontend/app/components/admin/backups/BackupHealthCard.tsx**: three-state drill banner — never verified (existing wording), fresh (<100 days: no banner; a fourth stat cell shows the date and key letter), stale (≥100 days: "run the quarterly drill" warning). `DRILL_STALE_DAYS = 100` = quarterly cadence + grace. Mock mode renders the stale state so dev exercises it.
- **frontend/app/components/admin/backups/RestoreRunbookCard.tsx**: new "Quarterly drill" section with the copyable `DRILL_KEY_USED=<A|B> DRILL_TARGET_URL=<unpooled-scratch-url> AGE_IDENTITY_FILE=... ./frontend/scripts/restore-drill.sh` command (snapshot-independent — the script self-selects the newest monthly artifact), plus a new prereq: one operator at a time, coordinated through the Maintenance Lead (there is no technical lock against concurrent restores).
- **docs/01-user-guide/**: new how-to (check backups and run one), a Backups section in troubleshooting, roles-table and quick-reference updates — the user guide previously had zero Backups-tab coverage. **docs/02-handoff + 03-development**: marker contract, drill sentences, one-operator rule.
- **Tests**: marker parse/absent/malformed (storage), never/fresh/stale flow-through (routes), banner states + drill command box (component).

## Testing
- [x] Full `yarn test:all` green (217 unit / 244 component / 126 integration / 112 e2e)
- [x] `bash -n frontend/scripts/restore-drill.sh`
- [x] `node build-scripts/generate-docs-content.mjs` — 39 docs, drift guard passes
- [x] Opus high-effort review; all findings (incl. a wrong copy-paste command that would have drilled the wrong artifact) fixed and re-verified

## Area(s) Touched
**Product areas**
- [ ] auth — sign-in, sessions, NextAuth, role-based access
- [x] admin — /admin shell (Diagnostics, Users, Import, Export tabs)
- [x] docs — /docs Resources page (rendering, navigation, search)
- [ ] ui/ux — frontend layout/styling not tied to a specific integration

**Integrations**
- [ ] google-calendar — Google Calendar sync
- [ ] zoom-api — Zoom meeting/host sync

**Engineering**
- [ ] security — auth hardening, data exposure, dependency/security scanning
- [x] testing — test suite (Jest/Playwright) changes
- [ ] github-actions — workflows, Dependabot config, other .github/ CI tooling
- [ ] cleanup — refactor or dead-code removal, no behavior change
- [ ] documentation — docs/ or README changes only

## Pre-merge Checklist
- [x] Code follows current formatting conventions and passes lint (`yarn lint`).
- [x] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
- [x] All test suites pass, both run locally and green in GitHub CI. **Do not merge if any test suite is failing.**
- [x] A test suite was added or updated for the feature/fix in this PR. **Double-check this if you change a feature and did not update the test suites**.
- [x] Only files relevant to this change are committed — no stray or unrelated files.
- [ ] If this branch has a merge conflict with master, master was merged into this branch first (not the other way around).
- [x] The rest of this PR description (Description, Testing) is filled out, not left as template placeholders.