### PR TITLE
feat(zoom): show per-host remaining capacity in the Zoom Host dropdown

### DIFF
--- a/docs/01-user-guide/explanation/how-sync-works.md
+++ b/docs/01-user-guide/explanation/how-sync-works.md
@@ -37,6 +37,6 @@ ICR uses a shared pool of licensed Zoom accounts across all rooms rather than de
 Leaving **Zoom Host** on "Automatic assignment" picks the **least-busy licensed host with spare capacity** (a licensed host can carry two concurrent meetings; a basic host is only used as a last resort) (see [Meeting Fields and Modes](../reference/meeting-fields-and-modes.md)). Note that pool hosts are fixed by system administrators and cannot be managed in the UI.
 
 - **All hosts busy:** If no host is free, the meeting still saves, but Zoom sync fails with a "no host available" error (see [Retry a Failed Sync](../how-to/retry-a-failed-sync.md)). Consequently, the meeting will also not sync to Google.
-- **Manual selection:** The dropdown displays live availability (✓ or ✕) for each host. Hand-picking is primarily useful for troubleshooting.
+- **Manual selection:** The dropdown displays each host's remaining capacity for the selected time as a badge — e.g. **1/2** in green (one of two slots free) or **0/2** in red (at capacity). Hand-picking is primarily useful for troubleshooting.
 - **Sync retry behavior:** Retrying a failed initial sync re-checks the pool and may assign a different host. Retrying a meeting that already has a Zoom link reuses the existing host.
 - **Host visibility:** The specific assigned host is intentionally hidden once synced—the UI simply shows "Synced."

--- a/frontend/app/components/meeting-form/ZoomHostField.module.scss
+++ b/frontend/app/components/meeting-form/ZoomHostField.module.scss
@@ -70,6 +70,28 @@
     color: $danger-color;
 }
 
+// "1/2"-style remaining-capacity badge per host (#472) -- free slots in green, at-capacity in
+// red, mirroring .checkIcon/.crossIcon's semantic colors.
+.slotBadge {
+    flex-shrink: 0;
+    font-size: 11px;
+    font-weight: 600;
+    font-variant-numeric: tabular-nums;
+    line-height: 1;
+    padding: 2px 6px;
+    border-radius: 999px;
+}
+
+.slotBadgeFree {
+    color: $success-text-color;
+    background: $success-bg-color;
+}
+
+.slotBadgeFull {
+    color: $danger-color;
+    background: $danger-bg-color;
+}
+
 .busyWarning {
     margin: 6px 0 0;
     padding: 8px 10px;

--- a/frontend/app/components/meeting-form/ZoomHostField.tsx
+++ b/frontend/app/components/meeting-form/ZoomHostField.tsx
@@ -65,7 +65,10 @@ export const ZoomHostField: React.FC<ZoomHostFieldProps> = ({
   getCandidate,
 }) => {
   const hosts = useZoomHostPool();
-  const [availability, setAvailability] = useState<Record<string, boolean> | null>(null);
+  // Per-host remaining capacity from the most recent check -- freeSlots reflects the
+  // candidate's worst occurrence (what auto-assignment would actually see), capacity the
+  // host's license tier (2 licensed / 1 basic). Null until a check resolves.
+  const [availability, setAvailability] = useState<Record<string, { freeSlots: number; capacity: number }> | null>(null);
   // 'checking' while the request is in flight; 'done'/'noHostAvailable' once it resolves.
   // 'done' clears itself after DONE_DISPLAY_MS; 'noHostAvailable' has no timer -- it stays up
   // until the debounce effect below clears it on the next date/time/recurrence change.
@@ -127,11 +130,11 @@ export const ZoomHostField: React.FC<ZoomHostFieldProps> = ({
       });
       if (!res.ok) return;
       const data = await res.json();
-      const next: Record<string, boolean> = {};
+      const next: Record<string, { freeSlots: number; capacity: number }> = {};
       let anyAvailable = false;
-      (data.hosts ?? []).forEach((h: { host: string; available: boolean }) => {
-        next[h.host] = h.available;
-        if (h.available) anyAvailable = true;
+      (data.hosts ?? []).forEach((h: { host: string; freeSlots: number; capacity: number }) => {
+        next[h.host] = { freeSlots: h.freeSlots, capacity: h.capacity };
+        if (h.freeSlots > 0) anyAvailable = true;
       });
       if (checkId === checkIdRef.current && isMountedRef.current) {
         setAvailability(next);
@@ -195,22 +198,29 @@ export const ZoomHostField: React.FC<ZoomHostFieldProps> = ({
     if (email) onZoomHostChange(email);
   };
 
-  // Right-aligned check/cross next to each host's label, reflecting the most recent
-  // automatic availability check -- no icon at all until a check has actually resolved
-  // (availability starts/resets to null) or for the Automatic option (never has a per-host
-  // result).
+  // Right-aligned "1/2"-style remaining-capacity badge next to each host's label, reflecting
+  // the most recent automatic availability check (#472) -- green with slots free, red at
+  // capacity. No badge at all until a check has actually resolved (availability starts/resets
+  // to null) or for the Automatic option (never has a per-host result).
   const renderElement = (label: string): React.ReactNode => {
     const email = labelToEmail[label];
-    const available = email ? availability?.[email] : undefined;
+    const slots = email ? availability?.[email] : undefined;
     return (
       <span className={styles.hostOption}>
         <span className={styles.hostLabel}>{label}</span>
-        {available !== undefined && (available ? <CheckIcon /> : <CrossIcon />)}
+        {slots !== undefined && (
+          <span
+            className={`${styles.slotBadge} ${slots.freeSlots > 0 ? styles.slotBadgeFree : styles.slotBadgeFull}`}
+            aria-label={slots.freeSlots > 0 ? `${slots.freeSlots} of ${slots.capacity} slots free` : 'At capacity'}
+          >
+            {slots.freeSlots}/{slots.capacity}
+          </span>
+        )}
       </span>
     );
   };
 
-  const selectedIsBusy = !!zoomHost && availability?.[zoomHost] === false;
+  const selectedIsBusy = !!zoomHost && availability?.[zoomHost]?.freeSlots === 0;
 
   return (
     <div className={styles.zoomHostField}>

--- a/frontend/services/zoom.ts
+++ b/frontend/services/zoom.ts
@@ -1,7 +1,7 @@
 import "server-only";
 import { Prisma } from "@prisma/client";
 import { IMeeting } from "../types/models";
-import { findResourceConflicts, findFirstFreePoolHost, OccurrenceInput } from "../util/meetings/resourceOverlap";
+import { findResourceConflicts, findFirstFreePoolHost, getPoolHostLoads, OccurrenceInput } from "../util/meetings/resourceOverlap";
 import { prisma } from "../lib/prisma";
 
 const ZOOM_BASE_API = process.env.NEXT_PUBLIC_ZOOM_BASE_API ?? "https://api.zoom.us/v2";
@@ -186,24 +186,24 @@ export async function getZoomHostCapacities(): Promise<Record<string, number>> {
   return inFlightCapacityRequest;
 }
 
-// Reports every pool host's availability against `candidate`, instead of stopping at the
-// first free one (contrast resolveZoomHost below) -- backs the Meeting Form's "Check host
-// availability" action, which needs to show a check/cross per host, not just resolve one.
-// Pool is small (<=5), so checking all of them in parallel is cheap. Capacity-aware: a
-// licensed host with one overlapping meeting still reports available (#446).
+// Reports every pool host's remaining capacity against `candidate`, instead of stopping at
+// the first free one (contrast resolveZoomHost below) -- backs the Meeting Form's per-host
+// "1/2"-style free-slot display (#472), which needs a count per host, not just one resolution.
+// freeSlots reflects the candidate's WORST occurrence (peak concurrency across all of them) —
+// what assignment would actually see — and 0 means the host is at capacity for this schedule.
 export async function checkZoomHostPoolAvailability(
   candidate: OccurrenceInput,
   opts: { excludeMid?: string } = {},
-): Promise<{ host: string; available: boolean }[]> {
+): Promise<{ host: string; freeSlots: number; capacity: number }[]> {
   const capacities = await getZoomHostCapacities();
-  return Promise.all(zoomHostPool.map(async (host) => {
-    const conflicts = await findResourceConflicts("zoomHost", host, candidate, prisma, {
-      excludeMid: opts.excludeMid,
-      includeSuspended: true,
-      capacity: capacities[host] ?? 1,
-    });
-    return { host, available: conflicts.length === 0 };
-  }));
+  const loads = await getPoolHostLoads(zoomHostPool, candidate, prisma, {
+    excludeMid: opts.excludeMid,
+    includeSuspended: true,
+  });
+  return loads.map(({ host, peak }) => {
+    const capacity = capacities[host] ?? 1;
+    return { host, capacity, freeSlots: Math.max(0, capacity - peak) };
+  });
 }
 
 // Picks a host with spare capacity for `candidate`, ordered as tiered least-connections --

--- a/frontend/tests/integration/zoom-host-endpoints-route.test.ts
+++ b/frontend/tests/integration/zoom-host-endpoints-route.test.ts
@@ -49,8 +49,8 @@ describe("POST /api/retrieve/zoom-host-availability", () => {
 
   it("delegates to checkZoomHostPoolAvailability and returns its result", async () => {
     mockedCheckAvailability.mockResolvedValue([
-      { host: "host1@icr.test", available: true },
-      { host: "host2@icr.test", available: false },
+      { host: "host1@icr.test", freeSlots: 1, capacity: 2 },
+      { host: "host2@icr.test", freeSlots: 0, capacity: 1 },
     ]);
 
     const response = await checkAvailability(request({
@@ -65,8 +65,8 @@ describe("POST /api/retrieve/zoom-host-availability", () => {
     const body = await response.json();
     expect(body).toEqual({
       hosts: [
-        { host: "host1@icr.test", available: true },
-        { host: "host2@icr.test", available: false },
+        { host: "host1@icr.test", freeSlots: 1, capacity: 2 },
+        { host: "host2@icr.test", freeSlots: 0, capacity: 1 },
       ],
     });
 

--- a/frontend/tests/unit/resourceOverlap.test.ts
+++ b/frontend/tests/unit/resourceOverlap.test.ts
@@ -6,6 +6,7 @@ import {
   findOverCapacityWindow,
   findFirstFreePoolHost,
   findResourceConflictRows,
+  getPoolHostLoads,
   OVERLAP_HORIZON_YEARS,
   type ConflictCandidateMeeting,
   type Occurrence,
@@ -511,6 +512,68 @@ describe("findFirstFreePoolHost — per-host capacities", () => {
       capacities: { [pool[1]]: 2 },
     });
     expect(host).toBe(pool[1]);
+  });
+});
+
+describe("getPoolHostLoads", () => {
+  beforeAll(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(utcDate(2026, 7, 1));
+  });
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
+  const pool = ["host-a@icr.test", "host-b@icr.test"];
+  const onHost = (host: string, startHour: number, endHour: number, day = 6): StubRow => ({
+    zoomHost: host,
+    startDateTime: utcDate(2026, 7, day, startHour, 0),
+    endDateTime: utcDate(2026, 7, day, endHour, 0),
+  });
+
+  it("reports each host's peak concurrency during the candidate, in pool order", async () => {
+    const candidate = {
+      startDateTime: utcDate(2026, 7, 6, 19, 0),
+      endDateTime: utcDate(2026, 7, 6, 21, 0),
+      isRecurring: false,
+      recurrencePattern: null,
+    };
+    const loads = await getPoolHostLoads(
+      pool,
+      candidate,
+      stubClient([
+        onHost(pool[0], 19, 20), onHost(pool[0], 19, 20),
+        // Disjoint inside the candidate -- host-b's peak is 1, not 2.
+        onHost(pool[1], 19, 20), onHost(pool[1], 20, 21),
+      ]),
+      { includeSuspended: true },
+    );
+    expect(loads).toEqual([
+      { host: pool[0], peak: 2 },
+      { host: pool[1], peak: 1 },
+    ]);
+  });
+
+  it("uses the candidate's worst occurrence, not the first", async () => {
+    // Weekly Thursday candidate (Jul 9, 16, 23, 30 2026 ET); host-a only collides on the
+    // second week -- the peak must still register, since assignment sees every occurrence.
+    const candidate = {
+      startDateTime: utcDate(2026, 7, 9, 19, 0),
+      endDateTime: utcDate(2026, 7, 9, 20, 0),
+      isRecurring: true,
+      recurrencePattern: {
+        type: "weekly",
+        startDate: utcDate(2026, 7, 9),
+        endDate: utcDate(2026, 7, 31),
+        interval: 1,
+        daysOfWeek: ["Thursday"],
+      },
+    };
+    const loads = await getPoolHostLoads(pool, candidate, stubClient([onHost(pool[0], 19, 20, 16)]), {
+      includeSuspended: true,
+    });
+    expect(loads[0]).toEqual({ host: pool[0], peak: 1 });
+    expect(loads[1]).toEqual({ host: pool[1], peak: 0 });
   });
 });
 

--- a/frontend/util/meetings/resourceOverlap.ts
+++ b/frontend/util/meetings/resourceOverlap.ts
@@ -393,19 +393,38 @@ export async function findFirstFreePoolHost(
 ): Promise<string | null> {
   if (pool.length === 0) return null;
 
+  const loads = await getPoolHostLoads(pool, candidate, client, opts);
+  const ranked = loads
+    .map((load, poolIndex) => ({ ...load, poolIndex, capacity: opts.capacities?.[load.host] ?? 1 }))
+    .filter(({ peak, capacity }) => peak < capacity)
+    .sort((a, b) =>
+      // Licensed tier (capacity >= 2) first, then least-loaded, then pool order.
+      (a.capacity >= 2 ? 0 : 1) - (b.capacity >= 2 ? 0 : 1) ||
+      a.peak - b.peak ||
+      a.poolIndex - b.poolIndex,
+    );
+
+  return ranked[0]?.host ?? null;
+}
+
+// Per-host peak concurrency against `candidate`, in pool order — the shared load figure
+// behind findFirstFreePoolHost's ranking above and the Meeting Form's per-host free-slot
+// display (services/zoom.ts's checkZoomHostPoolAvailability). One batched query for the whole
+// pool; `client` follows the same required-explicitly rule as findResourceConflicts above.
+export async function getPoolHostLoads(
+  pool: string[],
+  candidate: OccurrenceInput,
+  client: Prisma.TransactionClient,
+  opts: FindConflictsOptions = {},
+): Promise<{ host: string; peak: number }[]> {
+  if (pool.length === 0) return [];
+
   const [rangeStart, rangeEnd] = candidateHorizonRange(OVERLAP_HORIZON_YEARS);
   const candidateOccurrences = expandOccurrences(candidate, rangeStart, rangeEnd);
-  if (candidateOccurrences.length === 0) {
-    // Nothing to overlap with, but the tiered ordering below still applies -- returning
-    // pool[0] unconditionally could hand a basic host (and its silent 40-minute cap) to a
-    // meeting whose occurrences merely fall outside the horizon window.
-    const first = pool
-      .map((host, poolIndex) => ({ host, poolIndex, capacity: opts.capacities?.[host] ?? 1 }))
-      .sort((a, b) =>
-        (a.capacity >= 2 ? 0 : 1) - (b.capacity >= 2 ? 0 : 1) || a.poolIndex - b.poolIndex,
-      )[0];
-    return first?.host ?? null;
-  }
+  // Zero peaks, not an early host pick -- findFirstFreePoolHost's tiered ranking still runs
+  // over these, so a candidate whose occurrences fall outside the horizon window gets a
+  // licensed host first rather than whatever host is first in the pool.
+  if (candidateOccurrences.length === 0) return pool.map((host) => ({ host, peak: 0 }));
 
   const where: Prisma.MeetingWhereInput = {
     AND: [
@@ -439,33 +458,21 @@ export async function findFirstFreePoolHost(
     else occupiedByHost.set(meeting.zoomHost, [meeting]);
   }
 
-  const ranked = pool
-    .map((host, poolIndex) => {
-      const capacity = opts.capacities?.[host] ?? 1;
-      const hostOccurrenceLists = (occupiedByHost.get(host) ?? []).map((meeting) =>
-        expandOccurrences(
-          {
-            startDateTime: meeting.startDateTime,
-            endDateTime: meeting.endDateTime,
-            isRecurring: meeting.isRecurring,
-            recurrencePattern: meeting.recurrencePattern,
-          },
-          rangeStart,
-          rangeEnd,
-        ),
-      );
-      const peak = maxConcurrentDuring(candidateOccurrences, hostOccurrenceLists);
-      return { host, poolIndex, capacity, peak };
-    })
-    .filter(({ peak, capacity }) => peak < capacity)
-    .sort((a, b) =>
-      // Licensed tier (capacity >= 2) first, then least-loaded, then pool order.
-      (a.capacity >= 2 ? 0 : 1) - (b.capacity >= 2 ? 0 : 1) ||
-      a.peak - b.peak ||
-      a.poolIndex - b.poolIndex,
+  return pool.map((host) => {
+    const hostOccurrenceLists = (occupiedByHost.get(host) ?? []).map((meeting) =>
+      expandOccurrences(
+        {
+          startDateTime: meeting.startDateTime,
+          endDateTime: meeting.endDateTime,
+          isRecurring: meeting.isRecurring,
+          recurrencePattern: meeting.recurrencePattern,
+        },
+        rangeStart,
+        rangeEnd,
+      ),
     );
-
-  return ranked[0]?.host ?? null;
+    return { host, peak: maxConcurrentDuring(candidateOccurrences, hostOccurrenceLists) };
+  });
 }
 
 // The display-relevant subset of a meeting's recurrence pattern (no Date fields — those


### PR DESCRIPTION
Resolves #472

Stacked on #473 (`feat/zoom-host-priority`), which stacks on #470 — merge bottom-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Zoom host selection now displays remaining capacity badges, such as `1/2` or `0/2`.
  - Host availability reflects peak concurrent meeting usage, including suspended and recurring meetings.
  - Host selection prioritizes available hosts and accounts for capacity and current load.

- **Documentation**
  - Updated the user guide to explain capacity badges instead of availability checkmarks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description
- **frontend/services/zoom.ts**: `checkZoomHostPoolAvailability` returns `{ host, freeSlots, capacity }` instead of a boolean, built on the shared `getPoolHostLoads` peak count — so the Meeting Form's numbers come from exactly the math auto-assignment uses. `freeSlots` reflects the candidate's **worst** occurrence (a recurring meeting that only collides on week two still shows the reduced count).
- **frontend/util/meetings/resourceOverlap.ts**: `getPoolHostLoads` extracted from `findFirstFreePoolHost` (one batched pool query, per-host peak concurrency); the assignment path now consumes it, so display and assignment can't drift.
- **frontend/app/components/meeting-form/ZoomHostField.tsx** (+ `.module.scss`): the binary ✓/✕ per host becomes a `1/2`-style remaining-capacity pill — green with slots free, red at capacity, `tabular-nums`, aria-labeled — teaching the capacity-2 rule at the exact moment an admin would otherwise read a doubled-up host as a bug. "Selected host is busy" warning now keys off `freeSlots === 0`; the summary status lines keep their existing icons.
- **frontend/tests**: route test updated to the new shape; new `getPoolHostLoads` unit tests (peak counts in pool order; worst-occurrence via a weekly candidate colliding only on its second week).
- **docs**: how-sync-works.md's "✓ or ✕" description replaced with the badge behavior.

Manual pass on `yarn dev` (screenshot in the session): with one host seeded busy 7–9 PM and the form set to 7:30–8:30, the dropdown showed `0/1` red for the two busy basic hosts and `1/1` green for the free ones — live license lookup, worst-occurrence math, and both badge states verified against real data.

## Testing
- [x] Full suite green on this branch (250 unit / 248 component / 134 integration / 115 e2e; lint/lint:css/typecheck clean)
- [x] Manual: dropdown badges verified live against a seeded busy host (both colors, dev's all-basic capacities)

## Area(s) Touched
**Product areas**
- [x] ui/ux — frontend layout/styling not tied to a specific integration

**Integrations**
- [x] zoom-api — Zoom meeting/host sync

**Engineering**
- [x] testing — test suite (Jest/Playwright) changes

## Pre-merge Checklist
- [x] Code follows current formatting conventions and passes lint (`yarn lint`).
- [x] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
- [ ] All test suites pass, both run locally and green in GitHub CI. **Do not merge if any test suite is failing.**
- [x] A test suite was added or updated for the feature/fix in this PR. **Double-check this if you change a feature and did not update the test suites**.
- [x] Only files relevant to this change are committed — no stray or unrelated files.
- [x] If this branch has a merge conflict with master, master was merged into this branch first (not the other way around).
- [x] The rest of this PR description (Description, Testing) is filled out, not left as template placeholders.
