### PR TITLE
fix(docs): make the Pagefind search modal survive navigation and broken dialog close events

### DIFF
--- a/frontend/app/(main)/layout.tsx
+++ b/frontend/app/(main)/layout.tsx
@@ -12,6 +12,16 @@ export default async function RootLayout({ children }: PropsWithChildren) {
 
     return (
         <ClientLayout session={session}>
+            {/* Lives here, NOT in DocsShell: pagefind-component-ui.js's module singleton keeps
+                references into the first <pagefind-modal> it pairs with, and those references
+                don't survive the element being unmounted and recreated -- a /docs -> elsewhere ->
+                /docs client-side round trip previously left the docs search trigger flipping its
+                own state but opening nothing (GitHub #477). This layout never unmounts within a
+                (main) session, so the modal element (inert, display: none until opened; an
+                unregistered no-op tag until the docs shell first injects the Pagefind script)
+                mounts exactly once per real page load. The trigger stays in DocsShell -- fresh
+                triggers pair correctly against a live modal. */}
+            <pagefind-modal reset-on-close="true" />
             {children}
         </ClientLayout>
     );

--- a/frontend/app/components/docs/DocsShell.tsx
+++ b/frontend/app/components/docs/DocsShell.tsx
@@ -4,6 +4,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState, useTransition
 import Link from "next/link";
 import { useRouter, usePathname } from "next/navigation";
 import { TABLET_BREAKPOINT } from "../../../util/common/breakpoints";
+import { attachDialogCloseShim } from "../../../util/docs/dialogCloseShim";
 import type { DocMeta } from "../../../util/docs/loadDocs";
 import { usePagefindComponentUI } from "../../../hooks/usePagefindComponentUI";
 import TopLoadingBar from "../ui/displays/TopLoadingBar";
@@ -56,20 +57,69 @@ function docHref(slug: string): string {
 }
 
 // DocsShell is rendered from docs/layout.tsx, not from [[...slug]]/page.tsx -- layouts survive
-// a dynamic-segment change, pages don't. This is deliberate: pagefind-modal and
-// pagefind-modal-trigger below pair themselves up via generated IDs (aria-controls on the
-// trigger's button, matched against the modal dialog's own id) the first time each connects to
-// the DOM, and that pairing does not survive being torn down and recreated -- a second mount
-// within the same document leaves the trigger pointing at a dialog id that no longer exists, so
-// clicking it silently does nothing (no console error). Rendering both from a layout instead of
-// the page means they mount exactly once per docs session (only a real page load, i.e. a fresh
-// document, resets that), regardless of how many times the reader navigates between docs. See
+// a dynamic-segment change, pages don't, so doc-to-doc navigation never remounts the trigger.
+// <pagefind-modal> itself deliberately does NOT live here: leaving /docs entirely and returning
+// client-side unmounts and remounts this shell within the same document, while
+// pagefind-component-ui.js's module singleton persists -- a freshly-created modal desyncs from
+// the singleton's pairing state and the trigger opens nothing, silently (GitHub #477). The
+// modal is mounted once per real page load from app/(main)/layout.tsx instead (see the comment
+// there); fresh <pagefind-modal-trigger> elements pair correctly against that live modal. See
 // DocsArticle.tsx for the per-doc content (article + TOC) that's supposed to remount each time.
+
+// Guards Pagefind's modal against Chromium builds that never fire the dialog `close` event --
+// the second half of GitHub #477 (the first half is the modal remount desync fixed by mounting
+// it in app/(main)/layout.tsx). See util/docs/dialogCloseShim.ts for the mechanism.
+function usePagefindDialogCloseShim(): void {
+  useEffect(() => {
+    let cleanupDialog: (() => void) | null = null;
+
+    const attachToDialog = (dialog: HTMLDialogElement) => {
+      // Survives DocsShell remounts: the modal (and this dialog) live for the whole (main)
+      // session, so a previous shell's shim may already be watching.
+      if (dialog.dataset.closeShim === "true") return;
+      dialog.dataset.closeShim = "true";
+
+      const detach = attachDialogCloseShim(dialog);
+      cleanupDialog = () => {
+        detach();
+        delete dialog.dataset.closeShim;
+      };
+    };
+
+    // The dialog only exists once pagefind-component-ui.js has loaded and upgraded
+    // <pagefind-modal> (lazily injected -- see usePagefindComponentUI), so watch for it
+    // rather than assuming it's there on mount.
+    const modal = document.querySelector("pagefind-modal");
+    if (!modal) return;
+    const existing = modal.querySelector("dialog");
+    let upgradeObserver: MutationObserver | null = null;
+    if (existing) {
+      attachToDialog(existing);
+    } else {
+      upgradeObserver = new MutationObserver(() => {
+        const dialog = modal.querySelector("dialog");
+        if (dialog) {
+          upgradeObserver?.disconnect();
+          upgradeObserver = null;
+          attachToDialog(dialog);
+        }
+      });
+      upgradeObserver.observe(modal, { childList: true, subtree: true });
+    }
+
+    return () => {
+      upgradeObserver?.disconnect();
+      cleanupDialog?.();
+    };
+  }, []);
+}
+
 const DocsShell: React.FC<DocsShellProps> = ({ docsMeta, children }) => {
   const router = useRouter();
   const pathname = usePathname();
   const [isNavigating, startNavigation] = useTransition();
   usePagefindComponentUI();
+  usePagefindDialogCloseShim();
   const [sidebarOpen, setSidebarOpen] = useState(false);
   // null means "not yet measured" (no window on the server, client hasn't measured yet) --
   // same three-state convention useIsPhone()/useViewport() use elsewhere in this app. Rendering
@@ -295,11 +345,6 @@ const DocsShell: React.FC<DocsShellProps> = ({ docsMeta, children }) => {
   return (
     <div className={styles.page}>
       <TopLoadingBar active={isNavigating} label="Loading page" />
-      {/* Single instance for the whole docs session -- pagefind-modal-trigger (in the sidebar
-          below) and this connect automatically by sharing Pagefind's default "instance". Both
-          live here, in the layout-rendered shell, specifically so they never remount -- see this
-          component's own comment above. */}
-      <pagefind-modal reset-on-close="true" />
       <div ref={compactBarRef} className={`${styles.compactBar} ${compact ? styles.isCompact : ""}`}>
         {/* Panel-toggle + breadcrumb animate out together as search opens, freeing the whole bar
             (not just the breadcrumb's own space) for the searchbox -- see .compactBarChrome. */}

--- a/frontend/tests/component/dialogCloseShim.test.tsx
+++ b/frontend/tests/component/dialogCloseShim.test.tsx
@@ -1,0 +1,84 @@
+import { attachDialogCloseShim } from "../../util/docs/dialogCloseShim";
+
+// jsdom never fires a native `close` event when the `open` attribute is toggled directly,
+// which conveniently models the broken Chromium builds this shim exists for (see the module
+// comment) -- the compliant-browser path is simulated by dispatching the native event by hand.
+
+const flushMutations = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+describe("attachDialogCloseShim", () => {
+  let dialog: HTMLDialogElement;
+  let closeEvents: number;
+  let detach: (() => void) | null;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    dialog = document.createElement("dialog");
+    document.body.appendChild(dialog);
+    closeEvents = 0;
+    detach = null;
+  });
+
+  afterEach(() => {
+    detach?.();
+    dialog.remove();
+    jest.useRealTimers();
+  });
+
+  const countCloses = () => dialog.addEventListener("close", () => { closeEvents += 1; });
+
+  it("dispatches a synthetic close when the open attribute drops without a native event", async () => {
+    detach = attachDialogCloseShim(dialog);
+    countCloses();
+
+    dialog.setAttribute("open", "");
+    await jest.advanceTimersByTimeAsync(0);
+    dialog.removeAttribute("open");
+    await jest.advanceTimersByTimeAsync(150);
+
+    expect(closeEvents).toBe(1);
+  });
+
+  it("stays silent when the native close event arrives first (spec-compliant browsers)", async () => {
+    detach = attachDialogCloseShim(dialog);
+    countCloses();
+
+    dialog.setAttribute("open", "");
+    await jest.advanceTimersByTimeAsync(0);
+    // A compliant browser fires close alongside dropping the attribute.
+    dialog.removeAttribute("open");
+    dialog.dispatchEvent(new Event("close"));
+    await jest.advanceTimersByTimeAsync(150);
+
+    // Only the native event -- no synthetic duplicate on top of it.
+    expect(closeEvents).toBe(1);
+  });
+
+  it("re-arms for every open/close cycle", async () => {
+    detach = attachDialogCloseShim(dialog);
+    countCloses();
+
+    for (let cycle = 0; cycle < 2; cycle++) {
+      dialog.setAttribute("open", "");
+      await jest.advanceTimersByTimeAsync(0);
+      dialog.removeAttribute("open");
+      await jest.advanceTimersByTimeAsync(150);
+    }
+
+    expect(closeEvents).toBe(2);
+  });
+
+  it("stops watching after detach", async () => {
+    detach = attachDialogCloseShim(dialog);
+    countCloses();
+    detach();
+    detach = null;
+
+    dialog.setAttribute("open", "");
+    await jest.advanceTimersByTimeAsync(0);
+    dialog.removeAttribute("open");
+    await jest.advanceTimersByTimeAsync(150);
+
+    expect(closeEvents).toBe(0);
+  });
+});

--- a/frontend/util/docs/dialogCloseShim.ts
+++ b/frontend/util/docs/dialogCloseShim.ts
@@ -1,0 +1,33 @@
+// Some Chromium 150 builds (observed in Brave, 2026-08) close a native <dialog> without ever
+// firing its `close` event, violating the HTML spec (https://html.spec.whatwg.org/#close-the-dialog
+// step: "queue an element task ... fire an event named close"). Pagefind's modal resets its
+// internal open-flag only from that event, so one open+close left docs search permanently
+// unopenable until a hard reload (GitHub #477). This watches the dialog's `open` attribute and
+// re-dispatches a synthetic `close` when the native event doesn't arrive within a beat; on
+// spec-compliant browsers the native event always lands first and the shim never fires.
+
+// Long enough for the native close event's queued task to land first on compliant browsers,
+// short enough that Pagefind's bookkeeping still runs before a user can plausibly re-click.
+const NATIVE_CLOSE_GRACE_MS = 100;
+
+export function attachDialogCloseShim(dialog: HTMLDialogElement): () => void {
+  let sawNativeClose = false;
+  const markNativeClose = () => { sawNativeClose = true; };
+  dialog.addEventListener("close", markNativeClose);
+
+  const observer = new MutationObserver(() => {
+    if (dialog.open) {
+      sawNativeClose = false;
+      return;
+    }
+    setTimeout(() => {
+      if (!sawNativeClose && !dialog.open) dialog.dispatchEvent(new Event("close"));
+    }, NATIVE_CLOSE_GRACE_MS);
+  });
+  observer.observe(dialog, { attributes: true, attributeFilter: ["open"] });
+
+  return () => {
+    observer.disconnect();
+    dialog.removeEventListener("close", markNativeClose);
+  };
+}


### PR DESCRIPTION
Resolves #477

@coderabbitai summary

## Description
Full investigation record on #477. Two independent, individually-reproduced failure modes stacked behind the "flaky search trigger":

- **frontend/app/(main)/layout.tsx** + **frontend/app/components/docs/DocsShell.tsx**: `<pagefind-modal>` moves out of DocsShell into the `(main)` layout, mounting once per real page load. `pagefind-component-ui.js`'s module singleton persists for the whole browser session, but the modal previously remounted on every `/docs → elsewhere → /docs` client-side round trip — the fresh modal desynced from the singleton's pairing state (trigger `aria-controls` pointing at a dead dialog id), so the trigger flipped its own state and opened nothing. Fresh `<pagefind-modal-trigger>` elements pair correctly against a live modal, so the trigger stays where it was. DocsShell's stale "mounting from the layout makes pairing safe" comment rewritten to describe the real contract.
- **frontend/util/docs/dialogCloseShim.ts** (new) + `usePagefindDialogCloseShim` in DocsShell: some Chromium 150 builds (observed in Brave; verified with a bare `<dialog>` on three unrelated pages) close a native `<dialog>` **without ever firing its `close` event**, violating the HTML spec. Pagefind's modal resets its internal open-flag only from that event and `open()` no-ops while it's set — so search opened exactly once per page load and was dead after the first close until a hard reload ("flaky" = whether you'd already opened it that session). The shim watches the dialog's `open` attribute and dispatches the missing `close` event after a 100ms grace window; on spec-compliant browsers the native event always lands first and the shim never fires. Attached once per dialog (guarded by a `data` flag so it survives DocsShell remounts against the now-persistent modal).
- **frontend/tests/component/dialogCloseShim.test.tsx** (new): synthetic-close-when-native-missing, silent-when-native-arrives, re-arms per cycle, detach stops watching.

Verified live in the affected browser (Brave/Chromium 150, dev server): open → close → reopen → `/docs → / → /docs` round trip → open — every step that previously failed now works. Follow-ups noted on #477: upstream report to Brave/Chromium (3-line bare-dialog repro) and to Pagefind (deriving `isOpen` from `dialogEl.open` would immunize it).

## Testing
- [x] `yarn test:all` green (lint / lint:css / typecheck / 251 unit / 252 component / 134 integration / 115 e2e; 2 cold-start smoke flakes passed clean on isolated rerun)
- [x] New shim unit tests cover both browser behaviors
- [x] Manual matrix in the affected browser: first-open, reopen-after-close, and post-navigation open all verified working (each was a reproduced failure beforehand)

## Area(s) Touched
**Product areas**
- [x] docs — /docs Resources page (rendering, navigation, search)

**Engineering**
- [x] testing — test suite (Jest/Playwright) changes

## Pre-merge Checklist
- [x] Code follows current formatting conventions and passes lint (`yarn lint`).
- [x] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
- [ ] All test suites pass, both run locally and green in GitHub CI. **Do not merge if any test suite is failing.**
- [x] A test suite was added or updated for the feature/fix in this PR. **Double-check this if you change a feature and did not update the test suites**.
- [x] Only files relevant to this change are committed — no stray or unrelated files.
- [x] If this branch has a merge conflict with master, master was merged into this branch first (not the other way around).
- [x] The rest of this PR description (Description, Testing) is filled out, not left as template placeholders.
