### PR TITLE
chore(calendar): remove leftover console.log calls

### DIFF
--- a/frontend/app/components/calendar/desktop/CalendarSidebarShell.tsx
+++ b/frontend/app/components/calendar/desktop/CalendarSidebarShell.tsx
@@ -183,7 +183,6 @@ const CalendarSidebarShell: React.FC<CalendarSidebarShellProps> = ({
             meeting={selectedMeeting}
             onClose={onCloseEdit}
             onUpdateSuccess={() => {
-              console.log("Meeting updated!");
               triggerCalendarRefresh();
             }}
           />

--- a/frontend/app/components/calendar/desktop/DailyViewRow.tsx
+++ b/frontend/app/components/calendar/desktop/DailyViewRow.tsx
@@ -111,7 +111,6 @@ const DailyViewRow: React.FC<DailyViewRowProps> = ({
   const pendingPopoverAnchorRef = useRef(false);
 
   const handleBoxClick = (meetingId: string, el: HTMLElement) => {
-    console.log(`Meeting ${meetingId} clicked`);
     setSelectedMeetingID(meetingId);
     setSelectedNewMeeting(false);
     setAnchorEl(el);

--- a/frontend/app/components/calendar/desktop/DayView.tsx
+++ b/frontend/app/components/calendar/desktop/DayView.tsx
@@ -37,7 +37,6 @@ export const fetchMeetingsByDay = async (date: Date): Promise<Room[]> => {
     try {
       const response = await fetch(`/api/retrieve/meeting/day?startDate=${formattedDate}`);
       const data: IMeeting[] = await response.json();
-      console.log("[DayView] Raw API response for", formattedDate, ":", data);
 
       // ET day boundaries, not local-timezone midnight — the backend selected meetings
       // using ET day bounds, so clipping must line up with the same boundaries.
@@ -317,7 +316,6 @@ const DayView: React.FC<DayViewProps> = ({
 
   useEffect(() => {
     if (refreshTrigger > 0) {
-      console.log("Refreshing calendar due to trigger change:", refreshTrigger);
       // dayMeetingCache.clear() (inside fetchData(true)) wipes the prefetched neighbors too --
       // re-warm them once the visible day's own force-fetch has landed, or the next arrow click
       // within the 30s auto-refresh window would slide in stale content again.
@@ -368,7 +366,7 @@ const DayView: React.FC<DayViewProps> = ({
                 primaryColor={room.primaryColor}
                 meetingId={room.meetings[0]?.id || ""}
                 // onClick={() => handleMeetingChange(room.meetings[0]?.id || "")}
-                onClick={() => console.log(`Clicked on room: ${room.name}`)}
+                onClick={() => {}}
               />
             </div>
           ))}

--- a/frontend/app/components/calendar/shared/DayColumn.tsx
+++ b/frontend/app/components/calendar/shared/DayColumn.tsx
@@ -107,7 +107,6 @@ const DayColumn: React.FC<DayColumnProps> = ({
     const pendingPopoverAnchorRef = useRef(false);
 
     const handleBoxClick = (meetingId: string, el: HTMLElement) => {
-        console.log(`Meeting ${meetingId} clicked`);
         setSelectedMeetingID(meetingId);
         setSelectedNewMeeting(false);
         setAnchorEl(el);

--- a/frontend/hooks/useRangeMeetings.ts
+++ b/frontend/hooks/useRangeMeetings.ts
@@ -15,8 +15,6 @@ const fetchMeetingsByRange = async (startDate: Date, endDate: Date): Promise<Wee
     const cacheKey = `${formattedStart}-${formattedEnd}`;
 
     return rangeMeetingCache.getOrFetch(cacheKey, async () => {
-        console.log("[useRangeMeetings] Fetching meetings for range:", cacheKey);
-
         try {
             const response = await fetch(`/api/retrieve/meeting/range?startDate=${formattedStart}&endDate=${formattedEnd}`);
             // A failed response's body is { error: ... }, not a meeting array -- mapping it
@@ -25,7 +23,6 @@ const fetchMeetingsByRange = async (startDate: Date, endDate: Date): Promise<Wee
             // range as if it were a real, successful result for the rest of the session.
             if (!response.ok) throw new Error(`Range request failed with status ${response.status}`);
             const data = await response.json();
-            console.log("[useRangeMeetings] Raw API response for", cacheKey, ":", data);
             return mapRawMeetingsToWeekMeetings(data);
         } catch (error) {
             console.error("[useRangeMeetings] Error fetching meetings for", cacheKey, ":", error instanceof Error ? error.message : String(error));

--- a/frontend/hooks/useWeekMeetings.ts
+++ b/frontend/hooks/useWeekMeetings.ts
@@ -51,12 +51,9 @@ const fetchMeetingsByWeek = async (startDate: Date, endDate: Date): Promise<Week
     const cacheKey = `${formattedStart}-${formattedEnd}`;
 
     return weekMeetingCache.getOrFetch(cacheKey, async () => {
-        console.log("[useWeekMeetings] Fetching meetings for week:", cacheKey);
-
         try {
             const response = await fetch(`/api/retrieve/meeting/week?startDate=${formattedStart}&endDate=${formattedEnd}`);
             const data = await response.json();
-            console.log("[useWeekMeetings] Raw API response for", cacheKey, ":", data);
             return mapRawMeetingsToWeekMeetings(data);
         } catch (error) {
             // error objects don't serialize over CDP -- log the message directly so it's
@@ -168,7 +165,6 @@ export function useWeekMeetings(weekStartDate: Date, refreshTrigger: number = 0)
 
     useEffect(() => {
         if (refreshTrigger > 0) {
-            console.log("Refetching week meetings due to trigger change:", refreshTrigger);
             fetchWeekMeetings(true); // Force fetch (invalidate cache)
         }
     }, [refreshTrigger, fetchWeekMeetings]);


### PR DESCRIPTION
Closes #455

@coderabbitai summary

## Description
- **app/components/calendar/desktop/DayView.tsx**: removed leftover debug `console.log` calls (raw API response dump, refresh-trigger log, and a stray click handler that only logged); replaced the click handler with a no-op to satisfy `BoxText`'s required `onClick` prop.
- **app/components/calendar/desktop/DailyViewRow.tsx**: removed a debug `console.log` from `handleBoxClick`.
- **app/components/calendar/desktop/CalendarSidebarShell.tsx**: removed a debug `console.log` from the edit-meeting sidebar's `onUpdateSuccess` callback.
- **app/components/calendar/shared/DayColumn.tsx**: removed a debug `console.log` from `handleBoxClick`.
- **hooks/useWeekMeetings.ts** / **hooks/useRangeMeetings.ts**: removed the same pattern of debug logs (fetch announcement, raw API response dump, refresh-trigger log) from the calendar data hooks.

Pure deletion, no behavior change. `console.error`/`console.warn` calls were left untouched.

## Testing
- [x] `grep -rn "console.log" app/components/calendar/ hooks/` from `frontend/` returns nothing.
- [x] `yarn lint` — 0 errors (44 pre-existing warnings, unrelated to this change).
- [x] `yarn typecheck` — clean.
- [x] `yarn test:unit` — 19 suites / 251 tests passed.

## Area(s) Touched
**Product areas**
- [ ] auth — sign-in, sessions, NextAuth, role-based access
- [ ] admin — /admin shell (Diagnostics, Users, Import, Export tabs)
- [ ] docs — /docs Resources page (rendering, navigation, search)
- [ ] ui/ux — frontend layout/styling not tied to a specific integration

**Integrations**
- [ ] google-calendar — Google Calendar sync
- [ ] zoom-api — Zoom meeting/host sync

**Engineering**
- [ ] security — auth hardening, data exposure, dependency/security scanning
- [ ] testing — test suite (Jest/Playwright) changes
- [ ] github-actions — workflows, Dependabot config, other .github/ CI tooling
- [x] cleanup — refactor or dead-code removal, no behavior change
- [ ] documentation — docs/ or README changes only

## Pre-merge Checklist
- [x] Code follows current formatting conventions and passes lint (`yarn lint`).
- [x] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
- [x] All test suites pass, both run locally and green in GitHub CI. **Do not merge if any test suite is failing.**
- [ ] A test suite was added or updated for the feature/fix in this PR. **Double-check this if you change a feature and did not update the test suites**.
- [x] Only files relevant to this change are committed — no stray or unrelated files.
- [x] If this branch has a merge conflict with master, master was merged into this branch first (not the other way around).
- [x] The rest of this PR description (Description, Testing) is filled out, not left as template placeholders.
