### PR TITLE
fix(ui): unify escape and outside-click dismissal across layered UI

### DIFF
--- a/frontend/app/components/meeting-form/ViewMeeting.tsx
+++ b/frontend/app/components/meeting-form/ViewMeeting.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useLayoutEffect, useRef } from 'react';
+import React, { useState, useId, useLayoutEffect, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import styles from './ViewMeeting.module.scss';
 import DeleteRecurringModal from './DeleteRecurringModal';
@@ -28,6 +28,7 @@ import { MODE_ICON_NAME } from "../../../util/rooms/modeIcons";
 import { useZoomHostPool } from "../../../hooks/useZoomHostPool";
 import { usePopupPosition, POPUP_WIDTH } from "../../../hooks/usePopupPosition";
 import { useRetrySync } from "../../../hooks/useRetrySync";
+import { useDismissibleLayer } from "../../../hooks/useDismissibleLayer";
 
 // Extracts ET wall-clock time as "HH:MM" (24hr), which is what formatCompactTimeRange expects.
 const etTimeFmt = new Intl.DateTimeFormat('en-GB', {
@@ -176,6 +177,8 @@ const ViewMeetingDetails: React.FC<ViewMeetingDetailsProps> = ({
   const zoomHostPool = useZoomHostPool();
 
   const kebabRef = useRef<HTMLDivElement>(null);
+  const kebabFirstItemRef = useRef<HTMLButtonElement>(null);
+  const titleId = useId();
   // Ref *callback* rather than a plain useRef -- it fires exactly once when the paragraph
   // actually mounts (the portal renders nothing until popupPosition is set, so a plain ref
   // wouldn't be attached yet on the render where we'd otherwise want to measure it), and,
@@ -183,53 +186,26 @@ const ViewMeetingDetails: React.FC<ViewMeetingDetailsProps> = ({
   const [descNode, setDescNode] = useState<HTMLParagraphElement | null>(null);
   const { popupRef, popupPosition } = usePopupPosition(anchorEl);
 
-  // Closes the whole popup on an outside click -- clicks on the anchor box itself are left
-  // alone since that box's own onClick already handles re-selecting/toggling it. Desktop
-  // only: popupRef is never attached on phone (that branch renders inside BottomSheet, not
-  // the ref={popupRef} div below), so popupRef.current would always be null there --
-  // treating *every* click, including ones inside the sheet's own kebab menu, as "outside"
-  // and closing it immediately. BottomSheet already has its own correct backdrop-click-to-
-  // close handling for the phone case, so this effect simply doesn't need to run there.
-  useEffect(() => {
-    if (isPhone) return;
+  // Desktop only: popupRef is never attached on phone (that branch renders inside BottomSheet,
+  // not the ref={popupRef} div below), so every click -- including ones inside the sheet itself
+  // -- would read as "outside". BottomSheet provides its own dialog/dismissal behavior there.
+  useDismissibleLayer({
+    isOpen: !isPhone && !!anchorEl && !!popupPosition,
+    onDismiss: onBack,
+    contentRef: popupRef,
+    // Clicks on the anchor box are left alone -- that box's own onClick already handles
+    // re-selecting/toggling it.
+    ignoreEl: anchorEl,
+  });
 
-    const handleClickOutside = (event: MouseEvent) => {
-      const target = event.target as Node;
-      if (popupRef.current?.contains(target)) return;
-      if (anchorEl?.contains(target)) return;
-      // DatePicker's own calendar popup (e.g. SuspendMeetingModal's "Until" field) is portaled
-      // to document.body, so it's a DOM sibling of this popup, not a descendant -- without this
-      // check, clicking a day on it reads as an outside click and closes the whole thing.
-      if ((target as Element).closest?.('[data-datepicker-popup]')) return;
-      // Same escape hatch for the Delete/DeleteRecurring/Suspend/Resume modals below (see
-      // `modals`) -- they render via the shared Modal primitive, which portals to document.body
-      // in the same way, so a click on any of their buttons is also a DOM sibling of this popup,
-      // not a descendant. Without this, e.g. clicking DeleteMeetingModal's "Delete" button
-      // registers as an outside click and unmounts this whole popup (and the modal with it)
-      // before the button's own onClick can fire.
-      if ((target as Element).closest?.('[data-modal-popup]')) return;
-      onBack();
-    };
-
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => document.removeEventListener('mousedown', handleClickOutside);
-    // popupRef is a stable ref object (from usePopupPosition) -- included for exhaustive-deps,
-    // not because it ever changes.
-  }, [anchorEl, onBack, isPhone, popupRef]);
-
-  // Closes just the kebab dropdown on an outside click, independent of the popup-level one above.
-  useEffect(() => {
-    if (!kebabOpen) return;
-
-    const handleClickOutside = (event: MouseEvent) => {
-      if (!kebabRef.current?.contains(event.target as Node)) {
-        setKebabOpen(false);
-      }
-    };
-
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, [kebabOpen]);
+  // A layer of its own, stacked above the popup: the first Escape closes just this menu, and an
+  // outside click inside the popup body closes the menu without dismissing the popup too.
+  useDismissibleLayer({
+    isOpen: kebabOpen,
+    onDismiss: () => setKebabOpen(false),
+    contentRef: kebabRef,
+    initialFocusRef: kebabFirstItemRef,
+  });
 
   // Measures whether the (clamped) description overflows 3 lines, so the "Show more" toggle
   // only appears when there's actually more to show. Runs once against descNode's initial
@@ -392,7 +368,7 @@ const ViewMeetingDetails: React.FC<ViewMeetingDetailsProps> = ({
         <button className={styles.backButton} onClick={onBack}>
           <Icon name="back-arrow" ariaLabel="Back" />
         </button>
-        <h1>{title}</h1>
+        <h1 id={titleId}>{title}</h1>
         <span
           className={styles.settingLabel}
           style={{ backgroundColor: primaryColor, borderColor: primaryColor }}
@@ -413,7 +389,7 @@ const ViewMeetingDetails: React.FC<ViewMeetingDetailsProps> = ({
             </button>
             {kebabOpen && (
               <div className={styles.optionsMenu}>
-                <button onClick={() => { setKebabOpen(false); onEdit(); }}>Edit</button>
+                <button ref={kebabFirstItemRef} onClick={() => { setKebabOpen(false); onEdit(); }}>Edit</button>
                 {isSuspended ? (
                   <button className={styles.suspendOption} onClick={handleResumeClick}>Reactivate</button>
                 ) : hasPendingSuspension ? (
@@ -616,6 +592,9 @@ const ViewMeetingDetails: React.FC<ViewMeetingDetailsProps> = ({
       ref={popupRef}
       className={styles.popupAnchor}
       style={{ top: popupPosition.top, left: popupPosition.left, width: POPUP_WIDTH }}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={titleId}
     >
       {content}
       {modals}

--- a/frontend/app/components/meeting-form/ViewMeeting.tsx
+++ b/frontend/app/components/meeting-form/ViewMeeting.tsx
@@ -593,7 +593,6 @@ const ViewMeetingDetails: React.FC<ViewMeetingDetailsProps> = ({
       className={styles.popupAnchor}
       style={{ top: popupPosition.top, left: popupPosition.left, width: POPUP_WIDTH }}
       role="dialog"
-      aria-modal="true"
       aria-labelledby={titleId}
     >
       {content}

--- a/frontend/app/components/ui/inputs/Dropdown.module.scss
+++ b/frontend/app/components/ui/inputs/Dropdown.module.scss
@@ -156,6 +156,18 @@
     border-color: $brand-pink-color; /* Pink border when dropdown is active */
 }
 
+// Keyboard focus keeps the same brand-pink treatment the open state uses -- otherwise closing
+// the list (Escape, or picking an option) drops the trigger back to the browser's default blue
+// ring while it still holds focus.
+.DropdownButton:focus {
+    outline: none;
+}
+
+.DropdownButton:focus-visible {
+    border-color: $brand-pink-color;
+    box-shadow: inset 0 0 0 1px $brand-pink-color;
+}
+
 .locationList {
     position: absolute;
     top: 100%;
@@ -195,6 +207,16 @@
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+}
+
+// Options take focus when the list opens, so they need the same brand ring as the trigger
+// rather than the browser default.
+.dropdownItem:focus {
+    outline: none;
+}
+
+.dropdownItem:focus-visible {
+    box-shadow: inset 0 0 0 2px $brand-pink-color;
 }
 
 .dropdownItem:hover {

--- a/frontend/app/components/ui/inputs/Dropdown.tsx
+++ b/frontend/app/components/ui/inputs/Dropdown.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import Icon from "../displays/Icon";
 import styles from "./Dropdown.module.scss";
+import { useDismissibleLayer } from "../../../../hooks/useDismissibleLayer";
 
 interface DropdownProps {
   label: string | React.ReactNode;
@@ -39,7 +40,19 @@ const Dropdown: React.FC<DropdownProps> = ({
   const [selectedElement, setselectedElement] = useState<string | null>(value ?? null);
 
   const [activeDropdown, setActiveDropdown] = useState<string | null>(null);
-  const buttonRef = React.useRef<HTMLButtonElement>(null);
+  const containerRef = React.useRef<HTMLDivElement>(null);
+  const firstOptionRef = React.useRef<HTMLLIElement>(null);
+
+  const isOpen = activeDropdown === "element";
+
+  // containerRef (not the list) is the layer root, so a click on the trigger button reads as
+  // inside and is left to the button's own toggle instead of closing and immediately reopening.
+  useDismissibleLayer({
+    isOpen,
+    onDismiss: () => setActiveDropdown(null),
+    contentRef: containerRef,
+    initialFocusRef: firstOptionRef,
+  });
 
   React.useEffect(() => {
     // Intentionally mount-only: notifies the parent once with the initial value. Call
@@ -77,13 +90,11 @@ const Dropdown: React.FC<DropdownProps> = ({
   };
 
   const handleOptionKeyDown = (e: React.KeyboardEvent<HTMLLIElement>, element: string) => {
+    // Escape is handled by useDismissibleLayer (topmost layer only), which also restores focus
+    // to the trigger button on close.
     if (e.key === 'Enter' || e.key === ' ') {
       e.preventDefault();
       handleElementClick(element);
-      buttonRef.current?.focus();
-    } else if (e.key === 'Escape') {
-      setActiveDropdown(null);
-      buttonRef.current?.focus();
     }
   };
 
@@ -95,18 +106,17 @@ const Dropdown: React.FC<DropdownProps> = ({
 
   return (
     <div className={`${styles.dropdown} ${compact ? styles.compact : ''}`}>
-      <div className={styles.DropdownContainer}>
+      <div className={styles.DropdownContainer} ref={containerRef}>
         {isStringLabel && (
           <label className={styles.DropdownLabel}>
             <span>{label}</span>
           </label>
         )}
         <button
-          ref={buttonRef}
-          className={`${styles.DropdownButton} ${activeDropdown === "element" ? styles.activeDropdown : ''}`}
+          className={`${styles.DropdownButton} ${isOpen ? styles.activeDropdown : ''}`}
           onClick={() => handleDropdownToggle("element")}
           aria-haspopup="listbox"
-          aria-expanded={activeDropdown === "element"}
+          aria-expanded={isOpen}
           aria-label={ariaLabel}
         >
           <span className={styles.DropdownButtonContent}>
@@ -117,7 +127,7 @@ const Dropdown: React.FC<DropdownProps> = ({
           </span>
           <Icon name="drop-down-arrow" className={styles.dropdownArrow} />
         </button>
-        {activeDropdown === "element" && (
+        {isOpen && (
           <ul
             className={`${styles.elementList} ${!isStringLabel ? styles.elementListFullWidth : ''}`}
             role="listbox"
@@ -126,6 +136,7 @@ const Dropdown: React.FC<DropdownProps> = ({
             {elements.map((element, index) => (
               <li
                 key={index}
+                ref={index === 0 ? firstOptionRef : undefined}
                 role="option"
                 aria-selected={selectedElement === element}
                 tabIndex={0}

--- a/frontend/app/components/ui/inputs/Dropdown.tsx
+++ b/frontend/app/components/ui/inputs/Dropdown.tsx
@@ -43,7 +43,9 @@ const Dropdown: React.FC<DropdownProps> = ({
   const containerRef = React.useRef<HTMLDivElement>(null);
   const firstOptionRef = React.useRef<HTMLLIElement>(null);
 
-  const isOpen = activeDropdown === "element";
+  // isVisible is checked here too: the component returns null below when hidden, which would
+  // otherwise leave an unrenderable layer registered on the stack, swallowing Escape.
+  const isOpen = isVisible && activeDropdown === "element";
 
   // containerRef (not the list) is the layer root, so a click on the trigger button reads as
   // inside and is left to the button's own toggle instead of closing and immediately reopening.

--- a/frontend/hooks/useDialogBehavior.ts
+++ b/frontend/hooks/useDialogBehavior.ts
@@ -1,24 +1,8 @@
 import { useEffect, useRef, type RefObject } from "react";
 import { useIsomorphicLayoutEffect } from "./useViewport";
+import { LAYER_FOCUSABLE_SELECTOR, useLayerStack } from "./useDismissibleLayer";
 
-export const DIALOG_FOCUSABLE_SELECTOR =
-  'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
-
-// Module-scope stack of currently-open dialogs (by hook-instance id), topmost/most-recently-
-// opened last. A dialog opened *inside* another (e.g. ConflictOverrideModal opened from within
-// New Meeting's MobileFullScreenSheet) is a DOM sibling of its host under document.body, not a
-// descendant -- both dialogs' Escape listeners are separate handlers on the same `document`
-// node, so DOM containment/event.stopPropagation can't distinguish "inner" from "outer" (every
-// listener on a node fires regardless of another same-node listener's propagation state). Only
-// the topmost dialog on this stack responds to Escape, so closing the inner modal doesn't also
-// discard the form underneath it.
-//
-// Ordering is by open-effect commit order, not real DOM/visual nesting (there is none to read,
-// per above) -- correct for every actual call site here, since a nested dialog (e.g.
-// ConflictOverrideModal) only ever opens in response to a user action *after* its host is
-// already open and mounted, never in the same commit as its host.
-let nextDialogId = 0;
-const openDialogStack: number[] = [];
+export const DIALOG_FOCUSABLE_SELECTOR = LAYER_FOCUSABLE_SELECTOR;
 
 export interface UseDialogBehaviorOptions {
   isOpen: boolean;
@@ -40,6 +24,8 @@ export interface UseDialogBehaviorOptions {
 // focus restoration on close -- extracted from Modal.tsx so BottomSheet and
 // MobileFullScreenSheet (which can't just wrap Modal: both need their own portal/overlay
 // structure for drag-to-dismiss via motion/react) can provide the same dialog semantics.
+// Registers on the same layer stack as useDismissibleLayer, so Escape ordering is consistent
+// between dialogs and non-dialog layers (menus, dropdowns, the ViewMeeting popup).
 export function useDialogBehavior({
   isOpen,
   onClose,
@@ -61,24 +47,10 @@ export function useDialogBehavior({
     preventCloseRef.current = preventClose;
   });
 
-  // Lazily assigns a stable id the first time this hook instance runs -- mutating a ref during
-  // render like this is safe (and the idiomatic lazy-init pattern) since it's idempotent after
-  // the first call, unlike mutating state.
-  const dialogIdRef = useRef<number | null>(null);
-  if (dialogIdRef.current === null) dialogIdRef.current = nextDialogId++;
-
-  // Registers this dialog on the shared open-stack for as long as it's open (see the stack's
-  // own comment above) -- independent of the focus-management effect below, which cares about
-  // *this* dialog's own focus regardless of nesting.
-  useEffect(() => {
-    if (!isOpen) return;
-    const id = dialogIdRef.current as number;
-    openDialogStack.push(id);
-    return () => {
-      const index = openDialogStack.indexOf(id);
-      if (index !== -1) openDialogStack.splice(index, 1);
-    };
-  }, [isOpen]);
+  // Registers this dialog on the shared layer stack for as long as it's open -- independent of
+  // the focus-management effect below, which cares about *this* dialog's own focus regardless
+  // of nesting.
+  const layer = useLayerStack(isOpen, contentRef);
 
   // Capture-and-autofocus / restore-on-unmount, deps on isOpen only -- must run exactly once
   // per open/close transition, not on every re-render a parent causes while open.
@@ -105,10 +77,9 @@ export function useDialogBehavior({
 
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
-        // Only the topmost (most-recently-opened) dialog closes on Escape -- see the stack's
-        // own comment above for why DOM containment/stopPropagation can't do this instead.
-        const isTopmost = openDialogStack[openDialogStack.length - 1] === dialogIdRef.current;
-        if (isTopmost && !preventCloseRef.current) onCloseRef.current?.();
+        // Only the topmost (most-recently-opened) layer closes on Escape -- see useLayerStack's
+        // own comment for why DOM containment/stopPropagation can't do this instead.
+        if (layer.isTopmost() && !preventCloseRef.current) onCloseRef.current?.();
         return;
       }
       if (event.key !== "Tab") return;
@@ -129,5 +100,5 @@ export function useDialogBehavior({
 
     document.addEventListener("keydown", handleKeyDown);
     return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [isOpen, contentRef]);
+  }, [isOpen, contentRef, layer]);
 }

--- a/frontend/hooks/useDismissibleLayer.ts
+++ b/frontend/hooks/useDismissibleLayer.ts
@@ -1,0 +1,171 @@
+import { useEffect, useMemo, useRef, type RefObject } from "react";
+import { useIsomorphicLayoutEffect } from "./useViewport";
+
+export const LAYER_FOCUSABLE_SELECTOR =
+  'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+// Portaled children that are DOM siblings of their logical parent layer rather than
+// descendants, so DOM containment alone reads a click inside them as "outside" the layer that
+// owns them. Stack entries are already covered by containsFromHereUp below; this covers the
+// portals that aren't stack entries (DatePicker's calendar popup) and the parts of one that sit
+// outside its registered content root (Modal's overlay, around its dialog).
+const NESTED_PORTAL_SELECTOR = "[data-modal-popup], [data-datepicker-popup]";
+
+interface LayerEntry {
+  id: number;
+  contentRef: RefObject<HTMLElement | null>;
+}
+
+// Module-scope stack of every currently-open dismissible layer (dialogs, popups, menus,
+// dropdowns), topmost/most-recently-opened last. A layer opened *inside* another (a modal opened
+// from within a sheet, ViewMeeting's kebab menu inside its self-portaled popup) is usually a DOM
+// sibling of its host under document.body, not a descendant -- both layers' Escape listeners are
+// separate handlers on the same `document` node, so DOM containment/event.stopPropagation can't
+// distinguish "inner" from "outer" (every listener on a node fires regardless of another
+// same-node listener's propagation state). Only the topmost layer responds to Escape, so closing
+// an inner menu doesn't also discard the popup underneath it.
+//
+// Ordering is by open-effect commit order, not real DOM/visual nesting (there is none to read,
+// per above) -- correct for every actual call site, since a nested layer only ever opens in
+// response to a user action *after* its host is already open and mounted.
+let nextLayerId = 0;
+const layerStack: LayerEntry[] = [];
+
+export interface LayerStackHandle {
+  isTopmost: () => boolean;
+  // Whether a click landed inside this layer or anything stacked above it -- the portal-aware
+  // replacement for `contentRef.current.contains(target)`.
+  containsFromHereUp: (node: Node) => boolean;
+}
+
+// Registers a layer on the shared stack for as long as it is open, and exposes the two ordering
+// questions every dismissal path needs to ask.
+export function useLayerStack(
+  isOpen: boolean,
+  contentRef: RefObject<HTMLElement | null>,
+): LayerStackHandle {
+  // Lazily assigns a stable id the first time this hook instance runs -- mutating a ref during
+  // render like this is safe (and the idiomatic lazy-init pattern) since it's idempotent after
+  // the first call, unlike mutating state.
+  const idRef = useRef<number | null>(null);
+  if (idRef.current === null) idRef.current = nextLayerId++;
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const entry: LayerEntry = { id: idRef.current as number, contentRef };
+    layerStack.push(entry);
+    return () => {
+      const index = layerStack.indexOf(entry);
+      if (index !== -1) layerStack.splice(index, 1);
+    };
+    // contentRef is a ref object -- stable across renders, listed only for exhaustive-deps.
+  }, [isOpen, contentRef]);
+
+  // Stable identity so callers can safely list the handle in their own effect deps.
+  return useMemo<LayerStackHandle>(
+    () => ({
+      isTopmost: () => layerStack[layerStack.length - 1]?.id === idRef.current,
+      containsFromHereUp: (node: Node) => {
+        const index = layerStack.findIndex((entry) => entry.id === idRef.current);
+        if (index === -1) return false;
+        return layerStack
+          .slice(index)
+          .some((entry) => entry.contentRef.current?.contains(node) ?? false);
+      },
+    }),
+    [],
+  );
+}
+
+export interface UseDismissibleLayerOptions {
+  isOpen: boolean;
+  onDismiss: () => void;
+  // The layer's own content root. Clicks inside it (or inside anything stacked above it) never
+  // count as outside clicks.
+  contentRef: RefObject<HTMLElement | null>;
+  // Extra element that must not read as "outside" -- the trigger that opened this layer, when it
+  // lives outside contentRef (ViewMeeting's anchoring calendar box, whose own onClick already
+  // owns the toggle). A trigger *inside* contentRef needs nothing here.
+  ignoreEl?: HTMLElement | null;
+  // Overrides what receives focus on open; defaults to the first focusable descendant of
+  // contentRef.
+  initialFocusRef?: RefObject<HTMLElement | null>;
+  // Opt out of moving focus into the layer on open (and of restoring it on close) -- for layers
+  // whose host already owns focus management.
+  manageFocus?: boolean;
+  closeOnOutsideClick?: boolean;
+  closeOnEscape?: boolean;
+}
+
+// Shared dismissal behavior for any layered UI that is not a full dialog: Escape-to-close
+// targeting only the topmost layer, portal-aware outside-click-to-close, and focus in/out.
+// Dialogs use useDialogBehavior instead, which adds a focus trap and shares this same stack so
+// Escape ordering is consistent across both kinds of layer.
+export function useDismissibleLayer({
+  isOpen,
+  onDismiss,
+  contentRef,
+  ignoreEl,
+  initialFocusRef,
+  manageFocus = true,
+  closeOnOutsideClick = true,
+  closeOnEscape = true,
+}: UseDismissibleLayerOptions): void {
+  const layer = useLayerStack(isOpen, contentRef);
+
+  // Read inside the handlers instead of putting onDismiss in the effects' deps -- callers don't
+  // memoize it, so a plain dependency would re-subscribe the listeners on every parent re-render
+  // while the layer is still open.
+  const onDismissRef = useRef(onDismiss);
+  const ignoreElRef = useRef(ignoreEl);
+  useIsomorphicLayoutEffect(() => {
+    onDismissRef.current = onDismiss;
+    ignoreElRef.current = ignoreEl;
+  });
+
+  // Deps on isOpen only -- must run exactly once per open/close transition, not on every
+  // re-render a parent causes while open.
+  useEffect(() => {
+    if (!isOpen || !manageFocus) return;
+
+    const previouslyFocused = document.activeElement as HTMLElement | null;
+    const target =
+      initialFocusRef?.current ??
+      contentRef.current?.querySelectorAll<HTMLElement>(LAYER_FOCUSABLE_SELECTOR)[0];
+    target?.focus();
+
+    return () => {
+      previouslyFocused?.focus();
+    };
+    // contentRef/initialFocusRef are ref objects -- stable across renders, so including them
+    // doesn't change when this re-runs, but does satisfy exhaustive-deps.
+  }, [isOpen, manageFocus, contentRef, initialFocusRef]);
+
+  useEffect(() => {
+    if (!isOpen || !closeOnEscape) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      if (!layer.isTopmost()) return;
+      onDismissRef.current();
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen, closeOnEscape, layer]);
+
+  useEffect(() => {
+    if (!isOpen || !closeOnOutsideClick) return;
+
+    const handleMouseDown = (event: MouseEvent) => {
+      const target = event.target as Node;
+      if (layer.containsFromHereUp(target)) return;
+      if (ignoreElRef.current?.contains(target)) return;
+      if ((target as Element).closest?.(NESTED_PORTAL_SELECTOR)) return;
+      onDismissRef.current();
+    };
+
+    document.addEventListener("mousedown", handleMouseDown);
+    return () => document.removeEventListener("mousedown", handleMouseDown);
+  }, [isOpen, closeOnOutsideClick, layer]);
+}

--- a/frontend/tests/component/Dropdown.test.tsx
+++ b/frontend/tests/component/Dropdown.test.tsx
@@ -1,0 +1,89 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import Dropdown from "../../app/components/ui/inputs/Dropdown";
+
+const renderDropdown = (onChange = jest.fn()) => {
+  render(
+    <div>
+      <button>Outside</button>
+      <Dropdown
+        label="Repeats"
+        isVisible
+        elements={["Never", "Daily", "Weekly"]}
+        name="Select repeat"
+        onChange={onChange}
+      />
+    </div>,
+  );
+  // The closed trigger's accessible name is the `name` prop until something is selected.
+  return screen.getByRole("button", { name: "Select repeat" });
+};
+
+const openDropdown = (trigger: HTMLElement) => {
+  // Focused first so focus restoration has a realistic starting point -- fireEvent.click alone
+  // doesn't move focus in jsdom the way a real browser click on a button does.
+  trigger.focus();
+  fireEvent.click(trigger);
+};
+
+describe("Dropdown", () => {
+  it("opens on the trigger and closes again on a second click", () => {
+    const trigger = renderDropdown();
+    openDropdown(trigger);
+    expect(screen.getByRole("listbox")).toBeInTheDocument();
+
+    fireEvent.click(trigger);
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+  });
+
+  it("moves focus to the first option on open and back to the trigger on close", () => {
+    const trigger = renderDropdown();
+    openDropdown(trigger);
+    expect(screen.getByRole("option", { name: "Never" })).toHaveFocus();
+
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(trigger).toHaveFocus();
+  });
+
+  it("closes on Escape", () => {
+    const trigger = renderDropdown();
+    openDropdown(trigger);
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+  });
+
+  it("closes on an outside click", () => {
+    const trigger = renderDropdown();
+    openDropdown(trigger);
+    fireEvent.mouseDown(screen.getByRole("button", { name: "Outside" }));
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+  });
+
+  it("stays open on a click inside its own list", () => {
+    const trigger = renderDropdown();
+    openDropdown(trigger);
+    fireEvent.mouseDown(screen.getByRole("listbox"));
+    expect(screen.getByRole("listbox")).toBeInTheDocument();
+  });
+
+  it("selects an option, closes, and returns focus to the trigger", () => {
+    const onChange = jest.fn();
+    const trigger = renderDropdown(onChange);
+    openDropdown(trigger);
+
+    fireEvent.click(screen.getByRole("option", { name: "Weekly" }));
+    expect(onChange).toHaveBeenCalledWith("Weekly");
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+    expect(trigger).toHaveFocus();
+  });
+
+  it("selects an option on Enter", () => {
+    const onChange = jest.fn();
+    const trigger = renderDropdown(onChange);
+    openDropdown(trigger);
+
+    fireEvent.keyDown(screen.getByRole("option", { name: "Daily" }), { key: "Enter" });
+    expect(onChange).toHaveBeenCalledWith("Daily");
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/tests/component/ViewMeeting.test.tsx
+++ b/frontend/tests/component/ViewMeeting.test.tsx
@@ -60,7 +60,9 @@ describe("ViewMeeting", () => {
     renderViewMeeting({ ...baseProps, anchorEl: makeAnchorEl(), isPhone: false });
     expect(await screen.findByText("Serenity Group")).toBeInTheDocument();
     const dialog = screen.getByRole("dialog", { name: "Serenity Group" });
-    expect(dialog).toHaveAttribute("aria-modal", "true");
+    // Deliberately not aria-modal: focus isn't trapped and the page behind stays interactive,
+    // so announcing it as modal would misdescribe it to screen readers.
+    expect(dialog).not.toHaveAttribute("aria-modal");
   });
 
   describe("desktop dismissal", () => {

--- a/frontend/tests/component/ViewMeeting.test.tsx
+++ b/frontend/tests/component/ViewMeeting.test.tsx
@@ -56,10 +56,71 @@ describe("ViewMeeting", () => {
     await waitFor(() => expect(screen.queryByText("Serenity Group")).not.toBeInTheDocument());
   });
 
-  it("desktop: renders the meeting title once an anchorEl is present, outside any dialog role", async () => {
+  it("desktop: renders the meeting title once an anchorEl is present, inside a named dialog", async () => {
     renderViewMeeting({ ...baseProps, anchorEl: makeAnchorEl(), isPhone: false });
     expect(await screen.findByText("Serenity Group")).toBeInTheDocument();
-    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    const dialog = screen.getByRole("dialog", { name: "Serenity Group" });
+    expect(dialog).toHaveAttribute("aria-modal", "true");
+  });
+
+  describe("desktop dismissal", () => {
+    const openPopup = async () => {
+      const anchorEl = makeAnchorEl();
+      const onBack = jest.fn();
+      renderViewMeeting({ ...baseProps, anchorEl, isPhone: false, onBack });
+      await screen.findByText("Serenity Group");
+      return { anchorEl, onBack };
+    };
+
+    it("closes on Escape", async () => {
+      const { onBack } = await openPopup();
+      fireEvent.keyDown(document, { key: "Escape" });
+      expect(onBack).toHaveBeenCalledTimes(1);
+    });
+
+    it("closes on an outside click, but not on a click on its own anchor", async () => {
+      const { anchorEl, onBack } = await openPopup();
+      fireEvent.mouseDown(anchorEl);
+      expect(onBack).not.toHaveBeenCalled();
+
+      fireEvent.mouseDown(document.body);
+      expect(onBack).toHaveBeenCalledTimes(1);
+    });
+
+    it("closes the kebab menu first on Escape, and the popup only on the second press", async () => {
+      const { onBack } = await openPopup();
+      fireEvent.click(screen.getByRole("button", { name: "Meeting options" }));
+      expect(screen.getByRole("button", { name: "Edit" })).toHaveFocus();
+
+      fireEvent.keyDown(document, { key: "Escape" });
+      expect(screen.queryByRole("button", { name: "Edit" })).not.toBeInTheDocument();
+      expect(onBack).not.toHaveBeenCalled();
+
+      fireEvent.keyDown(document, { key: "Escape" });
+      expect(onBack).toHaveBeenCalledTimes(1);
+    });
+
+    it("closes only the kebab menu when the click lands elsewhere inside the popup", async () => {
+      const { onBack } = await openPopup();
+      fireEvent.click(screen.getByRole("button", { name: "Meeting options" }));
+
+      fireEvent.mouseDown(screen.getByRole("heading", { level: 1, name: "Serenity Group" }));
+      expect(screen.queryByRole("button", { name: "Edit" })).not.toBeInTheDocument();
+      expect(onBack).not.toHaveBeenCalled();
+    });
+
+    it("does not close on a click inside a modal it opened", async () => {
+      const { onBack } = await openPopup();
+      fireEvent.click(screen.getByRole("button", { name: "Meeting options" }));
+      fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+
+      // The modal portals to document.body as a DOM *sibling* of this popup, so containment
+      // alone would misread a click on its buttons as an outside click.
+      const dialogs = screen.getAllByRole("dialog");
+      const modal = dialogs[dialogs.length - 1];
+      fireEvent.mouseDown(modal);
+      expect(onBack).not.toHaveBeenCalled();
+    });
   });
 
   it("mobile: renders inside a bottom sheet even with no anchorEl", async () => {


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Accessibility**
  * Improved keyboard focus indicators and focus management for dropdowns, menus, dialogs, and popups.
  * Added clearer dialog labeling for assistive technologies.

* **Bug Fixes**
  * Improved Escape-key and outside-click behavior across layered UI elements.
  * Prevented interactions inside nested popups and modals from closing the wrong layer.
  * Restored focus appropriately after closing menus and dialogs.

* **Tests**
  * Expanded coverage for dropdown interactions, keyboard navigation, focus handling, and meeting dialog dismissal behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description
Escape/outside-click behavior was inconsistent across the app's layered UI: the meeting detail popup ignored Escape entirely (and never received focus or dialog semantics), its kebab menu ignored Escape, an outside click dismissed both layers at once, and the custom Dropdown never closed on outside click or Escape at all — the only way out was picking an option.

- **`hooks/useDismissibleLayer.ts`** (new): shared dismissal behavior for non-dialog layers — Escape targeting only the topmost open layer, portal-aware outside-click (a click inside a nested portaled child doesn't read as outside), and focus-on-open/focus-return-on-close. Exposes the underlying `useLayerStack` so dialogs and non-dialog layers share one stack.
- **`hooks/useDialogBehavior.ts`**: its private dialog stack is deleted in favor of the shared layer stack, so Escape ordering is consistent across modals, popups, menus, and dropdowns (`DIALOG_FOCUSABLE_SELECTOR` re-exported unchanged; Modal/BottomSheet/MobileFullScreenSheet call sites untouched).
- **`ViewMeeting.tsx`**: two hand-rolled outside-click effects replaced by two `useDismissibleLayer` calls (popup + kebab as a layer above it). Popup gains `role="dialog"` + `aria-labelledby`; with the kebab open, the first Escape closes the menu and the second closes the popup. Deliberately not `aria-modal` — focus isn't trapped and the page behind stays interactive.
- **`ui/inputs/Dropdown.tsx` + `.module.scss`**: dropdown is now a dismissible layer — Escape and outside click close it, focus moves to the first option on open and returns to the trigger on close, and the trigger/options get brand-pink `:focus-visible` rings instead of flipping to the browser-default blue.

## Testing
- [x] New `tests/component/Dropdown.test.tsx` (7 tests): toggle, focus in/return, Escape, outside click, inside click stays open, select by click/Enter.
- [x] `tests/component/ViewMeeting.test.tsx`: old-behavior test asserting *no* dialog role updated to assert a named dialog; new `desktop dismissal` block covers Escape, outside-vs-anchor click, two-stage kebab Escape, kebab-only close on in-popup click, and no false-positive close on clicks inside portaled modals.
- [x] Searched remaining suites for assertions encoding the old behavior — none found.
- [x] Full `yarn test:all` green: lint 0 errors, stylelint, typecheck, unit 251/251, component 264/264, integration 134/134, e2e 115/115.

## Area(s) Touched
**Product areas**
- [ ] auth — sign-in, sessions, NextAuth, role-based access
- [ ] admin — /admin shell (Diagnostics, Users, Import, Export tabs)
- [ ] docs — /docs Resources page (rendering, navigation, search)
- [x] ui/ux — frontend layout/styling not tied to a specific integration

**Integrations**
- [ ] google-calendar — Google Calendar sync
- [ ] zoom-api — Zoom meeting/host sync

**Engineering**
- [ ] security — auth hardening, data exposure, dependency/security scanning
- [x] testing — test suite (Jest/Playwright) changes
- [ ] github-actions — workflows, Dependabot config, other .github/ CI tooling
- [ ] cleanup — refactor or dead-code removal, no behavior change
- [ ] documentation — docs/ or README changes only

## Pre-merge Checklist
- [x] Code follows current formatting conventions and passes lint (`yarn lint`).
- [x] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
- [x] All test suites pass, both run locally and green in GitHub CI. **Do not merge if any test suite is failing.**
- [x] A test suite was added or updated for the feature/fix in this PR. **Double-check this if you change a feature and did not update the test suites**.
- [x] Only files relevant to this change are committed — no stray or unrelated files.
- [x] If this branch has a merge conflict with master, master was merged into this branch first (not the other way around).
- [x] The rest of this PR description (Description, Testing) is filled out, not left as template placeholders.
