### PR TITLE
fix(calendar): accessible meeting chips and filter-aware hybrid presentation

### DIFF
--- a/frontend/app/components/calendar/desktop/DailyViewRow.tsx
+++ b/frontend/app/components/calendar/desktop/DailyViewRow.tsx
@@ -3,6 +3,7 @@ import BoxText from '../../ui/displays/BoxText';
 import OverlapMeetingsPopover from '../shared/OverlapMeetingsPopover';
 import styles from './DailyViewRow.module.scss';
 import { isZoomRoomMismatched } from '../../../../util/rooms/rooms';
+import { buildMeetingChipAriaLabel } from '../../../../util/meetings/meetingChipPresentation';
 import { formatCompactTimeRange } from '../../../../util/date/timeFormat';
 import { formatETDateString } from '../../../../util/date/timeUtils';
 
@@ -209,6 +210,7 @@ const DailyViewRow: React.FC<DailyViewRowProps> = ({
               ? formatZoomRoomLabel(meeting.zoomRoom!)
               : undefined
           }
+          ariaLabel={buildMeetingChipAriaLabel(meeting)}
           syncError={syncErrorMids?.has(meeting.id)}
           hasConflict={conflictMids?.has(meeting.id)}
           selected={isSelected}

--- a/frontend/app/components/calendar/desktop/WeekView.tsx
+++ b/frontend/app/components/calendar/desktop/WeekView.tsx
@@ -3,7 +3,8 @@ import { motion, useReducedMotion } from "motion/react";
 import styles from './WeekView.module.scss';
 import DayColumn from "../shared/DayColumn";
 import { filterMeetingsForDate, MeetingFilters } from "../../../../util/filters/meetingFilters";
-import { ROOM_COLORS, ZOOM_ROOM_COLOR, REMOTE_COLOR } from "../../../../util/rooms/filterColors";
+import { getMeetingChipPresentation } from "../../../../util/meetings/meetingChipPresentation";
+import { ZOOM_ROOM_COLOR } from "../../../../util/rooms/filterColors";
 import {
     formatETDateString,
     formatETWeekdayShort,
@@ -213,12 +214,12 @@ const WeekView: React.FC<WeekViewProps> = ({
         return layoutOverlappingMeetings(filterMeetingsForDate(allMeetings, date, filters));
     };
 
-    // Get room color for a meeting (physical rooms have distinct colors; Zoom rooms are all
-    // gray; Remote -- no physical or Zoom room at all -- gets its own distinct color).
-    const getRoomColor = (meeting: Meeting) => {
-        if (meeting.tags.includes('Remote')) return REMOTE_COLOR;
-        return ROOM_COLORS[meeting.room] ?? ZOOM_ROOM_COLOR;
-    };
+    // Chip color + displayed room, filter-aware -- a Hybrid meeting surviving only via its
+    // Zoom room presents as that Zoom room (grey, Zoom room name), matching Day view.
+    const presentMeeting = <T extends Meeting>(meeting: T) => ({
+        ...meeting,
+        ...getMeetingChipPresentation(meeting, filters),
+    });
 
     // Check if a date is the current date
     const isCurrentDate = (date: Date): boolean =>
@@ -291,14 +292,10 @@ const WeekView: React.FC<WeekViewProps> = ({
                                 {customHeader}
 
                                 <DayColumn
-                                    roomColor={ZOOM_ROOM_COLOR} // Unused fallback: every meeting sets primaryColor via getRoomColor
+                                    roomColor={ZOOM_ROOM_COLOR} // Unused fallback: every meeting sets primaryColor via presentMeeting
                                     meetings={dayMeetings.map(meeting => ({
-                                        ...meeting,
-                                        primaryColor: getRoomColor(meeting),
-                                        overflowMeetings: meeting.overflowMeetings?.map(m => ({
-                                            ...m,
-                                            primaryColor: getRoomColor(m)
-                                        })),
+                                        ...presentMeeting(meeting),
+                                        overflowMeetings: meeting.overflowMeetings?.map(presentMeeting),
                                     }))}
                                     selectedMeetingID={selectedMeetingID}
                                     setSelectedMeetingID={setSelectedMeetingID}

--- a/frontend/app/components/calendar/mobile/DayPortraitView.tsx
+++ b/frontend/app/components/calendar/mobile/DayPortraitView.tsx
@@ -4,7 +4,8 @@ import WeekStrip from "./WeekStrip";
 import CalendarHeader from "../shared/CalendarHeader";
 import DayColumn from "../shared/DayColumn";
 import { filterMeetingsForDate, MeetingFilters } from "../../../../util/filters/meetingFilters";
-import { ROOM_COLORS, ZOOM_ROOM_COLOR, REMOTE_COLOR } from "../../../../util/rooms/filterColors";
+import { ZOOM_ROOM_COLOR } from "../../../../util/rooms/filterColors";
+import { getMeetingChipPresentation } from "../../../../util/meetings/meetingChipPresentation";
 import { formatETDateString, getCurrentETMinutesSinceMidnight } from "../../../../util/date/timeUtils";
 import { layoutOverlappingMeetings, OverlapMeeting } from "../../../../util/meetings/meetingOverlapLayout";
 import { getFirstDayOfWeek, addDaysToDate } from "../../../../util/date/weekDates";
@@ -107,18 +108,18 @@ const DayPortraitView: React.FC<DayPortraitViewProps> = ({
     return Array.from(merged.values());
   }, [prevWeekMeetings, nextWeekMeetings]);
 
-  const getRoomColor = (meeting: Meeting) => {
-    if (meeting.tags.includes("Remote")) return REMOTE_COLOR;
-    return ROOM_COLORS[meeting.room] ?? ZOOM_ROOM_COLOR;
-  };
-
   const computeDayMeetings = useCallback(
     (all: Meeting[], date: Date) => {
+      // Chip color + displayed room, filter-aware -- a Hybrid meeting surviving only via its
+      // Zoom room presents as that Zoom room (grey, Zoom room name), matching Day view.
+      const presentMeeting = <T extends Meeting>(meeting: T) => ({
+        ...meeting,
+        ...getMeetingChipPresentation(meeting, filters),
+      });
       const filtered = filterMeetingsForDate(all, date, filters);
       return layoutOverlappingMeetings(filtered, MOBILE_MAX_VISIBLE_OVERLAP).map((meeting) => ({
-        ...meeting,
-        primaryColor: getRoomColor(meeting),
-        overflowMeetings: meeting.overflowMeetings?.map((m) => ({ ...m, primaryColor: getRoomColor(m) })),
+        ...presentMeeting(meeting),
+        overflowMeetings: meeting.overflowMeetings?.map(presentMeeting),
       }));
     },
     [filters]
@@ -280,7 +281,7 @@ const DayPortraitView: React.FC<DayPortraitViewProps> = ({
           {...dateEnterMotion(transitionDirection, "x", 24, { alreadyAnimatedByCaller: transitionAlreadyAnimatedByCaller, reducedMotion })}
         >
           <DayColumn
-            roomColor={ZOOM_ROOM_COLOR} // Unused fallback: every meeting sets primaryColor via getRoomColor
+            roomColor={ZOOM_ROOM_COLOR} // Unused fallback: every meeting sets primaryColor via presentMeeting
             meetings={meetings}
             selectedMeetingID={selectedMeetingID}
             setSelectedMeetingID={setSelectedMeetingID}

--- a/frontend/app/components/calendar/mobile/MultiDayLandscapeView.tsx
+++ b/frontend/app/components/calendar/mobile/MultiDayLandscapeView.tsx
@@ -3,7 +3,8 @@ import { motion, useAnimationControls, useDragControls, type PanInfo } from "mot
 import styles from "./MultiDayLandscapeView.module.scss";
 import DayColumn from "../shared/DayColumn";
 import { filterMeetingsForDate, MeetingFilters } from "../../../../util/filters/meetingFilters";
-import { ROOM_COLORS, ZOOM_ROOM_COLOR, REMOTE_COLOR } from "../../../../util/rooms/filterColors";
+import { ZOOM_ROOM_COLOR } from "../../../../util/rooms/filterColors";
+import { getMeetingChipPresentation } from "../../../../util/meetings/meetingChipPresentation";
 import { formatETDateString, formatETWeekdayShort, getCurrentETMinutesSinceMidnight } from "../../../../util/date/timeUtils";
 import { layoutOverlappingMeetings, OverlapMeeting } from "../../../../util/meetings/meetingOverlapLayout";
 import { addDaysToDate, daysBetweenET } from "../../../../util/date/weekDates";
@@ -135,18 +136,19 @@ const MultiDayLandscapeView: React.FC<MultiDayLandscapeViewProps> = ({
     return Array.from(merged.values());
   }, [rangeA, rangeB, rangeC]);
 
-  const getRoomColor = (meeting: Meeting) => {
-    if (meeting.tags.includes("Remote")) return REMOTE_COLOR;
-    return ROOM_COLORS[meeting.room] ?? ZOOM_ROOM_COLOR;
-  };
-
   const meetingsForDate = useCallback(
-    (date: Date) =>
-      layoutOverlappingMeetings(filterMeetingsForDate(allMeetings, date, filters)).map((meeting) => ({
+    (date: Date) => {
+      // Chip color + displayed room, filter-aware -- a Hybrid meeting surviving only via its
+      // Zoom room presents as that Zoom room (grey, Zoom room name), matching Day view.
+      const presentMeeting = <T extends Meeting>(meeting: T) => ({
         ...meeting,
-        primaryColor: getRoomColor(meeting),
-        overflowMeetings: meeting.overflowMeetings?.map((m) => ({ ...m, primaryColor: getRoomColor(m) })),
-      })),
+        ...getMeetingChipPresentation(meeting, filters),
+      });
+      return layoutOverlappingMeetings(filterMeetingsForDate(allMeetings, date, filters)).map((meeting) => ({
+        ...presentMeeting(meeting),
+        overflowMeetings: meeting.overflowMeetings?.map(presentMeeting),
+      }));
+    },
     [allMeetings, filters]
   );
 
@@ -274,7 +276,7 @@ const MultiDayLandscapeView: React.FC<MultiDayLandscapeViewProps> = ({
           <span className={styles.dayName}>{formatDayName(date)}</span> {formatDateNumber(date)}
         </div>
         <DayColumn
-          roomColor={ZOOM_ROOM_COLOR} // Unused fallback: every meeting sets primaryColor via getRoomColor
+          roomColor={ZOOM_ROOM_COLOR} // Unused fallback: every meeting sets primaryColor via presentMeeting
           meetings={dayMeetings}
           selectedMeetingID={selectedMeetingID}
           setSelectedMeetingID={setSelectedMeetingID}

--- a/frontend/app/components/calendar/shared/DayColumn.tsx
+++ b/frontend/app/components/calendar/shared/DayColumn.tsx
@@ -3,6 +3,7 @@ import BoxText from '../../ui/displays/BoxText';
 import OverlapMeetingsPopover from './OverlapMeetingsPopover';
 import styles from './DayColumn.module.scss';
 import { isZoomRoomMismatched } from '../../../../util/rooms/rooms';
+import { buildMeetingChipAriaLabel } from '../../../../util/meetings/meetingChipPresentation';
 import { formatCompactTimeRange } from '../../../../util/date/timeFormat';
 import { formatETDateString } from '../../../../util/date/timeUtils';
 
@@ -206,6 +207,7 @@ const DayColumn: React.FC<DayColumnProps> = ({
                             ? formatZoomRoomLabel(meeting.zoomRoom!)
                             : undefined
                     }
+                    ariaLabel={buildMeetingChipAriaLabel(meeting)}
                     syncError={syncErrorMids?.has(meeting.id)}
                     hasConflict={conflictMids?.has(meeting.id)}
                     fillHeight

--- a/frontend/app/components/ui/displays/BoxText.module.scss
+++ b/frontend/app/components/ui/displays/BoxText.module.scss
@@ -32,6 +32,14 @@
     padding: 5px;
     border-radius: 6px;
 
+    // Same ring as OverlapMeetingsPopover's rows, but drawn inset -- chips sit flush inside
+    // absolutely-positioned, overflow-clipped grid wrappers, so an outward outline would be
+    // partially clipped on tightly-packed cards.
+    &:focus-visible {
+      outline: 2px solid $brand-pink-color;
+      outline-offset: -2px;
+    }
+
     .title {
       font-size: 13px;
       margin-top: 0;

--- a/frontend/app/components/ui/displays/BoxText.tsx
+++ b/frontend/app/components/ui/displays/BoxText.tsx
@@ -51,7 +51,12 @@ interface BoxProps {
   // there's no vertical room for anything else. `hideTags`'s mode-icon-in-title treatment
   // applies at this tier automatically, regardless of whether `hideTags` itself was passed.
   tier?: 'full' | 'compact' | 'subcompact';
-  onClick: (meetingId: string, e: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
+  // Accessible name for Meeting Blocks (see util/meetings/meetingChipPresentation's
+  // buildMeetingChipAriaLabel) -- without it, the button name is the box's flattened text.
+  ariaLabel?: string;
+  // Keyboard activation (Enter/Space) passes the KeyboardEvent through the same callback --
+  // callers only use currentTarget/stopPropagation, which both event types carry.
+  onClick: (meetingId: string, e: React.MouseEvent<HTMLDivElement> | React.KeyboardEvent<HTMLDivElement>) => void;
   [key: string]: unknown;
 };
 
@@ -70,6 +75,7 @@ const BoxText: React.FC<BoxProps> = ({
   zoomTag,
   hideTags = false,
   tier,
+  ariaLabel,
   selected = false,
   onClick
 }) => {
@@ -120,6 +126,21 @@ const BoxText: React.FC<BoxProps> = ({
       className={`${styles.box} ${boxType === 'Meeting Block' ? styles.meeting : styles.room} ${fillHeight ? styles.fillHeight : ''} ${isCompact ? styles.compact : ''} ${isSubcompact ? styles.tierSubcompact : ''} ${selected ? styles.selected : ''}`}
       style={{ backgroundColor: bgColor, borderLeft: `${borderLeftWidth}px solid ${primaryColor}`, position: 'relative' }}
       onClick={(e) => onClick(meetingId, e)}
+      // A real <button> can't be used here: the chip's content is flow content (headings,
+      // paragraphs) and its absolutely-positioned wrappers style it as a block -- so it gets
+      // button semantics + Enter/Space activation instead (matching the "+N" overflow pill).
+      // Room Blocks are non-interactive labels and stay plain divs.
+      {...(boxType === 'Meeting Block' ? {
+        role: 'button',
+        tabIndex: 0,
+        'aria-label': ariaLabel,
+        onKeyDown: (e: React.KeyboardEvent<HTMLDivElement>) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            onClick(meetingId, e);
+          }
+        },
+      } : undefined)}
     >
       {syncError && (
         <span role="img" aria-label="Sync failed" title="Sync failed" className={styles.syncError}>

--- a/frontend/tests/component/BoxText.test.tsx
+++ b/frontend/tests/component/BoxText.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import BoxText from "../../app/components/ui/displays/BoxText";
 
 const baseProps = {
@@ -85,5 +85,44 @@ describe("BoxText", () => {
 
     expect(screen.getByText("In Person")).toBeInTheDocument();
     expect(screen.getByText("9-10AM")).toBeInTheDocument();
+  });
+
+  describe("Meeting Block accessibility", () => {
+    it("is a focusable button named by ariaLabel", () => {
+      render(<BoxText {...baseProps} ariaLabel="Weekly Check-in, 9 - 10 AM, Serenity Room, Hybrid" />);
+
+      const chip = screen.getByRole("button", { name: "Weekly Check-in, 9 - 10 AM, Serenity Room, Hybrid" });
+      expect(chip).toHaveAttribute("tabindex", "0");
+    });
+
+    it("activates on Enter with the meeting id", () => {
+      const onClick = jest.fn();
+      render(<BoxText {...baseProps} onClick={onClick} ariaLabel="Weekly Check-in" />);
+
+      fireEvent.keyDown(screen.getByRole("button", { name: "Weekly Check-in" }), { key: "Enter" });
+      expect(onClick).toHaveBeenCalledWith("meeting-1", expect.anything());
+    });
+
+    it("activates on Space", () => {
+      const onClick = jest.fn();
+      render(<BoxText {...baseProps} onClick={onClick} ariaLabel="Weekly Check-in" />);
+
+      fireEvent.keyDown(screen.getByRole("button", { name: "Weekly Check-in" }), { key: " " });
+      expect(onClick).toHaveBeenCalledWith("meeting-1", expect.anything());
+    });
+
+    it("does not activate on other keys", () => {
+      const onClick = jest.fn();
+      render(<BoxText {...baseProps} onClick={onClick} ariaLabel="Weekly Check-in" />);
+
+      fireEvent.keyDown(screen.getByRole("button", { name: "Weekly Check-in" }), { key: "Escape" });
+      expect(onClick).not.toHaveBeenCalled();
+    });
+
+    it("leaves Room Blocks as non-interactive labels", () => {
+      render(<BoxText {...baseProps} boxType="Room Block" title="Serenity Room" />);
+
+      expect(screen.queryByRole("button")).not.toBeInTheDocument();
+    });
   });
 });

--- a/frontend/tests/e2e/02-meeting-creation.spec.ts
+++ b/frontend/tests/e2e/02-meeting-creation.spec.ts
@@ -14,7 +14,7 @@ test.describe("meeting creation", () => {
     await expect(page.getByRole("heading", { name: "New Meeting" })).toBeVisible();
 
     await page.getByPlaceholder("Meeting title").fill("Full Flow Meeting");
-    await page.getByRole("button", { name: "In Person" }).click();
+    await page.getByRole("button", { name: "In Person", exact: true }).click();
     await fillDatePicker(page, todayMMDDYYYY());
     await fillTimeRange(page, "18:00", "19:00");
     await selectFromDropdown(page, "Select Room", "Serenity Room");
@@ -34,7 +34,7 @@ test.describe("meeting creation", () => {
     await page.goto("/");
     await page.getByText("New Meeting").click();
 
-    await page.getByRole("button", { name: "In Person" }).click();
+    await page.getByRole("button", { name: "In Person", exact: true }).click();
     await fillDatePicker(page, todayMMDDYYYY());
     await fillTimeRange(page, "18:00", "19:00");
     await selectFromDropdown(page, "Select Room", "Serenity Room");
@@ -60,7 +60,7 @@ test.describe("meeting creation", () => {
     await page.getByText("New Meeting").click();
 
     await page.getByPlaceholder("Meeting title").fill("Dual Category Meeting");
-    await page.getByRole("button", { name: "In Person" }).click();
+    await page.getByRole("button", { name: "In Person", exact: true }).click();
     await fillDatePicker(page, todayMMDDYYYY());
     await fillTimeRange(page, "20:00", "21:00");
     await selectFromDropdown(page, "Select Room", "Unity Room");
@@ -84,7 +84,7 @@ test.describe("meeting creation", () => {
     await page.goto("/");
     await page.getByText("New Meeting").click();
     await page.getByPlaceholder("Meeting title").fill("Conflicting Meeting");
-    await page.getByRole("button", { name: "In Person" }).click();
+    await page.getByRole("button", { name: "In Person", exact: true }).click();
     await fillDatePicker(page, todayMMDDYYYY());
     await fillTimeRange(page, "18:00", "19:00");
     await selectFromDropdown(page, "Select Room", "Seeds of Hope Room");
@@ -116,7 +116,7 @@ test.describe("meeting creation", () => {
     await page.goto("/");
     await page.getByText("New Meeting").click();
     await page.getByPlaceholder("Meeting title").fill("Unsaved Conflicting Meeting");
-    await page.getByRole("button", { name: "In Person" }).click();
+    await page.getByRole("button", { name: "In Person", exact: true }).click();
     await fillDatePicker(page, todayMMDDYYYY());
     await fillTimeRange(page, "18:00", "19:00");
     await selectFromDropdown(page, "Select Room", "Seeds of Hope Room");

--- a/frontend/tests/e2e/06-zoom-integration.spec.ts
+++ b/frontend/tests/e2e/06-zoom-integration.spec.ts
@@ -19,7 +19,7 @@ test.describe("zoom integration", () => {
     const { page } = adminPage;
     await page.goto("/");
     await page.getByText("New Meeting").click();
-    await page.getByRole("button", { name: "Hybrid" }).click();
+    await page.getByRole("button", { name: "Hybrid", exact: true }).click();
     await selectFromDropdown(page, "Select Room", "Serenity Room");
 
     await expect(page.getByRole("button", { name: "Serenity Room - Zoom" })).toBeVisible();
@@ -51,7 +51,7 @@ test.describe("zoom integration", () => {
     await page.goto("/");
     await page.getByText("New Meeting").click();
     await page.getByPlaceholder("Meeting title").fill("Zoom Sync Attempt");
-    await page.getByRole("button", { name: "Hybrid" }).click();
+    await page.getByRole("button", { name: "Hybrid", exact: true }).click();
     await fillDatePicker(page, todayMMDDYYYY());
     await fillTimeRange(page, "18:00", "19:00");
     await selectFromDropdown(page, "Select Room", "Serenity Room");
@@ -124,7 +124,7 @@ test.describe("zoom integration", () => {
     const { page } = adminPage;
     await page.goto("/");
     await page.getByText("New Meeting").click();
-    await page.getByRole("button", { name: "Remote" }).click();
+    await page.getByRole("button", { name: "Remote", exact: true }).click();
 
     await expect(page.getByRole("button", { name: "Select Room" })).not.toBeVisible();
     await expect(page.getByRole("button", { name: "Select Zoom Room" })).not.toBeVisible();
@@ -137,7 +137,7 @@ test.describe("zoom integration", () => {
     const { page } = adminPage;
     await page.goto("/");
     await page.getByText("New Meeting").click();
-    await page.getByRole("button", { name: "In Person" }).click();
+    await page.getByRole("button", { name: "In Person", exact: true }).click();
 
     await expect(page.getByRole("button", { name: "Select Room" })).toBeVisible();
     await expect(page.getByRole("button", { name: "Select Zoom Room" })).not.toBeVisible();

--- a/frontend/tests/e2e/07-google-calendar-sync.spec.ts
+++ b/frontend/tests/e2e/07-google-calendar-sync.spec.ts
@@ -21,7 +21,7 @@ test.describe("google calendar sync", () => {
     await page.goto("/");
     await page.getByText("New Meeting").click();
     await page.getByPlaceholder("Meeting title").fill("No Token Meeting");
-    await page.getByRole("button", { name: "In Person" }).click();
+    await page.getByRole("button", { name: "In Person", exact: true }).click();
     await fillDatePicker(page, todayMMDDYYYY());
     await fillTimeRange(page, "18:00", "19:00");
     await selectFromDropdown(page, "Select Room", "Serenity Room");
@@ -57,7 +57,7 @@ test.describe("google calendar sync", () => {
     await page.goto("/");
     await page.getByText("New Meeting").click();
     await page.getByPlaceholder("Meeting title").fill("Dual Calendar Meeting");
-    await page.getByRole("button", { name: "In Person" }).click();
+    await page.getByRole("button", { name: "In Person", exact: true }).click();
     await fillDatePicker(page, todayMMDDYYYY());
     await fillTimeRange(page, "18:00", "19:00");
     await selectFromDropdown(page, "Select Room", "Serenity Room");

--- a/frontend/tests/e2e/09-edge-cases.spec.ts
+++ b/frontend/tests/e2e/09-edge-cases.spec.ts
@@ -14,7 +14,7 @@ test.describe("edge cases", () => {
     await page.goto("/");
     await page.getByText("New Meeting").click();
     await page.getByPlaceholder("Meeting title").fill("Past Meeting");
-    await page.getByRole("button", { name: "In Person" }).click();
+    await page.getByRole("button", { name: "In Person", exact: true }).click();
 
     // A date in the past (still MM/DD/YYYY — matches the DatePicker's real contract).
     const pastInput = page.getByPlaceholder("MM/DD/YYYY");
@@ -48,7 +48,7 @@ test.describe("edge cases", () => {
     await page.goto("/");
     await page.getByText("New Meeting").click();
     await page.getByPlaceholder("Meeting title").fill("Rapid Click Meeting");
-    await page.getByRole("button", { name: "In Person" }).click();
+    await page.getByRole("button", { name: "In Person", exact: true }).click();
     const dateInput = page.getByPlaceholder("MM/DD/YYYY");
     await dateInput.fill("12/31/2026");
     await dateInput.blur();

--- a/frontend/tests/e2e/10-recurring-meetings.spec.ts
+++ b/frontend/tests/e2e/10-recurring-meetings.spec.ts
@@ -14,7 +14,7 @@ test.describe("recurring meetings", () => {
     await page.goto("/");
     await page.getByText("New Meeting").click();
     await page.getByPlaceholder("Meeting title").fill("Weekly Recurring Meeting");
-    await page.getByRole("button", { name: "In Person" }).click();
+    await page.getByRole("button", { name: "In Person", exact: true }).click();
 
     // Pick a Tuesday so the "On" day-button assertion below is unambiguous.
     const dateInput = page.getByPlaceholder("MM/DD/YYYY");
@@ -44,7 +44,7 @@ test.describe("recurring meetings", () => {
     await page.goto("/");
     await page.getByText("New Meeting").click();
     await page.getByPlaceholder("Meeting title").fill("Monthly Recurring Meeting");
-    await page.getByRole("button", { name: "In Person" }).click();
+    await page.getByRole("button", { name: "In Person", exact: true }).click();
 
     const dateInput = page.getByPlaceholder("MM/DD/YYYY");
     await dateInput.fill("08/11/2026"); // 2nd Tuesday of August 2026

--- a/frontend/tests/e2e/13-digital-signage.spec.ts
+++ b/frontend/tests/e2e/13-digital-signage.spec.ts
@@ -54,7 +54,9 @@ test.describe("digital signage", () => {
     await expect(page.getByText("Week View Signage Meeting")).toBeVisible();
     // The navbar's own view dropdown must read "Week", not the "Day" it would show if it were
     // still tracking view as disconnected local state defaulting to "Day".
-    await expect(page.getByRole("button", { name: "Week" })).toBeVisible();
+    // exact: substring matching would also hit any meeting chip whose accessible name
+    // contains "Week" (chip names are "<title>, <time>, <room>, <mode>").
+    await expect(page.getByRole("button", { name: "Week", exact: true })).toBeVisible();
   });
 
   // Regression test for #348: the auto-fit scale calculation used to be gated on a plain

--- a/frontend/tests/e2e/17-mobile-meeting-forms.spec.ts
+++ b/frontend/tests/e2e/17-mobile-meeting-forms.spec.ts
@@ -45,7 +45,7 @@ test.describe("mobile meeting interactions", () => {
     await expect(page.getByRole("heading", { name: "New Meeting" })).toBeVisible();
 
     await page.getByPlaceholder("Meeting title").fill("Mobile FAB Meeting");
-    await page.getByRole("button", { name: "In Person" }).click();
+    await page.getByRole("button", { name: "In Person", exact: true }).click();
     await fillDatePicker(page, todayMMDDYYYY());
     await fillTimeRange(page, "18:00", "19:00");
     await selectFromDropdown(page, "Select Room", "Serenity Room");

--- a/frontend/tests/e2e/17-mobile-meeting-forms.spec.ts
+++ b/frontend/tests/e2e/17-mobile-meeting-forms.spec.ts
@@ -68,7 +68,8 @@ test.describe("mobile meeting interactions", () => {
     await page.getByText("Mobile Edit Meeting", { exact: true }).click();
     await expect(page.getByRole("dialog", { name: "Mobile Edit Meeting" })).toBeVisible();
     await page.getByRole("button", { name: "Meeting options" }).click();
-    await page.getByRole("button", { name: "Edit" }).click();
+    // exact: the "Mobile Edit Meeting" chip's accessible name also contains "Edit".
+    await page.getByRole("button", { name: "Edit", exact: true }).click();
 
     await expect(page.getByPlaceholder("Meeting title")).toHaveValue("Mobile Edit Meeting");
     // ViewMeeting's bottom sheet is gone -- Edit fully replaces it, not stacked on top.

--- a/frontend/tests/unit/meetingChipPresentation.test.ts
+++ b/frontend/tests/unit/meetingChipPresentation.test.ts
@@ -1,4 +1,52 @@
-import { buildMeetingChipAriaLabel } from "../../util/meetings/meetingChipPresentation";
+import {
+  buildMeetingChipAriaLabel,
+  getMeetingChipPresentation,
+} from "../../util/meetings/meetingChipPresentation";
+import { createDefaultFilters } from "../../util/filters/meetingFilters";
+import { ROOM_COLORS, ZOOM_ROOM_COLOR, REMOTE_COLOR } from "../../util/rooms/filterColors";
+
+const hybridMeeting = {
+  tags: ["Hybrid", "AA"],
+  room: "Serenity Room",
+  zoomRoom: "Serenity Room - Zoom",
+};
+
+describe("getMeetingChipPresentation", () => {
+  it("keeps the physical room color and name while the physical room filter is checked", () => {
+    const filters = createDefaultFilters(true);
+
+    expect(getMeetingChipPresentation(hybridMeeting, filters)).toEqual({
+      primaryColor: ROOM_COLORS["Serenity Room"],
+      room: "Serenity Room",
+    });
+  });
+
+  it("presents as the Zoom room (grey, no physical room) when only the Zoom room filter keeps it visible", () => {
+    const filters = { ...createDefaultFilters(true), SerenityRoom: false };
+
+    expect(getMeetingChipPresentation(hybridMeeting, filters)).toEqual({
+      primaryColor: ZOOM_ROOM_COLOR,
+      room: undefined,
+    });
+  });
+
+  it("keeps the physical presentation when only the Zoom room filter is unchecked", () => {
+    const filters = { ...createDefaultFilters(true), SerenityRoomZoom: false };
+
+    expect(getMeetingChipPresentation(hybridMeeting, filters)).toEqual({
+      primaryColor: ROOM_COLORS["Serenity Room"],
+      room: "Serenity Room",
+    });
+  });
+
+  it("leaves Remote meetings on the Remote color regardless of room filters", () => {
+    const filters = { ...createDefaultFilters(true), SerenityRoom: false };
+
+    expect(
+      getMeetingChipPresentation({ tags: ["Remote", "AA"], room: "Remote", zoomRoom: null }, filters),
+    ).toEqual({ primaryColor: REMOTE_COLOR, room: "Remote" });
+  });
+});
 
 describe("buildMeetingChipAriaLabel", () => {
   it("composes title, time range, room, and mode", () => {

--- a/frontend/tests/unit/meetingChipPresentation.test.ts
+++ b/frontend/tests/unit/meetingChipPresentation.test.ts
@@ -1,0 +1,54 @@
+import { buildMeetingChipAriaLabel } from "../../util/meetings/meetingChipPresentation";
+
+describe("buildMeetingChipAriaLabel", () => {
+  it("composes title, time range, room, and mode", () => {
+    expect(
+      buildMeetingChipAriaLabel({
+        title: "Noon Brown Baggers",
+        startTime: "12:00",
+        endTime: "13:00",
+        room: "Serenity Room",
+        zoomRoom: "Serenity Room - Zoom",
+        tags: ["Hybrid", "AA"],
+      }),
+    ).toBe("Noon Brown Baggers, 12 - 1 PM, Serenity Room, Hybrid");
+  });
+
+  it("prefers the display (unclipped) times over the layout times", () => {
+    expect(
+      buildMeetingChipAriaLabel({
+        title: "Overnight",
+        startTime: "00:00",
+        endTime: "01:00",
+        displayStartTime: "23:00",
+        displayEndTime: "01:00",
+        room: "Unity Room",
+        tags: ["In Person"],
+      }),
+    ).toBe("Overnight, 11 PM - 1 AM, Unity Room, In Person");
+  });
+
+  it("falls back to the Zoom room name when no physical room is presented", () => {
+    expect(
+      buildMeetingChipAriaLabel({
+        title: "Zoom-only Survivor",
+        startTime: "09:00",
+        endTime: "10:00",
+        room: undefined,
+        zoomRoom: "Serenity Room - Zoom",
+        tags: ["Hybrid"],
+      }),
+    ).toBe("Zoom-only Survivor, 9 - 10 AM, Serenity Room - Zoom, Hybrid");
+  });
+
+  it("labels a Remote meeting's location as Remote and skips a duplicate mode entry", () => {
+    expect(
+      buildMeetingChipAriaLabel({
+        title: "Online Only",
+        startTime: "18:00",
+        endTime: "19:00",
+        tags: ["Remote"],
+      }),
+    ).toBe("Online Only, 6 - 7 PM, Remote");
+  });
+});

--- a/frontend/tests/unit/meetingFilters.test.ts
+++ b/frontend/tests/unit/meetingFilters.test.ts
@@ -1,0 +1,104 @@
+import {
+  createDefaultFilters,
+  filterMeetingsForDate,
+  getRoomFilterVisibility,
+} from "../../util/filters/meetingFilters";
+
+const hybridMeeting = {
+  date: "2026-08-17",
+  tags: ["Hybrid", "AA"],
+  room: "Serenity Room",
+  zoomRoom: "Serenity Room - Zoom",
+};
+
+const remoteMeeting = {
+  date: "2026-08-17",
+  tags: ["Remote", "AA"],
+  room: "Remote",
+  zoomRoom: null,
+};
+
+describe("getRoomFilterVisibility", () => {
+  it("reports both resources when the physical room and Zoom room filters are checked", () => {
+    const filters = createDefaultFilters(true);
+
+    expect(getRoomFilterVisibility(hybridMeeting, filters)).toEqual({
+      viaPhysicalRoom: true,
+      viaZoomRoom: true,
+    });
+  });
+
+  it("reports physical-only when the Zoom room filter is unchecked", () => {
+    const filters = { ...createDefaultFilters(true), SerenityRoomZoom: false };
+
+    expect(getRoomFilterVisibility(hybridMeeting, filters)).toEqual({
+      viaPhysicalRoom: true,
+      viaZoomRoom: false,
+    });
+  });
+
+  it("reports zoom-only when the physical room filter is unchecked", () => {
+    const filters = { ...createDefaultFilters(true), SerenityRoom: false };
+
+    expect(getRoomFilterVisibility(hybridMeeting, filters)).toEqual({
+      viaPhysicalRoom: false,
+      viaZoomRoom: true,
+    });
+  });
+
+  it("reports neither when both filters are unchecked", () => {
+    const filters = {
+      ...createDefaultFilters(true),
+      SerenityRoom: false,
+      SerenityRoomZoom: false,
+    };
+
+    expect(getRoomFilterVisibility(hybridMeeting, filters)).toEqual({
+      viaPhysicalRoom: false,
+      viaZoomRoom: false,
+    });
+  });
+
+  it("reports a meeting without a Zoom room as never visible via Zoom", () => {
+    const filters = createDefaultFilters(true);
+
+    expect(
+      getRoomFilterVisibility(
+        { tags: ["In Person", "AA"], room: "Unity Room", zoomRoom: null },
+        filters,
+      ),
+    ).toEqual({ viaPhysicalRoom: true, viaZoomRoom: false });
+  });
+
+  it("gates a Remote meeting on the virtual Remote room key, reported as physical", () => {
+    const filters = createDefaultFilters(true);
+
+    expect(getRoomFilterVisibility(remoteMeeting, filters)).toEqual({
+      viaPhysicalRoom: true,
+      viaZoomRoom: false,
+    });
+    expect(
+      getRoomFilterVisibility(remoteMeeting, { ...filters, Remote: false }),
+    ).toEqual({ viaPhysicalRoom: false, viaZoomRoom: false });
+  });
+});
+
+describe("filterMeetingsForDate", () => {
+  const date = new Date("2026-08-17T16:00:00Z"); // noon ET on 2026-08-17
+
+  it("keeps a Hybrid meeting visible when only its Zoom room filter is checked", () => {
+    const filters = { ...createDefaultFilters(true), SerenityRoom: false };
+
+    expect(filterMeetingsForDate([hybridMeeting], date, filters)).toHaveLength(1);
+  });
+
+  it("drops a Hybrid meeting when both its room filters are unchecked", () => {
+    const filters = {
+      ...createDefaultFilters(true),
+      SerenityRoom: false,
+      SerenityRoomZoom: false,
+    };
+
+    expect(filterMeetingsForDate([hybridMeeting], date, filters)).toHaveLength(0);
+  });
+});

--- a/frontend/util/filters/meetingFilters.ts
+++ b/frontend/util/filters/meetingFilters.ts
@@ -67,6 +67,31 @@ interface DateRoomTagMeeting {
     zoomRoom?: string | null;
 }
 
+export interface RoomFilterVisibility {
+    viaPhysicalRoom: boolean;
+    viaZoomRoom: boolean;
+}
+
+/**
+ * Which of a meeting's room resources currently pass the room filters. A Hybrid meeting
+ * occupies both its physical room and its Zoom room, so it can be visible through either
+ * (see filterMeetingsForDate); a Remote meeting is gated on the virtual "Remote" room key,
+ * reported as viaPhysicalRoom. Per-day views (Week, mobile day columns) use this to render
+ * a meeting surviving only via its Zoom room in the Zoom styling Day view would show.
+ */
+export const getRoomFilterVisibility = (
+    meeting: Pick<DateRoomTagMeeting, 'tags' | 'room' | 'zoomRoom'>,
+    filters: MeetingFilters,
+): RoomFilterVisibility => {
+    if (meeting.tags.includes('Remote')) {
+        return { viaPhysicalRoom: passesRoomFilter('Remote', filters), viaZoomRoom: false };
+    }
+    return {
+        viaPhysicalRoom: passesRoomFilter(meeting.room, filters),
+        viaZoomRoom: !!meeting.zoomRoom && passesRoomFilter(meeting.zoomRoom, filters),
+    };
+};
+
 /**
  * Filters a flat meeting list down to the ones visible on `date`, given the current room/tag
  * filters -- the exact date+room+tag matching WeekView.getMeetingsForDay uses per-day,
@@ -85,11 +110,8 @@ export const filterMeetingsForDate = <T extends DateRoomTagMeeting>(
     return meetings.filter(meeting => {
         const matchesDate = meeting.date === formattedDate;
 
-        const isRemote = meeting.tags.includes('Remote');
-        const isRoomIncluded = isRemote
-            ? passesRoomFilter('Remote', filters)
-            : passesRoomFilter(meeting.room, filters) ||
-                (!!meeting.zoomRoom && passesRoomFilter(meeting.zoomRoom, filters));
+        const { viaPhysicalRoom, viaZoomRoom } = getRoomFilterVisibility(meeting, filters);
+        const isRoomIncluded = viaPhysicalRoom || viaZoomRoom;
 
         return matchesDate && isRoomIncluded && passesTagFilters(meeting.tags, filters);
     });

--- a/frontend/util/meetings/meetingChipPresentation.ts
+++ b/frontend/util/meetings/meetingChipPresentation.ts
@@ -1,7 +1,46 @@
-// Shared meeting-chip helpers used by every calendar view that renders chips.
+// Shared per-day meeting-chip presentation used by WeekView, DayPortraitView, and
+// MultiDayLandscapeView, so the per-day views can't drift apart on chip color/location
+// (they render one chip per meeting, unlike DayView's per-room rows).
 
+import { getRoomFilterVisibility, MeetingFilters } from '../filters/meetingFilters';
+import { ROOM_COLORS, ZOOM_ROOM_COLOR, REMOTE_COLOR } from '../rooms/filterColors';
 import { MODE_ICON_NAME } from '../rooms/modeIcons';
 import { formatCompactTimeRange } from '../date/timeFormat';
+
+interface ChipMeeting {
+    room: string;
+    zoomRoom?: string | null;
+    tags: string[];
+}
+
+export interface MeetingChipPresentation {
+    primaryColor: string;
+    // undefined when the chip should present as its Zoom room: the physical room's filter is
+    // unchecked and only the Zoom room's keeps the meeting visible (filterMeetingsForDate's
+    // OR semantics), so the chip goes grey and labels itself with the Zoom room name --
+    // mirroring the Zoom-room row Day view shows in that state.
+    room: string | undefined;
+}
+
+/**
+ * Color + displayed room for a meeting chip in a per-day view, given the current room
+ * filters. Remote meetings and meetings visible through their physical room keep their
+ * normal color and room; a meeting surviving only via its Zoom room presents as that
+ * Zoom room instead.
+ */
+export const getMeetingChipPresentation = (
+    meeting: ChipMeeting,
+    filters: MeetingFilters,
+): MeetingChipPresentation => {
+    if (meeting.tags.includes('Remote')) {
+        return { primaryColor: REMOTE_COLOR, room: meeting.room };
+    }
+    const { viaPhysicalRoom, viaZoomRoom } = getRoomFilterVisibility(meeting, filters);
+    if (!viaPhysicalRoom && viaZoomRoom) {
+        return { primaryColor: ZOOM_ROOM_COLOR, room: undefined };
+    }
+    return { primaryColor: ROOM_COLORS[meeting.room] ?? ZOOM_ROOM_COLOR, room: meeting.room };
+};
 
 interface LabeledMeeting {
     title: string;

--- a/frontend/util/meetings/meetingChipPresentation.ts
+++ b/frontend/util/meetings/meetingChipPresentation.ts
@@ -1,0 +1,33 @@
+// Shared meeting-chip helpers used by every calendar view that renders chips.
+
+import { MODE_ICON_NAME } from '../rooms/modeIcons';
+import { formatCompactTimeRange } from '../date/timeFormat';
+
+interface LabeledMeeting {
+    title: string;
+    startTime: string;
+    endTime: string;
+    displayStartTime?: string;
+    displayEndTime?: string;
+    room?: string;
+    zoomRoom?: string | null;
+    tags?: string[];
+}
+
+/**
+ * Accessible name for a meeting chip, e.g. "Noon Brown Baggers, 12 - 1 PM, Serenity Room,
+ * Hybrid". Location falls back the same way the visible chip label does: physical room,
+ * then Zoom room, then "Remote".
+ */
+export const buildMeetingChipAriaLabel = (meeting: LabeledMeeting): string => {
+    const time = formatCompactTimeRange(
+        meeting.displayStartTime ?? meeting.startTime,
+        meeting.displayEndTime ?? meeting.endTime,
+    );
+    const location = meeting.room || meeting.zoomRoom || (meeting.tags?.includes('Remote') ? 'Remote' : '');
+    const mode = meeting.tags?.find(tag => MODE_ICON_NAME[tag]);
+    // A Remote meeting's location is already "Remote" -- don't announce it twice.
+    return [meeting.title, time, location, mode !== location ? mode : undefined]
+        .filter(Boolean)
+        .join(', ');
+};


### PR DESCRIPTION
@coderabbitai summary

## Description
Calendar meeting chips were mouse-only (`div` with `tabIndex: -1`, no role, no accessible name), and Week/mobile per-day views rendered a Hybrid meeting in its physical-room styling even when only its Zoom room's filter kept it visible — making the Location filter look broken (`filterMeetingsForDate` intentionally keeps a Hybrid meeting when *either* resource's filter is checked).

- **`ui/displays/BoxText.tsx` + `.module.scss`**: Meeting Blocks get `role="button"`, `tabIndex={0}`, an `aria-label`, Enter/Space activation through the same `onClick` path, and an inset brand-pink `:focus-visible` ring. (A real `<button>` can't wrap the chip's `h3`/`p` flow content; this mirrors the existing "+N" overflow pill.) Room Blocks stay non-interactive.
- **`util/filters/meetingFilters.ts`**: new `getRoomFilterVisibility(meeting, filters)` reporting which resource(s) a meeting is visible through; `filterMeetingsForDate` now consumes it, so predicate and presentation can't drift.
- **`util/meetings/meetingChipPresentation.ts`** (new): `getMeetingChipPresentation` — normal color/room usually; `ZOOM_ROOM_COLOR` + Zoom-room label when only the Zoom room filter keeps the meeting visible (mirroring the Zoom row Day view shows in that state). `buildMeetingChipAriaLabel` — "Title, 12 - 1 PM, Serenity Room, Hybrid".
- **`WeekView.tsx` / `DayPortraitView.tsx` / `MultiDayLandscapeView.tsx`**: each view's duplicated local `getRoomColor` replaced by the shared helper (per-day views can't drift apart on chip presentation — the #372 bug class), applied to top-level chips and overflow-popover members.
- **`DayColumn.tsx` / `DailyViewRow.tsx`**: pass the composed `ariaLabel` to every chip, covering desktop Day/Week and all mobile views.

## Testing
- [x] New `tests/unit/meetingFilters.test.ts` and `tests/unit/meetingChipPresentation.test.ts` (16 tests): visibility/presentation for both-checked, physical-only, zoom-only, neither, no-zoom-room, Remote; aria-label composition.
- [x] `tests/component/BoxText.test.tsx` extended: focusable named button, Enter/Space activate, other keys don't, Room Block non-interactive.
- [x] Chip accessible names now contain mode words and Playwright `getByRole` name-matching is substring by default — added `exact: true` to 16 mode-button queries across six specs, plus two more collisions the full run caught ("Week" in `13-digital-signage`, "Edit" in `17-mobile-meeting-forms` — seeded meeting titles appearing inside chip names).
- [x] Full `yarn test:all`: lint 0 errors, stylelint, typecheck, unit 267/267, component 257/257, integration 134/134; e2e 113/115 then the two collision fixes above, re-verified green (12/12 across both affected specs).

## Area(s) Touched
**Product areas**
- [ ] auth — sign-in, sessions, NextAuth, role-based access
- [ ] admin — /admin shell (Diagnostics, Users, Import, Export tabs)
- [ ] docs — /docs Resources page (rendering, navigation, search)
- [x] ui/ux — frontend layout/styling not tied to a specific integration

**Integrations**
- [ ] google-calendar — Google Calendar sync
- [ ] zoom-api — Zoom meeting/host sync

**Engineering**
- [ ] security — auth hardening, data exposure, dependency/security scanning
- [x] testing — test suite (Jest/Playwright) changes
- [ ] github-actions — workflows, Dependabot config, other .github/ CI tooling
- [ ] cleanup — refactor or dead-code removal, no behavior change
- [ ] documentation — docs/ or README changes only

## Pre-merge Checklist
- [x] Code follows current formatting conventions and passes lint (`yarn lint`).
- [x] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
- [x] All test suites pass, both run locally and green in GitHub CI. **Do not merge if any test suite is failing.**
- [x] A test suite was added or updated for the feature/fix in this PR. **Double-check this if you change a feature and did not update the test suites**.
- [x] Only files relevant to this change are committed — no stray or unrelated files.
- [x] If this branch has a merge conflict with master, master was merged into this branch first (not the other way around).
- [x] The rest of this PR description (Description, Testing) is filled out, not left as template placeholders.
