### PR TITLE
fix(meeting-form): real form semantics, zero-length-time validation, and an unsaved-changes guard

### DIFF
--- a/frontend/app/components/meeting-form/DiscardChangesModal.module.scss
+++ b/frontend/app/components/meeting-form/DiscardChangesModal.module.scss
@@ -1,0 +1,101 @@
+@import '../../../styles/Variables.module';
+
+.modalOverlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgb(0 0 0 / 50%);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  // Same stacking reasoning as DeleteMeetingModal.module.scss's .modalOverlay -- this can be
+  // opened from inside ViewMeeting's own already-portaled .popupAnchor (z-index: 2000).
+  z-index: 2001;
+}
+
+.modalContent {
+  background-color: white;
+  border-radius: 8px;
+  width: 400px;
+  max-width: 90%;
+  padding: 24px;
+  font-family: "Source Sans Pro", sans-serif;
+  color: $black-color;
+  box-shadow: 0 4px 12px rgb(0 0 0 / 15%);
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 8px;
+}
+
+.iconCircle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background-color: $warning-bg-color;
+  color: $warning-text-color;
+  flex-shrink: 0;
+}
+
+.title {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 600;
+}
+
+// Aligned under the title text (36px icon circle + 12px header gap), matching this folder's
+// other confirm modals.
+.message {
+  margin: 0 0 24px;
+  padding-left: 48px;
+  font-size: 15px;
+  line-height: 1.5;
+  color: #444;
+}
+
+.buttonContainer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.cancelButton {
+  padding: 8px 16px;
+  border-radius: 6px;
+  border: 1.5px solid $light-grey-color;
+  background-color: white;
+  color: $black-color;
+  font-size: 14px;
+  font-weight: 600;
+  text-align: center;
+  cursor: pointer;
+
+  &:hover {
+    background-color: #F5F5F5;
+  }
+}
+
+.discardButton {
+  padding: 8px 16px;
+  border-radius: 6px;
+  border: none;
+  background-color: $danger-color;
+  color: $white-color;
+  font-size: 14px;
+  font-weight: 600;
+  text-align: center;
+  cursor: pointer;
+
+  &:hover {
+    background-color: #A32020;
+  }
+}

--- a/frontend/app/components/meeting-form/DiscardChangesModal.tsx
+++ b/frontend/app/components/meeting-form/DiscardChangesModal.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import Icon from '../ui/displays/Icon';
+import Modal from '../ui/overlays/Modal';
+import styles from './DiscardChangesModal.module.scss';
+
+interface DiscardChangesModalProps {
+  isOpen: boolean;
+  // What's being abandoned, e.g. "new meeting" / "edits to this meeting".
+  subject: string;
+  onKeepEditing: () => void;
+  onDiscard: () => void;
+}
+
+const DiscardChangesModal: React.FC<DiscardChangesModalProps> = ({
+  isOpen,
+  subject,
+  onKeepEditing,
+  onDiscard,
+}) => (
+  <Modal
+    isOpen={isOpen}
+    onClose={onKeepEditing}
+    overlayClassName={styles.modalOverlay}
+    contentClassName={styles.modalContent}
+    labelledBy="discard-changes-title"
+  >
+    <div className={styles.header}>
+      <span className={styles.iconCircle}>
+        <Icon name="warning-circle" size={20} />
+      </span>
+      <h2 id="discard-changes-title" className={styles.title}>Discard unsaved changes?</h2>
+    </div>
+
+    <p className={styles.message}>
+      Your {subject} hasn&apos;t been saved. Closing this panel discards it.
+    </p>
+
+    <div className={styles.buttonContainer}>
+      <button type="button" className={styles.cancelButton} onClick={onKeepEditing}>Keep editing</button>
+      <button type="button" className={styles.discardButton} onClick={onDiscard}>Discard</button>
+    </div>
+  </Modal>
+);
+
+export default DiscardChangesModal;

--- a/frontend/app/components/meeting-form/EditMeeting.tsx
+++ b/frontend/app/components/meeting-form/EditMeeting.tsx
@@ -248,6 +248,7 @@ const EditMeetingSidebar: React.FC<EditMeetingSidebarProps> =
           }
           emailTextField={<TextField
             input="Email"
+            type="email"
             label={<Icon name="mail" size={28} ariaLabel="Mail Icon" />}
             value={inputEmailValue}
             onChange={setEmailValue}

--- a/frontend/app/components/meeting-form/EditMeeting.tsx
+++ b/frontend/app/components/meeting-form/EditMeeting.tsx
@@ -11,6 +11,7 @@ import LabeledCheckbox from '../ui/inputs/CheckBox';
 import RecurringMeetingForm from './RecurringMeeting';
 import ZoomHostField from './ZoomHostField';
 import ConflictOverrideModal from './ConflictOverrideModal';
+import DiscardChangesModal from './DiscardChangesModal';
 import FormValidationBanner from './FormValidationBanner';
 import IconButton from '../ui/buttons/IconButton';
 
@@ -55,6 +56,9 @@ const EditMeetingSidebar: React.FC<EditMeetingSidebarProps> =
       liveValidationErrors,
       markFieldTouched,
       getFieldError,
+      timeRangeError,
+      isOvernight,
+      isDirty,
     } = useMeetingForm(meeting);
 
     const { showToast } = useToast();
@@ -65,6 +69,17 @@ const EditMeetingSidebar: React.FC<EditMeetingSidebarProps> =
     // Narrow Main Calendar sidebar gets ~80%-scaled field fonts; the "wide" embed (e.g.
     // Diagnostics Conflicts panel) has room to spare and keeps full size.
     const compact = layout === "sidebar";
+    const [isDiscardPromptOpen, setIsDiscardPromptOpen] = useState(false);
+
+    // Both user-driven close paths (Cancel, the X) go through here, so neither can silently
+    // drop in-progress edits.
+    const requestClose = () => {
+      if (isDirty) {
+        setIsDiscardPromptOpen(true);
+        return;
+      }
+      onClose();
+    };
 
     const submitMeeting = async (payload: IMeeting, confirmOverride: boolean) => {
       setIsSubmitting(true);
@@ -144,7 +159,7 @@ const EditMeetingSidebar: React.FC<EditMeetingSidebarProps> =
           <IconButton
             name="close"
             ariaLabel="Close"
-            onClick={onClose}
+            onClick={requestClose}
             className={styles.iconButton}
           />
         </div>
@@ -268,9 +283,21 @@ const EditMeetingSidebar: React.FC<EditMeetingSidebarProps> =
             compact={compact}
           />}
           handleMeetingSubmit={updateMeeting}
+          onCancel={requestClose}
           buttonText={isSubmitting ? "Updating…" : "Update Meeting"}
           isSubmitting={isSubmitting}
           layout={layout}
+          timeError={timeRangeError ?? undefined}
+          timeNote={isOvernight ? "Ends the next day." : undefined}
+        />
+        <DiscardChangesModal
+          isOpen={isDiscardPromptOpen}
+          subject="edits to this meeting"
+          onKeepEditing={() => setIsDiscardPromptOpen(false)}
+          onDiscard={() => {
+            setIsDiscardPromptOpen(false);
+            onClose();
+          }}
         />
         <ConflictOverrideModal
           isOpen={!!conflictState}

--- a/frontend/app/components/meeting-form/MeetingForm.module.scss
+++ b/frontend/app/components/meeting-form/MeetingForm.module.scss
@@ -67,6 +67,12 @@
   }
 }
 
+.formActions {
+  display: flex;
+  gap: 12px;
+  align-items: stretch;
+}
+
 .createMeetingButton {
   width: 100%;
   height: auto;
@@ -81,6 +87,43 @@
   padding: 10px 0;
   text-align: center;
   border-radius: 8px;
+}
+
+// Secondary pairing for .createMeetingButton, matching the outlined "Cancel" the confirm
+// modals in this folder use (DeleteMeetingModal.module.scss's .cancelButton).
+.cancelMeetingButton {
+  flex: 0 0 auto;
+  background-color: #fff;
+  color: $medium-grey-color;
+  border: 1px solid $grey-border-color;
+  font-family: 'Source Sans Pro', sans-serif;
+  font-weight: 600;
+  font-size: 18px;
+  line-height: 22.63px;
+  cursor: pointer;
+  padding: 10px 20px;
+  text-align: center;
+  border-radius: 8px;
+
+  &:hover:not(:disabled) {
+    background-color: #F7F7F7;
+  }
+}
+
+// Always in the flow, empty or not -- an error line that mounts and unmounts pushes every
+// control below it down and back up again.
+.fieldMessage {
+  display: block;
+  min-height: 18px;
+  margin-top: 4px;
+  font-family: 'Source Sans Pro', sans-serif;
+  font-size: 12px;
+  line-height: 18px;
+  color: $medium-grey-color;
+}
+
+.fieldMessageError {
+  color: $danger-color;
 }
 
 .meetingButtons {

--- a/frontend/app/components/meeting-form/MeetingForm.module.scss
+++ b/frontend/app/components/meeting-form/MeetingForm.module.scss
@@ -104,6 +104,18 @@
   flex-direction: column;
 }
 
+.requiredMark {
+  color: $danger-color;
+  margin-left: 2px;
+}
+
+.requiredLegend {
+  margin: 0 0 12px;
+  font-family: 'Source Sans Pro', sans-serif;
+  font-size: 11px;
+  color: $medium-grey-color;
+}
+
 /* Responsive adjustments */
 @media (width <= 768px) {
   .newMeetingSidebar {

--- a/frontend/app/components/meeting-form/MeetingForm.tsx
+++ b/frontend/app/components/meeting-form/MeetingForm.tsx
@@ -1,6 +1,6 @@
 // General component for EditMeeting and NewMeeting
 
-import React from 'react';
+import React, { useId } from 'react';
 import styles from "./MeetingForm.module.scss";
 
 export interface MeetingFormProps {
@@ -27,18 +27,47 @@ export interface MeetingFormProps {
   layout?: "sidebar" | "wide";
 }
 
+// Field slots receive their control as an element prop, so the <label> and the control it
+// names are assembled in different components -- this injects the id (plus the required
+// attributes) the label points at, rather than making every call site thread ids through.
+type InjectableProps = { id?: string; required?: boolean; "aria-required"?: boolean };
+function withFieldProps(element: React.ReactElement, props: InjectableProps): React.ReactElement {
+  return React.cloneElement(element as React.ReactElement<InjectableProps>, props);
+}
+
 // Wraps a field slot with an uppercase caption above it, in addition to that field's own
-// inline icon -- both together, matching the design mockup this form is based on.
-const Field: React.FC<{ caption?: string; className?: string; children: React.ReactNode }> = ({
-  caption,
-  className,
-  children,
-}) => (
-  <div className={className ?? styles.fieldSlot}>
-    {caption && <span className={styles.fieldCaption}>{caption}</span>}
-    {children}
-  </div>
-);
+// inline icon -- both together, matching the design mockup this form is based on. The caption
+// is the control's real <label> whenever the slot holds a single control (`htmlFor`); slots
+// holding several controls (the mode buttons, the category checkboxes) name themselves as a
+// group instead, since a <label> can only point at one control.
+const Field: React.FC<{
+  caption?: string;
+  htmlFor?: string;
+  required?: boolean;
+  asGroup?: boolean;
+  className?: string;
+  children: React.ReactNode;
+}> = ({ caption, htmlFor, required = false, asGroup = false, className, children }) => {
+  const captionId = useId();
+  const marker = required ? <span className={styles.requiredMark} aria-hidden="true">*</span> : null;
+
+  const captionNode = caption
+    ? htmlFor
+      ? <label className={styles.fieldCaption} htmlFor={htmlFor}>{caption}{marker}</label>
+      : <span className={styles.fieldCaption} id={asGroup ? captionId : undefined}>{caption}{marker}</span>
+    : null;
+
+  return (
+    <div
+      className={className ?? styles.fieldSlot}
+      role={asGroup ? "group" : undefined}
+      aria-labelledby={asGroup && caption ? captionId : undefined}
+    >
+      {captionNode}
+      {children}
+    </div>
+  );
+};
 
 export const MeetingForm: React.FC<MeetingFormProps> = ({
   meetingTitleTextField,
@@ -59,27 +88,62 @@ export const MeetingForm: React.FC<MeetingFormProps> = ({
   layout = "sidebar",
 }) => {
   const containerClassName = `${styles.newMeetingSidebar} ${layout === "wide" ? styles.wide : ""}`.trim();
+  const uid = useId();
+  const fieldId = (name: string) => `${uid}-${name}`;
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    void handleMeetingSubmit();
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLFormElement>) => {
+    if (event.key !== "Enter") return;
+    const target = event.target as HTMLElement;
+    // A textarea's Enter is a newline and never submits natively; an open Dropdown's Enter
+    // picks the focused option (see ui/inputs/Dropdown.tsx). Everything else keeps the
+    // browser's own implicit submission from a text field.
+    if (target.closest('[role="listbox"], [aria-expanded="true"]')) {
+      event.preventDefault();
+    }
+  };
 
   return (
-    <div className={containerClassName}>
-        <Field caption="Meeting name" className={`${styles.dummyComponent} ${styles.fieldFullWidth}`}>
-          {meetingTitleTextField}
+    // noValidate: this form's own validation (hooks/useMeetingForm.ts) owns rejection and
+    // messaging -- native constraint bubbles would pre-empt the validation banner while
+    // saying less about what's wrong. The `required` attributes stay for assistive tech.
+    <form className={containerClassName} onSubmit={handleSubmit} onKeyDown={handleKeyDown} noValidate>
+        <p className={`${styles.requiredLegend} ${styles.fieldFullWidth}`}>
+          <span className={styles.requiredMark} aria-hidden="true">*</span> Required
+        </p>
+        <Field
+          caption="Meeting name"
+          htmlFor={fieldId("title")}
+          required
+          className={`${styles.dummyComponent} ${styles.fieldFullWidth}`}
+        >
+          {withFieldProps(meetingTitleTextField, { id: fieldId("title"), required: true, "aria-required": true })}
         </Field>
-        <div className={`${styles.meetingButtons} ${styles.fieldFullWidth}`}>
-          <span className={styles.fieldCaption}>Mode</span>
+        <Field
+          caption="Mode"
+          asGroup
+          required
+          className={`${styles.meetingButtons} ${styles.fieldFullWidth}`}
+        >
           {modeTypeButtons}
-        </div>
+        </Field>
         {layout === "wide" ? (
           <div className={`${styles.dummyComponent} ${styles.fieldFullWidth} ${styles.dateTimeRow}`}>
-            <Field caption="Date">{DatePicker}</Field>
-            <Field caption="Time">{TimePicker}</Field>
+            <Field caption="Date" htmlFor={fieldId("date")} required>
+              {withFieldProps(DatePicker, { id: fieldId("date"), required: true, "aria-required": true })}
+            </Field>
+            <Field caption="Time" asGroup required>{TimePicker}</Field>
           </div>
         ) : (
           <>
-            <Field caption="Date" className={styles.dummyComponent}>
-              {DatePicker}
+            <Field caption="Date" htmlFor={fieldId("date")} required className={styles.dummyComponent}>
+              {withFieldProps(DatePicker, { id: fieldId("date"), required: true, "aria-required": true })}
             </Field>
-            <Field caption="Time" className={styles.dummyComponent}>
+            <Field caption="Time" asGroup required className={styles.dummyComponent}>
               {TimePicker}
             </Field>
           </>
@@ -87,31 +151,46 @@ export const MeetingForm: React.FC<MeetingFormProps> = ({
         <div className={`${styles.dummyComponent} ${styles.fieldFullWidth}`}>
           {RecurringMeeting}
         </div>
-        <Field caption="Categories" className={`${styles.dummyComponent} ${styles.fieldFullWidth}`}>
+        <Field caption="Categories" asGroup required className={`${styles.dummyComponent} ${styles.fieldFullWidth}`}>
           {meetingTypeDropdown}
         </Field>
         {(selectedMode === "Hybrid" || selectedMode === "In Person") && (
-        <Field caption="Room" className={styles.dummyComponent}>
+        <Field caption="Room" asGroup required className={styles.dummyComponent}>
           {roomSelectionDropdown}
         </Field>
         )}
         {selectedMode === "Hybrid" && (
-        <Field caption="Zoom room" className={styles.dummyComponent}>
+        <Field caption="Zoom room" asGroup required className={styles.dummyComponent}>
           {zoomRoomDropdown}
         </Field>
         )}
         {(selectedMode === "Hybrid" || selectedMode === "Remote") && (
-        <Field caption="Zoom host" className={styles.dummyComponent}>
+        <Field caption="Zoom host" asGroup className={styles.dummyComponent}>
           {zoomHostDropdown}
         </Field>
         )}
-        <Field caption="Email" className={`${styles.dummyComponent} ${styles.fieldFullWidth}`}>
-          {emailTextField}
+        <Field
+          caption="Group contact email"
+          htmlFor={fieldId("email")}
+          required
+          className={`${styles.dummyComponent} ${styles.fieldFullWidth}`}
+        >
+          {withFieldProps(emailTextField, { id: fieldId("email"), required: true, "aria-required": true })}
         </Field>
-        <Field caption="Description" className={`${styles.dummyComponent} ${styles.fieldFullWidth}`}>
-          {descriptionTextField}
+        <Field
+          caption="Description"
+          htmlFor={fieldId("description")}
+          className={`${styles.dummyComponent} ${styles.fieldFullWidth}`}
+        >
+          {withFieldProps(descriptionTextField, { id: fieldId("description") })}
         </Field>
-        <button className={`${styles.createMeetingButton} ${styles.fieldFullWidth}`} onClick={handleMeetingSubmit} disabled={isSubmitting}>{buttonText}</button>
-      </div>
+        <button
+          type="submit"
+          className={`${styles.createMeetingButton} ${styles.fieldFullWidth}`}
+          disabled={isSubmitting}
+        >
+          {buttonText}
+        </button>
+      </form>
   );
 };

--- a/frontend/app/components/meeting-form/MeetingForm.tsx
+++ b/frontend/app/components/meeting-form/MeetingForm.tsx
@@ -20,8 +20,16 @@ export interface MeetingFormProps {
   emailTextField: React.ReactElement;
   descriptionTextField: React.ReactElement;
   handleMeetingSubmit: () => Promise<void>;
+  // Discards the form -- the caller owns the unsaved-changes confirmation, since only it
+  // knows what closing the panel means in its host (sidebar, mobile sheet, inline card).
+  onCancel: () => void;
   buttonText: string
   isSubmitting?: boolean
+  // Cross-field start/end error, and the non-error note shown for an accepted overnight
+  // range. Rendered in one always-present line under the time row so that showing or
+  // clearing either can't shift every control below it.
+  timeError?: string;
+  timeNote?: string;
   // "wide" is a two-column layout for wider embedding contexts (e.g. an inline edit panel),
   // vs. the default single-column "sidebar" layout used in the Main Calendar sidebar.
   layout?: "sidebar" | "wide";
@@ -83,13 +91,27 @@ export const MeetingForm: React.FC<MeetingFormProps> = ({
   emailTextField,
   descriptionTextField,
   handleMeetingSubmit,
+  onCancel,
   buttonText,
   isSubmitting = false,
   layout = "sidebar",
+  timeError,
+  timeNote,
 }) => {
   const containerClassName = `${styles.newMeetingSidebar} ${layout === "wide" ? styles.wide : ""}`.trim();
   const uid = useId();
   const fieldId = (name: string) => `${uid}-${name}`;
+
+  // Always rendered (never conditionally mounted) so its height stays reserved whether or
+  // not there's currently something to say.
+  const timeMessage = (
+    <span
+      className={`${styles.fieldMessage} ${timeError ? styles.fieldMessageError : ""}`.trim()}
+      role={timeError ? "alert" : undefined}
+    >
+      {timeError ?? timeNote ?? " "}
+    </span>
+  );
 
   const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -101,8 +123,10 @@ export const MeetingForm: React.FC<MeetingFormProps> = ({
     const target = event.target as HTMLElement;
     // A textarea's Enter is a newline and never submits natively; an open Dropdown's Enter
     // picks the focused option (see ui/inputs/Dropdown.tsx). Everything else keeps the
-    // browser's own implicit submission from a text field.
-    if (target.closest('[role="listbox"], [aria-expanded="true"]')) {
+    // browser's own implicit submission from a text field. Deliberately not keyed off the
+    // trigger's aria-expanded: preventing default there would also swallow the Enter that
+    // closes the dropdown, and that trigger is a type="button" that can't submit anyway.
+    if (target.closest('[role="listbox"]')) {
       event.preventDefault();
     }
   };
@@ -136,7 +160,10 @@ export const MeetingForm: React.FC<MeetingFormProps> = ({
             <Field caption="Date" htmlFor={fieldId("date")} required>
               {withFieldProps(DatePicker, { id: fieldId("date"), required: true, "aria-required": true })}
             </Field>
-            <Field caption="Time" asGroup required>{TimePicker}</Field>
+            <Field caption="Time" asGroup required>
+              {TimePicker}
+              {timeMessage}
+            </Field>
           </div>
         ) : (
           <>
@@ -145,6 +172,7 @@ export const MeetingForm: React.FC<MeetingFormProps> = ({
             </Field>
             <Field caption="Time" asGroup required className={styles.dummyComponent}>
               {TimePicker}
+              {timeMessage}
             </Field>
           </>
         )}
@@ -184,13 +212,23 @@ export const MeetingForm: React.FC<MeetingFormProps> = ({
         >
           {withFieldProps(descriptionTextField, { id: fieldId("description") })}
         </Field>
-        <button
-          type="submit"
-          className={`${styles.createMeetingButton} ${styles.fieldFullWidth}`}
-          disabled={isSubmitting}
-        >
-          {buttonText}
-        </button>
+        <div className={`${styles.formActions} ${styles.fieldFullWidth}`}>
+          <button
+            type="button"
+            className={styles.cancelMeetingButton}
+            onClick={onCancel}
+            disabled={isSubmitting}
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            className={styles.createMeetingButton}
+            disabled={isSubmitting}
+          >
+            {buttonText}
+          </button>
+        </div>
       </form>
   );
 };

--- a/frontend/app/components/meeting-form/NewMeeting.tsx
+++ b/frontend/app/components/meeting-form/NewMeeting.tsx
@@ -11,6 +11,7 @@ import LabeledCheckbox from '../ui/inputs/CheckBox';
 import RecurringMeetingForm from './RecurringMeeting';
 import ZoomHostField from './ZoomHostField';
 import ConflictOverrideModal from './ConflictOverrideModal';
+import DiscardChangesModal from './DiscardChangesModal';
 import FormValidationBanner from './FormValidationBanner';
 import IconButton from '../ui/buttons/IconButton';
 
@@ -68,6 +69,9 @@ const NewMeetingSidebar = React.forwardRef<NewMeetingSidebarHandle, NewMeetingSi
       liveValidationErrors,
       markFieldTouched,
       getFieldError,
+      timeRangeError,
+      isOvernight,
+      isDirty,
     } = useMeetingForm(undefined, { selectedDate, selectedView });
 
     const { showToast } = useToast();
@@ -76,12 +80,24 @@ const NewMeetingSidebar = React.forwardRef<NewMeetingSidebarHandle, NewMeetingSi
     // the form, it just pauses submission until the modal's Cancel or "Save anyway".
     const [conflictState, setConflictState] = useState<{ payload: IMeeting; conflicts: ConflictListRow[] } | null>(null);
 
+    const [isDiscardPromptOpen, setIsDiscardPromptOpen] = useState(false);
+
     const handleCloseNewMeeting = () => {
       resetForm();
       setIsNewMeetingOpen(false);
     };
 
-    useImperativeHandle(ref, () => ({ requestClose: handleCloseNewMeeting }));
+    // Every close path the user can trigger (Cancel, the X, the mobile sheet's Escape) goes
+    // through here, so none of them can silently drop a half-filled form.
+    const requestCloseNewMeeting = () => {
+      if (isDirty) {
+        setIsDiscardPromptOpen(true);
+        return;
+      }
+      handleCloseNewMeeting();
+    };
+
+    useImperativeHandle(ref, () => ({ requestClose: requestCloseNewMeeting }));
 
     const submitMeeting = async (payload: IMeeting, confirmOverride: boolean) => {
       setIsSubmitting(true);
@@ -165,7 +181,7 @@ const NewMeetingSidebar = React.forwardRef<NewMeetingSidebarHandle, NewMeetingSi
           <IconButton
             name="close"
             ariaLabel="Close"
-            onClick={handleCloseNewMeeting}
+            onClick={requestCloseNewMeeting}
             className={styles.iconButton}
           />
         </div>
@@ -285,8 +301,20 @@ const NewMeetingSidebar = React.forwardRef<NewMeetingSidebarHandle, NewMeetingSi
             compact
           />}
           handleMeetingSubmit={createMeeting}
+          onCancel={requestCloseNewMeeting}
           buttonText={isSubmitting ? "Creating…" : "Create Meeting"}
           isSubmitting={isSubmitting}
+          timeError={timeRangeError ?? undefined}
+          timeNote={isOvernight ? "Ends the next day." : undefined}
+        />
+        <DiscardChangesModal
+          isOpen={isDiscardPromptOpen}
+          subject="new meeting"
+          onKeepEditing={() => setIsDiscardPromptOpen(false)}
+          onDiscard={() => {
+            setIsDiscardPromptOpen(false);
+            handleCloseNewMeeting();
+          }}
         />
         <ConflictOverrideModal
           isOpen={!!conflictState}

--- a/frontend/app/components/meeting-form/NewMeeting.tsx
+++ b/frontend/app/components/meeting-form/NewMeeting.tsx
@@ -265,6 +265,7 @@ const NewMeetingSidebar = React.forwardRef<NewMeetingSidebarHandle, NewMeetingSi
           }
           emailTextField={<TextField
             input="Email"
+            type="email"
             label={<Icon name="mail" size={28} ariaLabel="Mail Icon" />}
             value={inputEmailValue}
             onChange={setEmailValue}

--- a/frontend/app/components/ui/inputs/Dropdown.tsx
+++ b/frontend/app/components/ui/inputs/Dropdown.tsx
@@ -115,6 +115,9 @@ const Dropdown: React.FC<DropdownProps> = ({
           </label>
         )}
         <button
+          // Explicit: this trigger renders inside the meeting <form>, where a typeless
+          // button would default to submitting it.
+          type="button"
           className={`${styles.DropdownButton} ${isOpen ? styles.activeDropdown : ''}`}
           onClick={() => handleDropdownToggle("element")}
           aria-haspopup="listbox"

--- a/frontend/app/components/ui/inputs/ModeTypeButtons.tsx
+++ b/frontend/app/components/ui/inputs/ModeTypeButtons.tsx
@@ -16,7 +16,10 @@ const ModeButtons: React.FC<ModeButtonsProps> = ({ selectedMode, onModeSelect, c
 
   return (
     <div className={styles.meetingButtons}>
+      {/* Explicit type on all three: these render inside the meeting <form>, where a
+          typeless button would default to submitting it. */}
       <button
+        type="button"
         className={buttonClassName("Hybrid")}
         onClick={() => onModeSelect("Hybrid")}
       >
@@ -24,6 +27,7 @@ const ModeButtons: React.FC<ModeButtonsProps> = ({ selectedMode, onModeSelect, c
         Hybrid
       </button>
       <button
+        type="button"
         className={buttonClassName("In Person")}
         onClick={() => onModeSelect("In Person")}
       >
@@ -31,6 +35,7 @@ const ModeButtons: React.FC<ModeButtonsProps> = ({ selectedMode, onModeSelect, c
         In Person
       </button>
       <button
+        type="button"
         className={buttonClassName("Remote")}
         onClick={() => onModeSelect("Remote")}
       >

--- a/frontend/app/components/ui/inputs/TextField.module.scss
+++ b/frontend/app/components/ui/inputs/TextField.module.scss
@@ -36,10 +36,15 @@
     }
 }
 
+// Always in the flow, empty or not -- an error line that mounts and unmounts pushes every
+// control below it down and back up again.
 .textfieldErrorText {
+    display: block;
+    min-height: 18px;
     margin-top: 4px;
     font-family: 'Source Sans Pro', sans-serif;
     font-size: 12px;
+    line-height: 18px;
     color: $danger-color;
 }
 

--- a/frontend/app/components/ui/inputs/TextField.tsx
+++ b/frontend/app/components/ui/inputs/TextField.tsx
@@ -69,12 +69,16 @@ const TextField: React.FC<TextFieldProps> = ({
     <div className={styles.textfieldwrapper}>
       <div className={`${styles.textfieldcontainer} ${error ? styles.textfieldContainerError : ''}`}>
         {label && (
-          <label
+          // Decorative only: this is the field's inline icon, not its name -- the real
+          // <label> lives with the caller (e.g. MeetingForm's field caption), so exposing
+          // this too would append "Mail Icon" to the control's accessible name.
+          <span
             className={styles.textfieldlabel}
             style={{ fontSize: labelFontSize }}
+            aria-hidden="true"
           >
             {typeof label === "string" ? <span>{label}</span> : label}
-          </label>
+          </span>
         )}
         {multiline ? (
           <textarea

--- a/frontend/app/components/ui/inputs/TextField.tsx
+++ b/frontend/app/components/ui/inputs/TextField.tsx
@@ -107,7 +107,8 @@ const TextField: React.FC<TextFieldProps> = ({
           />
         )}
       </div>
-      {error && <span className={styles.textfieldErrorText}>{error}</span>}
+      {/* Rendered unconditionally so its height stays reserved -- see the class's own note. */}
+      <span className={styles.textfieldErrorText} role={error ? "alert" : undefined}>{error ?? ""}</span>
     </div>
   );
 };

--- a/frontend/app/components/ui/pickers/DatePicker.tsx
+++ b/frontend/app/components/ui/pickers/DatePicker.tsx
@@ -223,6 +223,15 @@ const DatePicker = ({ label, value: propValue = '', onChange, underlineOnFocus =
     }
   };
 
+  // This field only publishes what was typed on blur, so inside a <form> an Enter keypress
+  // would submit the stale committed date. Enter commits the typed text (and closes the
+  // calendar) instead of reaching the form's implicit submission.
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key !== 'Enter') return;
+    e.preventDefault();
+    handleBlur();
+  };
+
   const handleDateSelect = (date: Date) => {
   // date comes from MiniCalendar's underlying react-day-picker onSelect, which hands back a
   // local-midnight-anchored Date for whichever cell was clicked -- normalize via the same
@@ -241,9 +250,11 @@ const DatePicker = ({ label, value: propValue = '', onChange, underlineOnFocus =
 
   return (
     <div className={`${styles['date-picker-wrapper']} ${compact ? styles.compact : ''} ${isFocused && underlineOnFocus ? styles['underline'] : ''}`} ref={datePickerRef}>
-      <label className={styles['date-picker-label']}>
+      {/* Decorative only -- the field's real name comes from the caller's own <label> (see
+          TextField.tsx's inline icon for the same reasoning). */}
+      <span className={styles['date-picker-label']} aria-hidden="true">
         {typeof label === 'string' ? <span>{label}</span> : label}
-      </label>
+      </span>
       <div className={styles['date-picker-input-container']}>
         <input
           type="text"
@@ -251,6 +262,7 @@ const DatePicker = ({ label, value: propValue = '', onChange, underlineOnFocus =
           onChange={handleChange}
           onFocus={handleFocus}
           onBlur={handleBlur}
+          onKeyDown={handleKeyDown}
           placeholder="MM/DD/YYYY"
           className={styles['date-picker-input']}
           {...props}

--- a/frontend/app/components/ui/pickers/TimePicker.tsx
+++ b/frontend/app/components/ui/pickers/TimePicker.tsx
@@ -107,11 +107,14 @@ const TimePicker = ({ label, value: propValue = '', disablePast, onChange, compa
 
   return (
     <div className={`${styles['time-picker-wrapper']} ${compact ? styles.compact : ''}`}>
-      <label className={styles['time-picker-label']}>
+      {/* Decorative only -- a <label> can name one control, and this field is two (see
+          TextField.tsx's inline icon for the same reasoning). Each input names itself. */}
+      <span className={styles['time-picker-label']} aria-hidden="true">
         {typeof label === 'string' ? <span>{label}</span> : label}
-      </label>
+      </span>
       <input
         type="time"
+        aria-label="Start time"
         value={startTime}
         min={disablePast ? minTime : undefined}
         onChange={handleStartTimeChange}
@@ -122,6 +125,7 @@ const TimePicker = ({ label, value: propValue = '', disablePast, onChange, compa
       <span className={styles['time-range-separator']}> - </span>
       <input
         type="time"
+        aria-label="End time"
         value={endTime}
         onChange={handleEndTimeChange}
         onBlur={handleBlur}

--- a/frontend/hooks/useMeetingForm.ts
+++ b/frontend/hooks/useMeetingForm.ts
@@ -2,7 +2,12 @@ import { useCallback, useState } from 'react';
 import { IMeeting, IRecurrencePattern } from '../types/models';
 import { convertUTCToET, convertETToUTC, formatETDateString, getWeekDatesET, getCurrentETMinutesSinceMidnight, isConvertETToUTCValidationError, isDstGapError } from '../util/date/timeUtils';
 import { roomToZoomRoom } from '../util/rooms/rooms';
-import { DESCRIPTION_MAX_LENGTH, MAX_RECURRENCE_OCCURRENCES } from '../util/meetings/meetingValidation';
+import {
+    DESCRIPTION_MAX_LENGTH,
+    MAX_RECURRENCE_OCCURRENCES,
+    isOvernightTimeRange,
+    validateTimeRange,
+} from '../util/meetings/meetingValidation';
 
 // What the calendar is currently showing, used to seed a brand-new meeting's default
 // Date field -- see computeDefaultDate below.
@@ -161,6 +166,16 @@ function computeDefaultTime(): { time: string; rolledToNextDay: boolean } {
     };
 }
 
+// Comparable stringification of everything the form collects outside the recurrence
+// sub-form, for the unsaved-changes guard. calTypes is order-insensitive (the checkboxes
+// append in click order), so unchecking and rechecking a category isn't an "edit".
+function snapshotFields(values: {
+    title: string; mode: string; date: string; time: string; email: string;
+    description: string; room: string; calTypes: string[]; zoomRoom: string; zoomHost: string;
+}): string {
+    return JSON.stringify({ ...values, calTypes: [...values.calTypes].sort() });
+}
+
 export function useMeetingForm(initialMeeting?: IMeeting, defaultContext?: MeetingFormDefaultContext) {
     const [title, setTitle] = useState(initialMeeting?.title ?? "");
     const [mode, setMode] = useState<string>(initialMeeting?.modeType ?? "Hybrid");
@@ -211,6 +226,19 @@ export function useMeetingForm(initialMeeting?: IMeeting, defaultContext?: Meeti
         setTouchedFields((prev) => (prev.has(field) ? prev : new Set(prev).add(field)));
     }, []);
 
+    // Recurrence is tracked for dirtiness by comparing against RecurringMeeting.tsx's *first*
+    // report rather than against initialMeeting.recurrencePattern: that child rebuilds the
+    // pattern object from its own state on mount, so the rebuilt shape can differ from the
+    // stored one field-for-field while describing the same recurrence.
+    const [recurrenceBaseline, setRecurrenceBaseline] = useState<string | null>(null);
+    const [recurrenceSignature, setRecurrenceSignature] = useState<string | null>(null);
+    // Baseline for the unsaved-changes guard, seeded from the values the form opened with
+    // rather than re-derived from initialMeeting -- a brand-new form's computed date/time
+    // defaults count as untouched too.
+    const [fieldBaseline, setFieldBaseline] = useState(() =>
+        snapshotFields({ title, mode, date, time, email, description, room, calTypes, zoomRoom, zoomHost })
+    );
+
     // Must be stable: RecurringMeeting.tsx's effect depends on this callback, and an
     // unstable reference here caused an infinite render loop.
     const handleRecurringMeetingChange = useCallback((data: {
@@ -219,6 +247,9 @@ export function useMeetingForm(initialMeeting?: IMeeting, defaultContext?: Meeti
     }) => {
         setIsRecurring(data.isRecurring);
         setRecurrencePattern(data.recurrencePattern);
+        const signature = JSON.stringify(data);
+        setRecurrenceBaseline((previous) => previous ?? signature);
+        setRecurrenceSignature(signature);
     }, []);
 
     const handleRoomChange = (value: string) => {
@@ -243,21 +274,38 @@ export function useMeetingForm(initialMeeting?: IMeeting, defaultContext?: Meeti
     };
 
     const resetForm = () => {
-        setTitle("");
-        setMode("Hybrid");
         const resetTimeInfo = computeDefaultTime();
-        setDate(computeDefaultDate(defaultContext, resetTimeInfo.rolledToNextDay));
-        setTime(resetTimeInfo.time);
-        setEmail("");
-        setDescription("");
-        setRoom("");
-        setCalTypes([]);
-        setZoomRoom("");
-        setZoomHost("");
+        const resetValues = {
+            title: "",
+            mode: "Hybrid",
+            date: computeDefaultDate(defaultContext, resetTimeInfo.rolledToNextDay),
+            time: resetTimeInfo.time,
+            email: "",
+            description: "",
+            room: "",
+            calTypes: [] as string[],
+            zoomRoom: "",
+            zoomHost: "",
+        };
+        setTitle(resetValues.title);
+        setMode(resetValues.mode);
+        setDate(resetValues.date);
+        setTime(resetValues.time);
+        setEmail(resetValues.email);
+        setDescription(resetValues.description);
+        setRoom(resetValues.room);
+        setCalTypes(resetValues.calTypes);
+        setZoomRoom(resetValues.zoomRoom);
+        setZoomHost(resetValues.zoomHost);
         setIsRecurring(false);
         setRecurrencePattern(null);
         setSubmitAttempted(false);
         setTouchedFields(new Set());
+        // A reset form reads as untouched again -- rebaseline rather than leaving the values
+        // it opened with as the comparison point.
+        setFieldBaseline(snapshotFields(resetValues));
+        setRecurrenceBaseline(null);
+        setRecurrenceSignature(null);
     };
 
     const getValidationErrors = (): MeetingFormFieldError[] => {
@@ -278,6 +326,9 @@ export function useMeetingForm(initialMeeting?: IMeeting, defaultContext?: Meeti
             // throwing) on submit.
             const timeError = isoDateValue ? describeTimeValidationError(isoDateValue, startTime, endTime) : null;
             if (timeError) errors.push({ fields: ["date", "time"], message: timeError });
+
+            const rangeError = validateTimeRange(startTime, endTime);
+            if (rangeError) errors.push({ fields: ["time"], message: rangeError });
         }
 
         if (!email.trim()) {
@@ -380,6 +431,18 @@ export function useMeetingForm(initialMeeting?: IMeeting, defaultContext?: Meeti
     // mean listing every field it reads as a dependency array.
     const liveValidationErrors = submitAttempted ? getValidationErrors() : [];
 
+    const [currentStartTime, currentEndTime] = time?.split(' - ') || [];
+    // Not gated on touchedFields like getFieldError is: both times always hold a value (the
+    // form seeds defaults), so there's no "hasn't been reached yet" state to protect here.
+    const timeRangeError =
+        currentStartTime && currentEndTime ? validateTimeRange(currentStartTime, currentEndTime) : null;
+    const isOvernight =
+        !!currentStartTime && !!currentEndTime && isOvernightTimeRange(currentStartTime, currentEndTime);
+
+    const isDirty =
+        snapshotFields({ title, mode, date, time, email, description, room, calTypes, zoomRoom, zoomHost }) !== fieldBaseline ||
+        (recurrenceSignature !== null && recurrenceSignature !== recurrenceBaseline);
+
     // Independent of submitAttempted -- a field can show its own inline error the moment
     // it's been touched, even before any submit attempt (e.g. blurring an empty title on
     // the very first pass through the form).
@@ -410,6 +473,9 @@ export function useMeetingForm(initialMeeting?: IMeeting, defaultContext?: Meeti
         buildMeetingPayload,
         submitAttempted, setSubmitAttempted,
         liveValidationErrors,
+        timeRangeError,
+        isOvernight,
+        isDirty,
         markFieldTouched,
         getFieldError,
     };

--- a/frontend/tests/component/NewMeeting.test.tsx
+++ b/frontend/tests/component/NewMeeting.test.tsx
@@ -53,17 +53,23 @@ describe("NewMeetingSidebar", () => {
     expect(titleField.value).toBe("Serenity Group");
 
     // requestClose is invoked imperatively (not via a fireEvent user interaction, which RTL
-    // wraps in act() automatically), so it needs its own act() to flush resetForm()'s state
-    // updates before asserting on them.
+    // wraps in act() automatically), so it needs its own act() to flush the state updates
+    // before asserting on them.
     act(() => {
       ref.current?.requestClose();
     });
+
+    // Filled-in fields are unsaved changes, so closing asks first rather than discarding.
+    expect(screen.getByText("Discard unsaved changes?")).toBeInTheDocument();
+    expect(setIsNewMeetingOpen).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Discard" }));
 
     expect(titleField.value).toBe("");
     expect(setIsNewMeetingOpen).toHaveBeenCalledWith(false);
   });
 
-  it("Cancel/X and requestClose both route through the same reset behavior", async () => {
+  it("Cancel, the X, and requestClose all route through the same guarded close", async () => {
     const ref = React.createRef<NewMeetingSidebarHandle>();
     const setIsNewMeetingOpen = jest.fn();
     renderNewMeeting(ref, setIsNewMeetingOpen);
@@ -73,8 +79,57 @@ describe("NewMeetingSidebar", () => {
     fireEvent.change(titleField, { target: { value: "Serenity Group" } });
 
     fireEvent.click(screen.getByRole("button", { name: "Close" }));
+    expect(screen.getByText("Discard unsaved changes?")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Keep editing" }));
+    expect(titleField.value).toBe("Serenity Group");
+    expect(setIsNewMeetingOpen).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    fireEvent.click(screen.getByRole("button", { name: "Discard" }));
 
     expect(titleField.value).toBe("");
     expect(setIsNewMeetingOpen).toHaveBeenCalledWith(false);
+  });
+
+  it("closes straight away when nothing has been edited", async () => {
+    const ref = React.createRef<NewMeetingSidebarHandle>();
+    const setIsNewMeetingOpen = jest.fn();
+    renderNewMeeting(ref, setIsNewMeetingOpen);
+    await act(async () => {});
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(screen.queryByText("Discard unsaved changes?")).not.toBeInTheDocument();
+    expect(setIsNewMeetingOpen).toHaveBeenCalledWith(false);
+  });
+
+  it("names its fields with real labels", async () => {
+    const ref = React.createRef<NewMeetingSidebarHandle>();
+    renderNewMeeting(ref);
+    await act(async () => {});
+
+    expect(screen.getByLabelText(/^Meeting name/)).toBe(screen.getByPlaceholderText("Meeting title"));
+    expect(screen.getByLabelText(/^Group contact email/)).toHaveAttribute("type", "email");
+    expect(screen.getByLabelText(/^Date/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/^Description/)).toBeInTheDocument();
+  });
+
+  // An end time identical to the start would otherwise roll forward a day into a silent
+  // 24-hour meeting -- an end *earlier* than the start stays valid (that's overnight).
+  it("flags a start and end time that are the same, but not an overnight range", async () => {
+    const ref = React.createRef<NewMeetingSidebarHandle>();
+    renderNewMeeting(ref);
+    await act(async () => {});
+
+    const startTime = screen.getByLabelText("Start time");
+    const endTime = screen.getByLabelText("End time");
+
+    fireEvent.change(startTime, { target: { value: "18:00" } });
+    fireEvent.change(endTime, { target: { value: "18:00" } });
+    expect(screen.getByText(/End time must differ from the start time/)).toBeInTheDocument();
+
+    fireEvent.change(endTime, { target: { value: "01:00" } });
+    expect(screen.queryByText(/End time must differ from the start time/)).not.toBeInTheDocument();
+    expect(screen.getByText("Ends the next day.")).toBeInTheDocument();
   });
 });

--- a/frontend/tests/e2e/02-meeting-creation.spec.ts
+++ b/frontend/tests/e2e/02-meeting-creation.spec.ts
@@ -133,4 +133,52 @@ test.describe("meeting creation", () => {
     const created = await prisma.meeting.findFirst({ where: { title: "Unsaved Conflicting Meeting" } });
     expect(created).toBeNull();
   });
+
+  // An end time *earlier* than the start is a valid overnight meeting (buildMeetingPayload
+  // rolls the end onto the next day); an end identical to the start is the one case that
+  // silently becomes a 24-hour meeting, so it's the one the form rejects.
+  test("2.8 an end time identical to the start blocks submission, an overnight range doesn't", async ({ adminPage }) => {
+    const { page } = adminPage;
+    await page.goto("/");
+    await page.getByText("New Meeting").click();
+
+    await page.getByPlaceholder("Meeting title").fill("Zero Length Meeting");
+    await page.getByRole("button", { name: "In Person" }).click();
+    await fillDatePicker(page, todayMMDDYYYY());
+    await selectFromDropdown(page, "Select Room", "Serenity Room");
+    await toggleCalType(page, "AA");
+    await page.getByPlaceholder("Email").fill("zerolength@test.icr");
+
+    await fillTimeRange(page, "18:00", "18:00");
+    await expect(page.getByText(/End time must differ from the start time/)).toBeVisible();
+
+    await page.getByRole("button", { name: "Create Meeting" }).click();
+    await expect(page.getByText("Fix 1 field before saving")).toBeVisible();
+    await expect(page.getByRole("heading", { name: "New Meeting" })).toBeVisible();
+
+    // An overnight range clears the error and is accepted.
+    await fillTimeRange(page, "23:00", "01:00");
+    await expect(page.getByText(/End time must differ from the start time/)).toHaveCount(0);
+    await expect(page.getByText("Ends the next day.")).toBeVisible();
+
+    await page.getByRole("button", { name: "Create Meeting" }).click();
+    await expect(page.getByText("Meeting created successfully")).toBeVisible();
+  });
+
+  test("2.9 closing the form with unsaved changes asks before discarding", async ({ adminPage }) => {
+    const { page } = adminPage;
+    await page.goto("/");
+    await page.getByText("New Meeting").click();
+    await page.getByPlaceholder("Meeting title").fill("Half Filled Meeting");
+
+    await page.getByRole("button", { name: "Cancel" }).click();
+    await expect(page.getByText("Discard unsaved changes?")).toBeVisible();
+
+    await page.getByRole("button", { name: "Keep editing" }).click();
+    await expect(page.getByPlaceholder("Meeting title")).toHaveValue("Half Filled Meeting");
+
+    await page.getByRole("button", { name: "Cancel" }).click();
+    await page.getByRole("button", { name: "Discard" }).click();
+    await expect(page.getByRole("heading", { name: "New Meeting" })).toHaveCount(0);
+  });
 });

--- a/frontend/tests/e2e/support/formHelpers.ts
+++ b/frontend/tests/e2e/support/formHelpers.ts
@@ -11,12 +11,11 @@ export async function fillDatePicker(page: Page, mmddyyyy: string): Promise<void
   await input.blur();
 }
 
-// Fills the two native `<input type="time">` fields (start, end) — they have no
-// distinguishing attributes, so they're addressed by position.
+// Fills the two native `<input type="time">` fields, each named by its own aria-label
+// (a single <label> can't name both halves of the range).
 export async function fillTimeRange(page: Page, startHHMM: string, endHHMM: string): Promise<void> {
-  const timeInputs = page.locator('input[type="time"]');
-  await timeInputs.nth(0).fill(startHHMM);
-  await timeInputs.nth(1).fill(endHHMM);
+  await page.getByLabel("Start time").fill(startHHMM);
+  await page.getByLabel("End time").fill(endHHMM);
 }
 
 // Opens one of the ui/inputs/Dropdown.tsx menus by its placeholder button text

--- a/frontend/tests/unit/meetingTimeRange.test.ts
+++ b/frontend/tests/unit/meetingTimeRange.test.ts
@@ -1,0 +1,46 @@
+import {
+  SAME_START_AND_END_TIME_ERROR,
+  isOvernightTimeRange,
+  validateTimeRange,
+} from "../../util/meetings/meetingValidation";
+
+describe("validateTimeRange", () => {
+  it("accepts an ordinary same-day range", () => {
+    expect(validateTimeRange("18:00", "19:00")).toBeNull();
+  });
+
+  // The form collects one date plus two wall-clock times, and buildMeetingPayload rolls the
+  // end onto the next day when it lands earlier than the start -- that's how an overnight
+  // meeting is expressed, not a mistake to reject.
+  it("accepts an end earlier in the day as an overnight range", () => {
+    expect(validateTimeRange("23:00", "01:00")).toBeNull();
+    expect(validateTimeRange("23:30", "00:00")).toBeNull();
+  });
+
+  it("rejects an end identical to the start, which would silently become a 24-hour meeting", () => {
+    expect(validateTimeRange("18:00", "18:00")).toBe(SAME_START_AND_END_TIME_ERROR);
+    expect(validateTimeRange("00:00", "00:00")).toBe(SAME_START_AND_END_TIME_ERROR);
+  });
+
+  it("tolerates unpadded hours", () => {
+    expect(validateTimeRange("9:00", "09:00")).toBe(SAME_START_AND_END_TIME_ERROR);
+  });
+
+  // "Start and end time are required" already covers this case with a better message.
+  it("stays silent on unparseable input", () => {
+    expect(validateTimeRange("", "19:00")).toBeNull();
+    expect(validateTimeRange("18:00", "not-a-time")).toBeNull();
+  });
+});
+
+describe("isOvernightTimeRange", () => {
+  it("is true only when the end lands earlier in the day than the start", () => {
+    expect(isOvernightTimeRange("23:00", "01:00")).toBe(true);
+    expect(isOvernightTimeRange("18:00", "19:00")).toBe(false);
+    expect(isOvernightTimeRange("18:00", "18:00")).toBe(false);
+  });
+
+  it("is false for unparseable input", () => {
+    expect(isOvernightTimeRange("18:00", "")).toBe(false);
+  });
+});

--- a/frontend/util/meetings/meetingValidation.ts
+++ b/frontend/util/meetings/meetingValidation.ts
@@ -12,6 +12,48 @@ export const DESCRIPTION_MAX_LENGTH = 1024;
 // RecurringMeeting.tsx's SpinnerInput) so the UI can't submit a value this schema will reject.
 export const MAX_RECURRENCE_OCCURRENCES = 520;
 
+// INVARIANT: the meeting form collects one date plus a start and end wall-clock time, and an
+// end time earlier in the day than the start means the meeting runs past midnight onto the
+// next day -- hooks/useMeetingForm.ts's buildMeetingPayload rolls the end date forward for
+// exactly that case, and the calendar renders the result clipped per day (see
+// hooks/useWeekMeetings.ts). So end < start is valid input, not an error.
+//
+// An end *equal* to the start is the one unrepresentable case: the same roll-forward turns it
+// into a silent 24-hour meeting. There's no server-side backstop for it (by the time
+// meetingSchema sees the payload the end has already been rolled forward, so endDateTime >
+// startDateTime holds), which is why this rule is enforced on the form.
+export const SAME_START_AND_END_TIME_ERROR =
+  "End time must differ from the start time. To run past midnight, pick an end time earlier in the day.";
+
+const HH_MM = /^(\d{1,2}):(\d{2})$/;
+
+function toMinutes(time: string): number | null {
+  const match = time.match(HH_MM);
+  if (!match) return null;
+  const [, hours, minutes] = match;
+  return Number(hours) * 60 + Number(minutes);
+}
+
+/**
+ * Cross-field rule for the meeting form's start/end wall-clock times ("HH:MM" each).
+ * Returns null when the pair is acceptable — including an overnight pair — or when either
+ * value is unparseable, which the form's own "start and end time are required" rule covers.
+ */
+export function validateTimeRange(startTime: string, endTime: string): string | null {
+  const start = toMinutes(startTime);
+  const end = toMinutes(endTime);
+  if (start === null || end === null) return null;
+  return start === end ? SAME_START_AND_END_TIME_ERROR : null;
+}
+
+/** Whether an accepted start/end pair ("HH:MM") describes a meeting that runs past midnight. */
+export function isOvernightTimeRange(startTime: string, endTime: string): boolean {
+  const start = toMinutes(startTime);
+  const end = toMinutes(endTime);
+  if (start === null || end === null) return false;
+  return end < start;
+}
+
 // Shared by write/meeting and update/meeting — both expect the full IMeeting shape
 // (update is a full replace, not a partial patch). Validates shape/types, plus the business
 // rules hooks/useMeetingForm.ts's getValidationErrors enforces client-side (end > start, at


### PR DESCRIPTION
@coderabbitai summary

## Description
The meeting create/edit form was a div stack with no `<form>` element (Enter-to-submit did nothing), no `<label>` on any input, no cross-field time validation, no Cancel button, and silent discard of unsaved changes on close. Two commits, same surface:

**Commit 1 — form semantics** (`fix(meeting-form): give the meeting form real form and label semantics`)
- `MeetingForm.tsx`: real `<form onSubmit>` (`noValidate` — the hook's validation owns messaging); Enter submits from text fields but not inside textareas/open listboxes; each single-control slot's caption becomes a real `<label htmlFor>` (ids injected via `cloneElement`, so call sites don't thread them); multi-control slots (Mode, Categories, Room…) become `role="group"` + `aria-labelledby`; visible `*` required markers + legend and `required`/`aria-required` attributes.
- Email field: labeled "Group contact email", `type="email"`.
- `TextField`/`DatePicker`/`TimePicker`: decorative inline icons demoted to `aria-hidden` so they stop polluting accessible names; TimePicker inputs get "Start time"/"End time" labels; DatePicker's Enter commits the typed date instead of submitting a stale value.
- `Dropdown`/`ModeTypeButtons`: explicit `type="button"` — otherwise every typeless button inside the new form would submit it.

**Commit 2 — validation + reversibility** (`fix(meeting-form): reject a zero-length time range and confirm before discarding edits`)
- **Validation rule: `start === end` is rejected; `end < start` stays valid.** Overnight meetings are a supported feature — `buildMeetingPayload` rolls the end date forward when `end <= start` and the calendar renders overnight meetings clipped per day. The one unrepresentable input is an end *equal* to the start, which the roll-forward silently turned into a 24-hour meeting with no server backstop. New `validateTimeRange`/`isOvernightTimeRange` in `util/meetings/meetingValidation.ts` (with an INVARIANT comment); accepted overnight ranges show a non-error "Ends the next day." note.
- Error/note lines have reserved height (in `MeetingForm` and globally in `TextField`), so showing/clearing messages no longer shifts the form ~32px.
- Cancel button beside submit, and a `DiscardChangesModal` (built on the shared Modal primitive — no native dialogs) guards Cancel/✕/mobile-close when the form is dirty. Dirtiness compares against the opening snapshot: category order-insensitive, recurrence measured against the child's first report (it rebuilds the pattern object on mount).

## Testing
- [x] New `tests/unit/meetingTimeRange.test.ts` (7 cases): same-time rejected, overnight accepted, unpadded hours, unparseable input silent.
- [x] `tests/component/NewMeeting.test.tsx`: both existing tests encoded "closing resets immediately" — updated to route through the discard modal; added no-changes-closes-without-prompt, label/`type=email`, and same-time vs overnight messaging assertions.
- [x] New e2e 2.8 (same start/end blocked; overnight accepted and creatable) and 2.9 (Cancel with unsaved changes → Keep editing / Discard); `formHelpers.fillTimeRange` switched from positional `input[type=time]` to `getByLabel`.
- [x] Searched suites for old-behavior assertions: no test submitted an end-before-start range; the two reset-on-close tests above were the only ones encoding old behavior.
- [x] Full `yarn test:all` green: lint 0 errors, stylelint, typecheck, unit 258/258, component 255/255, integration 134/134, e2e 117/117.

## Area(s) Touched
**Product areas**
- [ ] auth — sign-in, sessions, NextAuth, role-based access
- [ ] admin — /admin shell (Diagnostics, Users, Import, Export tabs)
- [ ] docs — /docs Resources page (rendering, navigation, search)
- [x] ui/ux — frontend layout/styling not tied to a specific integration

**Integrations**
- [ ] google-calendar — Google Calendar sync
- [ ] zoom-api — Zoom meeting/host sync

**Engineering**
- [ ] security — auth hardening, data exposure, dependency/security scanning
- [x] testing — test suite (Jest/Playwright) changes
- [ ] github-actions — workflows, Dependabot config, other .github/ CI tooling
- [ ] cleanup — refactor or dead-code removal, no behavior change
- [ ] documentation — docs/ or README changes only

## Pre-merge Checklist
- [x] Code follows current formatting conventions and passes lint (`yarn lint`).
- [x] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
- [x] All test suites pass, both run locally and green in GitHub CI. **Do not merge if any test suite is failing.**
- [x] A test suite was added or updated for the feature/fix in this PR. **Double-check this if you change a feature and did not update the test suites**.
- [x] Only files relevant to this change are committed — no stray or unrelated files.
- [x] If this branch has a merge conflict with master, master was merged into this branch first (not the other way around).
- [x] The rest of this PR description (Description, Testing) is filled out, not left as template placeholders.
