### PR TITLE
feat(docs): add a copy button to Resources code blocks

### DIFF
--- a/frontend/app/components/docs/DocsArticle.tsx
+++ b/frontend/app/components/docs/DocsArticle.tsx
@@ -7,6 +7,7 @@ import type { DocEntry } from "../../../util/docs/loadDocs";
 import { useScrollNavHide } from "../../../hooks/useScrollNavHide";
 import { CheckIcon, ChevronDownIcon, CopyIcon, ExternalLinkIcon, TocToggleIcon } from "./DocsIcons";
 import TocList from "./DocsTocList";
+import { handleCodeCopyClick } from "../../../util/docs/codeCopy";
 import styles from "./DocsShell.module.scss";
 
 interface DocsArticleProps {
@@ -257,6 +258,9 @@ const DocsArticle: React.FC<DocsArticleProps> = ({ activeDoc }) => {
           ref={articleRef}
           className={styles.article}
           onScroll={handleArticleScroll}
+          // Delegated: the copy buttons live inside dangerouslySetInnerHTML content, so a
+          // per-button listener would be lost on every innerHTML re-assignment.
+          onClick={handleCodeCopyClick}
           dangerouslySetInnerHTML={articleHtml}
         />
 

--- a/frontend/app/components/docs/DocsShell.module.scss
+++ b/frontend/app/components/docs/DocsShell.module.scss
@@ -537,6 +537,65 @@
     }
   }
 
+  // parseMarkdown wraps every code block for the copy button; the wrapper takes over the pre's
+  // own bottom margin so spacing is unchanged. Button styling mirrors the Backups admin tab's
+  // commandCopyButton — both sit on the same dark code background.
+  :global(.codeBlock) {
+    position: relative;
+    margin: 0 0 20px;
+
+    :global(pre) {
+      margin: 0;
+
+      // The button floats over the code's top-right corner; without this an unwrapped first
+      // line can run underneath it.
+      padding-right: 44px;
+    }
+  }
+
+  :global(.codeCopyButton) {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    background: rgb(255 255 255 / 8%);
+    border: 1px solid rgb(255 255 255 / 20%);
+    border-radius: $radius-sm;
+    color: rgb(255 255 255 / 80%);
+    cursor: pointer;
+    padding: 4px 6px;
+
+    :global(.codeCopyIconCheck) {
+      display: none;
+    }
+
+    &:hover {
+      background: rgb(255 255 255 / 18%);
+      color: #fff;
+    }
+
+    &:focus-visible {
+      outline: 2px solid #fff;
+      outline-offset: 2px;
+    }
+
+    &[data-copied="true"] {
+      background: $success-text-color;
+      border-color: $success-text-color;
+      color: #fff;
+
+      :global(.codeCopyIconCopy) {
+        display: none;
+      }
+
+      :global(.codeCopyIconCheck) {
+        display: block;
+      }
+    }
+  }
+
   :global(table) {
     border-collapse: collapse;
     width: 100%;

--- a/frontend/config/jest.component.config.ts
+++ b/frontend/config/jest.component.config.ts
@@ -19,6 +19,11 @@ const config: Config = {
   },
   moduleNameMapper: {
     "^server-only$": "<rootDir>/tests/mocks/server-only.js",
+    // marked ships ESM-first (its exports map has no CJS entry) and jest doesn't transform
+    // node_modules, so importing it under jsdom hits a raw `export` token. The UMD build is
+    // the same code in require-able form — scoped mapping rather than a global
+    // transformIgnorePatterns carve-out.
+    "^marked$": "<rootDir>/node_modules/marked/lib/marked.umd.js",
     "\\.module\\.scss$": "identity-obj-proxy",
     "\\.css$": "identity-obj-proxy",
     "\\.(png|jpe?g|gif|svg)$": "<rootDir>/tests/mocks/fileMock.js",

--- a/frontend/config/jest.config.ts
+++ b/frontend/config/jest.config.ts
@@ -8,7 +8,12 @@ const config: Config = {
   rootDir: "..",
   testMatch: ["<rootDir>/tests/unit/**/*.test.ts"],
   transform: { "^.+\\.tsx?$": "@swc/jest" },
-  moduleNameMapper: { "^server-only$": "<rootDir>/tests/mocks/server-only.js" },
+  moduleNameMapper: {
+    "^server-only$": "<rootDir>/tests/mocks/server-only.js",
+    // Same mapping as jest.component.config.ts: marked is ESM-only and jest doesn't
+    // transform node_modules — the UMD build is the require-able form of the same code.
+    "^marked$": "<rootDir>/node_modules/marked/lib/marked.umd.js",
+  },
 };
 
 export default config;

--- a/frontend/tests/component/docsCodeCopy.test.tsx
+++ b/frontend/tests/component/docsCodeCopy.test.tsx
@@ -1,0 +1,89 @@
+import React from "react";
+import { render, screen, fireEvent, act, waitFor } from "@testing-library/react";
+import { parseMarkdown } from "../../util/docs/parseMarkdown";
+import { handleCodeCopyClick } from "../../util/docs/codeCopy";
+
+// Mirrors DocsArticle's real wiring: parseMarkdown's HTML via dangerouslySetInnerHTML with the
+// one delegated click handler on the container.
+const Article: React.FC<{ markdown: string }> = ({ markdown }) => (
+  <main
+    onClick={handleCodeCopyClick}
+    dangerouslySetInnerHTML={{ __html: parseMarkdown(markdown).html }}
+  />
+);
+
+const writeText = jest.fn();
+
+beforeEach(() => {
+  writeText.mockReset().mockResolvedValue(undefined);
+  // jsdom has no navigator.clipboard at all.
+  Object.defineProperty(navigator, "clipboard", {
+    value: { writeText },
+    configurable: true,
+  });
+});
+
+describe("docs code block copy button", () => {
+  it("copies the block's text and flips to the copied state", async () => {
+    render(<Article markdown={"```sh\nyarn test:all\n```"} />);
+    const button = screen.getByRole("button", { name: "Copy code block" });
+
+    fireEvent.click(button);
+
+    await waitFor(() => expect(button).toHaveAttribute("data-copied", "true"));
+    expect(writeText).toHaveBeenCalledWith("yarn test:all\n");
+    expect(button).toHaveAccessibleName("Copied");
+  });
+
+  it("reverts to the idle state after the reset delay", async () => {
+    jest.useFakeTimers();
+    try {
+      render(<Article markdown={"```\nx\n```"} />);
+      const button = screen.getByRole("button", { name: "Copy code block" });
+
+      // fireEvent + explicit flushes rather than userEvent: fake timers stall userEvent's
+      // internal waits.
+      fireEvent.click(button);
+      await act(async () => {});
+      expect(button).toHaveAttribute("data-copied", "true");
+
+      act(() => {
+        jest.advanceTimersByTime(2000);
+      });
+      expect(button).not.toHaveAttribute("data-copied");
+      expect(button).toHaveAccessibleName("Copy code block");
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it("copies only its own block when several are present", async () => {
+    render(<Article markdown={"```\nfirst\n```\n\n```\nsecond\n```"} />);
+    const buttons = screen.getAllByRole("button", { name: "Copy code block" });
+    expect(buttons).toHaveLength(2);
+
+    fireEvent.click(buttons[1]);
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith("second\n"));
+    expect(writeText).toHaveBeenCalledTimes(1);
+  });
+
+  it("stays un-flipped and points at manual selection when the clipboard write fails", async () => {
+    writeText.mockRejectedValue(new Error("denied"));
+    render(<Article markdown={"```\nx\n```"} />);
+    const button = screen.getByRole("button", { name: "Copy code block" });
+
+    fireEvent.click(button);
+
+    await waitFor(() =>
+      expect(button).toHaveAttribute("title", "Copy failed — select the text manually"),
+    );
+    expect(button).not.toHaveAttribute("data-copied");
+  });
+
+  it("ignores clicks elsewhere in the article", () => {
+    render(<Article markdown={"para\n\n```\nx\n```"} />);
+    fireEvent.click(screen.getByText("para"));
+    expect(writeText).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/tests/unit/parseMarkdown.test.ts
+++ b/frontend/tests/unit/parseMarkdown.test.ts
@@ -1,0 +1,34 @@
+import { parseMarkdown } from "../../util/docs/parseMarkdown";
+
+describe("parseMarkdown code blocks", () => {
+  it("wraps a fenced block in a codeBlock with a copy button ahead of the pre", () => {
+    const { html } = parseMarkdown("```sh\necho hello\n```");
+    expect(html).toContain('<div class="codeBlock">');
+    expect(html).toMatch(
+      /<button type="button" class="codeCopyButton" aria-label="Copy code block">[\s\S]*<\/button><pre>/,
+    );
+    expect(html).toContain("echo hello");
+  });
+
+  it("keeps marked's HTML escaping inside the wrapped block", () => {
+    const { html } = parseMarkdown("```\ncount < 1 && echo \"<done>\"\n```");
+    expect(html).toContain("count &lt; 1 &amp;&amp; echo &quot;&lt;done&gt;&quot;");
+    expect(html).not.toContain("<done>");
+  });
+
+  it("carries both state icons so the copy handler only flips an attribute", () => {
+    const { html } = parseMarkdown("```\nx\n```");
+    expect(html).toContain('class="codeCopyIconCopy"');
+    expect(html).toContain('class="codeCopyIconCheck"');
+  });
+
+  it("wraps every block, and leaves inline code and headings alone", () => {
+    const { html, toc } = parseMarkdown(
+      "## Setup\n\nRun `yarn dev` first.\n\n```\none\n```\n\ntext\n\n```\ntwo\n```",
+    );
+    expect(html.match(/class="codeBlock"/g)).toHaveLength(2);
+    expect(html).toContain("<code>yarn dev</code>");
+    expect(html).not.toMatch(/<code>yarn dev<\/code>[\s\S]*codeCopyButton[\s\S]*<code>yarn dev/);
+    expect(toc).toEqual([{ level: 2, text: "Setup", slug: "setup" }]);
+  });
+});

--- a/frontend/util/docs/codeCopy.ts
+++ b/frontend/util/docs/codeCopy.ts
@@ -1,0 +1,41 @@
+// Delegated click handler for the copy buttons parseMarkdown bakes into every docs code block.
+// One listener on the article root (see DocsArticle's <main onClick>) instead of one per button:
+// the article's content arrives via dangerouslySetInnerHTML, so per-node listeners would be
+// destroyed on every innerHTML re-assignment while delegation keeps working untouched.
+
+const COPIED_RESET_MS = 2000;
+
+const resetTimers = new WeakMap<HTMLElement, number>();
+
+export async function handleCodeCopyClick(event: { target: unknown }): Promise<void> {
+  const target = event.target as Element | null;
+  const button = target?.closest?.<HTMLElement>(".codeCopyButton");
+  if (!button) return;
+
+  const pre = button.closest(".codeBlock")?.querySelector("pre");
+  const text = pre?.textContent;
+  if (!text) return;
+
+  try {
+    await navigator.clipboard.writeText(text);
+  } catch {
+    // Clipboard can be denied/unavailable outside a secure context -- same fallback message as
+    // the Backups tab's copy button: leave the button un-flipped and point at manual selection.
+    button.title = "Copy failed — select the text manually";
+    return;
+  }
+
+  button.title = "";
+  button.dataset.copied = "true";
+  button.setAttribute("aria-label", "Copied");
+  const existing = resetTimers.get(button);
+  if (existing !== undefined) window.clearTimeout(existing);
+  resetTimers.set(
+    button,
+    window.setTimeout(() => {
+      delete button.dataset.copied;
+      button.setAttribute("aria-label", "Copy code block");
+      resetTimers.delete(button);
+    }, COPIED_RESET_MS),
+  );
+}

--- a/frontend/util/docs/parseMarkdown.ts
+++ b/frontend/util/docs/parseMarkdown.ts
@@ -66,10 +66,28 @@ function calloutIconSvg(kind: string): string {
 // natively).
 const CALLOUT_MARKER = /^\[!(NOTE|TIP|IMPORTANT|WARNING|CAUTION)\]\s*\n?/i;
 
+// ContentCopy / Check path data, same MUI-lift idiom as CALLOUT_ICON_PATHS above (Icon.tsx maps
+// "copy"/"check" to the same two icons). Both are always in the button's markup; which one shows
+// is CSS keyed off data-copied, so the copy handler (util/docs/codeCopy.ts) only flips one
+// attribute instead of rewriting SVG.
+const COPY_ICON_SVG =
+  '<svg class="codeCopyIconCopy" viewBox="0 0 24 24" width="14" height="14" fill="currentColor" aria-hidden="true"><path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2m0 16H8V7h11z"/></svg>';
+const CHECK_ICON_SVG =
+  '<svg class="codeCopyIconCheck" viewBox="0 0 24 24" width="14" height="14" fill="currentColor" aria-hidden="true"><path d="M9 16.17 4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"/></svg>';
+
 export function parseMarkdown(markdown: string): { html: string; toc: TocItem[] } {
   const toc: TocItem[] = [];
   const slugCounts = new Map<string, number>();
   const renderer = new Renderer();
+  // Wraps every fenced/indented code block with a copy button, mirroring the Backups admin
+  // tab's command box. The button ships inside the HTML string (not as a React child) because
+  // this article renders via dangerouslySetInnerHTML — DocsArticle owns the one delegated click
+  // handler (util/docs/codeCopy.ts), so the buttons survive innerHTML re-assignments with no
+  // re-decoration pass.
+  const baseCode = Renderer.prototype.code;
+  renderer.code = function (token: Tokens.Code) {
+    return `<div class="codeBlock"><button type="button" class="codeCopyButton" aria-label="Copy code block">${COPY_ICON_SVG}${CHECK_ICON_SVG}</button>${baseCode.call(this, token)}</div>\n`;
+  };
   renderer.blockquote = ({ text, tokens }: Tokens.Blockquote) => {
     const match = text.match(CALLOUT_MARKER);
     if (!match) {


### PR DESCRIPTION
@coderabbitai summary

## Description
Code blocks on the Resources pages had no copy affordance; the Backups admin tab's command box did. Every fenced/indented block in a docs article now gets the same top-right copy button — same translucent styling on the dark block, same copy → green check flip with a 2s revert, and the same "Copy failed — select the text manually" fallback when the clipboard API is unavailable.

- **`util/docs/parseMarkdown.ts`**: a `renderer.code` override wraps the default `<pre>` output in a `.codeBlock` with the button baked into the HTML string (raw inline SVGs, the same MUI-path-lift idiom the callout icons already use). The article renders via `dangerouslySetInnerHTML`, so a React child per block isn't possible — and buttons in the HTML survive innerHTML re-assignments with no re-decoration pass.
- **`util/docs/codeCopy.ts`** (new): the one delegated click handler — resolves the clicked button's own block, copies the `pre`'s text, flips `data-copied` + `aria-label`, reverts after 2s (re-click-safe via a per-button timer).
- **`app/components/docs/DocsArticle.tsx`**: attaches that handler to the article `<main>` (delegated because per-node listeners would be destroyed on every innerHTML re-assignment).
- **`DocsShell.module.scss`**: button styles mirroring `BackupsTab.module.scss`'s `commandCopyButton`; the wrapper takes over the pre's bottom margin so spacing is unchanged, and the pre gains right padding so long first lines don't run under the button.
- **`config/jest.config.ts` / `jest.component.config.ts`**: `marked` is ESM-only and Jest doesn't transform node_modules — importing `parseMarkdown` from a test hit a raw `export` token (the unit run even reported green while the new suite failed to load). Both configs now map `marked` to its UMD build, scoped to that one module rather than a global `transformIgnorePatterns` carve-out.

## Testing
- [x] New `tests/unit/parseMarkdown.test.ts` (4): wrapper + button placement, marked's HTML escaping preserved inside wrapped blocks, both state icons present, multi-block wrapping with inline code and headings untouched.
- [x] New `tests/component/docsCodeCopy.test.tsx` (5): copies the block's text and flips state, reverts after the 2s delay, copies only its own block among several, clipboard-failure path stays un-flipped with the manual-selection hint, clicks elsewhere are ignored.
- [x] Full `yarn test:all` green: lint 0 errors, stylelint, typecheck, unit 278/278, component 277/277, integration 134/134, e2e 117/117.

## Area(s) Touched
**Product areas**
- [ ] auth — sign-in, sessions, NextAuth, role-based access
- [ ] admin — /admin shell (Diagnostics, Users, Import, Export tabs)
- [x] docs — /docs Resources page (rendering, navigation, search)
- [x] ui/ux — frontend layout/styling not tied to a specific integration

**Integrations**
- [ ] google-calendar — Google Calendar sync
- [ ] zoom-api — Zoom meeting/host sync

**Engineering**
- [ ] security — auth hardening, data exposure, dependency/security scanning
- [x] testing — test suite (Jest/Playwright) changes
- [ ] github-actions — workflows, Dependabot config, other .github/ CI tooling
- [ ] cleanup — refactor or dead-code removal, no behavior change
- [ ] documentation — docs/ or README changes only

## Pre-merge Checklist
- [x] Code follows current formatting conventions and passes lint (`yarn lint`).
- [x] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
- [x] All test suites pass, both run locally and green in GitHub CI. **Do not merge if any test suite is failing.**
- [x] A test suite was added or updated for the feature/fix in this PR. **Double-check this if you change a feature and did not update the test suites**.
- [x] Only files relevant to this change are committed — no stray or unrelated files.
- [x] If this branch has a merge conflict with master, master was merged into this branch first (not the other way around).
- [x] The rest of this PR description (Description, Testing) is filled out, not left as template placeholders.
