### PR TITLE
fix(docs): read last-edited bylines from the GitHub API on shallow builds

### DIFF
--- a/docs/03-development/docs-site.md
+++ b/docs/03-development/docs-site.md
@@ -22,7 +22,13 @@ Key behaviors:
 - **Links between docs** are rewritten to `/docs/<slug>` URLs at build time, so ordinary relative
   markdown links work both on GitHub and in the app. `mailto:`/external links pass through.
 - **Images** live in `docs/01-user-guide/assets/` and are flat-copied to `public/docs-assets/`.
-- **"Last edited" bylines** come from git history, not frontmatter.
+- **"Last edited" bylines** come from git history, not frontmatter. On a full clone (local dev,
+  CI) that's `git log`; on a shallow clone (Vercel, where local git would report the truncated
+  history's boundary commit for every file) the generator queries the GitHub commits API instead,
+  optionally authenticated via `GITHUB_TOKEN`
+  (see [Environment Variables](environment-variables.md)). The API path is skipped on shallow
+  clones outside Vercel (e.g. CI's depth-1 checkouts, where no test reads bylines); there, and on
+  any lookup failure, the byline degrades to file mtime with no author.
 
 ## Adding, moving, or removing a doc
 

--- a/docs/03-development/environment-variables.md
+++ b/docs/03-development/environment-variables.md
@@ -90,3 +90,9 @@ These are deliberately separate credentials from the backup workflow's own GH Ac
 (`R2_ACCOUNT_ID`, `GCP_SERVICE_ACCOUNT`, etc. above) — the workflow's identities are create-only and
 never need to touch the app; the app's identities are read-only and never need write access to
 storage (the one exception, the GitHub PAT, needs write only to call `workflow_dispatch`).
+
+### Docs build (build-time, optional)
+
+| Variable | Purpose |
+|---|---|
+| `GITHUB_TOKEN` | Read-only GitHub token for the docs "Last edited" bylines on Vercel builds. The build clones shallowly, so `generate-docs-content.mjs` asks the GitHub commits API for each doc's last commit; unauthenticated calls work (public repo) but share GitHub's 60 req/hr per-IP limit with other tenants on the same builder IP. Missing or rate-limited → bylines degrade to build-time mtime with no author, never a failed build |

--- a/frontend/build-scripts/generate-docs-content.mjs
+++ b/frontend/build-scripts/generate-docs-content.mjs
@@ -198,24 +198,92 @@ function copyDocAssets() {
 // since it's just what actually happened. relPath is git-relative to repoRoot, not docsRoot,
 // since that's the working tree git was invoked in below.
 //
-// Falls back to the file's mtime (no author) when git has nothing: a doc that's been created or
-// edited but not yet committed -- true for most of this repo's docs/ during active work on
-// them -- has no history to read yet. Also falls back (with a console.warn) if the git binary
-// itself is unavailable or docsRoot isn't inside a git working tree, so a stripped-down build
-// environment degrades to "no byline" instead of failing the whole build.
-function lastEditInfo(relPath) {
+// On a shallow clone (Vercel's builder), local git is silently *wrong* rather than empty: the
+// truncated history's boundary commit appears to touch every file, so every doc would get the
+// deployed commit's author/date. Deep clone isn't the fix -- Vercel's clone step fails outright
+// on this repo's history ("There was a permanent problem cloning the repo") -- so shallow builds
+// ask the GitHub commits API for each doc's true last commit instead.
+function gitLastEditInfo(relPath) {
+  const output = execFileSync(
+    "git",
+    ["log", "-1", "--format=%aI%x09%an", "--", path.posix.join("docs", relPath)],
+    { cwd: repoRoot, encoding: "utf-8" }
+  ).trim();
+  if (!output) return null;
+  const [iso, author] = output.split("\t");
+  return { lastEdited: iso, editedBy: author };
+}
+
+const repoIsShallow = (() => {
   try {
-    const output = execFileSync(
-      "git",
-      ["log", "-1", "--format=%aI%x09%an", "--", path.posix.join("docs", relPath)],
-      { cwd: repoRoot, encoding: "utf-8" }
-    ).trim();
-    if (output) {
-      const [iso, author] = output.split("\t");
-      return { lastEdited: iso, editedBy: author };
+    return (
+      execFileSync("git", ["rev-parse", "--is-shallow-repository"], {
+        cwd: repoRoot,
+        encoding: "utf-8",
+      }).trim() === "true"
+    );
+  } catch {
+    return false;
+  }
+})();
+
+const GITHUB_OWNER = process.env.VERCEL_GIT_REPO_OWNER ?? "cornellh4i";
+const GITHUB_REPO = process.env.VERCEL_GIT_REPO_SLUG ?? "ithaca-recovery";
+// Pinned to the deployed commit so a build reflects exactly what it ships, not whatever master
+// moved to while the build ran.
+const GITHUB_REF = process.env.VERCEL_GIT_COMMIT_SHA ?? "master";
+
+async function githubLastEditInfo(relPath) {
+  const url = new URL(`https://api.github.com/repos/${GITHUB_OWNER}/${GITHUB_REPO}/commits`);
+  url.search = new URLSearchParams({
+    path: `docs/${relPath}`,
+    sha: GITHUB_REF,
+    per_page: "1",
+  }).toString();
+  const headers = {
+    Accept: "application/vnd.github+json",
+    // GitHub rejects requests without a User-Agent, and Node's fetch doesn't send one.
+    "User-Agent": `${GITHUB_REPO}-docs-build`,
+  };
+  // Optional: unauthenticated works (public repo) but shares a 60 req/hr per-IP limit across
+  // whoever else builds from the same Vercel builder IP; a token raises that to 5000/hr.
+  if (process.env.GITHUB_TOKEN) headers.Authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
+  // One retry: under the 8-wide fan-out a request occasionally dies to a transient socket reset,
+  // which would otherwise silently downgrade that one doc's byline to mtime for the whole deploy.
+  let lastError;
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      const res = await fetch(url, { headers });
+      if (!res.ok) throw new Error(`GitHub commits API returned ${res.status}`);
+      const author = (await res.json())[0]?.commit?.author;
+      return author ? { lastEdited: author.date, editedBy: author.name } : null;
+    } catch (err) {
+      lastError = err;
     }
+  }
+  throw lastError;
+}
+
+// Falls back to the file's mtime (no author) when neither source has anything: a doc that's been
+// created or edited but not yet committed -- common during active docs/ work -- has no history to
+// read yet. Also falls back (with a console.warn) on any git/API failure (git binary missing, not
+// a git working tree, GitHub rate limit or outage), so a degraded environment gets "no byline"
+// instead of a failed build.
+async function lastEditInfo(relPath) {
+  try {
+    // The API path is opt-in (Vercel, or a token) rather than automatic for every shallow clone:
+    // CI's depth-1 checkouts also run this script, and 39 unauthenticated calls per job from
+    // GitHub's shared runner IPs would just rate-limit noisily for bylines no test reads.
+    const info = repoIsShallow
+      ? process.env.VERCEL || process.env.GITHUB_TOKEN
+        ? await githubLastEditInfo(relPath)
+        : null
+      : gitLastEditInfo(relPath);
+    if (info) return info;
   } catch (err) {
-    console.warn(`generate-docs-content: git log failed for docs/${relPath}, falling back to mtime (${err.message})`);
+    console.warn(
+      `generate-docs-content: last-edit lookup failed for docs/${relPath}, falling back to mtime (${err.message})`
+    );
   }
   const mtime = fs.statSync(path.join(docsRoot, relPath)).mtime;
   return { lastEdited: mtime.toISOString(), editedBy: null };
@@ -231,18 +299,35 @@ function readingTimeMinutes(markdown) {
   return Math.max(1, Math.round(wordCount / WORDS_PER_MINUTE));
 }
 
+// Bounded fan-out for the per-doc GitHub API calls on shallow builds -- fully sequential adds
+// ~8s of fetch latency to every Vercel build, while unbounded parallelism trips GitHub's
+// secondary (abuse) rate limiting. Results keep MANIFEST order regardless of completion order.
+async function mapWithConcurrency(items, limit, fn) {
+  const results = new Array(items.length);
+  let next = 0;
+  await Promise.all(
+    Array.from({ length: Math.min(limit, items.length) }, async () => {
+      while (next < items.length) {
+        const i = next++;
+        results[i] = await fn(items[i]);
+      }
+    })
+  );
+  return results;
+}
+
 // Exported (not just written to outFile) so generate-pagefind-index.mjs can reuse this exact
 // array -- it needs the same slug/title/markdown data to build the search index, and importing
 // it here avoids that script re-reading docs/ itself or importing the generated *.ts* output
 // (plain node can't parse TypeScript module resolution the way webpack/tsc do).
-export const docs = MANIFEST.map(({ group, relPath }) => {
+export const docs = await mapWithConcurrency(MANIFEST, 8, async ({ group, relPath }) => {
   const raw = fs.readFileSync(path.join(docsRoot, relPath), "utf-8");
   const title = raw.match(TITLE_PATTERN)?.[1] ?? relPath;
   const slug = slugFromRelPath(relPath);
   const subgroup = subgroupFromRelPath(relPath);
   const currentDir = path.posix.dirname(relPath); // "." for a repo-root file
   const markdown = rewriteImageSrcs(rewriteInterPageLinks(raw, currentDir === "." ? "" : currentDir));
-  const { lastEdited, editedBy } = lastEditInfo(relPath);
+  const { lastEdited, editedBy } = await lastEditInfo(relPath);
   return { slug, title, group, subgroup, markdown, lastEdited, editedBy, readingTimeMinutes: readingTimeMinutes(markdown) };
 });
 


### PR DESCRIPTION
@coderabbitai summary

## Description
- **frontend/build-scripts/generate-docs-content.mjs**: on a shallow clone, `git log -1` reports the truncated history's boundary commit for every doc, so every byline showed the deployed commit's author/date. Shallow builds now query the GitHub commits API per doc (pinned to `VERCEL_GIT_COMMIT_SHA`), with one retry per request and an 8-wide concurrency cap to stay under GitHub's secondary rate limits. The API path is opt-in (`VERCEL` or `GITHUB_TOKEN` present) — CI's depth-1 checkouts skip straight to the existing mtime fallback instead of burning 39 unauthenticated calls per job. Any failure still degrades to mtime/"no byline" rather than failing the build. Deep clone was ruled out: Vercel's clone step fails outright on this repo's history.
- **docs/03-development/docs-site.md**, **docs/03-development/environment-variables.md**: document the new byline source chain and the optional `GITHUB_TOKEN` env var.

## Testing
- [ ] `cd frontend && node build-scripts/generate-docs-content.mjs` on a full clone — bylines still come from local `git log` (unchanged behavior).
- [ ] Simulate the Vercel path: in a shallow clone (`git clone --depth 1`), run the script with `VERCEL=1` (optionally `GITHUB_TOKEN` set) and confirm each doc's `lastEdited`/`editedBy` in the generated output matches that file's real last commit on GitHub, not the boundary commit.
- [ ] Same shallow clone without `VERCEL`/`GITHUB_TOKEN` (CI shape): script falls back to mtime with no API calls.

## Area(s) Touched
**Product areas**
- [ ] auth — sign-in, sessions, NextAuth, role-based access
- [ ] admin — /admin shell (Diagnostics, Users, Import, Export tabs)
- [X] docs — /docs Resources page (rendering, navigation, search)
- [ ] ui/ux — frontend layout/styling not tied to a specific integration

**Integrations**
- [ ] google-calendar — Google Calendar sync
- [ ] zoom-api — Zoom meeting/host sync

**Engineering**
- [ ] security — auth hardening, data exposure, dependency/security scanning
- [ ] testing — test suite (Jest/Playwright) changes
- [ ] github-actions — workflows, Dependabot config, other .github/ CI tooling
- [ ] cleanup — refactor or dead-code removal, no behavior change
- [ ] documentation — docs/ or README changes only

## Pre-merge Checklist
- [ ] Code follows current formatting conventions and passes lint (`yarn lint`).
- [ ] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
- [ ] All test suites pass, both run locally and green in GitHub CI. **Do not merge if any test suite is failing.**
- [ ] A test suite was added or updated for the feature/fix in this PR. **Double-check this if you change a feature and did not update the test suites**.
- [ ] Only files relevant to this change are committed — no stray or unrelated files.
- [ ] If this branch has a merge conflict with master, master was merged into this branch first (not the other way around).
- [ ] The rest of this PR description (Description, Testing) is filled out, not left as template placeholders.
