### PR TITLE
perf(conflicts): cache the ET formatter and dedupe occurrence expansion

### DIFF
--- a/frontend/util/date/timeUtils.ts
+++ b/frontend/util/date/timeUtils.ts
@@ -29,12 +29,17 @@ export const convertUTCToET = (utcDateString: string): string => {
 // ET wall-clock reading (year/month/day/hour/minute/second) of a UTC instant, as plain
 // numbers -- shared by convertETToUTC's offset search below. hour % 24 guards against ICU
 // builds that render midnight as "24" under hour12: false.
+// INVARIANT: the formatter is constructed once at module level, like every other formatter in
+// this file — constructing an Intl.DateTimeFormat per call loads ICU data each time (~0.1-1ms)
+// and this sits under every occurrence expansion (conflict scans, write-path checks), where it
+// runs tens of thousands of times per request at production meeting volume.
+const etPartsFmt = new Intl.DateTimeFormat('en-GB', {
+  timeZone: 'America/New_York',
+  year: 'numeric', month: '2-digit', day: '2-digit',
+  hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false,
+});
 const getETPartsAt = (ms: number) => {
-  const parts = new Intl.DateTimeFormat('en-GB', {
-    timeZone: 'America/New_York',
-    year: 'numeric', month: '2-digit', day: '2-digit',
-    hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false,
-  }).formatToParts(new Date(ms));
+  const parts = etPartsFmt.formatToParts(new Date(ms));
   const get = (type: Intl.DateTimeFormatPartTypes) =>
     parseInt(parts.find(p => p.type === type)?.value ?? '0');
   return {

--- a/frontend/util/meetings/resourceOverlap.ts
+++ b/frontend/util/meetings/resourceOverlap.ts
@@ -571,6 +571,19 @@ export function computeConflicts(
   const activeMeetings = meetings.filter((m) => !isDateSuspended(m.suspensions ?? [], todayStr));
   const conflicts: ConflictRow[] = [];
 
+  // A meeting occupies up to three resource fields (room, zoomRoom, zoomHost) and lands in one
+  // bucket per field — expanding its occurrences is the expensive part (a day-by-day walk over
+  // the whole horizon), so expand once per meeting per scan, not once per field.
+  const expansionCache = new Map<ConflictCandidateMeeting, Occurrence[]>();
+  const expandCached = (meeting: ConflictCandidateMeeting): Occurrence[] => {
+    let occurrences = expansionCache.get(meeting);
+    if (!occurrences) {
+      occurrences = expandOccurrences(meeting, rangeStart, rangeEnd);
+      expansionCache.set(meeting, occurrences);
+    }
+    return occurrences;
+  };
+
   const fieldMeetings: Record<"room" | "zoomRoom" | "zoomHost", ConflictCandidateMeeting[]> = {
     room: activeMeetings,
     zoomRoom: activeMeetings,
@@ -595,7 +608,7 @@ export function computeConflicts(
       const capacity = field === "zoomHost" ? (opts.zoomHostCapacities?.[value] ?? 1) : 1;
       const withOccurrences = bucketMeetings.map((meeting) => ({
         meeting,
-        occurrences: expandOccurrences(meeting, rangeStart, rangeEnd),
+        occurrences: expandCached(meeting),
       }));
 
       if (capacity <= 1) {


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Improved calendar processing efficiency when expanding recurring meetings.
  * Reduced unnecessary date and time calculations during conflict detection.
  * Preserved existing meeting scheduling and conflict-detection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description
- **frontend/util/date/timeUtils.ts**: `getETPartsAt` constructed a new `Intl.DateTimeFormat` on every call — ~31µs vs ~2.2µs cached (14×) — and it runs 2+ times per ET↔UTC conversion under every occurrence expansion (Diagnostics conflict scan, write-path conflict checks, Zoom host pool ranking). Hoisted to module level like every other formatter in the file, with an INVARIANT comment.
- **frontend/util/meetings/resourceOverlap.ts**: `computeConflicts` re-expanded each meeting's occurrences once per resource field (room, Zoom room, Zoom host — 3× for a Hybrid meeting). Now expands once per scan via a per-call cache.

At production volume (35 recurring series, several 6–7 days/week), the Diagnostics Conflicts endpoint exceeded Vercel's 10s limit and meeting writes took 3–7s. Benchmark on the real production series shapes (3-run average): `computeConflicts` full scan **2,088ms → 232ms (9×)**. No behavior change — pure constant-factor.

## Testing
- [x] Full `yarn test:all` green: lint 0 errors, lint:css, typecheck, unit 278/278, component 279/279, integration 134/134, e2e 117/117 — includes the DST brute-force suite (26k conversions), which pins `getETPartsAt`'s behavior.
- [x] Microbenchmark: per-call formatter construction 31.0µs vs cached 2.2µs; `computeConflicts` over the 34 live production series 2,088ms (master) vs 232ms (branch).
- [ ] Post-deploy: Admin → Diagnostics Conflicts card renders without timeout; meeting create/update returns in <1s.

## Area(s) Touched
**Product areas**
- [ ] auth — sign-in, sessions, NextAuth, role-based access
- [X] admin — /admin shell (Diagnostics, Users, Import, Export tabs)
- [ ] docs — /docs Resources page (rendering, navigation, search)
- [ ] ui/ux — frontend layout/styling not tied to a specific integration

**Integrations**
- [X] google-calendar — Google Calendar sync
- [X] zoom-api — Zoom meeting/host sync

**Engineering**
- [ ] security — auth hardening, data exposure, dependency/security scanning
- [ ] testing — test suite (Jest/Playwright) changes
- [ ] github-actions — workflows, Dependabot config, other .github/ CI tooling
- [ ] cleanup — refactor or dead-code removal, no behavior change
- [ ] documentation — docs/ or README changes only

## Pre-merge Checklist
- [X] Code follows current formatting conventions and passes lint (`yarn lint`).
- [X] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
- [X] All test suites pass, both run locally and green in GitHub CI. **Do not merge if any test suite is failing.**
- [ ] A test suite was added or updated for the feature/fix in this PR. **Double-check this if you change a feature and did not update the test suites**.
- [X] Only files relevant to this change are committed — no stray or unrelated files.
- [ ] If this branch has a merge conflict with master, master was merged into this branch first (not the other way around).
- [X] The rest of this PR description (Description, Testing) is filled out, not left as template placeholders.