### PR TITLE
feat(meetings): record edit provenance and fix diagnostics cards

### DIFF
--- a/frontend/app/(main)/page.tsx
+++ b/frontend/app/(main)/page.tsx
@@ -366,6 +366,7 @@ export default function HomePage() {
           title={selectedMeeting.title}
           description={selectedMeeting.description}
           creator={selectedMeeting.creator}
+          lastEditedBy={selectedMeeting.lastEditedBy}
           group={selectedMeeting.group}
 
           /* ViewMeetingDetails formats for ET display internally (formatETDateString, etTimeFmt,

--- a/frontend/app/api/update/meeting/route.ts
+++ b/frontend/app/api/update/meeting/route.ts
@@ -411,6 +411,8 @@ const updateMeeting = async (request: Request): Promise<Response> => {
           },
           data: {
             ...meetingFields,
+            // Server-managed provenance, like creator at create time -- who last saved an edit.
+            lastEditedBy: auth.user?.email ?? null,
             // Postgres' Json columns reject a literal `null` on write (needs the Prisma.DbNull
             // sentinel for a real SQL NULL) -- Mongo's connector accepted plain `null` here directly.
             // Left `undefined` when the client didn't send the field at all (the normal case --

--- a/frontend/app/api/update/meeting/route.ts
+++ b/frontend/app/api/update/meeting/route.ts
@@ -248,7 +248,9 @@ const updateMeeting = async (request: Request): Promise<Response> => {
     // edit reads/writes that field below.
     existingMeeting.googleCalendarEventIds = await reconcilePendingResume(existingMeeting);
 
-    const { mid, recurrencePattern, confirmOverride, ...meetingFields } = newMeeting;
+    // creator is server-managed provenance (set from the session at create time) -- an update
+    // must never overwrite it with the client's placeholder value.
+    const { mid, recurrencePattern, confirmOverride, creator: _creator, ...meetingFields } = newMeeting;
 
     // An explicit host reassignment (the Zoom Host dropdown set to a specific pool host,
     // different from whatever's currently assigned) -- hoisted above the confirmOverride block

--- a/frontend/app/api/write/meeting/route.ts
+++ b/frontend/app/api/write/meeting/route.ts
@@ -164,6 +164,9 @@ const createMeeting = async (request: Request) => {
       return NextResponse.json({ error: "Invalid meeting data", issues: parsed.error.issues }, { status: 400 });
     }
     const meetingData = parsed.data as IMeeting;
+    // The form doesn't collect a creator (it sends a placeholder) -- record the signed-in admin
+    // who actually created the meeting, server-side, so the value can't be spoofed either.
+    meetingData.creator = auth.user?.email ?? meetingData.creator;
 
     const { recurrencePattern, confirmOverride, ...meetingDetails } = meetingData;
     const isRecurring = !!recurrencePattern;

--- a/frontend/app/components/admin/diagnostics/SuspendedCard.tsx
+++ b/frontend/app/components/admin/diagnostics/SuspendedCard.tsx
@@ -144,10 +144,9 @@ const SuspendedCard: React.FC = () => {
               <div key={meeting.mid} className={styles.meetingRow}>
                 <div className={styles.syncIssueRow}>
                   <div>
-                    <span className={styles.meetingTitle}>{meeting.title}</span>{" "}
-                    <span className={styles.meetingTags}>({meeting.group})</span>
+                    <span className={styles.meetingTitle}>{meeting.title}</span>
                     <div className={styles.meetingMeta}>
-                      {meeting.room} · {meeting.modeType} · {meeting.calType.join(", ")}
+                      {[meeting.room, meeting.modeType, meeting.calType.join(", ")].filter(Boolean).join(" · ")}
                     </div>
                     <div className={`${styles.issueLine} ${styles.navyText}`}>
                       {formatSuspensionStatusText(meeting.suspendedSince, meeting.resumesAt, meeting.suspensionActive)}

--- a/frontend/app/components/admin/diagnostics/SyncIssuesCard.tsx
+++ b/frontend/app/components/admin/diagnostics/SyncIssuesCard.tsx
@@ -180,10 +180,9 @@ const SyncIssuesCard: React.FC = () => {
             <div key={meeting.mid} className={styles.meetingRow}>
               <div className={styles.syncIssueRow}>
                 <div>
-                  <span className={styles.meetingTitle}>{meeting.title}</span>{" "}
-                  <span className={styles.meetingTags}>({meeting.group})</span>
+                  <span className={styles.meetingTitle}>{meeting.title}</span>
                   <div className={styles.meetingMeta}>
-                    {meeting.room} · {meeting.modeType} · {meeting.calType.join(", ")}
+                    {[meeting.room, meeting.modeType, meeting.calType.join(", ")].filter(Boolean).join(" · ")}
                   </div>
                   {meeting.issues.map((issue) => (
                     <div

--- a/frontend/app/components/meeting-form/ViewMeeting.tsx
+++ b/frontend/app/components/meeting-form/ViewMeeting.tsx
@@ -68,6 +68,7 @@ type ViewMeetingDetailsProps = {
   isRecurring: boolean;
   recurrencePattern?: IRecurrencePattern
   currentOccurrenceDate?: Date; // Handles the specific occurrence date
+  lastEditedBy?: string | null; // Server-managed: session email of the last admin to save an edit
   googleSyncStatus?: string | null;
   googleSyncError?: string | null;
   zoomSyncStatus?: string | null;
@@ -111,6 +112,8 @@ const ViewMeetingDetails: React.FC<ViewMeetingDetailsProps> = ({
   title,
   modeType,
   description,
+  creator,
+  lastEditedBy,
   startDateTime,
   endDateTime,
   email,
@@ -494,6 +497,18 @@ const ViewMeetingDetails: React.FC<ViewMeetingDetailsProps> = ({
               <p className={styles.contactRow}>
                 <Icon name="person" />
                 <span>Host: {zoomHostLabel(zoomHost, zoomHostPool.indexOf(zoomHost))} — {zoomHost}</span>
+              </p>
+            )}
+            {/* Provenance is only shown when it's a real session email -- meetings created
+                before creator was server-set carry a literal placeholder ("Creator"). */}
+            {(creator?.includes("@") || lastEditedBy) && (
+              <p className={styles.contactRow}>
+                <Icon name="clock" />
+                <span>
+                  {creator?.includes("@") ? `Entered by ${creator}` : null}
+                  {creator?.includes("@") && lastEditedBy ? " · " : null}
+                  {lastEditedBy ? `Last edited by ${lastEditedBy}` : null}
+                </span>
               </p>
             )}
           </div>

--- a/frontend/prisma/migrations/20260819200000_add_meeting_last_edited_by/migration.sql
+++ b/frontend/prisma/migrations/20260819200000_add_meeting_last_edited_by/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Meeting" ADD COLUMN "lastEditedBy" TEXT;

--- a/frontend/prisma/schema.prisma
+++ b/frontend/prisma/schema.prisma
@@ -5,6 +5,10 @@ generator client {
 datasource db {
   provider = "postgresql"
   url      = env("DATABASE_URL")
+  // Migrations/introspection go over the direct (unpooled) connection: prisma migrate takes a
+  // session-scoped advisory lock, which pgbouncer transaction pooling scrambles across backends
+  // (intermittent P1002 on deploy -- same reason the backup workflow uses the unpooled string).
+  directUrl = env("DATABASE_URL_UNPOOLED")
 }
 
 enum Role {
@@ -56,6 +60,9 @@ model Meeting {
   // instead of the conflict silently vanishing because zoomHost has nothing to bucket on.
   attemptedZoomHost      String?
   zoomSyncError          String?
+  // Server-managed provenance (session email), like creator: null = never edited since import/
+  // creation. Both are set only by the API routes, never from client payloads.
+  lastEditedBy           String?
   deletedAt              DateTime?
   updatedAt              DateTime?            @updatedAt
 

--- a/frontend/tests/e2e/global-setup.ts
+++ b/frontend/tests/e2e/global-setup.ts
@@ -46,7 +46,9 @@ export default async function globalSetup(): Promise<void> {
   execFileSync(path.join(frontendRoot, "node_modules/.bin/prisma"), ["migrate", "deploy"], {
     cwd: frontendRoot,
     stdio: "inherit",
-    env: { ...process.env, DATABASE_URL: uri, CHECKPOINT_DISABLE: "1" },
+    // The embedded test server is a direct connection already, so the pooled and direct URLs
+    // (schema.prisma's url/directUrl) are the same thing here.
+    env: { ...process.env, DATABASE_URL: uri, DATABASE_URL_UNPOOLED: uri, CHECKPOINT_DISABLE: "1" },
     timeout: 60_000,
   });
 

--- a/frontend/tests/integration/globalSetup.ts
+++ b/frontend/tests/integration/globalSetup.ts
@@ -15,7 +15,9 @@ export default async function globalSetup(): Promise<void> {
   execFileSync(path.join(frontendRoot, "node_modules/.bin/prisma"), ["migrate", "deploy"], {
     cwd: frontendRoot,
     stdio: "inherit",
-    env: { ...process.env, DATABASE_URL: uri, CHECKPOINT_DISABLE: "1" },
+    // The embedded test server is a direct connection already, so the pooled and direct URLs
+    // (schema.prisma's url/directUrl) are the same thing here.
+    env: { ...process.env, DATABASE_URL: uri, DATABASE_URL_UNPOOLED: uri, CHECKPOINT_DISABLE: "1" },
     timeout: 60_000,
   });
 }

--- a/frontend/tests/integration/update-meeting-route.test.ts
+++ b/frontend/tests/integration/update-meeting-route.test.ts
@@ -23,7 +23,7 @@ jest.mock("next/server", () => ({
 
 jest.mock("../../services/auth", () => ({
   requireRole: jest.fn().mockResolvedValue({
-    user: { role: "ADMIN" },
+    user: { role: "ADMIN", email: "session-admin@test.icr" },
     accessToken: "fake-token",
   }),
 }));
@@ -146,6 +146,29 @@ test("a malformed body returns 400 with validation issues instead of a raw 500",
   const prisma = getTestPrismaClient();
   const found = await prisma.meeting.findUnique({ where: { mid: malformed.mid } });
   expect(found).toBeNull();
+});
+
+test("an update never overwrites the stored creator with the client payload's value", async () => {
+  mockedReconcileMeetingCalendars.mockResolvedValue({ updatedEventIds: {}, allSynced: true });
+
+  const prisma = getTestPrismaClient();
+  const mid = `m-${randomUUID()}`;
+  await prisma.meeting.create({ data: toMeetingCreateInput(buildMeetingPayload({
+    mid,
+    room: "Creator Preserve Room",
+    creator: "original-admin@test.icr",
+  })) });
+
+  const edit = buildMeetingPayload({ mid, room: "Creator Preserve Room", title: "Renamed", creator: "Spoofed Creator" });
+  const response = await PUT(new Request("http://localhost/api/update/meeting", {
+    method: "PUT",
+    body: JSON.stringify(edit),
+  }));
+  expect(response.status).toBe(200);
+
+  const stored = await prisma.meeting.findUnique({ where: { mid } });
+  expect(stored?.title).toBe("Renamed");
+  expect(stored?.creator).toBe("original-admin@test.icr");
 });
 
 test("a same-room time edit that now conflicts with another meeting on the same Zoom host fails soft instead of double-booking it", async () => {

--- a/frontend/tests/integration/update-meeting-route.test.ts
+++ b/frontend/tests/integration/update-meeting-route.test.ts
@@ -169,6 +169,7 @@ test("an update never overwrites the stored creator with the client payload's va
   const stored = await prisma.meeting.findUnique({ where: { mid } });
   expect(stored?.title).toBe("Renamed");
   expect(stored?.creator).toBe("original-admin@test.icr");
+  expect(stored?.lastEditedBy).toBe("session-admin@test.icr");
 });
 
 test("a same-room time edit that now conflicts with another meeting on the same Zoom host fails soft instead of double-booking it", async () => {

--- a/frontend/tests/integration/write-meeting-route.test.ts
+++ b/frontend/tests/integration/write-meeting-route.test.ts
@@ -195,6 +195,8 @@ test("creator is recorded from the session, not the client payload", async () =>
   const prisma = getTestPrismaClient();
   const stored = await prisma.meeting.findUnique({ where: { mid: payload.mid } });
   expect(stored?.creator).toBe("session-admin@test.icr");
+  // lastEditedBy is edit provenance -- a freshly created meeting has never been edited.
+  expect(stored?.lastEditedBy).toBeNull();
 
   await waitForGoogleSyncStatus(payload.mid);
 });

--- a/frontend/tests/integration/write-meeting-route.test.ts
+++ b/frontend/tests/integration/write-meeting-route.test.ts
@@ -24,7 +24,7 @@ jest.mock("next/server", () => ({
 
 jest.mock("../../services/auth", () => ({
   requireRole: jest.fn().mockResolvedValue({
-    user: { role: "ADMIN" },
+    user: { role: "ADMIN", email: "session-admin@test.icr" },
     accessToken: "fake-token",
   }),
 }));
@@ -179,6 +179,23 @@ test("a resolved Zoom host is persisted synchronously, before the deferred sync 
 
   // Lets the deferred sync finish before the test (and its mocks) tear down, rather than
   // guessing how long that takes.
+  await waitForGoogleSyncStatus(payload.mid);
+});
+
+test("creator is recorded from the session, not the client payload", async () => {
+  const payload = buildMeetingPayload({ room: "Creator Provenance Room", creator: "Spoofed Creator" });
+  const request = new Request("http://localhost/api/write/meeting", {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+
+  const response = await POST(request);
+  expect(response.status).toBe(201);
+
+  const prisma = getTestPrismaClient();
+  const stored = await prisma.meeting.findUnique({ where: { mid: payload.mid } });
+  expect(stored?.creator).toBe("session-admin@test.icr");
+
   await waitForGoogleSyncStatus(payload.mid);
 });
 

--- a/frontend/tests/unit/suspension.test.ts
+++ b/frontend/tests/unit/suspension.test.ts
@@ -51,6 +51,7 @@ function buildMeeting(overrides: Partial<Meeting> = {}): Omit<Meeting, "recurren
     calType: ["AA"],
     description: "",
     creator: "creator@test.icr",
+    lastEditedBy: null,
     group: "Group",
     startDateTime: new Date(now - DAY_MS),
     endDateTime: new Date(now - DAY_MS + 60 * 60 * 1000),

--- a/frontend/types/models.ts
+++ b/frontend/types/models.ts
@@ -13,6 +13,7 @@ interface IMeeting {
   mid: string;
   description: string;
   creator: string; // admin later on [optional]
+  lastEditedBy?: string | null; // server-managed: session email of the last admin to save an edit
   group: string; // group interface later on [optional]
   startDateTime: Date;
   endDateTime: Date;


### PR DESCRIPTION
@coderabbitai summary

## Description
- **frontend/app/api/write/meeting/route.ts, update/meeting/route.ts**: `creator` is now server-set from the session at create time and preserved on update; new `lastEditedBy` is server-set on every update (null = never edited). Both are provenance the client can no longer spoof — the form previously hardcoded `creator: 'Creator'` / `group: 'Group'` placeholders into every meeting.
- **frontend/prisma/schema.prisma + migrations/20260819200000_add_meeting_last_edited_by**: adds the nullable `lastEditedBy` column, and adds `directUrl = env("DATABASE_URL_UNPOOLED")` so `prisma migrate` runs over the direct connection — its session-scoped advisory lock was going through pgbouncer transaction pooling, which orphaned the lock across backends and intermittently failed production deploys with `P1002` (three master deploys today). `DATABASE_URL_UNPOOLED` is already set in Vercel production env; both test harnesses (`tests/integration/globalSetup.ts`, `tests/e2e/global-setup.ts`) pass it alongside `DATABASE_URL` (same embedded-Postgres URI — it's already direct).
- **frontend/app/components/admin/diagnostics/SuspendedCard.tsx, SyncIssuesCard.tsx**: drop the placeholder "(Group)" from display (the `group` field stays in the schema pending an ICR product decision) and build the meta line from non-empty parts only — Remote meetings rendered a stray leading "·".
- **frontend/app/components/meeting-form/ViewMeeting.tsx (+ page.tsx, types/models.ts)**: admin-only "Entered by … · Last edited by …" row, shown only for real email values so pre-existing placeholder data doesn't render.
- **Tests**: integration tests assert the session email is stored at create, that an update can't overwrite `creator`, and that `lastEditedBy` is set on update / null at create; unit fixture updated for the new Prisma column.

## Testing
- [x] `yarn typecheck`, targeted integration suites (write/update meeting routes) green locally; full `yarn test:all` green locally (lint / lint:css / typecheck clean, unit 278, component 279, integration 136, e2e 117).
- [ ] Post-deploy: the deploy log's `prisma migrate deploy` step connects to the non-pooler host and applies `add_meeting_last_edited_by`; editing any meeting then shows "Last edited by" in its admin detail panel.

## Area(s) Touched
**Product areas**
- [ ] auth — sign-in, sessions, NextAuth, role-based access
- [X] admin — /admin shell (Diagnostics, Users, Import, Export tabs)
- [ ] docs — /docs Resources page (rendering, navigation, search)
- [X] ui/ux — frontend layout/styling not tied to a specific integration

**Integrations**
- [ ] google-calendar — Google Calendar sync
- [ ] zoom-api — Zoom meeting/host sync

**Engineering**
- [ ] security — auth hardening, data exposure, dependency/security scanning
- [X] testing — test suite (Jest/Playwright) changes
- [ ] github-actions — workflows, Dependabot config, other .github/ CI tooling
- [ ] cleanup — refactor or dead-code removal, no behavior change
- [ ] documentation — docs/ or README changes only

## Pre-merge Checklist
- [X] Code follows current formatting conventions and passes lint (`yarn lint`).
- [X] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
- [ ] All test suites pass, both run locally and green in GitHub CI. **Do not merge if any test suite is failing.**
- [X] A test suite was added or updated for the feature/fix in this PR. **Double-check this if you change a feature and did not update the test suites**.
- [X] Only files relevant to this change are committed — no stray or unrelated files.
- [ ] If this branch has a merge conflict with master, master was merged into this branch first (not the other way around).
- [X] The rest of this PR description (Description, Testing) is filled out, not left as template placeholders.
