### PR TITLE
feat(calendar): collapse the sidebar before the week view scrolls horizontally

### DIFF
--- a/frontend/app/components/calendar/desktop/WeekView.module.scss
+++ b/frontend/app/components/calendar/desktop/WeekView.module.scss
@@ -124,9 +124,11 @@
 
 .dayColumn {
   flex: 1;
-  min-width: 155px;
 
-  /* Consistent with daily view's 155px column width */
+  /* Mirrors MIN_DAY_COLUMN_WIDTH (util/common/breakpoints.ts) — the shared narrowest-legible
+     day column, also mobile MultiDayLandscapeView's floor and what the sidebar-yield
+     breakpoint is derived from. Edit both together. */
+  min-width: 150px;
   position: relative;
   border-right: 1px solid $grey-border-color;
   scroll-snap-align: start;

--- a/frontend/app/components/calendar/mobile/MultiDayLandscapeView.tsx
+++ b/frontend/app/components/calendar/mobile/MultiDayLandscapeView.tsx
@@ -6,6 +6,7 @@ import { filterMeetingsForDate, MeetingFilters } from "../../../../util/filters/
 import { ZOOM_ROOM_COLOR } from "../../../../util/rooms/filterColors";
 import { getMeetingChipPresentation } from "../../../../util/meetings/meetingChipPresentation";
 import { formatETDateString, formatETWeekdayShort, getCurrentETMinutesSinceMidnight } from "../../../../util/date/timeUtils";
+import { MIN_DAY_COLUMN_WIDTH } from "../../../../util/common/breakpoints";
 import { layoutOverlappingMeetings, OverlapMeeting } from "../../../../util/meetings/meetingOverlapLayout";
 import { addDaysToDate, daysBetweenET } from "../../../../util/date/weekDates";
 import { useRangeMeetings } from "../../../../hooks/useRangeMeetings";
@@ -15,12 +16,12 @@ import TopLoadingBar from "../../ui/displays/TopLoadingBar";
 
 type Meeting = OverlapMeeting;
 
-// A day column needs at least this much width to stay legible at the compact tier (room +
+// A day column needs at least MIN_DAY_COLUMN_WIDTH to stay legible at the compact tier (room +
 // title, per BoxText's tier table) -- the day count below is derived from how many of these
 // actually fit the measured width, generalizing WeekView's fixed 7-day week into an
 // arbitrary-width "page". Never fewer than 1 (a very narrow width still shows something) or
 // more than 7 (a wide tablet lands back on a familiar week).
-const MIN_DAY_WIDTH = 150;
+const MIN_DAY_WIDTH = MIN_DAY_COLUMN_WIDTH;
 const MAX_DAYS = 7;
 // Portrait's 60px scaled down further -- this view trades some per-hour legibility for
 // headroom to show the day header row above each column within a short landscape viewport.

--- a/frontend/config/playwright.config.ts
+++ b/frontend/config/playwright.config.ts
@@ -31,5 +31,9 @@ export default defineConfig({
   // directly (spawns `next dev` itself, after Mongo + `prisma db push` are
   // ready) — Playwright's built-in webServer races against that async setup
   // since it isn't guaranteed to start after globalSetup finishes.
-  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
+  // Desktop Chrome's default 1280px viewport sits below SIDEBAR_YIELD_BREAKPOINT (1350 — see
+  // util/common/breakpoints.ts), where the sidebar auto-collapses; the suite's flows exercise
+  // the full-sidebar desktop experience, so pin a width comfortably above the expand edge.
+  // Tests that want the compact behavior set their own viewport explicitly.
+  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"], viewport: { width: 1440, height: 900 } } }],
 });

--- a/frontend/hooks/useBreakpoint.ts
+++ b/frontend/hooks/useBreakpoint.ts
@@ -1,28 +1,36 @@
 import { useEffect } from "react";
-import { TABLET_BREAKPOINT } from "../util/common/breakpoints";
+import { SIDEBAR_EXPAND_BREAKPOINT, SIDEBAR_YIELD_BREAKPOINT } from "../util/common/breakpoints";
 
-// Auto-collapses the sidebar the moment the window narrows past the tablet breakpoint.
-// One-way trigger: it only ever calls collapseSidebar() on a downward crossing, never
-// fights a manual expandSidebar() afterward (e.g. widening back past the threshold does
-// not auto re-expand, and narrowing again while already compact is a no-op call).
+type Zone = "narrow" | "between" | "wide";
+
+const zoneOf = (width: number): Zone =>
+  width < SIDEBAR_YIELD_BREAKPOINT ? "narrow" : width >= SIDEBAR_EXPAND_BREAKPOINT ? "wide" : "between";
+
+// Auto-collapses the sidebar the moment the window narrows past the point where the full
+// sidebar and an unscrolled week no longer fit side by side — the sidebar yields before the
+// calendar starts scrolling horizontally. Edge-triggered with hysteresis: collapse fires on
+// entering the narrow zone, expand on entering the wide zone, and nothing fires while moving
+// within or into the band between the two edges — so a manual toggle there is never fought,
+// and repeated resizes inside one zone are no-op.
 export function useBreakpoint(collapseSidebar: () => void, expandSidebar: () => void): void {
   useEffect(() => {
-    let wasAboveThreshold = window.innerWidth >= TABLET_BREAKPOINT;
-    if (!wasAboveThreshold) {  
-      collapseSidebar();  
-    }  
+    let zone = zoneOf(window.innerWidth);
+    if (zone === "narrow") {
+      collapseSidebar();
+    }
 
     const handleResize = () => {
-      const isAboveThreshold = window.innerWidth >= TABLET_BREAKPOINT;
-      if (wasAboveThreshold && !isAboveThreshold) {
+      const nextZone = zoneOf(window.innerWidth);
+      if (nextZone === zone) return;
+      if (nextZone === "narrow") {
         collapseSidebar();
-      } else if (!wasAboveThreshold && isAboveThreshold) {
+      } else if (nextZone === "wide") {
         expandSidebar();
       }
-      wasAboveThreshold = isAboveThreshold;
+      zone = nextZone;
     };
 
     window.addEventListener("resize", handleResize);
     return () => window.removeEventListener("resize", handleResize);
-  }, [collapseSidebar]);
+  }, [collapseSidebar, expandSidebar]);
 }

--- a/frontend/tests/component/useBreakpoint.test.tsx
+++ b/frontend/tests/component/useBreakpoint.test.tsx
@@ -1,0 +1,79 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import { act } from "react";
+import { useBreakpoint } from "../../hooks/useBreakpoint";
+import {
+  SIDEBAR_EXPAND_BREAKPOINT,
+  SIDEBAR_YIELD_BREAKPOINT,
+} from "../../util/common/breakpoints";
+
+function Harness({ collapse, expand }: { collapse: () => void; expand: () => void }) {
+  useBreakpoint(collapse, expand);
+  return null;
+}
+
+const originalWidth = window.innerWidth;
+
+function setWidth(value: number) {
+  Object.defineProperty(window, "innerWidth", { configurable: true, value });
+}
+
+function resizeTo(value: number) {
+  act(() => {
+    setWidth(value);
+    window.dispatchEvent(new Event("resize"));
+  });
+}
+
+afterEach(() => {
+  setWidth(originalWidth);
+});
+
+test("collapses on mount when the full sidebar and week no longer fit", () => {
+  const collapse = jest.fn();
+  const expand = jest.fn();
+  setWidth(SIDEBAR_YIELD_BREAKPOINT - 100);
+  render(<Harness collapse={collapse} expand={expand} />);
+  expect(collapse).toHaveBeenCalledTimes(1);
+  expect(expand).not.toHaveBeenCalled();
+});
+
+test("collapses once on crossing the yield edge downward, not on every narrower resize", () => {
+  const collapse = jest.fn();
+  const expand = jest.fn();
+  setWidth(SIDEBAR_EXPAND_BREAKPOINT + 200);
+  render(<Harness collapse={collapse} expand={expand} />);
+  expect(collapse).not.toHaveBeenCalled();
+
+  resizeTo(SIDEBAR_YIELD_BREAKPOINT - 1);
+  expect(collapse).toHaveBeenCalledTimes(1);
+
+  resizeTo(SIDEBAR_YIELD_BREAKPOINT - 200);
+  resizeTo(SIDEBAR_YIELD_BREAKPOINT - 400);
+  expect(collapse).toHaveBeenCalledTimes(1);
+});
+
+test("re-expands only past the higher expand edge (hysteresis), so the band between edges never fights a manual toggle", () => {
+  const collapse = jest.fn();
+  const expand = jest.fn();
+  setWidth(SIDEBAR_YIELD_BREAKPOINT - 100);
+  render(<Harness collapse={collapse} expand={expand} />);
+  expect(collapse).toHaveBeenCalledTimes(1);
+
+  // Widening into the dead band does nothing in either direction.
+  resizeTo(SIDEBAR_YIELD_BREAKPOINT + 10);
+  expect(expand).not.toHaveBeenCalled();
+  expect(collapse).toHaveBeenCalledTimes(1);
+
+  // Only crossing the expand edge re-expands.
+  resizeTo(SIDEBAR_EXPAND_BREAKPOINT + 1);
+  expect(expand).toHaveBeenCalledTimes(1);
+
+  // Narrowing back into the dead band does not re-collapse.
+  resizeTo(SIDEBAR_EXPAND_BREAKPOINT - 10);
+  expect(collapse).toHaveBeenCalledTimes(1);
+
+  // Crossing the yield edge does.
+  resizeTo(SIDEBAR_YIELD_BREAKPOINT - 1);
+  expect(collapse).toHaveBeenCalledTimes(2);
+});

--- a/frontend/tests/e2e/05-calendar-display.spec.ts
+++ b/frontend/tests/e2e/05-calendar-display.spec.ts
@@ -75,29 +75,46 @@ test.describe("calendar display", () => {
   // stayed a fixed pixel size while the rest of the header row scaled continuously with its
   // own container width (container queries, not viewport-based breakpoints). The pill in
   // particular couldn't scale at all -- it rendered as a DOM sibling of the container-query
-  // root, not a descendant, so cqi units had no ancestor to resolve against. Both widths stay
-  // above the tablet breakpoint (768px, see hooks/useViewport.ts) so the desktop shell -- and
-  // this container-query row -- stays mounted at both sizes; only the row's own available
-  // width (viewport minus the sidebar) changes.
+  // root, not a descendant, so cqi units had no ancestor to resolve against.
+  //
+  // Since the sidebar started yielding before the calendar scrolls (SIDEBAR_YIELD_BREAKPOINT),
+  // the narrow measurement runs with a compact sidebar, which *widens* the header row: the
+  // smallest desktop-mode container is now ~640px, past the pill's own clamp cap (2cqi caps
+  // 14px at ~524px) -- so the pill asserts at-cap at both widths, and continuous scaling is
+  // observed on the view-toggle icon, whose clamp caps later (~824px container). The narrow
+  // width sits below the yield edge, the wide one above the expand edge, and the measurement
+  // waits for the full sidebar's cross-fade unmount instead of racing it.
   test("calendar header: view-toggle icon and 'View only' pill scale continuously with the header row's own width", async ({ page }) => {
     await page.goto("/");
     const viewToggleIcon = page.locator('[data-icon-name="view-timeline"]');
     const pillText = page.getByText("View only - sign in as Admin to manage meetings");
     const pillIcon = page.locator('[data-icon-name="lock"]');
+    // "Clear all" only exists in the full sidebar's filter headers -- the compact variant's
+    // icon strip (and its tooltips, which still say "Location") has no such text.
+    const fullSidebarMarker = page.getByText("Clear all").first();
 
-    await page.setViewportSize({ width: 1400, height: 900 });
+    await page.setViewportSize({ width: 1500, height: 900 });
     await expect(viewToggleIcon).toBeVisible();
+    await expect(fullSidebarMarker).toBeVisible();
     const wideIconWidth = await viewToggleIcon.evaluate((el) => el.getBoundingClientRect().width);
     const widePillFontSize = parseFloat(await pillText.evaluate((el) => window.getComputedStyle(el).fontSize));
     const widePillIconWidth = await pillIcon.evaluate((el) => el.getBoundingClientRect().width);
 
-    await page.setViewportSize({ width: 820, height: 900 });
+    await page.setViewportSize({ width: 900, height: 900 });
+    // The sidebar auto-collapses below SIDEBAR_YIELD_BREAKPOINT; wait for the full variant's
+    // filter headings to unmount so the row is measured at its settled (compact-sidebar) width.
+    await expect(fullSidebarMarker).toBeHidden();
     const narrowIconWidth = await viewToggleIcon.evaluate((el) => el.getBoundingClientRect().width);
     const narrowPillFontSize = parseFloat(await pillText.evaluate((el) => window.getComputedStyle(el).fontSize));
     const narrowPillIconWidth = await pillIcon.evaluate((el) => el.getBoundingClientRect().width);
 
     expect(narrowIconWidth).toBeLessThan(wideIconWidth);
-    expect(narrowPillFontSize).toBeLessThan(widePillFontSize);
-    expect(narrowPillIconWidth).toBeLessThan(widePillIconWidth);
+    // Desktop mode can no longer reach the pill's sub-cap range -- both widths sit at the
+    // clamp max, which is the "it scales with the container, not frozen mid-range" contract
+    // #350 actually cares about.
+    expect(narrowPillFontSize).toBe(14);
+    expect(widePillFontSize).toBe(14);
+    expect(narrowPillIconWidth).toBe(14);
+    expect(widePillIconWidth).toBe(14);
   });
 });

--- a/frontend/util/common/breakpoints.ts
+++ b/frontend/util/common/breakpoints.ts
@@ -4,3 +4,23 @@
 export const PHONE_BREAKPOINT = 480;
 export const TABLET_BREAKPOINT = 768;
 export const DESKTOP_BREAKPOINT = 1024;
+
+// Narrowest day-of-meetings column that stays legible at BoxText's compact tier (room + title).
+// Shared by desktop WeekView (its .dayColumn min-width in WeekView.module.scss mirrors this —
+// edit both together) and mobile MultiDayLandscapeView's fits-how-many-days math.
+export const MIN_DAY_COLUMN_WIDTH = 150;
+
+// Mirrors CalendarSidebar.module.scss's .sidebar width and WeekView.module.scss's .timeColumn
+// min-width — same manual-sync contract as the Sass breakpoint tokens above.
+export const FULL_SIDEBAR_WIDTH = 240;
+export const WEEK_TIME_GUTTER_WIDTH = 60;
+
+// The viewport width below which the full sidebar and an unscrolled 7-day week no longer fit
+// side by side — the sidebar yields (auto-collapses) before the calendar is forced to scroll
+// horizontally. Derived, not hand-picked, so a column/sidebar width change moves it too.
+export const SIDEBAR_YIELD_BREAKPOINT =
+  FULL_SIDEBAR_WIDTH + WEEK_TIME_GUTTER_WIDTH + 7 * MIN_DAY_COLUMN_WIDTH;
+
+// Auto-re-expand only comfortably past the yield point — the gap is hysteresis so a window
+// dragged near the boundary doesn't flap the sidebar cross-fade.
+export const SIDEBAR_EXPAND_BREAKPOINT = SIDEBAR_YIELD_BREAKPOINT + 40;


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Improved responsive calendar layout sizing across desktop and mobile views.
  * Sidebar now collapses and expands more predictably as the window crosses responsive thresholds, avoiding repeated toggles in intermediate widths.
  * Desktop browser tests now use a consistent 1440×900 viewport.
* **Tests**
  * Added coverage for sidebar behavior during initial load and window resizing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description
- **frontend/util/common/breakpoints.ts**: adds `MIN_DAY_COLUMN_WIDTH = 150` (the shared narrowest-legible day column, matching mobile's BoxText compact-tier floor), sidebar/gutter mirror constants, and two derived thresholds: `SIDEBAR_YIELD_BREAKPOINT = 240 + 60 + 7×150 = 1350` and `SIDEBAR_EXPAND_BREAKPOINT = 1390` (hysteresis).
- **frontend/hooks/useBreakpoint.ts**: the sidebar previously auto-collapsed only below the 768px tablet breakpoint, leaving a ~768–1385px band (e.g. a laptop with a vertical browser tab bar) where the week view scrolled horizontally even though collapsing the sidebar would fit it. The hook is now three-zone and edge-triggered: collapse on entering the narrow zone (<1350), expand on entering the wide zone (≥1390), and silence in the band between — a manual toggle there is never fought, and boundary drags can't flap the sidebar cross-fade.
- **frontend/app/components/calendar/desktop/WeekView.module.scss**: day-column `min-width` 155px → 150px, unifying with mobile's floor. The old "consistent with daily view" rationale was cosmetic — Day view's 155 is its *hour*-column width on the horizontal axis, arithmetically coupled to time-position math, and is deliberately untouched.
- **frontend/app/components/calendar/mobile/MultiDayLandscapeView.tsx**: its local `MIN_DAY_WIDTH = 150` now aliases the shared constant.
- **frontend/config/playwright.config.ts**: pins the e2e viewport to 1440×900 — Desktop Chrome's 1280px default now lands inside the collapse zone, and the suite's flows exercise the full-sidebar desktop experience.
- **frontend/tests/component/useBreakpoint.test.tsx**: three cases covering collapse-on-mount, single edge-triggered collapse across repeated narrower resizes, and the full hysteresis behavior including the dead band.

## Testing
- [x] Full `yarn test:all` green locally: lint 0 errors, lint:css, typecheck, unit 278, component 282 (3 new), integration 136, e2e 117 (on the new 1440×900 viewport).
- [ ] Manual: with a vertical browser tab bar (or any window ~1200–1350px wide), the sidebar auto-collapses and the week view fits without horizontal scrolling; widening past ~1390px re-expands it; a manual toggle between ~1350–1390px sticks.

## Area(s) Touched
**Product areas**
- [ ] auth — sign-in, sessions, NextAuth, role-based access
- [ ] admin — /admin shell (Diagnostics, Users, Import, Export tabs)
- [ ] docs — /docs Resources page (rendering, navigation, search)
- [X] ui/ux — frontend layout/styling not tied to a specific integration

**Integrations**
- [ ] google-calendar — Google Calendar sync
- [ ] zoom-api — Zoom meeting/host sync

**Engineering**
- [ ] security — auth hardening, data exposure, dependency/security scanning
- [X] testing — test suite (Jest/Playwright) changes
- [ ] github-actions — workflows, Dependabot config, other .github/ CI tooling
- [ ] cleanup — refactor or dead-code removal, no behavior change
- [ ] documentation — docs/ or README changes only

## Pre-merge Checklist
- [X] Code follows current formatting conventions and passes lint (`yarn lint`).
- [X] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
- [X] All test suites pass, both run locally and green in GitHub CI. **Do not merge if any test suite is failing.**
- [X] A test suite was added or updated for the feature/fix in this PR. **Double-check this if you change a feature and did not update the test suites**.
- [X] Only files relevant to this change are committed — no stray or unrelated files.
- [ ] If this branch has a merge conflict with master, master was merged into this branch first (not the other way around).
- [X] The rest of this PR description (Description, Testing) is filled out, not left as template placeholders.