### PR TITLE
fix(calendar): derive the sidebar yield edge from measured layout

### DIFF
--- a/frontend/config/playwright.config.ts
+++ b/frontend/config/playwright.config.ts
@@ -31,9 +31,9 @@ export default defineConfig({
   // directly (spawns `next dev` itself, after Mongo + `prisma db push` are
   // ready) — Playwright's built-in webServer races against that async setup
   // since it isn't guaranteed to start after globalSetup finishes.
-  // Desktop Chrome's default 1280px viewport sits below SIDEBAR_YIELD_BREAKPOINT (1350 — see
+  // Desktop Chrome's default 1280px viewport sits below SIDEBAR_YIELD_BREAKPOINT (1490 — see
   // util/common/breakpoints.ts), where the sidebar auto-collapses; the suite's flows exercise
-  // the full-sidebar desktop experience, so pin a width comfortably above the expand edge.
-  // Tests that want the compact behavior set their own viewport explicitly.
-  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"], viewport: { width: 1440, height: 900 } } }],
+  // the full-sidebar desktop experience, so pin a width comfortably above the expand edge
+  // (1530). Tests that want the compact behavior set their own viewport explicitly.
+  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"], viewport: { width: 1600, height: 900 } } }],
 });

--- a/frontend/tests/e2e/05-calendar-display.spec.ts
+++ b/frontend/tests/e2e/05-calendar-display.spec.ts
@@ -93,7 +93,7 @@ test.describe("calendar display", () => {
     // icon strip (and its tooltips, which still say "Location") has no such text.
     const fullSidebarMarker = page.getByText("Clear all").first();
 
-    await page.setViewportSize({ width: 1500, height: 900 });
+    await page.setViewportSize({ width: 1600, height: 900 });
     await expect(viewToggleIcon).toBeVisible();
     await expect(fullSidebarMarker).toBeVisible();
     const wideIconWidth = await viewToggleIcon.evaluate((el) => el.getBoundingClientRect().width);

--- a/frontend/util/common/breakpoints.ts
+++ b/frontend/util/common/breakpoints.ts
@@ -10,16 +10,21 @@ export const DESKTOP_BREAKPOINT = 1024;
 // edit both together) and mobile MultiDayLandscapeView's fits-how-many-days math.
 export const MIN_DAY_COLUMN_WIDTH = 150;
 
-// Mirrors CalendarSidebar.module.scss's .sidebar width and WeekView.module.scss's .timeColumn
-// min-width — same manual-sync contract as the Sass breakpoint tokens above.
-export const FULL_SIDEBAR_WIDTH = 240;
-export const WEEK_TIME_GUTTER_WIDTH = 60;
+// What the expanded sidebar really costs the calendar, as rendered: the 240px panel
+// (CalendarSidebar.module.scss) plus its padding, the collapse-handle strip, and the gap to the
+// calendar. Measured from the live layout (window.innerWidth − .viewContainer width with the
+// full sidebar mounted) rather than summed from CSS — the naive 240 undercounted by ~108px.
+export const FULL_SIDEBAR_ZONE_WIDTH = 348;
+
+// The week view's minimum unscrolled content width, as rendered: 61px time gutter +
+// 7 × (MIN_DAY_COLUMN_WIDTH + 1px border) + header slack. Measured (.viewContainer scrollWidth
+// with columns pinned at their min) for the same reason as above.
+export const WEEK_MIN_CONTENT_WIDTH = 1142;
 
 // The viewport width below which the full sidebar and an unscrolled 7-day week no longer fit
 // side by side — the sidebar yields (auto-collapses) before the calendar is forced to scroll
-// horizontally. Derived, not hand-picked, so a column/sidebar width change moves it too.
-export const SIDEBAR_YIELD_BREAKPOINT =
-  FULL_SIDEBAR_WIDTH + WEEK_TIME_GUTTER_WIDTH + 7 * MIN_DAY_COLUMN_WIDTH;
+// horizontally. If sidebar or column dimensions change, re-measure the two constants above.
+export const SIDEBAR_YIELD_BREAKPOINT = FULL_SIDEBAR_ZONE_WIDTH + WEEK_MIN_CONTENT_WIDTH;
 
 // Auto-re-expand only comfortably past the yield point — the gap is hysteresis so a window
 // dragged near the boundary doesn't flap the sidebar cross-fade.


### PR DESCRIPTION
@coderabbitai summary

## Description
Follow-up to #502, which shipped with an idealized yield threshold (240 + 60 + 7×150 = 1350) that undercounted real chrome — in production, a ~1350–1490px window still scrolled the week horizontally with the sidebar expanded (reported live after #502 deployed).

- **frontend/util/common/breakpoints.ts**: the two inputs are now measured from live layout and documented as such — `FULL_SIDEBAR_ZONE_WIDTH = 348` (panel + padding + collapse handle + gap; the naive 240 undercounted by ~108px) and `WEEK_MIN_CONTENT_WIDTH = 1142` (61px gutter + 7 bordered min-width columns + header slack). Yield edge: **1490**, expand edge 1530.
- **frontend/config/playwright.config.ts**: e2e viewport 1440×900 → 1600×900 (1440 now sits below the yield edge).
- **frontend/tests/e2e/05-calendar-display.spec.ts**: the header-scaling test's wide measurement follows to 1600.

Verified live at a 1397px window on a local build: the sidebar auto-collapses and the week fits without horizontal scroll (residual `scrollWidth` delta is 1px of subpixel flex rounding, pre-existing and invisible under scroll-snap).

## Testing
- [x] Full `yarn test:all` green locally: lint 0 errors, lint:css, typecheck, unit 278, component 282, integration 136, e2e 117 (on the 1600×900 viewport).
- [ ] Post-deploy: at a ~1250–1480px window (e.g. vertical browser tab bar), the sidebar collapses on its own and Week view shows all 7 days without horizontal scrolling.

## Area(s) Touched
**Product areas**
- [ ] auth — sign-in, sessions, NextAuth, role-based access
- [ ] admin — /admin shell (Diagnostics, Users, Import, Export tabs)
- [ ] docs — /docs Resources page (rendering, navigation, search)
- [X] ui/ux — frontend layout/styling not tied to a specific integration

**Integrations**
- [ ] google-calendar — Google Calendar sync
- [ ] zoom-api — Zoom meeting/host sync

**Engineering**
- [ ] security — auth hardening, data exposure, dependency/security scanning
- [X] testing — test suite (Jest/Playwright) changes
- [ ] github-actions — workflows, Dependabot config, other .github/ CI tooling
- [ ] cleanup — refactor or dead-code removal, no behavior change
- [ ] documentation — docs/ or README changes only

## Pre-merge Checklist
- [X] Code follows current formatting conventions and passes lint (`yarn lint`).
- [X] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
- [X] All test suites pass, both run locally and green in GitHub CI. **Do not merge if any test suite is failing.**
- [ ] A test suite was added or updated for the feature/fix in this PR. **Double-check this if you change a feature and did not update the test suites**.
- [X] Only files relevant to this change are committed — no stray or unrelated files.
- [ ] If this branch has a merge conflict with master, master was merged into this branch first (not the other way around).
- [X] The rest of this PR description (Description, Testing) is filled out, not left as template placeholders.