### PR TITLE
feat(zoom): never mutate adopted or external Zoom meetings

### DIFF
--- a/frontend/app/(main)/page.tsx
+++ b/frontend/app/(main)/page.tsx
@@ -367,6 +367,7 @@ export default function HomePage() {
           description={selectedMeeting.description}
           creator={selectedMeeting.creator}
           lastEditedBy={selectedMeeting.lastEditedBy}
+          zoomManaged={selectedMeeting.zoomManaged}
           group={selectedMeeting.group}
 
           /* ViewMeetingDetails formats for ET display internally (formatETDateString, etTimeFmt,

--- a/frontend/app/api/delete/meeting/route.ts
+++ b/frontend/app/api/delete/meeting/route.ts
@@ -63,8 +63,15 @@ async function syncDeleteAll(
   // itself is gone.
   await tearDownPendingResumeSeries(meeting, accessToken);
   // Never delete an unmanaged Zoom meeting (adopted legacy / externally hosted): the group's
-  // meeting ID predates this app and must survive the app-side record's deletion.
-  if (meeting.zid && meeting.zoomManaged) await deleteZoomMeeting(meeting.zid);
+  // meeting ID predates this app and must survive the app-side record's deletion. A managed
+  // Zoom meeting can also be shared by a sibling row (one group, two schedule variants -- e.g.
+  // the Sat-hybrid/Sun-remote pairs), so it's only torn down once no other live row points at it.
+  if (meeting.zid && meeting.zoomManaged) {
+    const siblingCount = await prisma.meeting.count({
+      where: { zid: meeting.zid, deletedAt: null, mid: { not: meeting.mid } },
+    });
+    if (siblingCount === 0) await deleteZoomMeeting(meeting.zid);
+  }
   if (accessToken && meeting.zoomCalendarEventId && meeting.zoomRoom) {
     const calId = zoomRoomCalendarId[meeting.zoomRoom];
     if (calId) await deleteCalendarEvent(accessToken, meeting.zoomCalendarEventId, calId);

--- a/frontend/app/api/delete/meeting/route.ts
+++ b/frontend/app/api/delete/meeting/route.ts
@@ -62,7 +62,9 @@ async function syncDeleteAll(
   // the live pointer above would otherwise be left dangling on Google Calendar once the meeting
   // itself is gone.
   await tearDownPendingResumeSeries(meeting, accessToken);
-  if (meeting.zid) await deleteZoomMeeting(meeting.zid);
+  // Never delete an unmanaged Zoom meeting (adopted legacy / externally hosted): the group's
+  // meeting ID predates this app and must survive the app-side record's deletion.
+  if (meeting.zid && meeting.zoomManaged) await deleteZoomMeeting(meeting.zid);
   if (accessToken && meeting.zoomCalendarEventId && meeting.zoomRoom) {
     const calId = zoomRoomCalendarId[meeting.zoomRoom];
     if (calId) await deleteCalendarEvent(accessToken, meeting.zoomCalendarEventId, calId);

--- a/frontend/app/api/update/meeting/route.ts
+++ b/frontend/app/api/update/meeting/route.ts
@@ -110,7 +110,11 @@ async function syncUpdatedMeeting(
       } else {
         // Unmanaged Zoom meetings are never PATCHed -- the stored link is the contract; only
         // the calendars follow the app-side edit.
-        const ok = existingMeeting.zoomManaged ? await updateZoomMeeting(zid, newMeeting) : true;
+        // The pinned topic (if any) lives on the DB row, not the client payload -- thread it
+        // through so a managed PATCH keeps the meeting's established Zoom name.
+        const ok = existingMeeting.zoomManaged
+          ? await updateZoomMeeting(zid, { ...newMeeting, zoomTopic: existingMeeting.zoomTopic })
+          : true;
         if (!ok) zoomSynced = false;
       }
     } else if (!existingMeeting.zoomManaged) {

--- a/frontend/app/api/update/meeting/route.ts
+++ b/frontend/app/api/update/meeting/route.ts
@@ -113,6 +113,10 @@ async function syncUpdatedMeeting(
         const ok = existingMeeting.zoomManaged ? await updateZoomMeeting(zid, newMeeting) : true;
         if (!ok) zoomSynced = false;
       }
+    } else if (!existingMeeting.zoomManaged) {
+      // An unmanaged meeting with no zid means an admin deliberately points it outside the
+      // app's Zoom account -- never auto-provision an app-owned meeting under the flag that
+      // says the app doesn't own it.
     } else {
       // Already resolved (and persisted) synchronously in updateMeeting, before this ever
       // runs — see the comment there for why. This only does the network-bound half:

--- a/frontend/app/api/update/meeting/route.ts
+++ b/frontend/app/api/update/meeting/route.ts
@@ -64,8 +64,15 @@ async function syncUpdatedMeeting(
       // downstream zoomCalendarEventId === null branch recreates it on the new room's calendar
       // with the stored link.
       if (zid && existingMeeting.zoomManaged) {
-        const ok = await deleteZoomMeeting(zid);
-        if (!ok) zoomSynced = false;
+        // Shared-zid guard: a sibling row (same group, second schedule variant) may still point
+        // at this Zoom meeting -- only the last referencing row actually tears it down.
+        const siblingCount = await prisma.meeting.count({
+          where: { zid, deletedAt: null, mid: { not: mid } },
+        });
+        if (siblingCount === 0) {
+          const ok = await deleteZoomMeeting(zid);
+          if (!ok) zoomSynced = false;
+        }
       }
       if (accessToken && zoomCalendarEventId && oldZoomRoom) {
         const oldCalId = zoomRoomCalendarId[oldZoomRoom];

--- a/frontend/app/api/update/meeting/route.ts
+++ b/frontend/app/api/update/meeting/route.ts
@@ -57,8 +57,13 @@ async function syncUpdatedMeeting(
     const roomChanged = !!oldZoomRoom && oldZoomRoom !== newZoomRoom;
     const explicitHostChange = !!newMeeting.zoomHost && newMeeting.zoomHost !== existingMeeting.zoomHost;
 
-    if ((roomChanged || explicitHostChange) && existingMeeting.zoomManaged) {
-      if (zid) {
+    if (roomChanged || explicitHostChange) {
+      // Managed: the Zoom meeting is disposable, so tear it down for a fresh create below.
+      // Unmanaged: the Zoom meeting is ICR's (host changes were already 422'd upstream) -- keep
+      // zid/link/passcode and only move the join-link event between room calendars; the
+      // downstream zoomCalendarEventId === null branch recreates it on the new room's calendar
+      // with the stored link.
+      if (zid && existingMeeting.zoomManaged) {
         const ok = await deleteZoomMeeting(zid);
         if (!ok) zoomSynced = false;
       }
@@ -69,10 +74,12 @@ async function syncUpdatedMeeting(
           if (!ok) zoomSynced = false;
         }
       }
-      zid = null;
-      zoomLink = null;
-      zoomPasscode = null;
-      zoomHost = null;
+      if (existingMeeting.zoomManaged) {
+        zid = null;
+        zoomLink = null;
+        zoomPasscode = null;
+        zoomHost = null;
+      }
       zoomCalendarEventId = null;
     }
 
@@ -261,18 +268,16 @@ const updateMeeting = async (request: Request): Promise<Response> => {
     // already-assigned host untouched, is NOT a reassignment.
     const explicitHostChange = !!newMeeting.zoomHost && newMeeting.zoomHost !== existingMeeting.zoomHost;
 
-    // An unmanaged Zoom meeting (adopted legacy / externally hosted -- see schema.prisma's
-    // zoomManaged) can't be torn down and recreated by the app: a room or host change would
-    // silently replace the group's long-lived meeting ID. Reject up front with a clear message
-    // instead of half-applying the edit.
-    if (!existingMeeting.zoomManaged) {
-      const roomChangedUnmanaged = !!existingMeeting.zoomRoom && newMeeting.zoomRoom !== existingMeeting.zoomRoom;
-      if (roomChangedUnmanaged || explicitHostChange) {
-        return NextResponse.json(
-          { error: "This meeting's Zoom meeting is owned outside the app (legacy/external). Changing its Zoom room or host would replace the group's long-standing meeting ID — coordinate with ICR instead." },
-          { status: 422 },
-        );
-      }
+    // An unmanaged Zoom meeting's host is whoever owns it on Zoom's side (adopted legacy /
+    // externally hosted -- see schema.prisma's zoomManaged); the app can't reassign that, and
+    // persisting a different pool host would only make capacity accounting lie. Everything else
+    // (rooms, times, content) is app/calendar-side and stays editable -- a Zoom-room change
+    // just moves the join-link event between room calendars using the stored link.
+    if (!existingMeeting.zoomManaged && explicitHostChange) {
+      return NextResponse.json(
+        { error: "This meeting's Zoom meeting is ICR-owned (legacy/external); its host can't be reassigned from the app." },
+        { status: 422 },
+      );
     }
 
     // A count-bounded series (numberOfOccurrences set, no explicit endDate) has a real last

--- a/frontend/app/api/update/meeting/route.ts
+++ b/frontend/app/api/update/meeting/route.ts
@@ -57,7 +57,7 @@ async function syncUpdatedMeeting(
     const roomChanged = !!oldZoomRoom && oldZoomRoom !== newZoomRoom;
     const explicitHostChange = !!newMeeting.zoomHost && newMeeting.zoomHost !== existingMeeting.zoomHost;
 
-    if (roomChanged || explicitHostChange) {
+    if ((roomChanged || explicitHostChange) && existingMeeting.zoomManaged) {
       if (zid) {
         const ok = await deleteZoomMeeting(zid);
         if (!ok) zoomSynced = false;
@@ -94,7 +94,9 @@ async function syncUpdatedMeeting(
         zoomSyncError = "This time now conflicts with another meeting using the same Zoom host.";
         skipCalendarTimeSync = true;
       } else {
-        const ok = await updateZoomMeeting(zid, newMeeting);
+        // Unmanaged Zoom meetings are never PATCHed -- the stored link is the contract; only
+        // the calendars follow the app-side edit.
+        const ok = existingMeeting.zoomManaged ? await updateZoomMeeting(zid, newMeeting) : true;
         if (!ok) zoomSynced = false;
       }
     } else {
@@ -258,6 +260,20 @@ const updateMeeting = async (request: Request): Promise<Response> => {
     // down. A blank/"Automatic" selection, or resubmitting the form with the same
     // already-assigned host untouched, is NOT a reassignment.
     const explicitHostChange = !!newMeeting.zoomHost && newMeeting.zoomHost !== existingMeeting.zoomHost;
+
+    // An unmanaged Zoom meeting (adopted legacy / externally hosted -- see schema.prisma's
+    // zoomManaged) can't be torn down and recreated by the app: a room or host change would
+    // silently replace the group's long-lived meeting ID. Reject up front with a clear message
+    // instead of half-applying the edit.
+    if (!existingMeeting.zoomManaged) {
+      const roomChangedUnmanaged = !!existingMeeting.zoomRoom && newMeeting.zoomRoom !== existingMeeting.zoomRoom;
+      if (roomChangedUnmanaged || explicitHostChange) {
+        return NextResponse.json(
+          { error: "This meeting's Zoom meeting is owned outside the app (legacy/external). Changing its Zoom room or host would replace the group's long-standing meeting ID — coordinate with ICR instead." },
+          { status: 422 },
+        );
+      }
+    }
 
     // A count-bounded series (numberOfOccurrences set, no explicit endDate) has a real last
     // occurrence -- checking conflicts against the raw (still-null) endDate would expand it out

--- a/frontend/app/api/update/meeting/sync/route.ts
+++ b/frontend/app/api/update/meeting/sync/route.ts
@@ -73,6 +73,10 @@ const syncMeeting = async (request: Request): Promise<Response> => {
                 // sync only re-runs the calendar half against the stored link.
                 const ok = meeting.zoomManaged ? await updateZoomMeeting(zid, meetingForCalendar) : true;
                 if (!ok) zoomSynced = false;
+            } else if (!meeting.zoomManaged) {
+                // An unmanaged meeting with no zid points outside the app's Zoom account by
+                // deliberate choice -- a retry must not auto-provision an app-owned meeting
+                // under a flag that says the app doesn't own it.
             } else {
                 // Reserve a pool host under lock BEFORE ever calling the external Zoom API below
                 // -- closes #360's TOCTOU gap: two retries of this same meeting (or a retry

--- a/frontend/app/api/update/meeting/sync/route.ts
+++ b/frontend/app/api/update/meeting/sync/route.ts
@@ -69,7 +69,9 @@ const syncMeeting = async (request: Request): Promise<Response> => {
                 // is the "re-enter the queue" case, handled separately by update/meeting/route.ts).
                 // The conflict itself still surfaces independently via /api/admin/conflict-mids
                 // (Diagnostics), regardless of what happens here.
-                const ok = await updateZoomMeeting(zid, meetingForCalendar);
+                // Unmanaged (adopted/external) Zoom meetings are never PATCHed -- retrying the
+                // sync only re-runs the calendar half against the stored link.
+                const ok = meeting.zoomManaged ? await updateZoomMeeting(zid, meetingForCalendar) : true;
                 if (!ok) zoomSynced = false;
             } else {
                 // Reserve a pool host under lock BEFORE ever calling the external Zoom API below

--- a/frontend/app/components/meeting-form/EditMeeting.tsx
+++ b/frontend/app/components/meeting-form/EditMeeting.tsx
@@ -259,6 +259,9 @@ const EditMeetingSidebar: React.FC<EditMeetingSidebarProps> =
               isVisible={true}
               compact={compact}
               getCandidate={() => buildMeetingPayload(meeting.mid, meeting.status ?? 'Active')}
+              lockedReason={meeting.zoomManaged === false
+                ? "ICR-owned Zoom link (legacy) — the host can't be reassigned from the app."
+                : undefined}
             />
           }
           emailTextField={<TextField

--- a/frontend/app/components/meeting-form/ViewMeeting.tsx
+++ b/frontend/app/components/meeting-form/ViewMeeting.tsx
@@ -69,6 +69,7 @@ type ViewMeetingDetailsProps = {
   recurrencePattern?: IRecurrencePattern
   currentOccurrenceDate?: Date; // Handles the specific occurrence date
   lastEditedBy?: string | null; // Server-managed: session email of the last admin to save an edit
+  zoomManaged?: boolean; // false = ICR-owned/external Zoom meeting the app only points at
   googleSyncStatus?: string | null;
   googleSyncError?: string | null;
   zoomSyncStatus?: string | null;
@@ -114,6 +115,7 @@ const ViewMeetingDetails: React.FC<ViewMeetingDetailsProps> = ({
   description,
   creator,
   lastEditedBy,
+  zoomManaged,
   startDateTime,
   endDateTime,
   email,
@@ -497,6 +499,12 @@ const ViewMeetingDetails: React.FC<ViewMeetingDetailsProps> = ({
               <p className={styles.contactRow}>
                 <Icon name="person" />
                 <span>Host: {zoomHostLabel(zoomHost, zoomHostPool.indexOf(zoomHost))} — {zoomHost}</span>
+              </p>
+            )}
+            {zoomManaged === false && (
+              <p className={styles.contactRow}>
+                <Icon name="lock" />
+                <span>Legacy Zoom link — owned by ICR; the app keeps calendars in sync but never changes the Zoom meeting itself.</span>
               </p>
             )}
             {/* Provenance is only shown when it's a real session email -- meetings created

--- a/frontend/app/components/meeting-form/ZoomHostField.module.scss
+++ b/frontend/app/components/meeting-form/ZoomHostField.module.scss
@@ -11,6 +11,15 @@
     font-family: 'Source Sans Pro', sans-serif;
 }
 
+.lockedIndicator {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  color: $medium-grey-color;
+  margin: 0;
+}
+
 .checkDoneIndicator {
     display: flex;
     align-items: center;

--- a/frontend/app/components/meeting-form/ZoomHostField.tsx
+++ b/frontend/app/components/meeting-form/ZoomHostField.tsx
@@ -22,6 +22,10 @@ export interface ZoomHostFieldProps {
   // to send as-is (see util/meetingValidation.ts's zoomHostAvailabilityCheckSchema, which
   // only reads mid/startDateTime/endDateTime/isRecurring/recurrencePattern from it).
   getCandidate: () => IMeeting | null;
+  // When set, the field renders read-only with this explanation instead of the dropdown --
+  // used for meetings whose Zoom meeting the app doesn't own (zoomManaged: false), where a
+  // host reassignment is impossible (the server 422s it) rather than merely unavailable.
+  lockedReason?: string;
 }
 
 const CheckIcon: React.FC = () => (
@@ -63,6 +67,7 @@ export const ZoomHostField: React.FC<ZoomHostFieldProps> = ({
   isVisible,
   compact = false,
   getCandidate,
+  lockedReason,
 }) => {
   const hosts = useZoomHostPool();
   // Per-host remaining capacity from the most recent check -- freeSlots reflects the
@@ -181,6 +186,16 @@ export const ZoomHostField: React.FC<ZoomHostFieldProps> = ({
   }, [candidateKey]);
 
   if (!isVisible) return null;
+
+  if (lockedReason) {
+    return (
+      <div className={styles.zoomHostField}>
+        <p className={styles.lockedIndicator}>
+          <Icon name="lock" size={16} ariaLabel="Locked" /> {lockedReason}
+        </p>
+      </div>
+    );
+  }
 
   const labelToEmail: Record<string, string> = {};
   hosts.forEach((email, i) => { labelToEmail[zoomHostLabel(email, i)] = email; });

--- a/frontend/prisma/migrations/20260820030000_add_meeting_zoom_managed/migration.sql
+++ b/frontend/prisma/migrations/20260820030000_add_meeting_zoom_managed/migration.sql
@@ -1,2 +1,7 @@
 -- AlterTable
 ALTER TABLE "Meeting" ADD COLUMN "zoomManaged" BOOLEAN NOT NULL DEFAULT true;
+
+-- Backfill: the one meeting whose Zoom meeting lives on an account this app cannot control
+-- (Noon Brown Baggers, hosted externally -- see 2026-08-20 legacy-Zoom migration). Adopted
+-- in-account legacy meetings stay managed; this is a no-op on dev/test databases.
+UPDATE "Meeting" SET "zoomManaged" = false WHERE "zid" = '4013485321';

--- a/frontend/prisma/migrations/20260820030000_add_meeting_zoom_managed/migration.sql
+++ b/frontend/prisma/migrations/20260820030000_add_meeting_zoom_managed/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Meeting" ADD COLUMN "zoomManaged" BOOLEAN NOT NULL DEFAULT true;

--- a/frontend/prisma/migrations/20260820030000_add_meeting_zoom_managed/migration.sql
+++ b/frontend/prisma/migrations/20260820030000_add_meeting_zoom_managed/migration.sql
@@ -5,3 +5,35 @@ ALTER TABLE "Meeting" ADD COLUMN "zoomManaged" BOOLEAN NOT NULL DEFAULT true;
 -- (Noon Brown Baggers, hosted externally -- see 2026-08-20 legacy-Zoom migration). Adopted
 -- in-account legacy meetings stay managed; this is a no-op on dev/test databases.
 UPDATE "Meeting" SET "zoomManaged" = false WHERE "zid" = '4013485321';
+
+-- AlterTable
+ALTER TABLE "Meeting" ADD COLUMN "zoomTopic" TEXT;
+
+-- Backfill: pin the adopted legacy meetings' (and the two 2026-08-20-created meetings') exact
+-- Zoom topics so a managed edit can never rename them implicitly -- null zoomTopic derives
+-- title + mode suffix instead. Verbatim from the Zoom API on 2026-08-20; no-ops on dev/test.
+UPDATE "Meeting" SET "zoomTopic" = 'Daily Ithaca - Hybrid' WHERE "zid" = '81303529023';
+UPDATE "Meeting" SET "zoomTopic" = 'Keep It Simple - Hybrid' WHERE "zid" = '81841184487';
+UPDATE "Meeting" SET "zoomTopic" = 'Friday Night Women''s Group - AA- Hybrid 2nd Fri' WHERE "zid" = '81983669363';
+UPDATE "Meeting" SET "zoomTopic" = 'We Absolutely Insist on Enjoying Life - Zoom Only' WHERE "zid" = '82347415492';
+UPDATE "Meeting" SET "zoomTopic" = 'Progress not Perfection - AFG - Hybrid' WHERE "zid" = '82782481112';
+UPDATE "Meeting" SET "zoomTopic" = 'Women''s AA Group - Hybrid' WHERE "zid" = '83162888305';
+UPDATE "Meeting" SET "zoomTopic" = 'Monday Night Big Book - Hybrid' WHERE "zid" = '83285117507';
+UPDATE "Meeting" SET "zoomTopic" = 'Marijuana Anonymous - Hybrid' WHERE "zid" = '83465945284';
+UPDATE "Meeting" SET "zoomTopic" = 'How It Works AA - Hybrid' WHERE "zid" = '83536666917';
+UPDATE "Meeting" SET "zoomTopic" = 'PI-CPC AA Intergroup - Hybrid' WHERE "zid" = '83628425047';
+UPDATE "Meeting" SET "zoomTopic" = 'Al Anon Intergroup' WHERE "zid" = '83660784808';
+UPDATE "Meeting" SET "zoomTopic" = 'Recovering Couples Anonymous - Hybrid (Fall)' WHERE "zid" = '83945489280';
+UPDATE "Meeting" SET "zoomTopic" = 'Sunday 12 & 12 - Hybrid' WHERE "zid" = '84092177497';
+UPDATE "Meeting" SET "zoomTopic" = 'AFG - Friday' WHERE "zid" = '84334042952';
+UPDATE "Meeting" SET "zoomTopic" = 'GA - Zoom Only Sunday 530 PM' WHERE "zid" = '84944376249';
+UPDATE "Meeting" SET "zoomTopic" = 'Big Book Reading Group' WHERE "zid" = '85324331941';
+UPDATE "Meeting" SET "zoomTopic" = 'Weekend AFG - Hybrid' WHERE "zid" = '85466978793';
+UPDATE "Meeting" SET "zoomTopic" = 'One Day at a Time - Hybrid M-S - Zoom Only Sunday' WHERE "zid" = '85490891468';
+UPDATE "Meeting" SET "zoomTopic" = 'AA District Meeting' WHERE "zid" = '85760961749';
+UPDATE "Meeting" SET "zoomTopic" = 'Sex and Love Addicts Anonymous' WHERE "zid" = '86035030643';
+UPDATE "Meeting" SET "zoomTopic" = 'Thursday Night Ala-Non Group - Zoom Only' WHERE "zid" = '86588912277';
+UPDATE "Meeting" SET "zoomTopic" = 'Danby Tosspots' WHERE "zid" = '87447757338';
+UPDATE "Meeting" SET "zoomTopic" = 'Early Bird 7 AM Daily Meeting' WHERE "zid" = '89296128710';
+UPDATE "Meeting" SET "zoomTopic" = 'NA Spiritual Foundations ' WHERE "zid" = '89625374048';
+UPDATE "Meeting" SET "zoomTopic" = 'No Human Power - Zoom Only' WHERE "zid" = '89741511713';

--- a/frontend/prisma/schema.prisma
+++ b/frontend/prisma/schema.prisma
@@ -68,6 +68,10 @@ model Meeting {
   // (e.g. a group member's personal account). The app must never PATCH, delete, or recreate an
   // unmanaged Zoom meeting -- it is the client's property; only the stored link/passcode is ours.
   zoomManaged            Boolean              @default(true)
+  // The Zoom meeting's display topic. Null = derive from title + a mode suffix (" - Hybrid" /
+  // " - Zoom Only", ICR's own naming convention); non-null = pinned verbatim -- backfilled with
+  // the adopted legacy meetings' exact topics so an app-side edit never renames them by surprise.
+  zoomTopic              String?
   deletedAt              DateTime?
   updatedAt              DateTime?            @updatedAt
 

--- a/frontend/prisma/schema.prisma
+++ b/frontend/prisma/schema.prisma
@@ -63,6 +63,11 @@ model Meeting {
   // Server-managed provenance (session email), like creator: null = never edited since import/
   // creation. Both are set only by the API routes, never from client payloads.
   lastEditedBy           String?
+  // False for meetings whose Zoom meeting the app merely points at but does not own: ICR's
+  // legacy recurring meetings adopted in the 2026-08 migration, and externally hosted ones
+  // (e.g. a group member's personal account). The app must never PATCH, delete, or recreate an
+  // unmanaged Zoom meeting -- it is the client's property; only the stored link/passcode is ours.
+  zoomManaged            Boolean              @default(true)
   deletedAt              DateTime?
   updatedAt              DateTime?            @updatedAt
 

--- a/frontend/services/zoom.ts
+++ b/frontend/services/zoom.ts
@@ -241,12 +241,21 @@ function toZoomStartTime(date: Date): string {
   return `${get("year")}-${get("month")}-${get("day")}T${get("hour")}:${get("minute")}:${get("second")}`;
 }
 
+// ICR's own Zoom naming convention, applied when no explicit zoomTopic is pinned. Adopted
+// legacy meetings carry a pinned zoomTopic instead (their verbatim pre-app names) so an
+// app-side edit can never rename them implicitly.
+function zoomTopicFor(meeting: IMeeting): string {
+  if (meeting.zoomTopic) return meeting.zoomTopic;
+  const suffix = meeting.modeType === "Remote" ? " - Zoom Only" : meeting.modeType === "Hybrid" ? " - Hybrid" : "";
+  return `${meeting.title}${suffix}`;
+}
+
 function buildZoomMeetingBody(meeting: IMeeting) {
   const durationMinutes = Math.round(
     (new Date(meeting.endDateTime).getTime() - new Date(meeting.startDateTime).getTime()) / 60000,
   );
   return {
-    topic: meeting.title,
+    topic: zoomTopicFor(meeting),
     type: 2, // single stable meeting, reused across all occurrences
     start_time: toZoomStartTime(new Date(meeting.startDateTime)),
     duration: durationMinutes,

--- a/frontend/services/zoom.ts
+++ b/frontend/services/zoom.ts
@@ -265,7 +265,11 @@ export async function createZoomMeeting(meeting: IMeeting, hostEmail: string): P
     const res = await fetch(`${ZOOM_BASE_API}/users/${encodeURIComponent(hostEmail)}/meetings`, {
       method: "POST",
       headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
-      body: JSON.stringify(buildZoomMeetingBody(meeting)),
+      body: JSON.stringify(
+        meeting.isRecurring
+          ? (({ topic, agenda, settings }) => ({ topic, agenda, settings }))(buildZoomMeetingBody(meeting))
+          : buildZoomMeetingBody(meeting),
+      ),
     });
     invalidateZoomTokenIfUnauthorized(res);
     if (!res.ok) {
@@ -305,6 +309,11 @@ export async function getZoomMeetingInvitation(zid: string): Promise<string | nu
 }
 
 export async function updateZoomMeeting(zid: string, meeting: IMeeting): Promise<boolean> {
+  // A recurring series' Zoom meeting is a stable join target (legacy type 3, or endless type 8)
+  // whose schedule lives in the app/Google Calendar, not in Zoom -- PATCHing start_time/duration
+  // into it would distort the series (and Zoom silently rewrites past starts anyway). Only
+  // content fields are safe to update for recurring meetings.
+
   try {
     const token = await getZoomAccessToken();
     if (!token) return false;
@@ -312,7 +321,11 @@ export async function updateZoomMeeting(zid: string, meeting: IMeeting): Promise
     const res = await fetch(`${ZOOM_BASE_API}/meetings/${zid}`, {
       method: "PATCH",
       headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
-      body: JSON.stringify(buildZoomMeetingBody(meeting)),
+      body: JSON.stringify(
+        meeting.isRecurring
+          ? (({ topic, agenda, settings }) => ({ topic, agenda, settings }))(buildZoomMeetingBody(meeting))
+          : buildZoomMeetingBody(meeting),
+      ),
     });
     invalidateZoomTokenIfUnauthorized(res);
     if (!res.ok) console.error("Zoom updateMeeting error:", await res.text());

--- a/frontend/tests/integration/delete-meeting-route.test.ts
+++ b/frontend/tests/integration/delete-meeting-route.test.ts
@@ -33,9 +33,11 @@ jest.mock("../../services/zoom", () => ({
 }));
 
 import { deleteCalendarEvent } from "../../services/googleCalendar";
+import { deleteZoomMeeting } from "../../services/zoom";
 import { DELETE } from "../../app/api/delete/meeting/route";
 
 const mockedDelete = deleteCalendarEvent as jest.Mock;
+const mockedDeleteZoom = deleteZoomMeeting as jest.Mock;
 
 afterAll(async () => {
   await disconnectTestPrismaClient();
@@ -43,6 +45,7 @@ afterAll(async () => {
 
 beforeEach(() => {
   mockedDelete.mockClear();
+  mockedDeleteZoom.mockClear();
   mockCapturedAfterTasks.length = 0;
 });
 
@@ -54,6 +57,28 @@ beforeEach(() => {
 async function drainAfterTasks(): Promise<void> {
   await Promise.all(mockCapturedAfterTasks.splice(0, mockCapturedAfterTasks.length));
 }
+
+test("deleting a meeting whose Zoom meeting is unmanaged never deletes it from Zoom", async () => {
+  const meeting = await seedMeeting({ zid: "89296128710", zoomManaged: false });
+
+  const response = await DELETE(new Request("http://localhost/api/delete/meeting", {
+    method: "DELETE", body: JSON.stringify({ mid: meeting.mid, deleteOption: "all" }),
+  }));
+  expect(response.status).toBe(200);
+  await drainAfterTasks();
+  expect(mockedDeleteZoom).not.toHaveBeenCalled();
+});
+
+test("deleting a managed meeting still tears its Zoom meeting down", async () => {
+  const meeting = await seedMeeting({ zid: "80000000001", zoomManaged: true });
+
+  const response = await DELETE(new Request("http://localhost/api/delete/meeting", {
+    method: "DELETE", body: JSON.stringify({ mid: meeting.mid, deleteOption: "all" }),
+  }));
+  expect(response.status).toBe(200);
+  await drainAfterTasks();
+  expect(mockedDeleteZoom).toHaveBeenCalledWith("80000000001");
+});
 
 test("deleting a meeting with a pending pre-created resume series tears that series down too, not just the live event", async () => {
   const { meeting } = await seedRecurringMeeting({

--- a/frontend/tests/integration/delete-meeting-route.test.ts
+++ b/frontend/tests/integration/delete-meeting-route.test.ts
@@ -69,6 +69,28 @@ test("deleting a meeting whose Zoom meeting is unmanaged never deletes it from Z
   expect(mockedDeleteZoom).not.toHaveBeenCalled();
 });
 
+test("a managed Zoom meeting shared by two rows survives until the last referencing row is deleted", async () => {
+  // Unique to this test: the sibling count is a real DB query, and suites share the embedded
+  // Postgres — reusing a zid another suite seeds would make the count see foreign rows.
+  const shared = "70000000777";
+  const a = await seedMeeting({ zid: shared, zoomManaged: true, title: "Shared Pair A" });
+  const b = await seedMeeting({ zid: shared, zoomManaged: true, title: "Shared Pair B" });
+
+  let response = await DELETE(new Request("http://localhost/api/delete/meeting", {
+    method: "DELETE", body: JSON.stringify({ mid: a.mid, deleteOption: "all" }),
+  }));
+  expect(response.status).toBe(200);
+  await drainAfterTasks();
+  expect(mockedDeleteZoom).not.toHaveBeenCalled();
+
+  response = await DELETE(new Request("http://localhost/api/delete/meeting", {
+    method: "DELETE", body: JSON.stringify({ mid: b.mid, deleteOption: "all" }),
+  }));
+  expect(response.status).toBe(200);
+  await drainAfterTasks();
+  expect(mockedDeleteZoom).toHaveBeenCalledWith("70000000777");
+});
+
 test("deleting a managed meeting still tears its Zoom meeting down", async () => {
   const meeting = await seedMeeting({ zid: "80000000001", zoomManaged: true });
 

--- a/frontend/tests/integration/update-meeting-route.test.ts
+++ b/frontend/tests/integration/update-meeting-route.test.ts
@@ -170,6 +170,40 @@ test("an unmanaged Zoom meeting is never PATCHed by a plain edit, and the edit s
   expect(stored?.zoomSyncStatus).toBe("synced");
 });
 
+test("a Zoom-room change on an unmanaged meeting moves the calendar event but keeps the Zoom meeting", async () => {
+  mockedReconcileMeetingCalendars.mockResolvedValue({ updatedEventIds: {}, allSynced: true });
+
+  const prisma = getTestPrismaClient();
+  const mid = `m-${randomUUID()}`;
+  await prisma.meeting.create({ data: { ...toMeetingCreateInput(buildMeetingPayload({
+    mid, modeType: "Hybrid", room: "Unmanaged Move Room", zoomRoom: "Unmanaged Move Room - Zoom",
+    zid: "85466978793", zoomHost: "518board@gmail.com", zoomLink: "https://zoom.us/j/85466978793",
+    zoomCalendarEventId: "old-room-event",
+  })), zoomManaged: false, zoomSyncStatus: "synced" } });
+
+  const edit = buildMeetingPayload({
+    mid, modeType: "Hybrid", room: "Unmanaged Move Room 2", zoomRoom: "Unmanaged Move Room 2 - Zoom",
+    zid: "85466978793", zoomHost: "518board@gmail.com",
+  });
+  const response = await PUT(new Request("http://localhost/api/update/meeting", { method: "PUT", body: JSON.stringify(edit) }));
+  expect(response.status).toBe(200);
+
+  // The deferred sync persists the kept zid/link last — wait for the room change to land,
+  // then assert what the sync did (and didn't do) to Zoom.
+  const stored = await waitFor(async () => {
+    const m = await prisma.meeting.findUnique({ where: { mid } });
+    return m?.zoomRoom === "Unmanaged Move Room 2 - Zoom" && m.zoomSyncStatus === "synced" ? m : null;
+  });
+
+  // The Zoom meeting itself is never deleted, recreated, or PATCHed.
+  expect(mockedDeleteZoomMeeting).not.toHaveBeenCalled();
+  expect(mockedCreateZoomMeeting).not.toHaveBeenCalled();
+  expect(mockedUpdateZoomMeeting).not.toHaveBeenCalled();
+
+  expect(stored?.zid).toBe("85466978793");
+  expect(stored?.zoomLink).toBe("https://zoom.us/j/85466978793");
+});
+
 test("an explicit host change on an unmanaged Zoom meeting is rejected with 422 before touching Zoom", async () => {
   const prisma = getTestPrismaClient();
   const mid = `m-${randomUUID()}`;

--- a/frontend/tests/integration/update-meeting-route.test.ts
+++ b/frontend/tests/integration/update-meeting-route.test.ts
@@ -148,6 +148,27 @@ test("a malformed body returns 400 with validation issues instead of a raw 500",
   expect(found).toBeNull();
 });
 
+test("a managed edit threads the pinned zoomTopic into the Zoom PATCH instead of the title", async () => {
+  mockedUpdateZoomMeeting.mockResolvedValue(true);
+  mockedReconcileMeetingCalendars.mockResolvedValue({ updatedEventIds: {}, allSynced: true });
+
+  const prisma = getTestPrismaClient();
+  const mid = `m-${randomUUID()}`;
+  await prisma.meeting.create({ data: { ...toMeetingCreateInput(buildMeetingPayload({
+    mid, modeType: "Remote", room: "", zoomRoom: "", zid: "70000000778", zoomHost: "zoom@518icr.com",
+  })), zoomManaged: true, zoomTopic: "Keep It Simple - Hybrid", zoomSyncStatus: "synced" } });
+
+  const edit = buildMeetingPayload({ mid, modeType: "Remote", room: "", zoomRoom: "", title: "Tuesday Noon Al-Anon", zoomHost: "zoom@518icr.com" });
+  const response = await PUT(new Request("http://localhost/api/update/meeting", { method: "PUT", body: JSON.stringify(edit) }));
+  expect(response.status).toBe(200);
+
+  await waitFor(async () => (mockedUpdateZoomMeeting.mock.calls.length > 0 ? true : null));
+  expect(mockedUpdateZoomMeeting).toHaveBeenCalledWith(
+    "70000000778",
+    expect.objectContaining({ zoomTopic: "Keep It Simple - Hybrid" }),
+  );
+});
+
 test("an unmanaged Zoom meeting is never PATCHed by a plain edit, and the edit still succeeds", async () => {
   mockedReconcileMeetingCalendars.mockResolvedValue({ updatedEventIds: {}, allSynced: true });
 

--- a/frontend/tests/integration/update-meeting-route.test.ts
+++ b/frontend/tests/integration/update-meeting-route.test.ts
@@ -148,6 +148,46 @@ test("a malformed body returns 400 with validation issues instead of a raw 500",
   expect(found).toBeNull();
 });
 
+test("an unmanaged Zoom meeting is never PATCHed by a plain edit, and the edit still succeeds", async () => {
+  mockedReconcileMeetingCalendars.mockResolvedValue({ updatedEventIds: {}, allSynced: true });
+
+  const prisma = getTestPrismaClient();
+  const mid = `m-${randomUUID()}`;
+  await prisma.meeting.create({ data: { ...toMeetingCreateInput(buildMeetingPayload({
+    mid, modeType: "Remote", room: "", zoomRoom: "", zid: "40134853210", zoomHost: null,
+    zoomLink: "https://zoom.us/j/40134853210",
+  })), zoomManaged: false, zoomSyncStatus: "synced" } });
+
+  const edit = buildMeetingPayload({ mid, modeType: "Remote", room: "", zoomRoom: "", title: "Renamed Unmanaged" });
+  const response = await PUT(new Request("http://localhost/api/update/meeting", { method: "PUT", body: JSON.stringify(edit) }));
+  expect(response.status).toBe(200);
+
+  expect(mockedUpdateZoomMeeting).not.toHaveBeenCalled();
+  expect(mockedDeleteZoomMeeting).not.toHaveBeenCalled();
+  const stored = await prisma.meeting.findUnique({ where: { mid } });
+  expect(stored?.title).toBe("Renamed Unmanaged");
+  expect(stored?.zid).toBe("40134853210");
+  expect(stored?.zoomSyncStatus).toBe("synced");
+});
+
+test("an explicit host change on an unmanaged Zoom meeting is rejected with 422 before touching Zoom", async () => {
+  const prisma = getTestPrismaClient();
+  const mid = `m-${randomUUID()}`;
+  await prisma.meeting.create({ data: { ...toMeetingCreateInput(buildMeetingPayload({
+    mid, modeType: "Remote", room: "", zoomRoom: "", zid: "89296128710", zoomHost: "zoom@518icr.com",
+  })), zoomManaged: false } });
+
+  const edit = buildMeetingPayload({ mid, modeType: "Remote", room: "", zoomRoom: "", zoomHost: "518board@gmail.com" });
+  const response = await PUT(new Request("http://localhost/api/update/meeting", { method: "PUT", body: JSON.stringify(edit) }));
+  expect(response.status).toBe(422);
+  expect(mockedDeleteZoomMeeting).not.toHaveBeenCalled();
+  expect(mockedUpdateZoomMeeting).not.toHaveBeenCalled();
+
+  const stored = await prisma.meeting.findUnique({ where: { mid } });
+  expect(stored?.zid).toBe("89296128710");
+  expect(stored?.zoomHost).toBe("zoom@518icr.com");
+});
+
 test("an update never overwrites the stored creator with the client payload's value", async () => {
   mockedReconcileMeetingCalendars.mockResolvedValue({ updatedEventIds: {}, allSynced: true });
 

--- a/frontend/tests/integration/update-meeting-sync-route.test.ts
+++ b/frontend/tests/integration/update-meeting-sync-route.test.ts
@@ -227,6 +227,25 @@ describe("retrying an already-synced meeting (existing zid)", () => {
     expect(mockedReconcileMeetingCalendars).toHaveBeenCalled();
   });
 
+  test("an unmanaged Zoom meeting's retry skips the Zoom PATCH but still reconciles calendars", async () => {
+    mockedReconcileMeetingCalendars.mockResolvedValue({ updatedEventIds: {}, allSynced: true, googleSyncError: null });
+
+    const prisma = getTestPrismaClient();
+    const meetingData = buildSyncedMeetingData({ zoomManaged: false });
+    await prisma.meeting.create({ data: meetingData });
+
+    const response = await POST(new Request("http://localhost/api/update/meeting/sync", {
+      method: "POST",
+      body: JSON.stringify({ mid: meetingData.mid }),
+    }));
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.zoomSyncStatus).toBe("synced");
+
+    expect(mockedUpdateZoomMeeting).not.toHaveBeenCalled();
+    expect(mockedReconcileMeetingCalendars).toHaveBeenCalled();
+  });
+
   test("a real Zoom API failure marks zoomSyncStatus error and defers the calendar reconcile", async () => {
     mockedUpdateZoomMeeting.mockResolvedValue(false);
 

--- a/frontend/tests/unit/suspension.test.ts
+++ b/frontend/tests/unit/suspension.test.ts
@@ -53,6 +53,7 @@ function buildMeeting(overrides: Partial<Meeting> = {}): Omit<Meeting, "recurren
     creator: "creator@test.icr",
     lastEditedBy: null,
     zoomManaged: true,
+    zoomTopic: null,
     group: "Group",
     startDateTime: new Date(now - DAY_MS),
     endDateTime: new Date(now - DAY_MS + 60 * 60 * 1000),

--- a/frontend/tests/unit/suspension.test.ts
+++ b/frontend/tests/unit/suspension.test.ts
@@ -52,6 +52,7 @@ function buildMeeting(overrides: Partial<Meeting> = {}): Omit<Meeting, "recurren
     description: "",
     creator: "creator@test.icr",
     lastEditedBy: null,
+    zoomManaged: true,
     group: "Group",
     startDateTime: new Date(now - DAY_MS),
     endDateTime: new Date(now - DAY_MS + 60 * 60 * 1000),

--- a/frontend/types/models.ts
+++ b/frontend/types/models.ts
@@ -15,6 +15,7 @@ interface IMeeting {
   creator: string; // admin later on [optional]
   lastEditedBy?: string | null; // server-managed: session email of the last admin to save an edit
   zoomManaged?: boolean; // false = the app points at an ICR-owned/external Zoom meeting and never mutates it
+  zoomTopic?: string | null; // pinned Zoom display topic; null derives title + mode suffix
   group: string; // group interface later on [optional]
   startDateTime: Date;
   endDateTime: Date;

--- a/frontend/types/models.ts
+++ b/frontend/types/models.ts
@@ -14,6 +14,7 @@ interface IMeeting {
   description: string;
   creator: string; // admin later on [optional]
   lastEditedBy?: string | null; // server-managed: session email of the last admin to save an edit
+  zoomManaged?: boolean; // false = the app points at an ICR-owned/external Zoom meeting and never mutates it
   group: string; // group interface later on [optional]
   startDateTime: Date;
   endDateTime: Date;


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved handling of externally managed Zoom meetings.
  * External meetings are preserved during deletion and are not modified through Zoom.
  * Room or host changes for external meetings are rejected while calendar updates continue.
  * Recurring Zoom meeting updates now avoid changing scheduling details.

* **Bug Fixes**
  * Retry synchronization now preserves external Zoom meetings while still updating calendars.
  * Managed Zoom meetings continue to be updated and deleted as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description
Production meetings now point at ICR's legacy Zoom meetings (2026-08-20 migration): 23 client-owned recurring meetings, plus one hosted on an external Zoom account entirely. The app's Zoom-mutating paths would corrupt or destroy them: an edit PATCHes schedule fields into type-3 "no fixed time" meetings, a room/host change tears down and recreates (replacing the group's long-standing meeting ID), and a series delete calls the Zoom delete API. This PR makes those meetings structurally untouchable.

- **frontend/prisma/schema.prisma + migrations/20260820030000_add_meeting_zoom_managed**: `zoomManaged Boolean @default(true)` — false means the app merely points at the Zoom meeting (stored link/passcode) and must never mutate it. Post-deploy plan (revised): the in-account legacy meetings will be converted type-3 → type-8 in place (identity-preserving, verified empirically) and left managed; only the externally hosted meeting (Noon Brown Baggers) gets zoomManaged: false — unmanaged is reserved for meetings the account genuinely cannot control.
- **frontend/app/api/update/meeting/route.ts**: only an explicit host reassignment on an unmanaged meeting is rejected (422) — the real host is whoever owns the meeting on Zoom. Everything else stays editable: a Zoom-room change moves the join-link event between room calendars while preserving zid/link/passcode; time/content edits update app + calendars only (a Zoom meeting's schedule fields are display-only and never gate joinability).
- **Shared-zid reference counting** (delete + room-change teardown): three legacy meetings serve two schedule-variant rows each — a managed Zoom meeting is only torn down by the last live row referencing it.
- **UI surfacing**: the edit form locks the Zoom Host dropdown with an explanation when the meeting is unmanaged (instead of a post-submit 422), and ViewMeeting's admin rows tag unmanaged meetings as ICR-owned legacy links.
- **frontend/app/api/update/meeting/sync/route.ts**: retry-sync skips the Zoom PATCH for unmanaged meetings and re-runs only the calendar reconcile against the stored link.
- **frontend/app/api/delete/meeting/route.ts**: whole-series delete never deletes an unmanaged Zoom meeting.
- **`zoomTopic` (nullable, server-managed)**: the Zoom display name — null derives `title + ' - Hybrid'/' - Zoom Only'` (ICR's own convention); non-null is pinned verbatim. The migration backfills every adopted meeting's exact pre-app topic (verbatim from the Zoom API) plus the two newly created meetings' titles, so a managed edit can never rename a Zoom meeting implicitly — renames become a deliberate act on this field (UI for it is a future decision). The pinned value is threaded server-side into the PATCH; client payloads never carry it.
- **frontend/services/zoom.ts**: `updateZoomMeeting` stops sending `start_time`/`duration` for any recurring meeting — managed or not, a recurring series' Zoom meeting is a stable join target whose schedule lives in the app and Google Calendar (see technical-decisions.md); only `topic`/`agenda`/`settings` remain PATCHable.
- **Tests**: five new integration cases — unmanaged edit skips PATCH and succeeds; unmanaged host change 422s before touching Zoom; unmanaged retry-sync reconciles calendars without a PATCH; unmanaged delete leaves Zoom alone; managed delete still tears down.

## Testing
- [x] Full `yarn test:all` green locally: lint 0 errors, lint:css, typecheck, unit 278, component 282, integration 144 (9 new), e2e 117.
- [ ] Post-deploy: run the zoomManaged backfill, then Retry sync on a Hybrid meeting — Diagnostics stays clean and the room calendar picks up the legacy join link (Phase 3 of the migration).

## Area(s) Touched
**Product areas**
- [ ] auth — sign-in, sessions, NextAuth, role-based access
- [ ] admin — /admin shell (Diagnostics, Users, Import, Export tabs)
- [ ] docs — /docs Resources page (rendering, navigation, search)
- [ ] ui/ux — frontend layout/styling not tied to a specific integration

**Integrations**
- [ ] google-calendar — Google Calendar sync
- [X] zoom-api — Zoom meeting/host sync

**Engineering**
- [ ] security — auth hardening, data exposure, dependency/security scanning
- [X] testing — test suite (Jest/Playwright) changes
- [ ] github-actions — workflows, Dependabot config, other .github/ CI tooling
- [ ] cleanup — refactor or dead-code removal, no behavior change
- [ ] documentation — docs/ or README changes only

## Pre-merge Checklist
- [X] Code follows current formatting conventions and passes lint (`yarn lint`).
- [X] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
- [X] All test suites pass, both run locally and green in GitHub CI. **Do not merge if any test suite is failing.**
- [X] A test suite was added or updated for the feature/fix in this PR. **Double-check this if you change a feature and did not update the test suites**.
- [X] Only files relevant to this change are committed — no stray or unrelated files.
- [ ] If this branch has a merge conflict with master, master was merged into this branch first (not the other way around).
- [X] The rest of this PR description (Description, Testing) is filled out, not left as template placeholders.

