### PR TITLE
feat(zoom): create recurring series as endless type-8 meetings

### DIFF
--- a/frontend/services/zoom.ts
+++ b/frontend/services/zoom.ts
@@ -1,7 +1,7 @@
 import "server-only";
 import { Prisma } from "@prisma/client";
 import { IMeeting } from "../types/models";
-import { findResourceConflicts, findFirstFreePoolHost, getPoolHostLoads, OccurrenceInput } from "../util/meetings/resourceOverlap";
+import { expandOccurrences, findResourceConflicts, findFirstFreePoolHost, getPoolHostLoads, OccurrenceInput } from "../util/meetings/resourceOverlap";
 import { prisma } from "../lib/prisma";
 
 const ZOOM_BASE_API = process.env.NEXT_PUBLIC_ZOOM_BASE_API ?? "https://api.zoom.us/v2";
@@ -241,6 +241,54 @@ function toZoomStartTime(date: Date): string {
   return `${get("year")}-${get("month")}-${get("day")}T${get("hour")}:${get("minute")}:${get("second")}`;
 }
 
+// Zoom's weekday numbering for recurrence.weekly_days / monthly_week_day (1 = Sunday).
+const ZOOM_WEEKDAY: Record<string, number> = {
+  Sunday: 1, Monday: 2, Tuesday: 3, Wednesday: 4, Thursday: 5, Friday: 6, Saturday: 7,
+};
+
+// Maps the app's recurrence pattern onto Zoom's recurrence object so a recurring series is a
+// real type-8 recurring meeting on Zoom (visible as a series in the host's portal). An
+// unbounded series sends end_times: 0 -- undocumented but exactly what the Zoom portal itself
+// stores for its own "no end" meetings (verified empirically 2026-08-20; Zoom's PATCH path
+// clamps it to a ~2-year rolling horizon, which future edits keep pushing forward).
+function buildZoomRecurrence(meeting: IMeeting): Record<string, unknown> | null {
+  if (!meeting.isRecurring || !meeting.recurrencePattern) return null;
+  const p = meeting.recurrencePattern;
+  const end = p.endDate
+    ? { end_date_time: new Date(p.endDate).toISOString().replace(/\.\d{3}Z$/, "Z") }
+    : p.numberOfOccurrences
+      // Zoom rejects counts above 50 -- a longer bounded series still ends on time because the
+      // app/calendars own the real schedule; Zoom's copy just under-shows the tail.
+      ? { end_times: Math.min(p.numberOfOccurrences, 50) }
+      : { end_times: 0 };
+  if (p.type === "monthly") {
+    if (p.weekOfMonth != null && (p.daysOfWeek ?? []).length > 0) {
+      return { type: 3, repeat_interval: p.interval ?? 1, monthly_week: p.weekOfMonth,
+        monthly_week_day: ZOOM_WEEKDAY[(p.daysOfWeek ?? [])[0]] ?? 1, ...end };
+    }
+    if (p.dayOfMonth != null) {
+      return { type: 3, repeat_interval: p.interval ?? 1, monthly_day: p.dayOfMonth, ...end };
+    }
+  }
+  const days = (p.daysOfWeek ?? []).map((d) => ZOOM_WEEKDAY[d]).filter(Boolean);
+  return { type: 2, repeat_interval: p.interval ?? 1, ...(days.length ? { weekly_days: days.join(",") } : {}), ...end };
+}
+
+// A recurring meeting's Zoom start_time is its next FUTURE occurrence, never the series
+// anchor: Zoom silently rewrites a past start_time to "now" (verified 2026-08-20), and a
+// backdated anchor (e.g. a lease-year import) would otherwise file the meeting under the
+// host's past meetings.
+function nextOccurrenceStart(meeting: IMeeting): Date {
+  if (!meeting.isRecurring || !meeting.recurrencePattern) return new Date(meeting.startDateTime);
+  const now = new Date();
+  const horizon = new Date(now.getTime() + 370 * 24 * 60 * 60 * 1000);
+  const occurrences = expandOccurrences(
+    { ...meeting, recurrencePattern: meeting.recurrencePattern } as Parameters<typeof expandOccurrences>[0],
+    now, horizon,
+  );
+  return occurrences[0]?.start ?? new Date(meeting.startDateTime);
+}
+
 // ICR's own Zoom naming convention, applied when no explicit zoomTopic is pinned. Adopted
 // legacy meetings carry a pinned zoomTopic instead (their verbatim pre-app names) so an
 // app-side edit can never rename them implicitly.
@@ -254,10 +302,15 @@ function buildZoomMeetingBody(meeting: IMeeting) {
   const durationMinutes = Math.round(
     (new Date(meeting.endDateTime).getTime() - new Date(meeting.startDateTime).getTime()) / 60000,
   );
+  const recurrence = buildZoomRecurrence(meeting);
   return {
     topic: zoomTopicFor(meeting),
-    type: 2, // single stable meeting, reused across all occurrences
-    start_time: toZoomStartTime(new Date(meeting.startDateTime)),
+    // Recurring series are real recurring meetings on Zoom (type 8, usually endless via
+    // end_times: 0) -- one stable meeting ID across all occurrences, now with the schedule
+    // visible in the host's portal. One-time meetings stay plain scheduled (type 2).
+    type: recurrence ? 8 : 2,
+    ...(recurrence ? { recurrence } : {}),
+    start_time: toZoomStartTime(recurrence ? nextOccurrenceStart(meeting) : new Date(meeting.startDateTime)),
     duration: durationMinutes,
     timezone: "America/New_York",
     agenda: meeting.description,
@@ -274,11 +327,7 @@ export async function createZoomMeeting(meeting: IMeeting, hostEmail: string): P
     const res = await fetch(`${ZOOM_BASE_API}/users/${encodeURIComponent(hostEmail)}/meetings`, {
       method: "POST",
       headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
-      body: JSON.stringify(
-        meeting.isRecurring
-          ? (({ topic, agenda, settings }) => ({ topic, agenda, settings }))(buildZoomMeetingBody(meeting))
-          : buildZoomMeetingBody(meeting),
-      ),
+      body: JSON.stringify(buildZoomMeetingBody(meeting)),
     });
     invalidateZoomTokenIfUnauthorized(res);
     if (!res.ok) {
@@ -318,10 +367,10 @@ export async function getZoomMeetingInvitation(zid: string): Promise<string | nu
 }
 
 export async function updateZoomMeeting(zid: string, meeting: IMeeting): Promise<boolean> {
-  // A recurring series' Zoom meeting is a stable join target (legacy type 3, or endless type 8)
-  // whose schedule lives in the app/Google Calendar, not in Zoom -- PATCHing start_time/duration
-  // into it would distort the series (and Zoom silently rewrites past starts anyway). Only
-  // content fields are safe to update for recurring meetings.
+  // Managed recurring meetings mirror their real schedule to Zoom (type 8 + recurrence, built
+  // from the same pattern the app/calendars use) -- each successful PATCH also re-extends
+  // Zoom's ~2-year rolling occurrence horizon. Unmanaged meetings never reach this function
+  // (gated at every call site); their Zoom-side schedule is the owner's business.
 
   try {
     const token = await getZoomAccessToken();
@@ -330,11 +379,7 @@ export async function updateZoomMeeting(zid: string, meeting: IMeeting): Promise
     const res = await fetch(`${ZOOM_BASE_API}/meetings/${zid}`, {
       method: "PATCH",
       headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
-      body: JSON.stringify(
-        meeting.isRecurring
-          ? (({ topic, agenda, settings }) => ({ topic, agenda, settings }))(buildZoomMeetingBody(meeting))
-          : buildZoomMeetingBody(meeting),
-      ),
+      body: JSON.stringify(buildZoomMeetingBody(meeting)),
     });
     invalidateZoomTokenIfUnauthorized(res);
     if (!res.ok) console.error("Zoom updateMeeting error:", await res.text());

--- a/frontend/tests/unit/zoom.test.ts
+++ b/frontend/tests/unit/zoom.test.ts
@@ -150,6 +150,89 @@ describe("toZoomStartTime / buildZoomMeetingBody (via createZoomMeeting's reques
   });
 });
 
+describe("type-8 recurrence mapping (via createZoomMeeting's request body)", () => {
+  it("sends a never-ending weekly multi-day series as type 8 with weekly_days and end_times 0", async () => {
+    const { getCapturedBody } = mockFetchCapturingBody();
+    const meeting = buildMeeting({
+      isRecurring: true,
+      recurrencePattern: {
+        type: "weekly", startDate: new Date("2026-07-01T23:00:00.000Z"), endDate: null,
+        daysOfWeek: ["Monday", "Wednesday", "Friday"], firstDayOfWeek: "Sunday", interval: 1,
+      },
+    });
+
+    await createZoomMeeting(meeting, "host@test.icr");
+
+    const body = getCapturedBody();
+    expect(body?.type).toBe(8);
+    expect(body?.recurrence).toEqual({ type: 2, repeat_interval: 1, weekly_days: "2,4,6", end_times: 0 });
+  });
+
+  it("maps a week-of-month monthly pattern to Zoom's monthly_week/monthly_week_day", async () => {
+    const { getCapturedBody } = mockFetchCapturingBody();
+    const meeting = buildMeeting({
+      isRecurring: true,
+      recurrencePattern: {
+        type: "monthly", startDate: new Date("2026-07-07T21:30:00.000Z"), endDate: null,
+        daysOfWeek: ["Tuesday"], weekOfMonth: 1, firstDayOfWeek: "Sunday", interval: 1,
+      },
+    });
+
+    await createZoomMeeting(meeting, "host@test.icr");
+
+    expect(getCapturedBody()?.recurrence).toEqual({ type: 3, repeat_interval: 1, monthly_week: 1, monthly_week_day: 3, end_times: 0 });
+  });
+
+  it("caps a count-bounded series at Zoom's 50-occurrence limit without failing the create", async () => {
+    const { getCapturedBody } = mockFetchCapturingBody();
+    const meeting = buildMeeting({
+      isRecurring: true,
+      recurrencePattern: {
+        type: "weekly", startDate: new Date("2026-07-01T23:00:00.000Z"), endDate: null,
+        numberOfOccurrences: 200, daysOfWeek: ["Wednesday"], firstDayOfWeek: "Sunday", interval: 1,
+      },
+    });
+
+    await createZoomMeeting(meeting, "host@test.icr");
+
+    expect(getCapturedBody()?.recurrence).toMatchObject({ end_times: 50 });
+  });
+
+  it("clamps a backdated series' start_time to its next future occurrence", async () => {
+    const { getCapturedBody } = mockFetchCapturingBody();
+    // Anchored far in the past; the recurrence is every Wednesday 19:00-20:00 ET.
+    const meeting = buildMeeting({
+      isRecurring: true,
+      startDateTime: new Date("2026-07-01T23:00:00.000Z"),
+      endDateTime: new Date("2026-07-02T00:00:00.000Z"),
+      recurrencePattern: {
+        type: "weekly", startDate: new Date("2026-07-01T23:00:00.000Z"), endDate: null,
+        daysOfWeek: ["Wednesday"], firstDayOfWeek: "Sunday", interval: 1,
+      },
+    });
+
+    await createZoomMeeting(meeting, "host@test.icr");
+
+    const body = getCapturedBody();
+    // Whatever today is, the sent start must not be the backdated July 1 anchor and must be
+    // in the future (as an ET wall-clock string at the series' 19:00 time).
+    expect(body?.start_time).not.toBe("2026-07-01T19:00:00");
+    expect(String(body?.start_time)).toMatch(/T19:00:00$/);
+    expect(new Date(`${body?.start_time}-04:00`).getTime()).toBeGreaterThan(Date.now() - 24 * 60 * 60 * 1000);
+  });
+
+  it("keeps a one-time meeting as plain type 2 with no recurrence", async () => {
+    const { getCapturedBody } = mockFetchCapturingBody();
+    const meeting = buildMeeting({ isRecurring: false });
+
+    await createZoomMeeting(meeting, "host@test.icr");
+
+    const body = getCapturedBody();
+    expect(body?.type).toBe(2);
+    expect(body?.recurrence).toBeUndefined();
+  });
+});
+
 describe("token-fetch failure paths", () => {
   it("returns null/false without throwing when Zoom credentials aren't configured", async () => {
     delete process.env.ZOOM_CLIENT_ID;


### PR DESCRIPTION
@coderabbitai summary

## Description
- **frontend/services/zoom.ts**: recurring series now reach Zoom as **type 8 with a real recurrence object** instead of a one-time meeting frozen at the first occurrence. Zoom's own portal-created "no end" meetings store `end_times: 0` (verified empirically 2026-08-20, including that the PATCH path clamps it to a ~2-year rolling horizon which every managed PATCH re-extends as a side effect).
  - Pattern mapping: weekly multi-day (`weekly_days`), every-N-weeks (`repeat_interval`), month-by-weekday (`monthly_week`/`monthly_week_day`), month-by-date (`monthly_day`).
  - Bounded series: `end_date_time` from the pattern's end date, or `end_times` capped at Zoom's documented 50-occurrence limit — the app and calendars own the true end; Zoom's copy just under-shows the tail.
  - `start_time` clamps to the **next future occurrence**: Zoom silently rewrites past starts to "now" and files the meeting under the host's past meetings (the failure mode the backdated lease-year import exposed).
  - `updateZoomMeeting` for managed recurring meetings now mirrors the full schedule (replacing #505's omit-schedule stopgap); unmanaged meetings never reach it.
- **frontend/tests/unit/zoom.test.ts**: five new request-body tests — endless weekly multi-day, week-of-month mapping, the 50-cap, the future-start clamp on a backdated anchor, and one-time meetings staying plain type 2.

Idle-meeting horizon re-extension (a managed series never edited for ~2 years) is deliberately out of scope — tracked as a follow-up issue.

## Testing
- [x] Full `yarn test:all` green locally: lint, lint:css, typecheck, unit 283 (5 new), component 282, integration 144, e2e 117.
- [ ] Post-deploy: create a recurring test meeting in dev — the host's Zoom portal shows a recurring series with the correct days, dated at the next occurrence.

## Area(s) Touched
**Product areas**
- [ ] auth — sign-in, sessions, NextAuth, role-based access
- [ ] admin — /admin shell (Diagnostics, Users, Import, Export tabs)
- [ ] docs — /docs Resources page (rendering, navigation, search)
- [ ] ui/ux — frontend layout/styling not tied to a specific integration

**Integrations**
- [ ] google-calendar — Google Calendar sync
- [X] zoom-api — Zoom meeting/host sync

**Engineering**
- [ ] security — auth hardening, data exposure, dependency/security scanning
- [X] testing — test suite (Jest/Playwright) changes
- [ ] github-actions — workflows, Dependabot config, other .github/ CI tooling
- [ ] cleanup — refactor or dead-code removal, no behavior change
- [ ] documentation — docs/ or README changes only

## Pre-merge Checklist
- [X] Code follows current formatting conventions and passes lint (`yarn lint`).
- [X] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
- [X] All test suites pass, both run locally and green in GitHub CI. **Do not merge if any test suite is failing.**
- [X] A test suite was added or updated for the feature/fix in this PR.
- [X] Only files relevant to this change are committed — no stray or unrelated files.
- [ ] If this branch has a merge conflict with master, master was merged into this branch first (not the other way around).
- [X] The rest of this PR description (Description, Testing) is filled out, not left as template placeholders.