### PR TITLE
fix(zoom): compare host emails case-insensitively in capacity and conflict accounting

### DIFF
--- a/frontend/app/api/update/meeting/route.ts
+++ b/frontend/app/api/update/meeting/route.ts
@@ -55,7 +55,10 @@ async function syncUpdatedMeeting(
     // dropdown. A blank/"Automatic" selection is NOT a reassignment -- it just means "don't
     // force a specific host," so whatever host is already assigned is kept as-is.
     const roomChanged = !!oldZoomRoom && oldZoomRoom !== newZoomRoom;
-    const explicitHostChange = !!newMeeting.zoomHost && newMeeting.zoomHost !== existingMeeting.zoomHost;
+    // Case-insensitive (#504): a casing-only difference (Zoom-registered vs ZOOM_HOSTS casing)
+    // is the same physical host, not a reassignment.
+    const explicitHostChange = !!newMeeting.zoomHost &&
+      newMeeting.zoomHost.toLowerCase() !== (existingMeeting.zoomHost ?? "").toLowerCase();
 
     if (roomChanged || explicitHostChange) {
       // Managed: the Zoom meeting is disposable, so tear it down for a fresh create below.
@@ -281,7 +284,10 @@ const updateMeeting = async (request: Request): Promise<Response> => {
     // below so the blocking conflict check can use it too, not just the resolution step further
     // down. A blank/"Automatic" selection, or resubmitting the form with the same
     // already-assigned host untouched, is NOT a reassignment.
-    const explicitHostChange = !!newMeeting.zoomHost && newMeeting.zoomHost !== existingMeeting.zoomHost;
+    // Case-insensitive (#504): a casing-only difference (Zoom-registered vs ZOOM_HOSTS casing)
+    // is the same physical host, not a reassignment.
+    const explicitHostChange = !!newMeeting.zoomHost &&
+      newMeeting.zoomHost.toLowerCase() !== (existingMeeting.zoomHost ?? "").toLowerCase();
 
     // An unmanaged Zoom meeting's host is whoever owns it on Zoom's side (adopted legacy /
     // externally hosted -- see schema.prisma's zoomManaged); the app can't reassign that, and

--- a/frontend/tests/unit/resourceOverlap.test.ts
+++ b/frontend/tests/unit/resourceOverlap.test.ts
@@ -258,6 +258,43 @@ describe("computeConflicts", () => {
     expect(conflicts[0].value).toBe("host1@icr.test");
   });
 
+  it("buckets two casings of one host email together (#504), keeping a real stored casing in the row", () => {
+    const withHost: ConflictCandidateMeeting = { ...baseMeeting, zoomHost: "518Board@gmail.com" };
+    const meetingTwo: ConflictCandidateMeeting = {
+      ...baseMeeting,
+      mid: "m2",
+      title: "Meeting Two",
+      room: "Unity Room",
+      zoomHost: "518board@gmail.com",
+      startDateTime: utcDate(2026, 7, 6, 19, 30),
+      endDateTime: utcDate(2026, 7, 6, 20, 30),
+    };
+
+    const conflicts = computeConflicts([withHost, meetingTwo]);
+    expect(conflicts).toHaveLength(1);
+    expect(conflicts[0].field).toBe("zoomHost");
+    expect(conflicts[0].value).toBe("518Board@gmail.com");
+  });
+
+  it("resolves a host's capacity case-insensitively, so two meetings on one licensed host stay healthy across casings", () => {
+    const withHost: ConflictCandidateMeeting = { ...baseMeeting, zoomHost: "518Board@gmail.com" };
+    const meetingTwo: ConflictCandidateMeeting = {
+      ...baseMeeting,
+      mid: "m2",
+      title: "Meeting Two",
+      room: "Unity Room",
+      zoomHost: "518board@gmail.com",
+      startDateTime: utcDate(2026, 7, 6, 19, 30),
+      endDateTime: utcDate(2026, 7, 6, 20, 30),
+    };
+
+    // Capacities arrive keyed in ZOOM_HOSTS casing; the bucket's display value is DB casing.
+    const conflicts = computeConflicts([withHost, meetingTwo], OVERLAP_HORIZON_YEARS, {
+      zoomHostCapacities: { "518board@GMAIL.com": 2 },
+    });
+    expect(conflicts).toEqual([]);
+  });
+
   it("flags a zoomHost conflict even when one of the two meetings is suspended", () => {
     // Unlike room/zoomRoom, a suspended meeting's Zoom host is still genuinely reserved
     // (its Zoom sync is skipped, not torn down) -- see resolveZoomHost's includeSuspended: true.
@@ -450,6 +487,15 @@ describe("findFirstFreePoolHost — per-host capacities", () => {
       capacities: { [pool[0]]: 2, [pool[1]]: 1 },
     });
     expect(host).toBe(pool[0]);
+  });
+
+  it("counts a row stored in Zoom-registered casing against the ZOOM_HOSTS-cased pool entry (#504)", async () => {
+    // Without case-insensitive bucketing this row splits into a phantom host, both pool
+    // entries look idle, and least-loaded would pick pool[0] -- over-booking the real host.
+    const host = await findFirstFreePoolHost(pool, candidate, stubClient([onHost("Licensed@ICR.test", 19, 20)]), {
+      capacities: { [pool[0]]: 2, [pool[1]]: 2 },
+    });
+    expect(host).toBe(pool[1]);
   });
 
   it("uses a basic host only once every licensed host is at capacity", async () => {

--- a/frontend/util/meetings/resourceOverlap.ts
+++ b/frontend/util/meetings/resourceOverlap.ts
@@ -229,10 +229,17 @@ const candidateHorizonRange = (horizonYears: number): [Date, Date] => {
   return [rangeStart, rangeEnd];
 };
 
+// Host emails are identity-compared case-insensitively everywhere (#504): email addresses are
+// case-insensitive in reality, and Zoom's API reports them in registered casing
+// (518Board@gmail.com) while ZOOM_HOSTS and the DB may carry another — a casing mismatch must
+// never split one physical host into two accounting buckets. Stored/displayed values keep
+// their original casing; only comparison keys normalize.
+export const hostKey = (email: string): string => email.toLowerCase();
+
 const fieldWhere = (field: ResourceField, value: string): Prisma.MeetingWhereInput => {
   if (field === "room") return { room: value };
   if (field === "zoomRoom") return { zoomRoom: value };
-  return { zoomHost: value };
+  return { zoomHost: { equals: value, mode: "insensitive" } };
 };
 
 export type FindConflictsOptions = {
@@ -429,7 +436,7 @@ export async function getPoolHostLoads(
   const where: Prisma.MeetingWhereInput = {
     AND: [
       notDeleted,
-      { zoomHost: { in: pool } },
+      { zoomHost: { in: pool, mode: "insensitive" } },
       ...(opts.excludeMid ? [{ mid: { not: opts.excludeMid } }] : []),
     ],
   };
@@ -453,13 +460,14 @@ export async function getPoolHostLoads(
   const occupiedByHost = new Map<string, typeof meetings>();
   for (const meeting of meetings) {
     if (!meeting.zoomHost) continue;
-    const bucket = occupiedByHost.get(meeting.zoomHost);
+    const key = hostKey(meeting.zoomHost);
+    const bucket = occupiedByHost.get(key);
     if (bucket) bucket.push(meeting);
-    else occupiedByHost.set(meeting.zoomHost, [meeting]);
+    else occupiedByHost.set(key, [meeting]);
   }
 
   return pool.map((host) => {
-    const hostOccurrenceLists = (occupiedByHost.get(host) ?? []).map((meeting) =>
+    const hostOccurrenceLists = (occupiedByHost.get(hostKey(host)) ?? []).map((meeting) =>
       expandOccurrences(
         {
           startDateTime: meeting.startDateTime,
@@ -590,8 +598,16 @@ export function computeConflicts(
     zoomHost: meetings,
   };
 
+  // Capacity keys arrive in ZOOM_HOSTS casing while bucket values may carry DB casing --
+  // normalize once here so the lookup below can't miss (#504).
+  const capacityByHostKey = new Map(
+    Object.entries(opts.zoomHostCapacities ?? {}).map(([host, capacity]) => [hostKey(host), capacity]),
+  );
+
   (["room", "zoomRoom", "zoomHost"] as const).forEach((field) => {
     const buckets = new Map<string, ConflictCandidateMeeting[]>();
+    // zoomHost buckets key case-insensitively (#504); rows still display a real stored casing.
+    const displayValues = new Map<string, string>();
     for (const meeting of fieldMeetings[field]) {
       // A meeting whose explicit zoomHost pick lost out to another meeting has zoomHost: null
       // (nothing was actually assigned) but still real-y wants that host -- bucket it under
@@ -599,13 +615,16 @@ export function computeConflicts(
       // already-known conflict (see its zoomSyncError) silently vanishing from this panel.
       const value = field === "zoomHost" ? (meeting.zoomHost ?? meeting.attemptedZoomHost) : meeting[field];
       if (!value) continue;
-      const bucket = buckets.get(value);
+      const key = field === "zoomHost" ? hostKey(value) : value;
+      if (!displayValues.has(key)) displayValues.set(key, value);
+      const bucket = buckets.get(key);
       if (bucket) bucket.push(meeting);
-      else buckets.set(value, [meeting]);
+      else buckets.set(key, [meeting]);
     }
 
-    for (const [value, bucketMeetings] of buckets) {
-      const capacity = field === "zoomHost" ? (opts.zoomHostCapacities?.[value] ?? 1) : 1;
+    for (const [key, bucketMeetings] of buckets) {
+      const value = displayValues.get(key) ?? key;
+      const capacity = field === "zoomHost" ? (capacityByHostKey.get(key) ?? 1) : 1;
       const withOccurrences = bucketMeetings.map((meeting) => ({
         meeting,
         occurrences: expandCached(meeting),


### PR DESCRIPTION
@coderabbitai summary

Part 2 of the Zoom-housekeeping stack (stacked on the drift PR; GitHub retargets on merge). 

Resolves #504 

## Description
- Zoom reports host emails in registered casing (`518Board@gmail.com`, `IT@518ICR.com`) while `ZOOM_HOSTS` and the DB may carry another; exact-string comparison split one physical host into two accounting buckets — the allocator could over-book a licensed host past its 2-concurrent cap, and Diagnostics missed cross-casing overlaps.
- `resourceOverlap.ts`: exported `hostKey()` (lowercase at the comparison boundary; stored/displayed values keep their casing). `getPoolHostLoads` queries `mode: "insensitive"` and buckets by normalized key; `fieldWhere`'s zoomHost filter goes insensitive; `computeConflicts` buckets zoomHost case-insensitively (rows still display a real stored casing) and resolves capacities through a normalized lookup.
- `update/meeting/route.ts`: a casing-only difference in the Zoom Host field no longer counts as a host reassignment (which would have torn down a managed meeting or 422'd an unmanaged one).

## Testing
- [x] 3 new unit tests: two casings of one host land in one conflict bucket (display casing preserved), capacity resolves across casing (2-on-licensed stays healthy), and a cross-cased DB row counts against the pool entry in host allocation (would over-book without the fix).

## Area(s) Touched
**Product areas**
- [ ] auth — sign-in, sessions, NextAuth, role-based access
- [ ] admin — /admin shell (Diagnostics, Users, Import, Export tabs)
- [ ] docs — /docs Resources page (rendering, navigation, search)
- [ ] ui/ux — frontend layout/styling not tied to a specific integration

**Integrations**
- [ ] google-calendar — Google Calendar sync
- [X] zoom-api — Zoom meeting/host sync

**Engineering**
- [ ] security — auth hardening, data exposure, dependency/security scanning
- [X] testing — test suite (Jest/Playwright) changes
- [ ] github-actions — workflows, Dependabot config, other .github/ CI tooling
- [ ] cleanup — refactor or dead-code removal, no behavior change
- [ ] documentation — docs/ or README changes only

## Pre-merge Checklist
- [X] Code follows current formatting conventions and passes lint (`yarn lint`).
- [X] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
- [X] All test suites pass, both run locally and green in GitHub CI. **Do not merge if any test suite is failing.**
- [X] A test suite was added or updated for the feature/fix in this PR.
- [X] Only files relevant to this change are committed — no stray or unrelated files.
- [ ] If this branch has a merge conflict with master, master was merged into this branch first (not the other way around).
- [X] The rest of this PR description (Description, Testing) is filled out, not left as template placeholders.