### PR TITLE
feat(zoom): monthly maintenance scan for credential drift and horizon re-extension

### DIFF
--- a/.github/workflows/zoom-scan.yml
+++ b/.github/workflows/zoom-scan.yml
@@ -1,0 +1,39 @@
+name: Zoom Maintenance Scan
+
+on:
+  schedule:
+    # Monthly, 06:23 UTC on the 1st -- an offset minute for the same scheduler pile-up reason
+    # as backup-db.yml. Frequency rationale: drift is a rare human action (detection also
+    # happens whenever an admin opens a meeting), and the type-8 occurrence horizon Zoom clamps
+    # to is ~2 years, so monthly keeps everything fresh with orders of magnitude to spare.
+    - cron: "23 6 1 * *"
+  workflow_dispatch:
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: yarn
+          cache-dependency-path: frontend/yarn.lock
+      - run: yarn install --frozen-lockfile
+      - name: Scan Zoom meetings (credential drift + horizon re-extension)
+        # react-server condition: services/zoom.ts imports "server-only", whose default build
+        # throws outside a Next server context; the condition resolves its no-op build. Nothing
+        # in the script's import graph resolves React itself, so the condition changes nothing else.
+        run: npx tsx scripts/zoom-scan.ts
+        env:
+          NODE_OPTIONS: --conditions=react-server
+          DATABASE_URL_UNPOOLED: ${{ secrets.DATABASE_URL_UNPOOLED }}
+          ZOOM_CLIENT_ID: ${{ secrets.ZOOM_CLIENT_ID }}
+          ZOOM_CLIENT_SECRET: ${{ secrets.ZOOM_CLIENT_SECRET }}
+          ZOOM_ACCOUNT_ID: ${{ secrets.ZOOM_ACCOUNT_ID }}

--- a/docs/01-user-guide/explanation/how-sync-works.md
+++ b/docs/01-user-guide/explanation/how-sync-works.md
@@ -31,7 +31,7 @@ The platform is the single source of truth. Changes made here sync automatically
 
 The platform can't see day-to-day changes made in the Zoom portal. If someone changes a meeting's passcode there, the links and passcode the platform has published keep pointing at the old values — members clicking them get a passcode prompt that rejects what the platform shows.
 
-The platform checks for this when an admin opens the meeting: if the live Zoom link or passcode no longer matches the saved copy, a **"Zoom settings were changed outside the app"** notice appears — click **Sync from Zoom** to adopt the new settings and republish the calendar events. Prefer making changes in the platform where possible; if the Zoom side must change, open the meeting here afterwards and sync.
+The platform checks for this when an admin opens the meeting, and a monthly background scan checks every meeting: if the live Zoom link or passcode no longer matches the saved copy, the meeting gets the sync-attention badge on the calendar and a **"Zoom settings were changed outside the app"** notice in its details — click **Sync from Zoom** to adopt the new settings and republish the calendar events. Prefer making changes in the platform where possible; if the Zoom side must change, open the meeting here afterwards and sync. The same monthly scan also keeps each recurring meeting's Zoom-side occurrence list extended, so long-untouched meetings never age off Zoom's schedule.
 
 ## Why sync can fail, and what the sync-error badge means
 

--- a/docs/01-user-guide/reference/icon-and-badge-legend.md
+++ b/docs/01-user-guide/reference/icon-and-badge-legend.md
@@ -13,7 +13,7 @@ the app's older icons and need re-capturing by an admin — what each icon means
 | Co-present (mode tag) | Meeting is **Hybrid** | Mode picker, calendar tags, detail panel |
 | Amber triangle | Room/Zoom room/Zoom host **conflict** | Calendar block (top-left), detail panel, overlap popover |
 | "+N" pill (block corner) | Cluster hides N more **overlapping** meetings | Day/Week view, when 2+ meetings share a slot |
-| Red broken-ring + "!" | Google Calendar/Zoom **sync failed** | Calendar block (top-right), detail panel |
+| Red broken-ring + "!" | Google Calendar/Zoom **sync needs attention** — a failed sync, or Zoom settings changed outside the app | Calendar block (top-right), detail panel |
 | Pause (⏸) | Meeting is **suspended** | Suspend dialog, Admin Diagnostics |
 | Video icon + room name | Zoom room doesn't match the physical room's default pairing | Calendar block (top-right) |
 
@@ -77,6 +77,10 @@ an exclamation mark — what other pages call the "⚠ badge" — not the amber 
 two can appear on the same meeting, in opposite corners. The small button next to "Retry sync"
 expands a per-service breakdown of what failed. See
 [Retry a Failed Sync](../how-to/retry-a-failed-sync.md).
+
+The same icon also appears when nothing failed but the meeting's Zoom settings were
+[changed outside the app](../explanation/how-sync-works.md#zoom-side-changes-are-detected-not-synced-live) —
+opening the meeting shows which case it is and the one-click fix.
 
 ![A sync-error icon on a calendar block](../assets/sync-error-badge.png)
 

--- a/docs/02-handoff/credentials-and-integrations.md
+++ b/docs/02-handoff/credentials-and-integrations.md
@@ -58,6 +58,16 @@ required payment method is the same ICR card (R2 itself stays on the free plan).
 | `GCS_ARCHIVE_BUCKET` | Name of the archive-project GCS bucket (`icr-db-backups-archive`) — pure redundancy + immutability copy, bucket-level retention policy (400 days, unlocked) | GitHub Actions **variable** | Prod account | Retention is bucket-level, not per-object — see [Backups and Recovery](backups-and-recovery.md) for why 400d covers both GFS tiers there |
 | `AGE_PUBLIC_KEY_A` / `AGE_PUBLIC_KEY_B` | Two `age` public keys each backup is encrypted to (`age -r A -r B`) — either private key alone decrypts (OR, not AND), so the archive survives one holder being unreachable | GitHub Actions **variables** — public keys are safe even if leaked (can only encrypt) | Key custody, not an account: **Key A** = the H4I Maintenance Lead's password manager (Nathnael Tesfaw, nbt26@cornell.edu); **Key B** = Matt Kaskela, ICR President (Matt.Kaskela@518icr.com), who also holds all ICR-side credentials | Both **private** keys are never put in GitHub, Vercel, or any CI system, in any form — including a GitHub "environment secret". Rotation/compromise procedure: [Backup Infrastructure Setup](../03-development/backup-infra-setup.md) |
 
+### Zoom maintenance scan (GitHub Actions secrets)
+
+The monthly `zoom-scan.yml` workflow (credential-drift sweep + recurring-meeting horizon
+re-extension — see [How Sync Works](../01-user-guide/explanation/how-sync-works.md#zoom-side-changes-are-detected-not-synced-live))
+reuses `DATABASE_URL_UNPOOLED` from the backup workflow above, plus repo-secret **copies** of the
+app's `ZOOM_CLIENT_ID` / `ZOOM_CLIENT_SECRET` / `ZOOM_ACCOUNT_ID` (same Server-to-Server app as
+the Vercel env vars — rotating the Marketplace secret means updating **both** places). A red run
+means drift detection and horizon maintenance stopped; re-run via workflow_dispatch after
+fixing.
+
 ### Backups admin tab (Vercel env vars)
 
 | Credential | Purpose | Where it lives | Controlled by | Coordination needed before changing |

--- a/frontend/app/api/admin/sync-error-mids/route.ts
+++ b/frontend/app/api/admin/sync-error-mids/route.ts
@@ -18,7 +18,14 @@ export const GET = async () => {
   const meetings = await prisma.meeting.findMany({
     where: {
       deletedAt: null,
-      OR: [{ googleSyncStatus: "error" }, { zoomSyncStatus: "error" }],
+      OR: [
+        { googleSyncStatus: "error" },
+        { zoomSyncStatus: "error" },
+        // Persisted Zoom credential drift (see zoomDriftDetectedAt in schema.prisma) rides the
+        // same badge: both mean "this meeting's published copies need sync attention", and
+        // opening the meeting shows which one it is.
+        { zoomDriftDetectedAt: { not: null } },
+      ],
     },
     select: { mid: true },
   });

--- a/frontend/app/api/admin/zoom-drift/[mid]/route.ts
+++ b/frontend/app/api/admin/zoom-drift/[mid]/route.ts
@@ -17,7 +17,7 @@ export const GET = async (request: NextRequest) => {
   const mid = request.nextUrl.pathname.split("/").pop() as string;
   const meeting = await prisma.meeting.findFirst({
     where: { mid, deletedAt: null },
-    select: { zid: true, zoomLink: true, zoomPasscode: true },
+    select: { zid: true, zoomLink: true, zoomPasscode: true, zoomDriftDetectedAt: true },
   });
   if (!meeting) {
     return NextResponse.json({ error: "Meeting not found" }, { status: 404 });
@@ -38,5 +38,15 @@ export const GET = async (request: NextRequest) => {
   const drift =
     live.joinUrl !== meeting.zoomLink ||
     live.passcode !== (meeting.zoomPasscode || null);
+
+  // Keep the persisted flag (the calendar badge's source) in step with what this fresh check
+  // just learned -- an admin opening the meeting is a better signal than waiting for the next
+  // monthly scan, in both directions.
+  if (drift !== (meeting.zoomDriftDetectedAt !== null)) {
+    await prisma.meeting.update({
+      where: { mid },
+      data: { zoomDriftDetectedAt: drift ? new Date() : null },
+    });
+  }
   return NextResponse.json({ drift });
 };

--- a/frontend/app/api/update/meeting/sync/route.ts
+++ b/frontend/app/api/update/meeting/sync/route.ts
@@ -59,6 +59,7 @@ const syncMeeting = async (request: Request): Promise<Response> => {
             let zoomHost = meeting.zoomHost;
             let zoomCalendarEventId = meeting.zoomCalendarEventId;
             let zoomSynced = true;
+            let liveCredentialsFetched = false;
             zoomSyncError = null;
 
             if (zid) {
@@ -73,6 +74,7 @@ const syncMeeting = async (request: Request): Promise<Response> => {
                 if (liveCredentials?.joinUrl) {
                     zoomLink = liveCredentials.joinUrl;
                     zoomPasscode = liveCredentials.passcode;
+                    liveCredentialsFetched = true;
                 }
                 // Retry re-asserts an already-working Zoom meeting's existing claim -- nothing
                 // about this meeting's own details changed, so a conflict introduced later by a
@@ -161,7 +163,13 @@ const syncMeeting = async (request: Request): Promise<Response> => {
             const zoomInvitation = zid ? (await getZoomMeetingInvitation(zid)) ?? meeting.zoomInvitation : null;
             await prisma.meeting.update({
                 where: { mid },
-                data: { zid, zoomLink, zoomPasscode, zoomInvitation, zoomHost, zoomCalendarEventId, zoomSyncStatus, zoomSyncError },
+                data: {
+                    zid, zoomLink, zoomPasscode, zoomInvitation, zoomHost, zoomCalendarEventId, zoomSyncStatus, zoomSyncError,
+                    // The stored copy now equals Zoom's truth (adopted above, or just created),
+                    // so any persisted drift flag is resolved. A failed credentials fetch left
+                    // stored values possibly stale -- the flag must survive it.
+                    ...(zid && meeting.zid && !liveCredentialsFetched ? {} : { zoomDriftDetectedAt: null }),
+                },
             });
         }
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -68,6 +68,7 @@
     "pagefind": "^1.5.2",
     "stylelint": "^17.14.1",
     "stylelint-config-standard-scss": "^17.0.0",
+    "tsx": "^4.23.12",
     "typescript": "6.0.3"
   },
   "resolutions": {

--- a/frontend/prisma/migrations/20260821000000_add_zoom_drift_detected_at/migration.sql
+++ b/frontend/prisma/migrations/20260821000000_add_zoom_drift_detected_at/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Meeting" ADD COLUMN "zoomDriftDetectedAt" TIMESTAMP(3);

--- a/frontend/prisma/schema.prisma
+++ b/frontend/prisma/schema.prisma
@@ -72,6 +72,11 @@ model Meeting {
   // " - Zoom Only", ICR's own naming convention); non-null = pinned verbatim -- backfilled with
   // the adopted legacy meetings' exact topics so an app-side edit never renames them by surprise.
   zoomTopic              String?
+  // When the live Zoom passcode/join URL was last seen differing from the stored copy (set by
+  // the monthly zoom-scan workflow and the on-open drift check; cleared once a retry sync
+  // adopts the live values). Non-null feeds the calendar's sync-attention badge without any
+  // Zoom call on the bulk retrieve paths.
+  zoomDriftDetectedAt    DateTime?
   deletedAt              DateTime?
   updatedAt              DateTime?            @updatedAt
 

--- a/frontend/scripts/zoom-scan.ts
+++ b/frontend/scripts/zoom-scan.ts
@@ -1,0 +1,99 @@
+// Monthly Zoom maintenance scan (.github/workflows/zoom-scan.yml; also runnable locally with
+// the same env vars). Two jobs in one pass over every Zoom-enabled meeting:
+//
+// 1. Credential drift: compare each meeting's live Zoom passcode/join URL against the stored
+//    copy and persist the result in zoomDriftDetectedAt -- the calendar badge's data source,
+//    so bulk calendar paths never call Zoom themselves (GitHub #509). Detection only: adoption
+//    stays with the admin-driven retry-sync route, where a human sees what changed.
+// 2. Horizon re-extension: PATCH every MANAGED recurring meeting's schedule. Zoom clamps a
+//    PATCHed endless (end_times: 0) type-8 series to a rolling window (~110 weekly / 60
+//    monthly occurrences from the PATCH date), so a series edited never again would run out of
+//    listed occurrences after ~2 years; a monthly re-PATCH keeps every horizon perpetually
+//    fresh with no per-meeting bookkeeping (GitHub #508). Unmanaged meetings are never
+//    PATCHed -- drift detection is the only thing the scan does to them.
+//
+// Uses the app's own zoom service (single source of truth for the meeting body, pinned
+// zoomTopic handling included). Run via:
+//   NODE_OPTIONS='--conditions=react-server' npx tsx scripts/zoom-scan.ts
+// (the condition neutralizes services/zoom.ts's "server-only" guard outside Next).
+import { PrismaClient } from "@prisma/client";
+import { getZoomMeetingCredentials, updateZoomMeeting } from "../services/zoom";
+import type { IMeeting } from "../types/models";
+
+const databaseUrl = process.env.DATABASE_URL_UNPOOLED ?? process.env.DATABASE_URL;
+if (!databaseUrl) {
+  console.error("DATABASE_URL_UNPOOLED or DATABASE_URL is required");
+  process.exit(1);
+}
+const prisma = new PrismaClient({ datasources: { db: { url: databaseUrl } } });
+
+async function main(): Promise<void> {
+  const meetings = await prisma.meeting.findMany({
+    where: { deletedAt: null, zid: { not: null } },
+    include: { recurrencePattern: true },
+    orderBy: { title: "asc" },
+  });
+
+  // One Zoom GET per distinct zid -- shared legacy meetings serve multiple rows.
+  const byZid = new Map<string, typeof meetings>();
+  for (const meeting of meetings) {
+    const group = byZid.get(meeting.zid as string);
+    if (group) group.push(meeting);
+    else byZid.set(meeting.zid as string, [meeting]);
+  }
+
+  let driftSet = 0, driftCleared = 0, extended = 0, failures = 0;
+
+  for (const [zid, group] of byZid) {
+    const live = await getZoomMeetingCredentials(zid);
+    if (!live?.joinUrl) {
+      // Unreachable/deleted on Zoom's side is a sync problem, not drift -- leave flags as-is
+      // and let a human-driven retry surface the real error.
+      console.error(`skip ${zid} (${group.map((m) => m.title).join(" + ")}): credentials unavailable`);
+      failures++;
+      continue;
+    }
+
+    for (const meeting of group) {
+      const drift =
+        live.joinUrl !== meeting.zoomLink ||
+        live.passcode !== (meeting.zoomPasscode || null);
+      if (drift !== (meeting.zoomDriftDetectedAt !== null)) {
+        await prisma.meeting.update({
+          where: { mid: meeting.mid },
+          data: { zoomDriftDetectedAt: drift ? new Date() : null },
+        });
+        drift ? driftSet++ : driftCleared++;
+        console.log(`${drift ? "DRIFT" : "clear"} ${zid} ${meeting.title}`);
+      }
+    }
+
+    // Shared-zid pairs are skipped: their Zoom recurrence is the UNION of both rows' schedules
+    // (built at the 2026-08 type-8 conversion), and updateZoomMeeting only knows one row's
+    // pattern -- a PATCH from either row would silently narrow the union (e.g. drop the
+    // Sunday-only sibling's day). Union-aware PATCHing is tracked as a follow-up; until then
+    // shared meetings' horizons re-extend only when deliberately edited.
+    const representative = group.length === 1 && group[0].zoomManaged && group[0].isRecurring && group[0].status !== "Suspended"
+      ? group[0]
+      : null;
+    if (representative) {
+      const ok = await updateZoomMeeting(zid, {
+        ...representative,
+        recurrencePattern: representative.recurrencePattern ?? null,
+      } as unknown as IMeeting);
+      if (ok) extended++;
+      else {
+        failures++;
+        console.error(`horizon PATCH failed for ${zid} (${representative.title})`);
+      }
+    }
+  }
+
+  console.log(`scan done: ${byZid.size} zids, drift set ${driftSet} / cleared ${driftCleared}, horizons re-extended ${extended}, failures ${failures}`);
+  // Failures should page (workflow goes red) but only after the whole pool was attempted.
+  if (failures > 0) process.exit(1);
+}
+
+main()
+  .catch((error) => { console.error(error); process.exitCode = 1; })
+  .finally(() => prisma.$disconnect());

--- a/frontend/tests/integration/sync-error-mids-route.test.ts
+++ b/frontend/tests/integration/sync-error-mids-route.test.ts
@@ -43,6 +43,7 @@ test("returns the mids of meetings with a Google Calendar or Zoom sync error", a
 
   const midGoogleError = `m-${randomUUID()}`;
   const midZoomError = `m-${randomUUID()}`;
+  const midDrifted = `m-${randomUUID()}`;
   const midSynced = `m-${randomUUID()}`;
   const midPending = `m-${randomUUID()}`;
   const midDeleted = `m-${randomUUID()}`;
@@ -52,6 +53,11 @@ test("returns the mids of meetings with a Google Calendar or Zoom sync error", a
   });
   await prisma.meeting.create({
     data: buildMeetingData({ mid: midZoomError, googleSyncStatus: "synced", zoomSyncStatus: "error" }),
+  });
+  // Both channels healthy but the stored Zoom credentials drifted from the live ones -- rides
+  // the same needs-sync-attention badge as an error.
+  await prisma.meeting.create({
+    data: buildMeetingData({ mid: midDrifted, googleSyncStatus: "synced", zoomSyncStatus: "synced", zoomDriftDetectedAt: new Date() }),
   });
   // Neither channel in an error state -- must not show up as a false positive.
   await prisma.meeting.create({
@@ -71,7 +77,7 @@ test("returns the mids of meetings with a Google Calendar or Zoom sync error", a
   expect(response.status).toBe(200);
   const body = await response.json();
 
-  expect(body.mids).toEqual(expect.arrayContaining([midGoogleError, midZoomError]));
+  expect(body.mids).toEqual(expect.arrayContaining([midGoogleError, midZoomError, midDrifted]));
   expect(body.mids).not.toContain(midSynced);
   expect(body.mids).not.toContain(midPending);
   expect(body.mids).not.toContain(midDeleted);

--- a/frontend/tests/integration/update-meeting-sync-route.test.ts
+++ b/frontend/tests/integration/update-meeting-sync-route.test.ts
@@ -277,6 +277,44 @@ describe("retrying an already-synced meeting (existing zid)", () => {
     expect(after?.zoomLink).toBe("http://zoom.test/existing?pwd=rotated");
   });
 
+  test("adopting live credentials clears a persisted drift flag", async () => {
+    mockedUpdateZoomMeeting.mockResolvedValue(true);
+    mockedGetZoomMeetingCredentials.mockResolvedValue({ passcode: "rotated", joinUrl: "http://zoom.test/existing?pwd=rotated" });
+    mockedReconcileMeetingCalendars.mockResolvedValue({ updatedEventIds: {}, allSynced: true, googleSyncError: null });
+
+    const prisma = getTestPrismaClient();
+    const meetingData = buildSyncedMeetingData({ zoomPasscode: "original", zoomDriftDetectedAt: new Date() });
+    await prisma.meeting.create({ data: meetingData });
+
+    await POST(new Request("http://localhost/api/update/meeting/sync", {
+      method: "POST",
+      body: JSON.stringify({ mid: meetingData.mid }),
+    }));
+
+    const after = await prisma.meeting.findUnique({ where: { mid: meetingData.mid } });
+    expect(after?.zoomDriftDetectedAt).toBeNull();
+  });
+
+  test("a failed credentials fetch leaves a persisted drift flag standing", async () => {
+    mockedUpdateZoomMeeting.mockResolvedValue(true);
+    mockedGetZoomMeetingCredentials.mockResolvedValue(null);
+    mockedReconcileMeetingCalendars.mockResolvedValue({ updatedEventIds: {}, allSynced: true, googleSyncError: null });
+
+    const prisma = getTestPrismaClient();
+    const flaggedAt = new Date();
+    const meetingData = buildSyncedMeetingData({ zoomPasscode: "original", zoomDriftDetectedAt: flaggedAt });
+    await prisma.meeting.create({ data: meetingData });
+
+    await POST(new Request("http://localhost/api/update/meeting/sync", {
+      method: "POST",
+      body: JSON.stringify({ mid: meetingData.mid }),
+    }));
+
+    // Stored credentials may still be stale (the fetch failed), so the flag must survive.
+    const after = await prisma.meeting.findUnique({ where: { mid: meetingData.mid } });
+    expect(after?.zoomDriftDetectedAt).not.toBeNull();
+  });
+
   test("an unreachable Zoom credentials fetch keeps the stored passcode and link", async () => {
     mockedUpdateZoomMeeting.mockResolvedValue(true);
     mockedGetZoomMeetingCredentials.mockResolvedValue(null);

--- a/frontend/tests/integration/zoom-drift-route.test.ts
+++ b/frontend/tests/integration/zoom-drift-route.test.ts
@@ -40,6 +40,23 @@ test("reports drift when the live Zoom passcode differs from the stored one", as
   expect(response.status).toBe(200);
   expect(await response.json()).toEqual({ drift: true });
   expect(mockedGetCredentials).toHaveBeenCalledWith("70000000901");
+
+  // The fresh check persists what it learned -- this flag is the calendar badge's source.
+  const after = await getTestPrismaClient().meeting.findUnique({ where: { mid: meeting.mid } });
+  expect(after?.zoomDriftDetectedAt).not.toBeNull();
+});
+
+test("a fresh check that finds no drift clears a previously persisted flag", async () => {
+  const meeting = await seedMeeting({
+    zid: "70000000909", zoomLink: "http://zoom.test/j/70000000909?pwd=x", zoomPasscode: "x",
+    zoomDriftDetectedAt: new Date(),
+  });
+  mockedGetCredentials.mockResolvedValue({ passcode: "x", joinUrl: "http://zoom.test/j/70000000909?pwd=x" });
+
+  const response = await GET(driftRequest(meeting.mid));
+  expect(await response.json()).toEqual({ drift: false });
+  const after = await getTestPrismaClient().meeting.findUnique({ where: { mid: meeting.mid } });
+  expect(after?.zoomDriftDetectedAt).toBeNull();
 });
 
 test("a passcode-only change is drift even when the join URL is unchanged", async () => {

--- a/frontend/tests/unit/suspension.test.ts
+++ b/frontend/tests/unit/suspension.test.ts
@@ -54,6 +54,7 @@ function buildMeeting(overrides: Partial<Meeting> = {}): Omit<Meeting, "recurren
     lastEditedBy: null,
     zoomManaged: true,
     zoomTopic: null,
+    zoomDriftDetectedAt: null,
     group: "Group",
     startDateTime: new Date(now - DAY_MS),
     endDateTime: new Date(now - DAY_MS + 60 * 60 * 1000),

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -940,6 +940,136 @@
   resolved "https://registry.yarnpkg.com/@epic-web/invariant/-/invariant-1.0.0.tgz#1073e5dee6dd540410784990eb73e4acd25c9813"
   integrity sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==
 
+"@esbuild/aix-ppc64@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz#bf6e10303bcf2e7c686975fa52f937ec2728d8bc"
+  integrity sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==
+
+"@esbuild/android-arm64@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz#0c6246bc8d2c4d172aac2db3fb1190d72bd65504"
+  integrity sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==
+
+"@esbuild/android-arm@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.28.2.tgz#2d84ece6a4e2684d92be26ee13d42757d831c381"
+  integrity sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==
+
+"@esbuild/android-x64@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.28.2.tgz#fc38d4d6358d8dc1cf53f09f7589fe436eb64801"
+  integrity sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==
+
+"@esbuild/darwin-arm64@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz#f83afeeac1d7dac01c7a2fd012b3e451a0591fcc"
+  integrity sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==
+
+"@esbuild/darwin-x64@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz#510147c055a795588dbbe14fd6b1b8ad0a2f30de"
+  integrity sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==
+
+"@esbuild/freebsd-arm64@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz#093b9200ecf0b115ba4e5e248a7485c9c5f8bd5e"
+  integrity sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==
+
+"@esbuild/freebsd-x64@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz#0be22b6df925d213e841ea87123af5df80b0faf7"
+  integrity sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==
+
+"@esbuild/linux-arm64@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz#1bdbc651cda9ba9995c53ed9c71ceaa65094762d"
+  integrity sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==
+
+"@esbuild/linux-arm@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz#beb12ad72b84f72d28488cc1b8ee9f7eb141d753"
+  integrity sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==
+
+"@esbuild/linux-ia32@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz#b81f9d55529b45c206a46a138214b1aa6879696b"
+  integrity sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==
+
+"@esbuild/linux-loong64@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz#598667241a04c99b76ed6ef940ac50038c419f98"
+  integrity sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==
+
+"@esbuild/linux-mips64el@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz#1c51eb9cea903f53d97b5af3b1841db70f5596ca"
+  integrity sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==
+
+"@esbuild/linux-ppc64@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz#63dd61f17ceb31a81227f413feac8a71bc2c51f2"
+  integrity sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==
+
+"@esbuild/linux-riscv64@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz#3763b08fde5cf25ab1facb8e7752edfe45fbfc27"
+  integrity sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==
+
+"@esbuild/linux-s390x@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz#1a137ff293a82906eb3176385bd7e8e0e5cfb7cb"
+  integrity sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==
+
+"@esbuild/linux-x64@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz#268b36211c146ca54f8fe12c578a8d6ef8979485"
+  integrity sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==
+
+"@esbuild/netbsd-arm64@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz#22571ad951d62bb6accc82d8d1fad5c8c1ac0ba1"
+  integrity sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==
+
+"@esbuild/netbsd-x64@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz#42fcc57297eb0a0ca3f5fc475291f4c1a3f7c0de"
+  integrity sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==
+
+"@esbuild/openbsd-arm64@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz#9eb32af104ac3dacf4edca01f596664aab0c73ef"
+  integrity sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==
+
+"@esbuild/openbsd-x64@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz#febed2402d6088225e91f20fb4ce2522ad0a4efd"
+  integrity sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==
+
+"@esbuild/openharmony-arm64@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz#85641c3d466428bfbccea5f21c26836663fef5ce"
+  integrity sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==
+
+"@esbuild/sunos-x64@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz#a736f9d8962481045fc4c3e54f5479f22c870fb4"
+  integrity sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==
+
+"@esbuild/win32-arm64@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz#ee5ab40fad186201b652a33f8a5eb149e9e42532"
+  integrity sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==
+
+"@esbuild/win32-ia32@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz#c40d28a6d99a127da6711f2afd74b11cb63b06a7"
+  integrity sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==
+
+"@esbuild/win32-x64@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz#b21affb804cc167c133d95f45b3a1dc1323b9a87"
+  integrity sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==
+
 "@eslint-community/eslint-utils@4.9.1":
   version "4.9.1"
   resolved "https://registry.yarnpkg.com/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz#4e90af67bc51ddee6cdef5284edf572ec376b595"
@@ -3752,6 +3882,38 @@ es-toolkit@^1.46.0:
   resolved "https://registry.yarnpkg.com/es-toolkit/-/es-toolkit-1.50.0.tgz#2665c21d0ab76286f478ece3a235463097aeabd3"
   integrity sha512-OyZKhUVvEep9ITEiwHn8GKnMRQIVqoSIX7WnRbkWgJkllCujilqP2rD0u979tkl8wqyc8ICwlc1UBVv/Sl1G6w==
 
+esbuild@~0.28.0:
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.28.2.tgz#0f43bd1bad955b72d24e2261e3abe5957ccf0816"
+  integrity sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==
+  optionalDependencies:
+    "@esbuild/aix-ppc64" "0.28.2"
+    "@esbuild/android-arm" "0.28.2"
+    "@esbuild/android-arm64" "0.28.2"
+    "@esbuild/android-x64" "0.28.2"
+    "@esbuild/darwin-arm64" "0.28.2"
+    "@esbuild/darwin-x64" "0.28.2"
+    "@esbuild/freebsd-arm64" "0.28.2"
+    "@esbuild/freebsd-x64" "0.28.2"
+    "@esbuild/linux-arm" "0.28.2"
+    "@esbuild/linux-arm64" "0.28.2"
+    "@esbuild/linux-ia32" "0.28.2"
+    "@esbuild/linux-loong64" "0.28.2"
+    "@esbuild/linux-mips64el" "0.28.2"
+    "@esbuild/linux-ppc64" "0.28.2"
+    "@esbuild/linux-riscv64" "0.28.2"
+    "@esbuild/linux-s390x" "0.28.2"
+    "@esbuild/linux-x64" "0.28.2"
+    "@esbuild/netbsd-arm64" "0.28.2"
+    "@esbuild/netbsd-x64" "0.28.2"
+    "@esbuild/openbsd-arm64" "0.28.2"
+    "@esbuild/openbsd-x64" "0.28.2"
+    "@esbuild/openharmony-arm64" "0.28.2"
+    "@esbuild/sunos-x64" "0.28.2"
+    "@esbuild/win32-arm64" "0.28.2"
+    "@esbuild/win32-ia32" "0.28.2"
+    "@esbuild/win32-x64" "0.28.2"
+
 escalade@^3.1.1, escalade@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.2.0.tgz#011a3f69856ba189dffa7dc8fcce99d2a87903e5"
@@ -4258,7 +4420,7 @@ fsevents@2.3.2:
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
   integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
 
-fsevents@^2.3.3:
+fsevents@^2.3.3, fsevents@~2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
   integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
@@ -7512,6 +7674,15 @@ tslib@^2.4.0, tslib@^2.6.2, tslib@^2.8.0:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
+
+tsx@^4.23.12:
+  version "4.23.12"
+  resolved "https://registry.yarnpkg.com/tsx/-/tsx-4.23.12.tgz#3a4919591cd9b9e00011b75e596c8ab8db23c09c"
+  integrity sha512-FDf4L4sYzKtzWYhU/Xm0AQFdTjdIxNo9ElTf2mxXM6k8YMHXzYUe4yODVaXP4V9uMFbVg8c0qyBccK2OOxb45Q==
+  dependencies:
+    esbuild "~0.28.0"
+  optionalDependencies:
+    fsevents "~2.3.3"
 
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"


### PR DESCRIPTION
@coderabbitai summary

Part 3 of the Zoom-housekeeping stack (on #511 → #510). 

Resolves #508, Resolves #509

## Description
- **`Meeting.zoomDriftDetectedAt`** (+ migration): persisted drift flag — set/cleared by the monthly scan and the on-open drift check, cleared when retry-sync adopts live credentials (and deliberately NOT cleared when the retry's credential fetch failed).
- **`scripts/zoom-scan.ts` + `.github/workflows/zoom-scan.yml`** (monthly + workflow_dispatch): one pass over every Zoom-enabled meeting — one GET per distinct zid.
  - *Drift sweep*: persists live-vs-stored comparison per row; detection only, adoption stays with the admin-driven retry.
  - *Horizon re-extension (#508)*: re-PATCHes each managed recurring meeting's schedule, refreshing Zoom's ~2-year rolling occurrence clamp with no per-meeting bookkeeping. Unmanaged meetings are never PATCHed. **Shared-zid pairs are skipped**: their Zoom recurrence is the union of two rows' schedules, and a one-row PATCH would narrow it (that hazard also exists on a normal edit of a shared row — pre-existing from #506, follow-up issue to come).
  - Runs the app's own `services/zoom.ts` via tsx with `--conditions=react-server` (neutralizes the `server-only` guard; nothing in the script's import graph resolves React).
- **Calendar badge**: drifted meetings ride the existing sync-attention badge — `sync-error-mids` adds `zoomDriftDetectedAt != null` to its OR. Bulk calendar paths still never call Zoom; opening the meeting shows which case it is.
- **Docs**: How Sync Works and the Icon and Badge Legend now cover the scan and the badge's broadened meaning.

## Setup required before first run
Three new repo secrets: `ZOOM_CLIENT_ID`, `ZOOM_CLIENT_SECRET`, `ZOOM_ACCOUNT_ID` (`DATABASE_URL_UNPOOLED` already exists for backups). Then a manual workflow_dispatch validates end-to-end.

## Testing
- [x] 3 new integration tests (drift GET persists/clears the flag; retry-sync clears on adoption; flag survives a failed credential fetch) + drifted-meeting case in the sync-error-mids test.
- [x] Full `yarn test:all` green on the stack tip: lint, lint:css, typecheck, unit 287, component 287, integration 158, e2e 117.
- [ ] Post-merge: set secrets, run workflow_dispatch once, confirm the summary line and that no false drift flags appear.

## Area(s) Touched
**Product areas**
- [ ] auth — sign-in, sessions, NextAuth, role-based access
- [ ] admin — /admin shell (Diagnostics, Users, Import, Export tabs)
- [ ] docs — /docs Resources page (rendering, navigation, search)
- [ ] ui/ux — frontend layout/styling not tied to a specific integration

**Integrations**
- [ ] google-calendar — Google Calendar sync
- [X] zoom-api — Zoom meeting/host sync

**Engineering**
- [ ] security — auth hardening, data exposure, dependency/security scanning
- [X] testing — test suite (Jest/Playwright) changes
- [X] github-actions — workflows, Dependabot config, other .github/ CI tooling
- [ ] cleanup — refactor or dead-code removal, no behavior change
- [ ] documentation — docs/ or README changes only

## Pre-merge Checklist
- [X] Code follows current formatting conventions and passes lint (`yarn lint`).
- [X] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
- [X] All test suites pass, both run locally and green in GitHub CI. **Do not merge if any test suite is failing.**
- [X] A test suite was added or updated for the feature/fix in this PR.
- [X] Only files relevant to this change are committed — no stray or unrelated files.
- [ ] If this branch has a merge conflict with master, master was merged into this branch first (not the other way around).
- [X] The rest of this PR description (Description, Testing) is filled out, not left as template placeholders.