### PR TITLE
feat(zoom): surface shared Zoom links and show schedule divergence as a pending state

### DIFF
--- a/frontend/app/(main)/page.tsx
+++ b/frontend/app/(main)/page.tsx
@@ -371,6 +371,8 @@ export default function HomePage() {
           creator={selectedMeeting.creator}
           lastEditedBy={selectedMeeting.lastEditedBy}
           zoomManaged={selectedMeeting.zoomManaged}
+          sharedWith={selectedMeeting.sharedWith}
+          zoomScheduleDiverged={selectedMeeting.zoomScheduleDiverged}
           group={selectedMeeting.group}
 
           /* ViewMeetingDetails formats for ET display internally (formatETDateString, etTimeFmt,

--- a/frontend/app/api/retrieve/meeting/[id]/route.ts
+++ b/frontend/app/api/retrieve/meeting/[id]/route.ts
@@ -3,6 +3,7 @@ import { getAuth } from "../../../../../services/auth";
 import { prisma } from "../../../../../lib/prisma";
 import { toPublicMeeting } from "../../../../../util/meetings/publicMeeting";
 import { getUnresolvedSuspension } from "../../../../../util/meetings/suspension";
+import { isSharedZoomScheduleCompatible } from "../../../../../util/meetings/sharedZoomSchedule";
 import { formatETDateString } from "../../../../../util/date/timeUtils";
 const getMeeting = async(request: NextRequest) => {
   try {
@@ -49,12 +50,35 @@ const getMeeting = async(request: NextRequest) => {
     // internal fields like resumeEventIds) isn't meant to be public API surface.
     const { suspensions: _suspensions, ...meetingWithoutSuspensions } = meeting;
     const isAdminSession = session?.user?.role === "ADMIN" || session?.user?.role === "SUPER_ADMIN";
+
+    // A few legacy Zoom meetings serve more than one platform row (one shared zid, union
+    // schedule on Zoom). Admins need to know before editing that the schedule they're changing
+    // feeds a link another meeting also uses, and whether Zoom is currently waiting on the
+    // sibling to match. Admin-only (BUG-022): the sibling's title/mode is never public.
+    const siblings = isAdminSession && meeting.zid
+      ? await prisma.meeting.findMany({
+          where: { zid: meeting.zid, deletedAt: null, mid: { not: meeting.mid } },
+          select: {
+            title: true, modeType: true, isRecurring: true,
+            startDateTime: true, endDateTime: true,
+            recurrencePattern: { select: { type: true, interval: true } },
+          },
+        })
+      : [];
+    const sharedZoom = siblings.length > 0
+      ? {
+          sharedWith: siblings.map(({ title, modeType }) => ({ title, modeType })),
+          zoomScheduleDiverged: !isSharedZoomScheduleCompatible([meeting, ...siblings]),
+        }
+      : {};
+
     const body = isAdminSession
       ? {
           ...meetingWithoutSuspensions,
           resumesAt: relevantSuspension?.to ?? null,
           suspendedSince: relevantSuspension?.from ?? null,
           suspensionActive,
+          ...sharedZoom,
         }
       : toPublicMeeting({ ...meeting, recurrencePattern: meeting.recurrencePattern ?? null });
 

--- a/frontend/app/components/meeting-form/EditMeeting.tsx
+++ b/frontend/app/components/meeting-form/EditMeeting.tsx
@@ -61,6 +61,12 @@ const EditMeetingSidebar: React.FC<EditMeetingSidebarProps> =
       isDirty,
     } = useMeetingForm(meeting);
 
+    // Populated only for admin sessions by retrieve/meeting/[id] -- empty for a meeting whose
+    // Zoom link is its own.
+    const sharedWithText = (meeting.sharedWith ?? [])
+      .map((row) => `${row.title} (${row.modeType})`)
+      .join(', ');
+
     const { showToast } = useToast();
     const [isSubmitting, setIsSubmitting] = useState(false);
     // Holds the payload + conflict rows across the confirm round-trip -- a 409 doesn't discard
@@ -261,6 +267,9 @@ const EditMeetingSidebar: React.FC<EditMeetingSidebarProps> =
               getCandidate={() => buildMeetingPayload(meeting.mid, meeting.status ?? 'Active')}
               lockedReason={meeting.zoomManaged === false
                 ? "Legacy Zoom link; host can't be reassigned from the app."
+                : undefined}
+              sharedLinkNote={sharedWithText
+                ? `This Zoom link is shared with ${sharedWithText}; the schedule saved here feeds that same Zoom meeting.`
                 : undefined}
             />
           }

--- a/frontend/app/components/meeting-form/MeetingSyncStatusBand.module.scss
+++ b/frontend/app/components/meeting-form/MeetingSyncStatusBand.module.scss
@@ -122,7 +122,7 @@
   }
 }
 
-.conflictBlock, .suspensionBlock {
+.conflictBlock, .suspensionBlock, .sharedScheduleBlock {
   display: flex;
   align-items: flex-start;
   gap: 8px;

--- a/frontend/app/components/meeting-form/MeetingSyncStatusBand.tsx
+++ b/frontend/app/components/meeting-form/MeetingSyncStatusBand.tsx
@@ -17,6 +17,13 @@ interface MeetingSyncStatusBandProps {
   // The live Zoom passcode/join URL no longer match the stored copy (someone changed them in
   // the Zoom portal) -- resolved by the same retry action, which adopts Zoom's values.
   zoomDrift: boolean;
+  // This meeting shares its Zoom link with another row whose schedule no longer matches, so
+  // Zoom keeps its current schedule until both agree. A pending state, not a failure -- the
+  // app and Google calendars already follow this row's own edit.
+  sharedScheduleDiverged: boolean;
+  // The sharing rows, pre-formatted as "Title (Mode)" by ViewMeeting -- the same text its
+  // shared-link row shows.
+  sharedWithText: string;
   syncing: boolean;
   onRetrySync: () => void;
   conflictCount: number;
@@ -39,6 +46,8 @@ const MeetingSyncStatusBand: React.FC<MeetingSyncStatusBandProps> = ({
   zoomSyncStatus,
   zoomSyncError,
   zoomDrift,
+  sharedScheduleDiverged,
+  sharedWithText,
   syncing,
   onRetrySync,
   conflictCount,
@@ -50,7 +59,7 @@ const MeetingSyncStatusBand: React.FC<MeetingSyncStatusBandProps> = ({
   const [syncDetailsOpen, setSyncDetailsOpen] = useState(false);
   const hasSyncFailure = googleSyncStatus === 'error' || zoomSyncStatus === 'error';
 
-  if (!isAdmin || !(hasSyncFailure || zoomDrift || conflictCount > 0 || hasSuspension)) return null;
+  if (!isAdmin || !(hasSyncFailure || zoomDrift || sharedScheduleDiverged || conflictCount > 0 || hasSuspension)) return null;
 
   return (
     <div className={styles.statusBand}>
@@ -101,6 +110,16 @@ const MeetingSyncStatusBand: React.FC<MeetingSyncStatusBandProps> = ({
           >
             {syncing ? 'Syncing…' : 'Sync from Zoom'}
           </button>
+        </div>
+      )}
+
+      {sharedScheduleDiverged && (
+        <div className={styles.sharedScheduleBlock}>
+          <Icon name="warning" />
+          <span>
+            This meeting shares its Zoom link with {sharedWithText}, which still has a different
+            schedule — Zoom updates once both match (edit it too, or revert).
+          </span>
         </div>
       )}
 

--- a/frontend/app/components/meeting-form/ViewMeeting.tsx
+++ b/frontend/app/components/meeting-form/ViewMeeting.tsx
@@ -10,7 +10,7 @@ import TagList from '../ui/displays/TagList';
 import BottomSheet from '../ui/overlays/BottomSheet';
 import Icon from '../ui/displays/Icon';
 
-import { IRecurrencePattern } from '../../../types/models';
+import { IRecurrencePattern, ISharedZoomRow } from '../../../types/models';
 import { formatCompactTimeRange, formatMeetingDateLine } from "../../../util/date/timeFormat";
 import {
   convertETToUTC,
@@ -70,6 +70,12 @@ type ViewMeetingDetailsProps = {
   currentOccurrenceDate?: Date; // Handles the specific occurrence date
   lastEditedBy?: string | null; // Server-managed: session email of the last admin to save an edit
   zoomManaged?: boolean; // false = ICR-owned/external Zoom meeting the app only points at
+  // Other active rows on the same Zoom link (shared legacy meetings) -- admin-only, like the
+  // rest of the contact group it renders in.
+  sharedWith?: ISharedZoomRow[];
+  // Those rows' schedules disagree, so Zoom is holding its current schedule until they match.
+  // A pending state, not a failure: the app and Google calendars already follow this row.
+  zoomScheduleDiverged?: boolean;
   googleSyncStatus?: string | null;
   googleSyncError?: string | null;
   zoomSyncStatus?: string | null;
@@ -116,6 +122,8 @@ const ViewMeetingDetails: React.FC<ViewMeetingDetailsProps> = ({
   creator,
   lastEditedBy,
   zoomManaged,
+  sharedWith,
+  zoomScheduleDiverged = false,
   startDateTime,
   endDateTime,
   email,
@@ -384,6 +392,8 @@ const ViewMeetingDetails: React.FC<ViewMeetingDetailsProps> = ({
   const primaryColor = ROOM_COLORS[room] ?? ZOOM_ROOM_COLOR;
   const primaryLocation = room || (zoomRoom ? stripZoomSuffix(zoomRoom) : '');
   const showZoomMismatchRow = !!(room && zoomRoom && isZoomRoomMismatched(room, zoomRoom));
+  const sharedRows = sharedWith ?? [];
+  const sharedWithText = sharedRows.map((row) => `${row.title} (${row.modeType})`).join(', ');
 
   const content = (
     <div className={styles.meetingDetails}>
@@ -435,6 +445,8 @@ const ViewMeetingDetails: React.FC<ViewMeetingDetailsProps> = ({
           zoomSyncStatus={zoomSyncStatus}
           zoomSyncError={zoomSyncError}
           zoomDrift={zoomDrift}
+          sharedScheduleDiverged={zoomScheduleDiverged && sharedRows.length > 0}
+          sharedWithText={sharedWithText}
           syncing={syncing}
           onRetrySync={handleRetrySync}
           conflictCount={conflictCount}
@@ -506,7 +518,7 @@ const ViewMeetingDetails: React.FC<ViewMeetingDetailsProps> = ({
           </div>
         )}
 
-        {isAdmin && (email || zoomHost) && (
+        {isAdmin && (email || zoomHost || sharedRows.length > 0) && (
           <div className={`${styles.contactGroup} ${description ? styles.withDivider : ''}`}>
             {email && (
               <p className={styles.contactRow}>
@@ -518,6 +530,12 @@ const ViewMeetingDetails: React.FC<ViewMeetingDetailsProps> = ({
               <p className={styles.contactRow}>
                 <Icon name="person" />
                 <span>Host: {zoomHostLabel(zoomHost, zoomHostPool.indexOf(zoomHost))} — {zoomHost}</span>
+              </p>
+            )}
+            {sharedRows.length > 0 && (
+              <p className={styles.contactRow}>
+                <Icon name="link" />
+                <span>Zoom link shared with {sharedWithText}</span>
               </p>
             )}
             {zoomManaged === false && (

--- a/frontend/app/components/meeting-form/ZoomHostField.module.scss
+++ b/frontend/app/components/meeting-form/ZoomHostField.module.scss
@@ -11,6 +11,7 @@
     font-family: 'Source Sans Pro', sans-serif;
 }
 
+.sharedLinkNote,
 .lockedIndicator {
   display: flex;
   align-items: center;

--- a/frontend/app/components/meeting-form/ZoomHostField.tsx
+++ b/frontend/app/components/meeting-form/ZoomHostField.tsx
@@ -26,6 +26,9 @@ export interface ZoomHostFieldProps {
   // used for meetings whose Zoom meeting the app doesn't own (zoomManaged: false), where a
   // host reassignment is impossible (the server 422s it) rather than merely unavailable.
   lockedReason?: string;
+  // Informational only (the edit is allowed): this meeting's Zoom link is shared with other
+  // rows, so the schedule saved here feeds a Zoom meeting they use too.
+  sharedLinkNote?: string;
 }
 
 const CheckIcon: React.FC = () => (
@@ -68,6 +71,7 @@ export const ZoomHostField: React.FC<ZoomHostFieldProps> = ({
   compact = false,
   getCandidate,
   lockedReason,
+  sharedLinkNote,
 }) => {
   const hosts = useZoomHostPool();
   // Per-host remaining capacity from the most recent check -- freeSlots reflects the
@@ -187,9 +191,16 @@ export const ZoomHostField: React.FC<ZoomHostFieldProps> = ({
 
   if (!isVisible) return null;
 
+  const sharedNote = sharedLinkNote ? (
+    <p className={styles.sharedLinkNote}>
+      <Icon name="link" size={16} ariaLabel="Shared Zoom link" /> {sharedLinkNote}
+    </p>
+  ) : null;
+
   if (lockedReason) {
     return (
       <div className={styles.zoomHostField}>
+        {sharedNote}
         <p className={styles.lockedIndicator}>
           <Icon name="lock" size={16} ariaLabel="Locked" /> {lockedReason}
         </p>
@@ -239,6 +250,7 @@ export const ZoomHostField: React.FC<ZoomHostFieldProps> = ({
 
   return (
     <div className={styles.zoomHostField}>
+      {sharedNote}
       {status === 'checking' && (
         <p className={styles.checkingIndicator}>Checking host availability…</p>
       )}

--- a/frontend/app/components/ui/displays/Icon.tsx
+++ b/frontend/app/components/ui/displays/Icon.tsx
@@ -45,6 +45,7 @@ import LockOutlinedIcon from "@mui/icons-material/LockOutlined";
 import ErrorOutlineIcon from "@mui/icons-material/ErrorOutline";
 import WarningAmberIcon from "@mui/icons-material/WarningAmber";
 import ContentCopyIcon from "@mui/icons-material/ContentCopy";
+import LinkIcon from "@mui/icons-material/Link";
 import FileDownloadOutlinedIcon from "@mui/icons-material/FileDownloadOutlined";
 import type { SvgIconComponent } from "@mui/icons-material";
 
@@ -123,6 +124,7 @@ const MUI_ICONS = {
     // variants.
     "warning-amber": WarningAmberIcon,
     copy: ContentCopyIcon,
+    link: LinkIcon,
     download: FileDownloadOutlinedIcon,
 } satisfies Record<string, SvgIconComponent>;
 

--- a/frontend/services/zoom.ts
+++ b/frontend/services/zoom.ts
@@ -2,6 +2,7 @@ import "server-only";
 import { Prisma } from "@prisma/client";
 import { IMeeting } from "../types/models";
 import { expandOccurrences, findResourceConflicts, findFirstFreePoolHost, getPoolHostLoads, OccurrenceInput } from "../util/meetings/resourceOverlap";
+import { isSharedZoomScheduleCompatible } from "../util/meetings/sharedZoomSchedule";
 import { prisma } from "../lib/prisma";
 
 const ZOOM_BASE_API = process.env.NEXT_PUBLIC_ZOOM_BASE_API ?? "https://api.zoom.us/v2";
@@ -262,14 +263,9 @@ function buildZoomRecurrence(meeting: IMeeting, siblings: IMeeting[] = []): Reco
   if (!meeting.isRecurring || !meeting.recurrencePattern) return siblings.length ? "incompatible" : null;
   if (siblings.length > 0) {
     const rows = [meeting, ...siblings];
-    const timeOf = (m: IMeeting) => toZoomStartTime(new Date(m.startDateTime)).slice(11);
-    const durationOf = (m: IMeeting) => new Date(m.endDateTime).getTime() - new Date(m.startDateTime).getTime();
-    const compatible = rows.every((m) =>
-      m.isRecurring && m.recurrencePattern && m.recurrencePattern.type === "weekly" &&
-      (m.recurrencePattern.interval ?? 1) === (meeting.recurrencePattern?.interval ?? 1) &&
-      timeOf(m) === timeOf(meeting) && durationOf(m) === durationOf(meeting),
-    );
-    if (!compatible) return "incompatible";
+    // Same compatibility rule the retrieve route reports to the UI as a divergence -- shared
+    // so the two can never disagree about whether Zoom is waiting on a sibling edit.
+    if (!isSharedZoomScheduleCompatible(rows)) return "incompatible";
     const unionDays = [...new Set(rows.flatMap((m) => m.recurrencePattern?.daysOfWeek ?? []))]
       .map((d) => ZOOM_WEEKDAY[d]).filter(Boolean).sort((a, b) => a - b);
     // Always unbounded: every shared meeting is an endless adopted legacy series; a union of

--- a/frontend/tests/component/ViewMeeting.test.tsx
+++ b/frontend/tests/component/ViewMeeting.test.tsx
@@ -304,4 +304,53 @@ describe("ViewMeeting", () => {
       expect(driftCalls).toHaveLength(0);
     });
   });
+
+  // A few legacy Zoom meetings serve two platform rows on one zid. Both the sharing row and
+  // the divergence notice are admin-only (BUG-022) -- the sibling's title/mode never reaches a
+  // public viewer, and the retrieve route omits the fields entirely for one.
+  describe("shared Zoom link", () => {
+    const sharedProps = {
+      ...baseProps,
+      modeType: "Hybrid",
+      zid: "70000001101",
+      zoomLink: "http://zoom.test/j/70000001101",
+      sharedWith: [{ title: "One Day at a Time", modeType: "Remote" }],
+      isPhone: false,
+    };
+
+    it("shows the sharing row for an admin", async () => {
+      renderViewMeeting({ ...sharedProps, anchorEl: makeAnchorEl() });
+      expect(await screen.findByText(/Zoom link shared with One Day at a Time \(Remote\)/)).toBeInTheDocument();
+    });
+
+    it("hides the sharing row from a non-admin viewer", async () => {
+      renderViewMeeting({ ...sharedProps, anchorEl: makeAnchorEl(), isAdmin: false });
+      await screen.findByText("Serenity Group");
+      expect(screen.queryByText(/Zoom link shared with/)).not.toBeInTheDocument();
+    });
+
+    it("renders no sharing row when the Zoom link is this meeting's alone", async () => {
+      renderViewMeeting({ ...sharedProps, anchorEl: makeAnchorEl(), sharedWith: undefined });
+      await screen.findByText("Serenity Group");
+      expect(screen.queryByText(/Zoom link shared with/)).not.toBeInTheDocument();
+    });
+
+    it("adds the pending-divergence notice, with no action, when the schedules disagree", async () => {
+      renderViewMeeting({ ...sharedProps, anchorEl: makeAnchorEl(), zoomScheduleDiverged: true });
+      expect(await screen.findByText(/which still has a different\s+schedule/)).toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: /Retry sync|Sync from Zoom/ })).not.toBeInTheDocument();
+    });
+
+    it("omits the divergence notice while the schedules still match", async () => {
+      renderViewMeeting({ ...sharedProps, anchorEl: makeAnchorEl(), zoomScheduleDiverged: false });
+      await screen.findByText("Serenity Group");
+      expect(screen.queryByText(/still has a different/)).not.toBeInTheDocument();
+    });
+
+    it("hides the divergence notice from a non-admin viewer", async () => {
+      renderViewMeeting({ ...sharedProps, anchorEl: makeAnchorEl(), zoomScheduleDiverged: true, isAdmin: false });
+      await screen.findByText("Serenity Group");
+      expect(screen.queryByText(/still has a different/)).not.toBeInTheDocument();
+    });
+  });
 });

--- a/frontend/tests/integration/retrieve-meeting-detail-route.test.ts
+++ b/frontend/tests/integration/retrieve-meeting-detail-route.test.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from "next/server";
-import { seedMeeting } from "../factories/meeting";
+import { seedMeeting, seedRecurringMeeting } from "../factories/meeting";
 import { disconnectTestPrismaClient } from "../factories/db";
+import { convertETToUTC, formatETDateString } from "../../util/date/timeUtils";
 
 jest.mock("../../services/auth", () => ({
   getAuth: jest.fn(),
@@ -63,4 +64,66 @@ test("a SUPER_ADMIN-role session gets the full record", async () => {
   const body = await getMeetingDetail(meeting.mid);
   expect(body.creator).toBe("Someone Private");
   expect(body.email).toBe("private@test.icr");
+});
+
+// A few legacy Zoom meetings serve two platform rows on one zid (one union schedule on Zoom).
+// The sibling lookup below is what tells an admin the link is shared and whether Zoom is
+// waiting on the other row to match again.
+describe("shared Zoom link siblings", () => {
+  const etDate = formatETDateString(new Date());
+  const at = (time: string) => new Date(convertETToUTC(`${etDate}T${time}`));
+
+  const seedSharedPair = async (zid: string, siblingTimes: { start: string; end: string }) => {
+    const { meeting } = await seedRecurringMeeting(
+      { zid, title: "Early Bird", modeType: "Hybrid", startDateTime: at("18:00:00"), endDateTime: at("19:00:00") },
+      { daysOfWeek: ["Monday"] },
+    );
+    await seedRecurringMeeting(
+      {
+        zid, title: "One Day at a Time", modeType: "Remote",
+        startDateTime: at(siblingTimes.start), endDateTime: at(siblingTimes.end),
+      },
+      { daysOfWeek: ["Sunday"] },
+    );
+    return meeting;
+  };
+
+  test("an admin sees the sibling rows, with no divergence while the schedules still match", async () => {
+    mockedGetAuth.mockResolvedValue({ user: { role: "ADMIN" } });
+    const meeting = await seedSharedPair("70000001101", { start: "18:00:00", end: "19:00:00" });
+
+    const body = await getMeetingDetail(meeting.mid);
+    expect(body.sharedWith).toEqual([{ title: "One Day at a Time", modeType: "Remote" }]);
+    expect(body.zoomScheduleDiverged).toBe(false);
+  });
+
+  test("divergence flips true when a sibling's time-of-day no longer matches", async () => {
+    mockedGetAuth.mockResolvedValue({ user: { role: "ADMIN" } });
+    const meeting = await seedSharedPair("70000001102", { start: "20:00:00", end: "21:00:00" });
+
+    const body = await getMeetingDetail(meeting.mid);
+    expect(body.sharedWith).toHaveLength(1);
+    expect(body.zoomScheduleDiverged).toBe(true);
+  });
+
+  test("an unshared meeting carries neither field", async () => {
+    mockedGetAuth.mockResolvedValue({ user: { role: "ADMIN" } });
+    const meeting = await seedMeeting({ zid: "70000001103" });
+
+    const body = await getMeetingDetail(meeting.mid);
+    expect(body).not.toHaveProperty("sharedWith");
+    expect(body).not.toHaveProperty("zoomScheduleDiverged");
+  });
+
+  // BUG-022: the sibling's title/mode is admin-only -- a public viewer of a shared meeting
+  // gets the same allowlisted fields as any other meeting.
+  test("a public caller never gets the sibling data, even on a shared meeting", async () => {
+    const meeting = await seedSharedPair("70000001104", { start: "20:00:00", end: "21:00:00" });
+    mockedGetAuth.mockResolvedValue(null);
+
+    const body = await getMeetingDetail(meeting.mid);
+    expect(Object.keys(body).sort()).toEqual(PUBLIC_MEETING_FIELDS);
+    expect(body).not.toHaveProperty("sharedWith");
+    expect(body).not.toHaveProperty("zoomScheduleDiverged");
+  });
 });

--- a/frontend/types/models.ts
+++ b/frontend/types/models.ts
@@ -41,6 +41,13 @@ interface IMeeting {
   // now) vs. is merely scheduled for a future date. Only meaningful when suspendedSince is
   // non-null.
   suspensionActive?: boolean;
+  // Other active rows sharing this meeting's Zoom link (same zid), populated only by
+  // retrieve/meeting/[id] for admin sessions -- absent/empty whenever the link is this
+  // meeting's alone. Never part of the public payload (util/meetings/publicMeeting.ts).
+  sharedWith?: ISharedZoomRow[];
+  // Those rows' schedules can't currently be expressed as one Zoom series, so Zoom keeps the
+  // schedule it already has until they match again. Same population rules as sharedWith.
+  zoomScheduleDiverged?: boolean;
   isRecurring: boolean;
   recurrencePattern?: IRecurrencePattern | null;
   googleCalendarEventId?: string | null;
@@ -56,6 +63,11 @@ interface IMeeting {
   // Set true to resubmit a payload that already saw (and was shown) a room/zoomRoom conflict --
   // never persisted, write/update strip it before the Prisma write.
   confirmOverride?: boolean;
+}
+
+interface ISharedZoomRow {
+  title: string;
+  modeType: string;
 }
 
 interface IRecurrencePattern {
@@ -94,4 +106,4 @@ interface ILeaseSettings {
   emailTemplate: string;
 }
 
-export type { IAdmin, IMeeting, IRecurrencePattern, IRoomRate, ILeaseSettings };
+export type { IAdmin, IMeeting, ISharedZoomRow, IRecurrencePattern, IRoomRate, ILeaseSettings };

--- a/frontend/util/meetings/sharedZoomSchedule.ts
+++ b/frontend/util/meetings/sharedZoomSchedule.ts
@@ -1,0 +1,39 @@
+import { getETTimeOfDay } from "../date/timeUtils";
+
+// The subset of a meeting row this comparison reads -- deliberately structural, so both the
+// Prisma row (with its included recurrencePattern) and an IMeeting satisfy it without casting.
+export interface SharedZoomScheduleRow {
+  isRecurring: boolean;
+  startDateTime: Date | string;
+  endDateTime: Date | string;
+  recurrencePattern?: { type: string; interval: number } | null;
+}
+
+const etTimeOfDayKey = (value: Date | string): string => {
+  const { hour, minute, second } = getETTimeOfDay(new Date(value));
+  return `${hour}:${minute}:${second}`;
+};
+
+/**
+ * Whether every row sharing one Zoom meeting (one zid) can be expressed as a single Zoom
+ * series: all weekly, same interval, same ET time-of-day, same duration -- differing only in
+ * weekdays, which Zoom holds as the union. Anything else has no single-series representation,
+ * so Zoom's schedule is left untouched (services/zoom.ts) and the UI reports the divergence as
+ * a pending state rather than an error.
+ */
+export function isSharedZoomScheduleCompatible(rows: SharedZoomScheduleRow[]): boolean {
+  if (rows.length < 2) return true;
+  const [reference] = rows;
+  if (!reference.isRecurring || !reference.recurrencePattern) return false;
+  const referenceInterval = reference.recurrencePattern.interval ?? 1;
+  const referenceTime = etTimeOfDayKey(reference.startDateTime);
+  const durationOf = (row: SharedZoomScheduleRow) =>
+    new Date(row.endDateTime).getTime() - new Date(row.startDateTime).getTime();
+  const referenceDuration = durationOf(reference);
+  return rows.every((row) =>
+    row.isRecurring && row.recurrencePattern && row.recurrencePattern.type === "weekly" &&
+    (row.recurrencePattern.interval ?? 1) === referenceInterval &&
+    etTimeOfDayKey(row.startDateTime) === referenceTime &&
+    durationOf(row) === referenceDuration,
+  );
+}


### PR DESCRIPTION
@coderabbitai summary

Part 2, stacked on the rehost PR (GitHub retargets on merge). Closes #518.

## Description
- **`util/meetings/sharedZoomSchedule.ts`** (new): `isSharedZoomScheduleCompatible(rows)` — the weekly/same-interval/same-ET-time/same-duration rule, extracted so `buildZoomRecurrence` (services/zoom.ts, now calls it) and the retrieve route share one definition. Placed in util rather than the `server-only` zoom service so it stays dependency-light.
- **`retrieve/meeting/[id]`**: the **admin branch only** now includes `sharedWith: [{title, modeType}]` and `zoomScheduleDiverged` when other active rows share the meeting's zid. Public branch untouched, zero extra queries for public callers (BUG-022 pattern held; the integration tests pin the public payload's exact keys).
- **ViewMeeting**: admin-only "Zoom link shared with X (Mode)" row (new `link` icon); when diverged, `MeetingSyncStatusBand` shows an action-less warning: the sibling still has a different schedule — Zoom updates once both match. Deliberately **not** an error and no 422 anywhere: blocking divergence would deadlock the legitimate two-step "move both rows" flow (the first edit always diverges transiently); calendars follow each row immediately, only Zoom's own listing waits.
- **EditMeeting/ZoomHostField**: informational shared-link note near the Zoom fields, mirroring the unmanaged `lockedReason` plumbing.
- Issue item 3 (sharpened "host is fixed" conflict copy) is intentionally dropped, not deferred: the rehost PR under this one makes host reassignment real, so that copy would be wrong the day both merge.

## Testing
- [x] 6 new ViewMeeting component tests (row/notice render, non-admin hidden, unshared absent, no action button) and 4 new retrieve-route integration tests (admin sees fields, divergence flips on a mismatched sibling, unshared carries neither, public payload keys unchanged).
- [x] Full `yarn test:all` green on this branch (stack tip): unit 291, component 294, integration 166, e2e 117.

## Area(s) Touched
**Product areas**
- [X] ui/ux — frontend layout/styling not tied to a specific integration

**Integrations**
- [X] zoom-api — Zoom meeting/host sync

**Engineering**
- [X] testing — test suite (Jest/Playwright) changes

## Pre-merge Checklist
- [X] Code follows current formatting conventions and passes lint (`yarn lint`).
- [X] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
- [X] All test suites pass, both run locally and green in GitHub CI. **Do not merge if any test suite is failing.**
- [X] A test suite was added or updated for the feature/fix in this PR.
- [X] Only files relevant to this change are committed — no stray or unrelated files.
- [ ] If this branch has a merge conflict with master, master was merged into this branch first (not the other way around).
- [X] The rest of this PR description (Description, Testing) is filled out, not left as template placeholders.