### PR TITLE
fix(meeting-form): rename legacy Zoom link copy to external

### DIFF
--- a/frontend/app/api/update/meeting/route.ts
+++ b/frontend/app/api/update/meeting/route.ts
@@ -344,14 +344,14 @@ const updateMeeting = async (request: Request): Promise<Response> => {
     const explicitHostChange = !!newMeeting.zoomHost &&
       newMeeting.zoomHost.toLowerCase() !== (existingMeeting.zoomHost ?? "").toLowerCase();
 
-    // An unmanaged Zoom meeting's host is whoever owns it on Zoom's side (adopted legacy /
-    // externally hosted -- see schema.prisma's zoomManaged); the app can't reassign that, and
+    // An unmanaged Zoom meeting's host is whoever owns it on Zoom's side (externally
+    // hosted -- see schema.prisma's zoomManaged); the app can't reassign that, and
     // persisting a different pool host would only make capacity accounting lie. Everything else
     // (rooms, times, content) is app/calendar-side and stays editable -- a Zoom-room change
     // just moves the join-link event between room calendars using the stored link.
     if (!existingMeeting.zoomManaged && explicitHostChange) {
       return NextResponse.json(
-        { error: "This meeting's Zoom meeting is legacy; its host can't be reassigned from the app." },
+        { error: "This meeting's Zoom meeting is externally owned; its host can't be reassigned from the app." },
         { status: 422 },
       );
     }

--- a/frontend/app/components/meeting-form/EditMeeting.tsx
+++ b/frontend/app/components/meeting-form/EditMeeting.tsx
@@ -266,7 +266,7 @@ const EditMeetingSidebar: React.FC<EditMeetingSidebarProps> =
               compact={compact}
               getCandidate={() => buildMeetingPayload(meeting.mid, meeting.status ?? 'Active')}
               lockedReason={meeting.zoomManaged === false
-                ? "Legacy Zoom link; host can't be reassigned from the app."
+                ? "External Zoom link; host can't be reassigned from the app."
                 : undefined}
               sharedLinkNote={sharedWithText
                 ? `This Zoom link is shared with ${sharedWithText}; the schedule saved here feeds that same Zoom meeting.`

--- a/frontend/app/components/meeting-form/ViewMeeting.tsx
+++ b/frontend/app/components/meeting-form/ViewMeeting.tsx
@@ -541,7 +541,7 @@ const ViewMeetingDetails: React.FC<ViewMeetingDetailsProps> = ({
             {zoomManaged === false && (
               <p className={styles.contactRow}>
                 <Icon name="lock" />
-                <span>Legacy Zoom link; the app keeps calendars in sync but never changes the Zoom host.</span>
+                <span>External Zoom link; the app keeps calendars in sync but never changes the Zoom host.</span>
               </p>
             )}
             {/* Provenance is only shown when it's a real session email -- meetings created

--- a/frontend/prisma/schema.prisma
+++ b/frontend/prisma/schema.prisma
@@ -63,10 +63,10 @@ model Meeting {
   // Server-managed provenance (session email), like creator: null = never edited since import/
   // creation. Both are set only by the API routes, never from client payloads.
   lastEditedBy           String?
-  // False for meetings whose Zoom meeting the app merely points at but does not own: ICR's
-  // legacy recurring meetings adopted in the 2026-08 migration, and externally hosted ones
-  // (e.g. a group member's personal account). The app must never PATCH, delete, or recreate an
-  // unmanaged Zoom meeting -- it is the client's property; only the stored link/passcode is ours.
+  // False for meetings whose Zoom meeting lives on an account the app has no control over
+  // (e.g. an outside organization's or a group member's personal account). The app must never
+  // PATCH, delete, or recreate an unmanaged Zoom meeting -- only the stored link/passcode is
+  // ours. ICR's own adopted legacy meetings are managed (true) like any other.
   zoomManaged            Boolean              @default(true)
   // The Zoom meeting's display topic. Null = derive from title + a mode suffix (" - Hybrid" /
   // " - Zoom Only", ICR's own naming convention); non-null = pinned verbatim -- backfilled with


### PR DESCRIPTION
@coderabbitai summary

## Description
- The three "Legacy Zoom link" strings (ViewMeeting lock row, EditMeeting lock reason, host-change 422 error) now say **External** — the locked state marks ownership (an account the app has no control over), not age. ICR's adopted legacy meetings are fully managed and carry no label, so "legacy" invited exactly the wrong inference.
- `schema.prisma`'s `zoomManaged` comment corrected: it still claimed the adopted legacy meetings are unmanaged, which has been false since the type-8 conversion (only externally-owned meetings are `false`).
- Matches the user-guide terminology renamed on master ("External Zoom links" section + anchors).

## Testing
- [x] Copy-only + comment changes; no assertions referenced the old strings. Typecheck clean, ViewMeeting component suite 27/27, update-meeting-route integration 20/20, lint 0 errors.

## Area(s) Touched
**Product areas**
- [X] ui/ux — frontend layout/styling not tied to a specific integration

**Integrations**
- [X] zoom-api — Zoom meeting/host sync

## Pre-merge Checklist
- [X] Code follows current formatting conventions and passes lint (`yarn lint`).
- [X] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
- [X] All test suites pass, both run locally and green in GitHub CI. **Do not merge if any test suite is failing.**
- [ ] A test suite was added or updated for the feature/fix in this PR. (Copy-only; no behavior change.)
- [X] Only files relevant to this change are committed — no stray or unrelated files.
- [ ] If this branch has a merge conflict with master, master was merged into this branch first (not the other way around).
- [X] The rest of this PR description (Description, Testing) is filled out, not left as template placeholders.