### PR TITLE
feat(meetings): support this/this-and-following/all scopes when editing a recurring meeting

### DIFF
--- a/docs/01-user-guide/explanation/how-sync-works.md
+++ b/docs/01-user-guide/explanation/how-sync-works.md
@@ -7,7 +7,8 @@ Every meeting has up to three synced copies: an event on its category calendar, 
 | Action in the platform | Google Calendar events | Zoom meeting |
 |---|---|---|
 | **Create** | Created on the category calendar (and Zoom room calendar for Hybrid and Remote) | Created — under one stable ID and link |
-| **Edit** (always the whole series) | Updated to match | Rescheduled to match — retain the meeting ID, link, and passcode |
+| **Edit** (This event / This and following) | Affected occurrence(s) updated; a recurring edit splits or detaches the Google event(s) to match | Untouched — the detached/tail row inherits the same meeting ID, link, and passcode |
+| **Edit** (All events) | Updated to match | Rescheduled to match — retain the meeting ID, link, and passcode |
 | **Change Zoom Host** | Events keep the same link | Moved to the new host — ID, link, and passcode unchanged (a replacement is only created if Zoom refuses the move) |
 | **Delete** (one occurrence / this-and-following) | Affected occurrences removed | Untouched |
 | **Delete** (whole series) | All events removed | Deleted — unless another platform meeting still shares the same Zoom meeting, or it's an [external link](#external-zoom-links) the platform doesn't own |

--- a/docs/01-user-guide/explanation/why-some-actions-cant-be-undone.md
+++ b/docs/01-user-guide/explanation/why-some-actions-cant-be-undone.md
@@ -16,7 +16,10 @@
 
 ## Editing Recurring Series
 
-Edits to a recurring series apply to **all occurrences**. To modify a single date without affecting the rest:
+Saving an edit to a recurring meeting asks which occurrences it applies to — **This event**, **This and following events**, or **All events** (see [Create, Edit, and Delete Meetings](../how-to/create-edit-delete-meetings.md)). The Zoom link stays the same across all three; only Google Calendar and the meeting's own details change.
 
-1. Delete the single occurrence.
-2. Create a separate, standalone meeting for that specific date (see [Create, Edit, and Delete Meetings](../how-to/create-edit-delete-meetings.md)).
+- **This event** detaches the clicked occurrence into its own standalone meeting — it's no longer part of the series and won't follow future edits to it.
+- **This and following events** splits the series in two at the clicked date: everything before keeps its old details, everything from that date on picks up the new ones.
+- **All events** applies the change to the entire series, same as before.
+
+There's no "undo" for a scope choice once saved — picking the wrong one means repeating the edit with the correct scope.

--- a/docs/01-user-guide/how-to/create-edit-delete-meetings.md
+++ b/docs/01-user-guide/how-to/create-edit-delete-meetings.md
@@ -19,10 +19,19 @@ saved either way, see [how sync works](../explanation/how-sync-works.md) for why
 
 All fields can be edited, including mode and recurrence. Editing never changes a meeting's Zoom link or passcode — even reassigning the Zoom Host moves the existing Zoom meeting rather than creating a new one. For the few meetings on an [external Zoom link](../explanation/how-sync-works.md#external-zoom-links), the Zoom Host field is locked and the Zoom side isn't touched at all.
 
-> [!IMPORTANT]
-> For a recurring meeting, editing updates the **entire series** — there's no per-occurrence edit.
-> See [why some actions can't be undone](../explanation/why-some-actions-cant-be-undone.md#editing-recurring-series)
-> for the reasoning and the workaround if only one date needs to differ.
+**Recurring:** clicking **"Update Meeting"** on a recurring meeting offers the same three-way
+scope choice as delete:
+
+| Option | Effect |
+|---|---|
+| This event | Only the clicked occurrence changes; it becomes a standalone meeting, separate from the series |
+| This and following events | The clicked occurrence and everything after it changes; the series splits in two at that date |
+| All events | The entire series changes, same as every other occurrence |
+
+Changing the recurrence settings themselves (frequency, days, end date) disables **This event** —
+a recurrence change can only apply going forward or to the whole series, never to a single date.
+See [why some actions can't be undone](../explanation/why-some-actions-cant-be-undone.md#editing-recurring-series)
+for what each option means for undoing a mistake.
 
 ## Double-booking a room, Zoom room, or Zoom host
 

--- a/docs/01-user-guide/how-to/create-edit-delete-meetings.md
+++ b/docs/01-user-guide/how-to/create-edit-delete-meetings.md
@@ -19,8 +19,8 @@ saved either way, see [how sync works](../explanation/how-sync-works.md) for why
 
 All fields can be edited, including mode and recurrence. Editing never changes a meeting's Zoom link or passcode — even reassigning the Zoom Host moves the existing Zoom meeting rather than creating a new one. For the few meetings on an [external Zoom link](../explanation/how-sync-works.md#external-zoom-links), the Zoom Host field is locked and the Zoom side isn't touched at all.
 
-**Recurring:** clicking **"Update Meeting"** on a recurring meeting offers the same three-way
-scope choice as delete:
+**Recurring:** clicking **"Update Meeting"** on a recurring meeting asks which occurrences to
+change:
 
 | Option | Effect |
 |---|---|

--- a/docs/01-user-guide/reference/quick-reference-card.md
+++ b/docs/01-user-guide/reference/quick-reference-card.md
@@ -22,6 +22,7 @@
 **Edit a meeting**
 1. Click meeting → click **⋮** → **"Edit"**
 2. Change fields → click **"Update Meeting"**
+3. Recurring: choose "This event" / "This and following events" / "All events" in the dialog
 
 **Delete a meeting**
 1. Click meeting → click **⋮** → **"Delete"**

--- a/docs/02-handoff/technical-decisions.md
+++ b/docs/02-handoff/technical-decisions.md
@@ -137,6 +137,23 @@ Each section ends with a **Revisit if:** line — the condition under which this
 
 ---
 
+## Recurring-Series Edit Scopes: Split Rows, Not an Exception Table
+
+**Decision:** Editing a recurring meeting is scoped like deleting one — **This event**, **This and following events**, or **All events**. The two partial scopes reuse delete's existing series primitives on the parent (an `excludedDates` push for one occurrence, an `endDate` trim for a split) and put the edited values in a **new ordinary `Meeting` row**: a detached one-time row for "This event", a new series starting at the clicked occurrence for "This and following". `Meeting.splitFromMid` links every split-off row to its root series' `mid` (chains propagate the root, so one lineage shares one value). There is no per-occurrence override/exception table.
+
+**Why:**
+- Delete already encoded "remove one occurrence" and "end the series here" purely inside `RecurrencePattern` (`excludedDates`, trimmed `endDate`); every consumer (calendar expansion, conflict checking, Google Calendar EXDATE/UNTIL sync) already honors those. Reusing them means an edit-scope row is just a normal meeting to the rest of the system — no second code path through expansion, conflicts, or sync.
+- Split-off rows **inherit the parent's Zoom meeting** (`zid`, link, passcode, host, `zoomManaged`, pinned topic) instead of provisioning a new one — members keep the link they know, and the shared-`zid` machinery (union schedule, schedule-neutral PATCH on divergence, last-row-standing delete guard) already governs multiple rows on one `zid`. Consistent with delete's contract: partial scopes never touch Zoom.
+- On Google Calendar the parent gets the same EXDATE/UNTIL patch delete uses; the new row gets its own events and sync statuses, so the standard per-meeting sync badges/retry apply to each half independently.
+- The whole scoped write (parent trim/exclusion, conflict check of the new row, row creation) runs in one advisory-lock-guarded transaction, parent first, so the new row can't collide with occurrences the same edit just removed.
+- `splitFromMid` exists chiefly for the lease export: a split series is one lease obligation, so the CSV bills each lineage once (see the leasing section below).
+- Scope fields (`editScope`, `occurrenceDate`) are parsed by a separate schema from the shared meeting payload, so the create route can never absorb them.
+- **Suspend keeps whole-series semantics only** — deliberately out of scope: suspension is already a soft "this and following" (trim + pre-created resume series), and removing a single occurrence exists via delete's "This event". Per-occurrence suspension would add a second exception mechanism for little gain.
+
+**Revisit if:** ICR ever needs to edit a single occurrence *without* changing the members' join expectations breaking down — e.g. per-occurrence Zoom scheduling — which would require Zoom occurrence-level API support this model deliberately avoids; or if lineage chains grow long enough that "latest segment wins" stops being the right lease representative.
+
+---
+
 ## Leasing Documents: DB-configured CSV Export
 
 **Decision:** The Export tab's "Export Lease CSV" button exports a CSV file rather than calling the PandaDoc API directly, and its inputs (lease period, per-room rates, agent contact, email template) are stored in a `LeaseSettings` singleton rather than hardcoded in a component.

--- a/docs/03-development/api-reference.md
+++ b/docs/03-development/api-reference.md
@@ -90,11 +90,25 @@ Retrieve all meetings for an arbitrary date range (used by mobile's prev/current
 
 Zoom sync runs the same mode-gated, resolve-before-publish way as `POST /api/write/meeting` above (same `"pending"` deferral if Zoom can't resolve). If `zoomRoom` changed, the old Zoom meeting and (Hybrid-only) calendar event are deleted and a fresh Zoom meeting/calendar event are created under the new room — a Zoom meeting can't move rooms. If instead the Meeting Form's Zoom Host dropdown was used to explicitly reassign the host, the existing Zoom meeting is transferred to that host in place (`schedule_for`), preserving its ID, passcode and join link; a Zoom-side refusal falls back to the same tear-down-and-recreate, except on a `zid` another meeting shares, where the host is left unchanged and the failure is reported. Otherwise the existing Zoom meeting is updated in place, after re-checking its host is still free for the (possibly moved) time.
 
-**Request body:** `IMeeting` (must include `mid`)
+A recurring meeting's edit can be scoped to less than the whole series via two extra top-level body fields, parsed separately from the `IMeeting` payload itself:
 
-**Response:** `200 OK` — updated `IMeeting`
+| Field | Type | Description |
+|---|---|---|
+| `editScope` | `"this" \| "thisAndFollowing" \| "all"` | Optional; omitted or `"all"` is the whole-series behavior described above. Non-recurring meetings reject `"this"`/`"thisAndFollowing"` with `400`. |
+| `occurrenceDate` | ISO 8601 | Required when `editScope` is `"this"`/`"thisAndFollowing"` (`400` otherwise); must land on a live occurrence of the pattern (not excluded, not past the series end) or the request is rejected with `400`. |
+
+`editScope: "this"` pushes that occurrence's date onto the parent's `RecurrencePattern.excludedDates` and creates a new, detached, non-recurring `Meeting` row (its own `mid`) carrying the request body's edited field values, anchored to `occurrenceDate`. The body's `recurrencePattern` must be omitted for this scope (`400` otherwise — a single occurrence has no recurrence of its own).
+
+`editScope: "thisAndFollowing"` trims the parent's `RecurrencePattern.endDate` to end the day before `occurrenceDate` and creates a new recurring `Meeting` + `RecurrencePattern` (its own `mid`) starting at `occurrenceDate`, using the request body's `recurrencePattern` (required for this scope — `400` otherwise) and edited field values.
+
+Either way, the new row inherits the parent's Zoom identity (`zid`, `zoomHost`, `zoomManaged`, `zoomTopic`, and — for a Hybrid meeting — `zoomRoom`) rather than provisioning a new Zoom meeting; it gets its own Google Calendar event(s), created the same way `POST /api/write/meeting` creates a new meeting's events. Its `splitFromMid` is set to the parent's own root series mid (propagated through, not reset, if the parent itself was already a split-off row), so every row produced by repeated splits of the same original series still shares one lineage root. The parent's Google Calendar event is adjusted to match — an `EXDATE` for `"this"`, an `RRULE UNTIL` trim for `"thisAndFollowing"` — the same way `deleteOption` on `DELETE /api/delete/meeting` adjusts it.
+
+**Request body:** `IMeeting` (must include `mid`), plus `editScope`/`occurrenceDate` above
+
+**Response:** `200 OK` — updated `IMeeting`; when `editScope` was `"this"`/`"thisAndFollowing"`, also includes `newMid` (the new split-off row's `mid`)
 **Error:** `404 Not Found` if `mid` doesn't exist
-**Error:** `400 Bad Request` — request body fails schema validation (issues listed in the response)
+**Error:** `400 Bad Request` — request body fails schema validation, or one of the `editScope` rules above (issues listed in the response)
+**Error:** `409 Conflict` — the edit's room/Zoom-room/Zoom-host would collide with another meeting; body includes `conflicts`. Resubmit with `confirmOverride: true` to save anyway. For a scoped edit, this checks the new split-off row's own occurrence(s), not the parent's.
 
 ---
 

--- a/frontend/app/(main)/page.tsx
+++ b/frontend/app/(main)/page.tsx
@@ -318,6 +318,7 @@ export default function HomePage() {
           onCloseEdit={handleCloseEdit}
           isNewMeetingOpen={isNewMeetingOpen}
           setIsNewMeetingOpen={setIsNewMeetingOpen}
+          occurrenceDate={lastClickedDate}
         />
       )}
       {isPhone && isAdmin && (
@@ -356,6 +357,7 @@ export default function HomePage() {
                 meeting={selectedMeeting}
                 onClose={handleCloseEdit}
                 onUpdateSuccess={triggerCalendarRefresh}
+                occurrenceDate={lastClickedDate}
               />
             )}
           </MobileFullScreenSheet>

--- a/frontend/app/api/update/meeting/route.ts
+++ b/frontend/app/api/update/meeting/route.ts
@@ -1,14 +1,19 @@
-import { Meeting, Prisma, Role } from "@prisma/client";
+import { randomUUID } from "crypto";
+import { Meeting, RecurrencePattern, SuspensionPeriod, Prisma, Role } from "@prisma/client";
 import { NextResponse, after } from "next/server";
 import { requireRole } from "../../../../services/auth";
 import { IMeeting } from "../../../../types/models";
-import { createCalendarEvent, updateCalendarEvent, deleteCalendarEvent, reconcileMeetingCalendars } from "../../../../services/googleCalendar";
+import {
+  createCalendarEvent, updateCalendarEvent, deleteCalendarEvent, reconcileMeetingCalendars,
+  deleteCalendarOccurrence, trimCalendarEventSeries, calendarIdsForMeeting,
+} from "../../../../services/googleCalendar";
 import { createZoomMeeting, updateZoomMeeting, deleteZoomMeeting, getZoomHostCapacities, getZoomMeetingInvitation, rehostZoomMeeting, resolveZoomHost, zoomHostPool, zoomRoomCalendarId } from "../../../../services/zoom";
 import { findResourceConflicts, findResourceConflictRows, ConflictRow, ResourceConflictAbort } from "../../../../util/meetings/resourceOverlap";
 import { lockResourceClaims, ResourceClaim } from "../../../../util/meetings/resourceLocks";
-import { meetingSchema } from "../../../../util/meetings/meetingValidation";
-import { reconcilePendingResume } from "../../../../util/meetings/suspension";
+import { meetingSchema, editScopeSchema } from "../../../../util/meetings/meetingValidation";
+import { reconcilePendingResume, tearDownPendingResumeSeries } from "../../../../util/meetings/suspension";
 import { calculateEndDateFromOccurrences } from "../../../../util/meetings/meetingOccurrences";
+import { EditScope, exclusionInstant, trimmedEndDate, isLiveOccurrence, rootSplitMid } from "../../../../util/meetings/editScope";
 import { prisma } from "../../../../lib/prisma";
 
 // Runs after the response is sent (see after() call below) — failure updates googleSyncStatus
@@ -296,16 +301,319 @@ async function syncUpdatedMeeting(
   }
 }
 
+// Runs after the response is sent — parent-side Google Calendar half of a scoped edit ('this'
+// excludes one occurrence via EXDATE, 'thisAndFollowing' trims the RRULE UNTIL). Mirrors delete/
+// meeting/route.ts's syncDeleteOccurrence/syncTrimSeries exactly (same helpers, same math) --
+// duplicated locally since routes don't export their internals for reuse.
+async function syncScopedParentCalendar(
+  scope: 'this' | 'thisAndFollowing',
+  accessToken: string | undefined,
+  calendarIds: Record<string, string>,
+  eventIds: Record<string, string>,
+  startDateTime: Date,
+  occurrenceISODate: string,
+): Promise<void> {
+  if (!accessToken) return;
+  for (const [cat, calId] of Object.entries(calendarIds)) {
+    const eventId = eventIds[cat];
+    if (!eventId) continue;
+    if (scope === 'this') await deleteCalendarOccurrence(accessToken, eventId, startDateTime, occurrenceISODate, calId);
+    else await trimCalendarEventSeries(accessToken, eventId, occurrenceISODate, calId);
+  }
+}
+
+// Runs after the response is sent — creates the split-off row's own Google Calendar events (and
+// its Zoom-Room event, if any) and persists its sync statuses. No Zoom API call: the row
+// inherits the parent's zid/zoomHost/zoomLink (see handleScopedEdit), so there's nothing for
+// Zoom sync to do beyond marking it synced -- mirrors write/meeting/route.ts's syncNewMeeting,
+// minus the Zoom-provisioning half.
+async function syncSplitMeeting(
+  newMid: string,
+  meetingData: IMeeting,
+  isRecurring: boolean,
+  accessToken: string | undefined,
+): Promise<void> {
+  const zoomEnabled = meetingData.modeType === 'Hybrid' || meetingData.modeType === 'Remote';
+  const meetingForSync: IMeeting = { ...meetingData, isRecurring };
+
+  let googleCalendarEventIds: Record<string, string> | undefined;
+  let googleSyncStatus: string | undefined;
+  let googleSyncError: string | null | undefined;
+
+  if (accessToken) {
+    const requestedCalTypes = meetingData.calType ?? [];
+    const calendarIds = calendarIdsForMeeting(requestedCalTypes);
+    const eventIds: Record<string, string> = {};
+    const unconfiguredCat = requestedCalTypes.find((cat) => !calendarIds[cat]);
+    let syncError: string | null = unconfiguredCat
+      ? `Calendar for "${unconfiguredCat}" is not configured.`
+      : null;
+    for (const [cat, calId] of Object.entries(calendarIds)) {
+      const { id, error } = await createCalendarEvent(accessToken, meetingForSync, calId);
+      if (id) eventIds[cat] = id;
+      else syncError = syncError ?? error;
+    }
+    const synced = requestedCalTypes.length > 0 && requestedCalTypes.every((cat) => eventIds[cat]);
+    googleCalendarEventIds = eventIds;
+    googleSyncStatus = synced ? 'synced' : 'error';
+    googleSyncError = synced ? null : syncError;
+  } else {
+    googleSyncStatus = 'error';
+    googleSyncError = "No Google Calendar access token available for this sync.";
+  }
+
+  let zoomCalendarEventId: string | null = null;
+  let zoomSynced = true;
+  let zoomSyncError: string | null = null;
+  if (zoomEnabled && accessToken && meetingData.zoomLink && meetingData.zoomRoom) {
+    const calId = zoomRoomCalendarId[meetingData.zoomRoom];
+    if (calId) {
+      const { id: eventId, error } = await createCalendarEvent(accessToken, meetingForSync, calId, meetingData.zoomLink);
+      if (eventId) zoomCalendarEventId = eventId;
+      else {
+        zoomSynced = false;
+        zoomSyncError = error ?? "The split-off meeting's Zoom calendar event failed to sync.";
+      }
+    }
+  }
+
+  await prisma.meeting.update({
+    where: { mid: newMid },
+    data: {
+      googleCalendarEventIds, googleSyncStatus, googleSyncError,
+      ...(zoomEnabled
+        ? { zoomCalendarEventId, zoomSyncStatus: zoomSynced ? 'synced' : 'error', zoomSyncError: zoomSynced ? null : zoomSyncError }
+        : {}),
+    },
+  });
+}
+
+// Handles editScope 'this' / 'thisAndFollowing': trims/excludes the parent series and splits the
+// edited values off into a new detached (scope 'this') or new recurring (scope
+// 'thisAndFollowing') Meeting row. Only reached once the caller has already confirmed the parent
+// is recurring, occurrenceDate is present, and occurrenceDate lands on a live occurrence -- see
+// the branch in updateMeeting below.
+async function handleScopedEdit(
+  auth: { accessToken?: string; user?: { email?: string | null } | null },
+  existingMeeting: Meeting & { recurrencePattern: RecurrencePattern | null; suspensions: SuspensionPeriod[] },
+  newMeeting: IMeeting,
+  scope: 'this' | 'thisAndFollowing',
+  occurrenceDate: Date,
+  confirmOverride: boolean,
+): Promise<Response> {
+  const mid = existingMeeting.mid;
+  const newMid = randomUUID();
+  const splitFromMid = rootSplitMid(existingMeeting);
+  const occurrenceISODate = occurrenceDate.toISOString();
+  const isRecurringSplit = scope === 'thisAndFollowing';
+
+  let calculatedEndDate: Date | null = null;
+  if (isRecurringSplit) {
+    const rp = newMeeting.recurrencePattern!;
+    calculatedEndDate = rp.endDate ?? null;
+    if (rp.numberOfOccurrences && !rp.endDate) {
+      calculatedEndDate = calculateEndDateFromOccurrences(
+        occurrenceDate, rp.daysOfWeek || [], rp.numberOfOccurrences, rp.interval || 1,
+        rp.type, rp.weekOfMonth ?? null, rp.dayOfMonth ?? null,
+      );
+    }
+  }
+
+  // License-dependent per-host capacities, resolved before the locked transaction below -- same
+  // reasoning as the 'all' path (a Zoom API round trip while advisory locks are held would
+  // extend lock hold time by an external call's latency; cached 12h, usually a no-op).
+  const hostCapacities = await getZoomHostCapacities();
+
+  let txResult: { updatedParent: Meeting & { recurrencePattern: RecurrencePattern | null }; createdMeeting: Meeting; hasStaleResumeSeries: boolean };
+  try {
+    txResult = await prisma.$transaction(async (tx) => {
+      const claims: ResourceClaim[] = [];
+      if (newMeeting.room) claims.push({ type: "room", value: newMeeting.room });
+      if (existingMeeting.zoomRoom) claims.push({ type: "zoomRoom", value: existingMeeting.zoomRoom });
+      if (existingMeeting.zoomHost) claims.push({ type: "zoomHost", value: existingMeeting.zoomHost });
+      await lockResourceClaims(tx, claims);
+
+      // Trim/exclude the parent BEFORE conflict-checking the new row's candidate below, so the
+      // parent's own remaining occurrences (post-trim) don't self-collide with it.
+      const updatedParent = await tx.meeting.update({
+        where: { mid },
+        data: {
+          lastEditedBy: auth.user?.email ?? null,
+          recurrencePattern: scope === 'this'
+            ? { update: { excludedDates: { push: exclusionInstant(occurrenceDate) } } }
+            : { update: { endDate: trimmedEndDate(occurrenceDate) } },
+        },
+        include: { recurrencePattern: true },
+      });
+
+      // A pending resume series pre-created for a scheduled suspension only makes sense if the
+      // series still reaches that far -- mirrors delete/meeting/route.ts's identical check.
+      let hasStaleResumeSeries = false;
+      if (scope === 'thisAndFollowing') {
+        const newEndDate = updatedParent.recurrencePattern!.endDate!;
+        hasStaleResumeSeries = existingMeeting.suspensions.some(
+          (s) => !s.promoted && s.resumeEventIds && s.to && s.to.getTime() > newEndDate.getTime(),
+        );
+      }
+
+      const candidate = {
+        mid: newMid,
+        title: newMeeting.title,
+        room: newMeeting.room,
+        zoomRoom: existingMeeting.zoomRoom,
+        zoomHost: existingMeeting.zoomHost,
+        status: newMeeting.status ?? existingMeeting.status,
+        calType: newMeeting.calType,
+        startDateTime: newMeeting.startDateTime,
+        endDateTime: newMeeting.endDateTime,
+        isRecurring: isRecurringSplit,
+        recurrencePattern: isRecurringSplit
+          ? { ...newMeeting.recurrencePattern!, startDate: occurrenceDate, endDate: calculatedEndDate, excludedDates: newMeeting.recurrencePattern!.excludedDates ?? [] }
+          : null,
+      };
+
+      // The new row's candidate date is already excluded from/past the end of the parent's own
+      // (just-trimmed, in this same tx) pattern, so it can't self-collide -- but scope 'this'
+      // still needs the parent mid excluded explicitly, since the parent's *other* occurrences
+      // remain in play for the room/zoomRoom/zoomHost scan and excludeMid only affects whether
+      // the parent's own row is queried at all, not which of its occurrences match.
+      const excludeMid = scope === 'this' ? mid : undefined;
+
+      if (!confirmOverride) {
+        const conflictRows: ConflictRow[] = [];
+        if (candidate.room) {
+          conflictRows.push(...await findResourceConflictRows("room", candidate.room, candidate, tx, { excludeMid }));
+        }
+        if (candidate.zoomRoom) {
+          conflictRows.push(...await findResourceConflictRows("zoomRoom", candidate.zoomRoom, candidate, tx, { excludeMid }));
+        }
+        if (candidate.zoomHost) {
+          conflictRows.push(...await findResourceConflictRows(
+            "zoomHost", candidate.zoomHost, candidate, tx,
+            { excludeMid, includeSuspended: true, capacity: hostCapacities[candidate.zoomHost] ?? 1 },
+          ));
+        }
+        if (conflictRows.length > 0) {
+          throw new ResourceConflictAbort(conflictRows);
+        }
+      }
+
+      const createdMeeting = await tx.meeting.create({
+        data: {
+          mid: newMid,
+          title: newMeeting.title,
+          description: newMeeting.description,
+          creator: auth.user?.email ?? existingMeeting.creator,
+          lastEditedBy: null,
+          group: newMeeting.group,
+          startDateTime: newMeeting.startDateTime,
+          endDateTime: newMeeting.endDateTime,
+          email: newMeeting.email,
+          calType: newMeeting.calType,
+          modeType: newMeeting.modeType,
+          room: newMeeting.room,
+          status: newMeeting.status ?? existingMeeting.status,
+          isRecurring: isRecurringSplit,
+          // Inherited, not re-provisioned -- see the Zoom-inheritance decision in editScope.ts's
+          // callers. The shared-zid PATCH machinery (services/zoom.ts) already discovers this row
+          // as a sibling on subsequent edits since it queries by zid.
+          zid: existingMeeting.zid,
+          zoomLink: existingMeeting.zoomLink,
+          zoomPasscode: existingMeeting.zoomPasscode,
+          zoomInvitation: existingMeeting.zoomInvitation,
+          zoomRoom: existingMeeting.zoomRoom,
+          zoomHost: existingMeeting.zoomHost,
+          zoomManaged: existingMeeting.zoomManaged,
+          zoomTopic: existingMeeting.zoomTopic,
+          splitFromMid,
+          ...(isRecurringSplit
+            ? {
+                recurrencePattern: {
+                  create: {
+                    type: newMeeting.recurrencePattern!.type,
+                    startDate: occurrenceDate,
+                    endDate: calculatedEndDate,
+                    numberOfOccurrences: newMeeting.recurrencePattern!.numberOfOccurrences ?? undefined,
+                    daysOfWeek: newMeeting.recurrencePattern!.daysOfWeek ?? [],
+                    firstDayOfWeek: newMeeting.recurrencePattern!.firstDayOfWeek,
+                    interval: newMeeting.recurrencePattern!.interval,
+                    weekOfMonth: newMeeting.recurrencePattern!.weekOfMonth ?? null,
+                    dayOfMonth: newMeeting.recurrencePattern!.dayOfMonth ?? null,
+                    excludedDates: newMeeting.recurrencePattern!.excludedDates ?? [],
+                  },
+                },
+              }
+            : {}),
+        },
+      });
+
+      return { updatedParent, createdMeeting, hasStaleResumeSeries };
+    }, { timeout: 10_000, maxWait: 10_000 });
+  } catch (error) {
+    if (error instanceof ResourceConflictAbort) {
+      return NextResponse.json(
+        { error: "This meeting conflicts with an existing meeting's room, Zoom room, or Zoom host.", conflicts: error.conflicts },
+        { status: 409 },
+      );
+    }
+    throw error;
+  }
+
+  const { updatedParent, createdMeeting, hasStaleResumeSeries } = txResult;
+  const calendarIds = calendarIdsForMeeting(existingMeeting.calType ?? []);
+  const eventIds = (existingMeeting.googleCalendarEventIds ?? {}) as Record<string, string>;
+
+  after(
+    syncScopedParentCalendar(scope, auth.accessToken, calendarIds, eventIds, existingMeeting.startDateTime, occurrenceISODate)
+      .catch((error) => console.error("syncScopedParentCalendar threw:", error)),
+  );
+  if (hasStaleResumeSeries) {
+    after(tearDownPendingResumeSeries(existingMeeting, auth.accessToken).catch((error) =>
+      console.error("tearDownPendingResumeSeries threw:", error)));
+  }
+  after(
+    syncSplitMeeting(
+      newMid,
+      { ...newMeeting, mid: newMid, zid: existingMeeting.zid, zoomLink: existingMeeting.zoomLink, zoomRoom: existingMeeting.zoomRoom },
+      isRecurringSplit,
+      auth.accessToken,
+    ).catch(async (error) => {
+      console.error("syncSplitMeeting threw:", error);
+      try {
+        await prisma.meeting.update({
+          where: { mid: newMid },
+          data: { googleSyncStatus: 'error', googleSyncError: "Sync job failed unexpectedly." },
+        });
+      } catch (persistError) {
+        console.error("Failed to persist split-meeting sync failure status:", persistError);
+      }
+    }),
+  );
+
+  return NextResponse.json({ ...updatedParent, newMid: createdMeeting.mid });
+}
+
 const updateMeeting = async (request: Request): Promise<Response> => {
   try {
     const auth = await requireRole(Role.ADMIN);
     if (auth instanceof Response) return auth;
 
-    const parsed = meetingSchema.safeParse(await request.json());
+    const rawBody = await request.json();
+    const parsed = meetingSchema.safeParse(rawBody);
     if (!parsed.success) {
       return NextResponse.json({ error: "Invalid meeting data", issues: parsed.error.issues }, { status: 400 });
     }
     const newMeeting = parsed.data as IMeeting;
+
+    // Parsed separately from meetingSchema (see editScopeSchema's comment) -- absent or 'all'
+    // means the current whole-series behavior below; 'this'/'thisAndFollowing' hand off to
+    // handleScopedEdit instead.
+    const scopeParsed = editScopeSchema.safeParse(rawBody);
+    if (!scopeParsed.success) {
+      return NextResponse.json({ error: "Invalid edit scope", issues: scopeParsed.error.issues }, { status: 400 });
+    }
+    const editScope: EditScope = scopeParsed.data.editScope ?? 'all';
+    const occurrenceDate = scopeParsed.data.occurrenceDate ?? null;
 
     // Read before lockResourceClaims acquires anything below -- accepted gap, not covered by
     // this fix: two concurrent edits to this *same* meeting could each compute
@@ -329,6 +637,48 @@ const updateMeeting = async (request: Request): Promise<Response> => {
     // googleCalendarEventIds if its date has arrived but nothing's promoted it yet, before this
     // edit reads/writes that field below.
     existingMeeting.googleCalendarEventIds = await reconcilePendingResume(existingMeeting);
+
+    if (editScope !== 'all') {
+      if (!existingMeeting.recurrencePattern) {
+        return NextResponse.json(
+          { error: "This meeting is not recurring; editScope must be omitted or 'all'." },
+          { status: 400 },
+        );
+      }
+      if (!occurrenceDate) {
+        return NextResponse.json({ error: "occurrenceDate is required for this edit scope." }, { status: 400 });
+      }
+      if (editScope === 'this' && newMeeting.recurrencePattern) {
+        return NextResponse.json(
+          { error: "editScope 'this' edits a single occurrence and cannot include a recurrencePattern." },
+          { status: 400 },
+        );
+      }
+      if (editScope === 'thisAndFollowing' && !newMeeting.recurrencePattern) {
+        return NextResponse.json(
+          { error: "editScope 'thisAndFollowing' requires a recurrencePattern for the new series." },
+          { status: 400 },
+        );
+      }
+      const pattern = existingMeeting.recurrencePattern;
+      const patternLike = {
+        type: pattern.type,
+        startDate: pattern.startDate,
+        endDate: pattern.endDate,
+        interval: pattern.interval,
+        daysOfWeek: pattern.daysOfWeek ?? [],
+        weekOfMonth: pattern.weekOfMonth,
+        dayOfMonth: pattern.dayOfMonth,
+        excludedDates: pattern.excludedDates ?? [],
+      };
+      if (!isLiveOccurrence(patternLike, occurrenceDate)) {
+        return NextResponse.json(
+          { error: "occurrenceDate does not fall on a live occurrence of this meeting's recurrence pattern." },
+          { status: 400 },
+        );
+      }
+      return handleScopedEdit(auth, existingMeeting, newMeeting, editScope, occurrenceDate, !!newMeeting.confirmOverride);
+    }
 
     // creator is server-managed provenance (set from the session at create time) -- an update
     // must never overwrite it with the client's placeholder value.
@@ -375,10 +725,21 @@ const updateMeeting = async (request: Request): Promise<Response> => {
         recurrencePattern.dayOfMonth ?? null,
       );
     }
+    // BUG FIX: recurrencePattern.excludedDates is optional on the client payload -- when the
+    // client doesn't resubmit per-occurrence deletions, this must fall back to the meeting's own
+    // stored excludedDates, not silently drop them. Without this, a series with any 'this'-scope
+    // exclusions would have its candidate occurrences expanded WITHOUT those exclusions here,
+    // producing false-positive 409s against its own already-excluded dates.
     const candidate = {
       ...newMeeting,
       isRecurring: !!recurrencePattern,
-      recurrencePattern: recurrencePattern ? { ...recurrencePattern, endDate: calculatedEndDate } : null,
+      recurrencePattern: recurrencePattern
+        ? {
+            ...recurrencePattern,
+            endDate: calculatedEndDate,
+            excludedDates: recurrencePattern.excludedDates ?? existingMeeting.recurrencePattern?.excludedDates ?? [],
+          }
+        : null,
     };
 
     // A new Zoom host is only needed when this meeting has no Zoom meeting to keep using —

--- a/frontend/app/components/calendar/desktop/CalendarSidebarShell.tsx
+++ b/frontend/app/components/calendar/desktop/CalendarSidebarShell.tsx
@@ -26,6 +26,11 @@ interface CalendarSidebarShellProps {
   // second, independent boolean.
   isNewMeetingOpen: boolean;
   setIsNewMeetingOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  // The clicked occurrence's date, threaded through to EditMeetingSidebar so a recurring
+  // meeting's edit save can offer the same three-scope choice delete already offers -- see
+  // EditMeeting.tsx's occurrenceDate prop doc for why this value (not ViewMeeting's re-anchored
+  // displayStartDate) is the one passed through.
+  occurrenceDate?: Date | null;
 }
 
 // Matches the staggered fade durations set on .sidebarLayerOutgoing/.sidebarLayerEntered in
@@ -67,6 +72,7 @@ const CalendarSidebarShell: React.FC<CalendarSidebarShellProps> = ({
   onCloseEdit,
   isNewMeetingOpen,
   setIsNewMeetingOpen,
+  occurrenceDate,
 }) => {
   const { isCompact, collapseSidebar, expandSidebar } = useSidebar();
   useBreakpoint(collapseSidebar, expandSidebar);
@@ -185,6 +191,7 @@ const CalendarSidebarShell: React.FC<CalendarSidebarShellProps> = ({
             onUpdateSuccess={() => {
               triggerCalendarRefresh();
             }}
+            occurrenceDate={occurrenceDate}
           />
         </div>
       ) : (

--- a/frontend/app/components/meeting-form/EditMeeting.tsx
+++ b/frontend/app/components/meeting-form/EditMeeting.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import { MeetingForm } from './MeetingForm';
 
 import TextField from '../ui/inputs/TextField';
@@ -13,6 +13,7 @@ import ZoomHostField from './ZoomHostField';
 import ConflictOverrideModal from './ConflictOverrideModal';
 import DiscardChangesModal from './DiscardChangesModal';
 import FormValidationBanner from './FormValidationBanner';
+import EditRecurringModal, { EditScope } from './EditRecurringModal';
 import IconButton from '../ui/buttons/IconButton';
 
 import { IMeeting } from '../../../types/models'
@@ -21,8 +22,24 @@ import { useMeetingForm, CAL_TYPE_OPTIONS, CAL_TYPE_COLOR, DESCRIPTION_MAX_LENGT
 import { ConflictListRow } from '../../../util/meetings/conflictDisplay';
 import { useToast } from '../shared/ToastProvider';
 import { pollMeetingSyncStatus, describeSyncFailure } from '../../../services/syncMeeting';
+import { convertETToUTC, formatETDateString, getETTimeOfDay, isDstGapError } from '../../../util/date/timeUtils';
 
 import styles from './MeetingForm.module.scss';
+
+// "the date the action takes effect" for EditRecurringModal -- mirrors ViewMeeting.tsx's
+// identical helper (same copy convention across the app's recurring-scope modals).
+const formatEffectiveDate = (date: Date): string =>
+  new Intl.DateTimeFormat('en-US', { timeZone: 'America/New_York', weekday: 'long', month: 'long', day: 'numeric' })
+    .format(date);
+
+// Not part of IMeeting (types/models.ts is shared with the concurrently-in-progress backend
+// work) -- these three fields are the update/meeting PUT contract's edit-scope extension.
+// editScope/occurrenceDate drive server-side occurrence splitting; newMid is only ever read
+// off a response, never sent.
+type EditMeetingPayload = IMeeting & {
+  editScope?: EditScope;
+  occurrenceDate?: string;
+};
 
 interface EditMeetingSidebarProps {
   meeting: IMeeting;
@@ -31,10 +48,16 @@ interface EditMeetingSidebarProps {
   // "wide" is used when this form is embedded inline in a wider context (e.g. the Diagnostics
   // Conflicts panel) rather than the narrow Main Calendar sidebar. See MeetingForm's layout prop.
   layout?: "sidebar" | "wide";
+  // The specific occurrence the calendar box/popup was clicked on -- same value page.tsx's
+  // handleDelete sends as deleteOption's occurrenceDate (lastClickedDate), kept consistent with
+  // that call site rather than ViewMeeting's re-anchored displayStartDate. Absent at the two
+  // Diagnostics mount sites (ConflictList/SyncIssuesCard), which have no click to attribute a
+  // date to -- absence there means "always scope 'all'", the pre-existing behavior.
+  occurrenceDate?: Date | null;
 }
 
 const EditMeetingSidebar: React.FC<EditMeetingSidebarProps> =
-  ({ meeting, onClose, onUpdateSuccess, layout = "sidebar" }) => {
+  ({ meeting, onClose, onUpdateSuccess, layout = "sidebar", occurrenceDate }) => {
     const {
       title: inputMeetingTitleValue, setTitle: setMeetingTitleValue,
       mode: selectedMode,
@@ -46,6 +69,7 @@ const EditMeetingSidebar: React.FC<EditMeetingSidebarProps> =
       calTypes: selectedCalTypes,
       zoomRoom: selectedZoomRoom, setZoomRoom: setSelectedZoomRoom,
       zoomHost: selectedZoomHost, setZoomHost: setSelectedZoomHost,
+      isRecurring,
       handleRecurringMeetingChange,
       handleRoomChange,
       handleModeSelect,
@@ -59,6 +83,8 @@ const EditMeetingSidebar: React.FC<EditMeetingSidebarProps> =
       timeRangeError,
       isOvernight,
       isDirty,
+      isRecurrenceDirty,
+      isDateDirty,
     } = useMeetingForm(meeting);
 
     // Populated only for admin sessions by retrieve/meeting/[id] -- empty for a meeting whose
@@ -70,12 +96,28 @@ const EditMeetingSidebar: React.FC<EditMeetingSidebarProps> =
     const { showToast } = useToast();
     const [isSubmitting, setIsSubmitting] = useState(false);
     // Holds the payload + conflict rows across the confirm round-trip -- a 409 doesn't discard
-    // the edit, it just pauses submission until the modal's Cancel or "Save anyway".
-    const [conflictState, setConflictState] = useState<{ payload: IMeeting; conflicts: ConflictListRow[] } | null>(null);
+    // the edit, it just pauses submission until the modal's Cancel or "Save anyway". The
+    // conflict retry (onConfirm below) resubmits this exact payload, so any editScope/
+    // occurrenceDate applyEditScope already stamped onto it survives the retry for free.
+    const [conflictState, setConflictState] = useState<{ payload: EditMeetingPayload; conflicts: ConflictListRow[] } | null>(null);
     // Narrow Main Calendar sidebar gets ~80%-scaled field fonts; the "wide" embed (e.g.
     // Diagnostics Conflicts panel) has room to spare and keeps full size.
     const compact = layout === "sidebar";
     const [isDiscardPromptOpen, setIsDiscardPromptOpen] = useState(false);
+    // A scope choice only makes sense when the meeting was AND still is recurring, with known
+    // occurrence context (absent at the Diagnostics mount sites). Turning recurrence off in the
+    // form (meeting.isRecurring true, current isRecurring false) is inherently an all-events
+    // restructure -- the payload carries no recurrencePattern, so scope 'thisAndFollowing' would
+    // 400 server-side and 'this' is already disabled by isRecurrenceDirty -- so that case skips
+    // the modal too and submits as today (no editScope, whole-series behavior). Turning
+    // recurrence ON for a previously non-recurring meeting also skips it: there's no existing
+    // series for occurrenceDate to scope against.
+    const canScopeEdit = !!(meeting.isRecurring && isRecurring && occurrenceDate);
+    const [isScopeModalOpen, setIsScopeModalOpen] = useState(false);
+    // The payload built at the moment Save was pressed -- EditRecurringModal's own choice
+    // handler applies the scope onto this rather than rebuilding from current form state, since
+    // nothing in the form can change while the modal is up front of it.
+    const pendingPayloadRef = useRef<IMeeting | null>(null);
 
     // Both user-driven close paths (Cancel, the X) go through here, so neither can silently
     // drop in-progress edits.
@@ -87,7 +129,7 @@ const EditMeetingSidebar: React.FC<EditMeetingSidebarProps> =
       onClose();
     };
 
-    const submitMeeting = async (payload: IMeeting, confirmOverride: boolean) => {
+    const submitMeeting = async (payload: EditMeetingPayload, confirmOverride: boolean) => {
       setIsSubmitting(true);
       try {
         const response = await fetch('/api/update/meeting', {
@@ -129,6 +171,19 @@ const EditMeetingSidebar: React.FC<EditMeetingSidebarProps> =
           const message = describeSyncFailure(result);
           if (message) showToast({ variant: "error", title: message, persistent: true });
         });
+
+        // A 'this'/'thisAndFollowing' edit detaches or tails off a *new* row (newMid) that
+        // inherits this meeting's Zoom link rather than getting one of its own -- no Zoom call
+        // runs for it, so only Google Calendar sync is worth waiting on.
+        if (meetingResponse.newMid) {
+          pollMeetingSyncStatus(meetingResponse.newMid, {
+            expectGoogle: (payload.calType?.length ?? 0) > 0,
+            expectZoom: false,
+          }).then((result) => {
+            const message = describeSyncFailure(result);
+            if (message) showToast({ variant: "error", title: message, persistent: true });
+          });
+        }
       } catch (error) {
         console.error('There was an error fetching the data:', error);
         showToast({
@@ -138,6 +193,54 @@ const EditMeetingSidebar: React.FC<EditMeetingSidebarProps> =
       } finally {
         setIsSubmitting(false);
       }
+    };
+
+    // Scope: 'all' (or no occurrence context) submits the payload untouched -- current,
+    // unscoped whole-series behavior. Scope 'this'/'thisAndFollowing' stamps editScope +
+    // occurrenceDate on for the server, and strips recurrencePattern under 'this' specifically
+    // (the server 400s a single-occurrence edit that still carries series recurrence rules;
+    // EditRecurringModal also disables that option whenever recurrence was actually changed, so
+    // this only ever discards an unmodified/inherited pattern, never a real edit).
+    const applyEditScope = (payload: IMeeting, scope: EditScope): EditMeetingPayload => {
+      if (scope === 'all' || !occurrenceDate) return payload;
+
+      let { startDateTime, endDateTime } = payload;
+      // The form seeds Date/Time from the series' anchor row (retrieve/meeting/[id] returns
+      // the *master* row's startDateTime), not the clicked occurrence -- for a recurring
+      // meeting those can be weeks apart. If the user left the Date field untouched, re-anchor
+      // onto the occurrence's ET calendar date (keeping the form's, possibly edited,
+      // time-of-day) so the detached/tail row lands on the right day instead of the anchor's.
+      // An edited Date field is the user's explicit choice and is left alone. Mirrors
+      // ViewMeeting.tsx's identical re-anchor for the View popup's own display.
+      if (!isDateDirty) {
+        const occurrenceDateStr = formatETDateString(occurrenceDate);
+        const { hour, minute, second } = getETTimeOfDay(startDateTime);
+        try {
+          const newStart = new Date(convertETToUTC(`${occurrenceDateStr}T${hour}:${minute}:${second}`));
+          // Milliseconds have no timezone component -- getETTimeOfDay doesn't carry them,
+          // restore directly from the payload's own start rather than losing precision.
+          newStart.setUTCMilliseconds(startDateTime.getUTCMilliseconds());
+          const duration = endDateTime.getTime() - startDateTime.getTime();
+          startDateTime = newStart;
+          endDateTime = new Date(newStart.getTime() + duration);
+        } catch (err) {
+          // The occurrence date re-anchored onto this time-of-day lands in the DST
+          // spring-forward gap -- not reachable in practice (the calendar never renders a gap
+          // occurrence to click), guarded defensively so a future caller can't crash here.
+          if (!isDstGapError(err)) throw err;
+          console.warn(`Could not re-anchor onto ${occurrenceDateStr}: ${(err as Error).message}`);
+        }
+      }
+
+      const scoped: EditMeetingPayload = {
+        ...payload,
+        startDateTime,
+        endDateTime,
+        editScope: scope,
+        occurrenceDate: occurrenceDate.toISOString(),
+      };
+      if (scope === 'this') delete scoped.recurrencePattern;
+      return scoped;
     };
 
     const updateMeeting = async () => {
@@ -155,7 +258,20 @@ const EditMeetingSidebar: React.FC<EditMeetingSidebarProps> =
       const updatedMeeting = buildMeetingPayload(meeting.mid, meeting.status ?? 'Active');
       if (!updatedMeeting) return;
 
+      if (canScopeEdit) {
+        pendingPayloadRef.current = updatedMeeting;
+        setIsScopeModalOpen(true);
+        return;
+      }
+
       await submitMeeting(updatedMeeting, false);
+    };
+
+    const handleScopeChoice = async (scope: EditScope) => {
+      const payload = pendingPayloadRef.current;
+      pendingPayloadRef.current = null;
+      if (!payload) return;
+      await submitMeeting(applyEditScope(payload, scope), false);
     };
 
     return (
@@ -311,6 +427,19 @@ const EditMeetingSidebar: React.FC<EditMeetingSidebarProps> =
             onClose();
           }}
         />
+        {canScopeEdit && (
+          <EditRecurringModal
+            isOpen={isScopeModalOpen}
+            title={meeting.title}
+            effectiveDateText={formatEffectiveDate(occurrenceDate as Date)}
+            onClose={() => {
+              setIsScopeModalOpen(false);
+              pendingPayloadRef.current = null;
+            }}
+            onSave={handleScopeChoice}
+            disableThis={isRecurrenceDirty}
+          />
+        )}
         <ConflictOverrideModal
           isOpen={!!conflictState}
           conflicts={conflictState?.conflicts ?? []}

--- a/frontend/app/components/meeting-form/EditRecurringModal.module.scss
+++ b/frontend/app/components/meeting-form/EditRecurringModal.module.scss
@@ -1,0 +1,148 @@
+@import 'https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600&display=swap';
+@import '../../../styles/Variables.module';
+
+.modalOverlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgb(0 0 0 / 50%);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  // See DeleteRecurringModal.module.scss's identical comment -- must beat ViewMeeting's
+  // .popupAnchor (z-index: 2000) since this can also be reached from that popup's Edit action.
+  z-index: 2001;
+}
+
+.modalContent {
+  background-color: white;
+  border-radius: 8px;
+  width: 400px;
+  max-width: 90%;
+  padding: 24px;
+  font-family: "Source Sans Pro", sans-serif;
+  color: $black-color;
+  box-shadow: 0 4px 12px rgb(0 0 0 / 15%);
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 8px;
+}
+
+.iconCircle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+
+  // Neutral/informational, not danger -- an edit isn't destructive the way delete is.
+  background-color: $info-bg-color;
+  color: $info-text-color;
+  flex-shrink: 0;
+}
+
+.modalTitle {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 600;
+}
+
+.message {
+  margin: 0 0 20px;
+  padding-left: 48px;
+  font-size: 15px;
+  line-height: 1.5;
+  color: #444;
+}
+
+.effectiveDate {
+  color: $info-text-color;
+}
+
+.optionsContainer {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  margin-bottom: 20px;
+}
+
+.optionItem {
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+}
+
+.optionItemDisabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.disabledHint {
+  margin: -10px 0 0 30px;
+  font-size: 13px;
+  color: $medium-grey-color;
+}
+
+.radioInput {
+  margin-right: 12px;
+  accent-color: #4285F4;
+  width: 18px;
+  height: 18px;
+  cursor: pointer;
+
+  &:disabled {
+    cursor: not-allowed;
+  }
+}
+
+.radioLabel {
+  font-size: 16px;
+  cursor: pointer;
+}
+
+.buttonContainer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 24px;
+}
+
+.cancelButton {
+  padding: 8px 16px;
+  border-radius: 6px;
+  border: 1.5px solid $light-grey-color;
+  background-color: white;
+  color: $black-color;
+  font-size: 14px;
+  font-weight: 600;
+  text-align: center;
+  cursor: pointer;
+
+  &:hover {
+    background-color: #F5F5F5;
+  }
+}
+
+.saveButton {
+  padding: 8px 16px;
+  border-radius: 6px;
+  border: none;
+  background-color: $link-color;
+  color: $white-color;
+  font-size: 14px;
+  font-weight: 600;
+  text-align: center;
+  cursor: pointer;
+
+  &:hover {
+    background-color: #005FCC;
+  }
+}

--- a/frontend/app/components/meeting-form/EditRecurringModal.tsx
+++ b/frontend/app/components/meeting-form/EditRecurringModal.tsx
@@ -1,0 +1,139 @@
+import React, { useEffect, useState } from 'react';
+import Icon from '../ui/displays/Icon';
+import Modal from '../ui/overlays/Modal';
+import styles from './EditRecurringModal.module.scss';
+
+export type EditScope = 'this' | 'thisAndFollowing' | 'all';
+
+interface EditRecurringModalProps {
+  isOpen: boolean;
+  title: string;
+  effectiveDateText: string;
+  onClose: () => void;
+  onSave: (option: EditScope) => void;
+  // True when the form's recurrence settings were changed in this edit session -- the server
+  // 400s a scope: 'this' payload that still carries recurrencePattern, so that option is
+  // disabled rather than silently dropping the user's recurrence change.
+  disableThis?: boolean;
+}
+
+const EditRecurringModal: React.FC<EditRecurringModalProps> = ({
+  isOpen,
+  title,
+  effectiveDateText,
+  onClose,
+  onSave,
+  disableThis = false,
+}) => {
+  const [selectedOption, setSelectedOption] = useState<EditScope>('this');
+
+  // Keeps the disabled "This event" option from staying selected once recurrence changes make
+  // it unavailable -- re-checked each time the modal opens rather than continuously, so it
+  // doesn't fight a mid-session click back to a valid option.
+  useEffect(() => {
+    if (isOpen && disableThis && selectedOption === 'this') {
+      setSelectedOption('thisAndFollowing');
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen, disableThis]);
+
+  const handleOptionSelect = (option: EditScope) => {
+    setSelectedOption(option);
+  };
+
+  const handleSave = () => {
+    onSave(selectedOption);
+    onClose();
+  };
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      overlayClassName={styles.modalOverlay}
+      contentClassName={styles.modalContent}
+      labelledBy="edit-recurring-title"
+    >
+      <div className={styles.header}>
+        <span className={styles.iconCircle}>
+          <Icon name="repeat" size={20} />
+        </span>
+        <h2 id="edit-recurring-title" className={styles.modalTitle}>Edit recurring event</h2>
+      </div>
+
+      <p className={styles.message}>
+        {selectedOption === 'this' ? (
+          <>
+            Only the occurrence of <strong>{title}</strong> on{' '}
+            <strong className={styles.effectiveDate}>{effectiveDateText}</strong> will change —
+            it becomes a standalone meeting, separate from the series.
+          </>
+        ) : selectedOption === 'thisAndFollowing' ? (
+          <>
+            <strong>{title}</strong> will change starting{' '}
+            <strong className={styles.effectiveDate}>{effectiveDateText}</strong>, including
+            every occurrence after it. The series splits into two at this date.
+          </>
+        ) : (
+          <>
+            <strong>{title}</strong> will change across the entire series — every occurrence,
+            including ones before{' '}
+            <strong className={styles.effectiveDate}>{effectiveDateText}</strong>.
+          </>
+        )}{' '}
+        The Zoom link stays the same.
+      </p>
+
+      <div className={styles.optionsContainer}>
+        <div className={`${styles.optionItem} ${disableThis ? styles.optionItemDisabled : ''}`}>
+          <input
+            type="radio"
+            id="edit-this-event"
+            name="edit-option"
+            checked={selectedOption === 'this'}
+            onChange={() => handleOptionSelect('this')}
+            disabled={disableThis}
+            className={styles.radioInput}
+          />
+          <label htmlFor="edit-this-event" className={styles.radioLabel}>This event</label>
+        </div>
+        {disableThis && (
+          <p className={styles.disabledHint}>
+            Recurrence changes apply to the whole series, so this option isn&apos;t available.
+          </p>
+        )}
+
+        <div className={styles.optionItem}>
+          <input
+            type="radio"
+            id="edit-this-and-following"
+            name="edit-option"
+            checked={selectedOption === 'thisAndFollowing'}
+            onChange={() => handleOptionSelect('thisAndFollowing')}
+            className={styles.radioInput}
+          />
+          <label htmlFor="edit-this-and-following" className={styles.radioLabel}>This and following events</label>
+        </div>
+
+        <div className={styles.optionItem}>
+          <input
+            type="radio"
+            id="edit-all-events"
+            name="edit-option"
+            checked={selectedOption === 'all'}
+            onChange={() => handleOptionSelect('all')}
+            className={styles.radioInput}
+          />
+          <label htmlFor="edit-all-events" className={styles.radioLabel}>All events</label>
+        </div>
+      </div>
+
+      <div className={styles.buttonContainer}>
+        <button className={styles.cancelButton} onClick={onClose}>Cancel</button>
+        <button className={styles.saveButton} onClick={handleSave}>Save</button>
+      </div>
+    </Modal>
+  );
+};
+
+export default EditRecurringModal;

--- a/frontend/hooks/useMeetingForm.ts
+++ b/frontend/hooks/useMeetingForm.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { IMeeting, IRecurrencePattern } from '../types/models';
 import { convertUTCToET, convertETToUTC, formatETDateString, getWeekDatesET, getCurrentETMinutesSinceMidnight, isConvertETToUTCValidationError, isDstGapError } from '../util/date/timeUtils';
 import { roomToZoomRoom } from '../util/rooms/rooms';
@@ -187,6 +187,11 @@ export function useMeetingForm(initialMeeting?: IMeeting, defaultContext?: Meeti
             ? formatDateForPicker(initialMeeting.startDateTime)
             : computeDefaultDate(defaultContext, defaultTimeInfo!.rolledToNextDay)
     );
+    // Snapshot of the Date field's own opening value, separate from fieldBaseline's combined
+    // snapshot -- EditMeeting.tsx needs to know specifically whether the *date* was touched
+    // (not just "something changed") to decide whether a scoped save should re-anchor onto the
+    // clicked occurrence or respect the user's explicit date edit. Set once, like fieldBaseline.
+    const [dateBaseline, setDateBaseline] = useState(date);
     const [time, setTime] = useState<string>(() =>
         initialMeeting
             ? `${formatTimeForPicker(initialMeeting.startDateTime)} - ${formatTimeForPicker(initialMeeting.endDateTime)}`
@@ -226,12 +231,26 @@ export function useMeetingForm(initialMeeting?: IMeeting, defaultContext?: Meeti
         setTouchedFields((prev) => (prev.has(field) ? prev : new Set(prev).add(field)));
     }, []);
 
-    // Recurrence is tracked for dirtiness by comparing against RecurringMeeting.tsx's *first*
-    // report rather than against initialMeeting.recurrencePattern: that child rebuilds the
-    // pattern object from its own state on mount, so the rebuilt shape can differ from the
-    // stored one field-for-field while describing the same recurrence.
+    // Recurrence is tracked for dirtiness by comparing against RecurringMeeting.tsx's report
+    // rather than against initialMeeting.recurrencePattern: that child rebuilds the pattern
+    // object from its own state on mount, so the rebuilt shape can differ from the stored one
+    // field-for-field while describing the same recurrence.
     const [recurrenceBaseline, setRecurrenceBaseline] = useState<string | null>(null);
     const [recurrenceSignature, setRecurrenceSignature] = useState<string | null>(null);
+    // RecurringMeeting.tsx's mount can report MORE than once with no user input at all: e.g. a
+    // stored pattern with an empty daysOfWeek (a real, persisted shape -- not just a test
+    // fixture) makes its own "seed a default weekday" effect fire a *second*, self-corrected
+    // report right after its first. Locking the baseline onto that first (pre-correction) report
+    // would read the self-correction itself as a user edit -- false-positive dirty/disabled-
+    // 'This event' for a meeting nobody touched. Instead, the baseline keeps tracking the latest
+    // report for a brief settling window after mount (these cascades are synchronous React state
+    // updates with no real async gap, so they always finish well within one macrotask, long
+    // before a user could physically interact) and only freezes once that window closes.
+    const recurrenceSettlingRef = useRef(true);
+    useEffect(() => {
+        const settleId = setTimeout(() => { recurrenceSettlingRef.current = false; }, 0);
+        return () => clearTimeout(settleId);
+    }, []);
     // Baseline for the unsaved-changes guard, seeded from the values the form opened with
     // rather than re-derived from initialMeeting -- a brand-new form's computed date/time
     // defaults count as untouched too.
@@ -248,8 +267,13 @@ export function useMeetingForm(initialMeeting?: IMeeting, defaultContext?: Meeti
         setIsRecurring(data.isRecurring);
         setRecurrencePattern(data.recurrencePattern);
         const signature = JSON.stringify(data);
-        setRecurrenceBaseline((previous) => previous ?? signature);
         setRecurrenceSignature(signature);
+        // While still settling, every report becomes the new baseline (see
+        // recurrenceSettlingRef's comment above) -- once the window closes, only the first
+        // baseline value stands and subsequent reports are real, comparable edits.
+        setRecurrenceBaseline((previous) =>
+            recurrenceSettlingRef.current || previous === null ? signature : previous
+        );
     }, []);
 
     const handleRoomChange = (value: string) => {
@@ -304,6 +328,7 @@ export function useMeetingForm(initialMeeting?: IMeeting, defaultContext?: Meeti
         // A reset form reads as untouched again -- rebaseline rather than leaving the values
         // it opened with as the comparison point.
         setFieldBaseline(snapshotFields(resetValues));
+        setDateBaseline(resetValues.date);
         setRecurrenceBaseline(null);
         setRecurrenceSignature(null);
     };
@@ -439,9 +464,21 @@ export function useMeetingForm(initialMeeting?: IMeeting, defaultContext?: Meeti
     const isOvernight =
         !!currentStartTime && !!currentEndTime && isOvernightTimeRange(currentStartTime, currentEndTime);
 
+    // Exposed separately from isDirty below -- EditRecurringModal disables its "This event"
+    // option specifically when recurrence settings changed (the server 400s recurrencePattern
+    // under scope 'this'), not for any other field edit.
+    const isRecurrenceDirty = recurrenceSignature !== null && recurrenceSignature !== recurrenceBaseline;
+
+    // Exposed separately too -- EditMeeting.tsx's scoped-save re-anchoring needs to know
+    // specifically whether the Date field itself was hand-edited: the edit form seeds its Date
+    // from the series' anchor row (retrieve/meeting/[id] returns the master row), not the
+    // clicked occurrence, so an untouched Date field is re-anchored onto the occurrence date
+    // while an edited one is respected as the user's explicit choice.
+    const isDateDirty = date !== dateBaseline;
+
     const isDirty =
         snapshotFields({ title, mode, date, time, email, description, room, calTypes, zoomRoom, zoomHost }) !== fieldBaseline ||
-        (recurrenceSignature !== null && recurrenceSignature !== recurrenceBaseline);
+        isRecurrenceDirty;
 
     // Independent of submitAttempted -- a field can show its own inline error the moment
     // it's been touched, even before any submit attempt (e.g. blurring an empty title on
@@ -476,6 +513,8 @@ export function useMeetingForm(initialMeeting?: IMeeting, defaultContext?: Meeti
         timeRangeError,
         isOvernight,
         isDirty,
+        isRecurrenceDirty,
+        isDateDirty,
         markFieldTouched,
         getFieldError,
     };

--- a/frontend/prisma/migrations/20260821010000_add_meeting_split_from_mid/migration.sql
+++ b/frontend/prisma/migrations/20260821010000_add_meeting_split_from_mid/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "Meeting" ADD COLUMN "splitFromMid" TEXT;
+
+-- CreateIndex
+CREATE INDEX "Meeting_splitFromMid_idx" ON "Meeting"("splitFromMid");

--- a/frontend/prisma/schema.prisma
+++ b/frontend/prisma/schema.prisma
@@ -77,6 +77,12 @@ model Meeting {
   // adopts the live values). Non-null feeds the calendar's sync-attention badge without any
   // Zoom call on the bulk retrieve paths.
   zoomDriftDetectedAt    DateTime?
+  // Set on a Meeting row created by a scoped recurring edit ('this' / 'thisAndFollowing', see
+  // util/meetings/editScope.ts) -- the ORIGINAL series' mid, so every row a lineage of splits
+  // produces still shares one root regardless of how many times it's been split again (a split
+  // of an already-split-off row propagates ITS splitFromMid, not its own mid). Null for a
+  // meeting that has never been split off from another series.
+  splitFromMid           String?
   deletedAt              DateTime?
   updatedAt              DateTime?            @updatedAt
 
@@ -86,6 +92,7 @@ model Meeting {
   @@index([zoomHost])
   @@index([room])
   @@index([zoomRoom])
+  @@index([splitFromMid])
 }
 
 model RecurrencePattern {

--- a/frontend/tests/component/EditMeeting.test.tsx
+++ b/frontend/tests/component/EditMeeting.test.tsx
@@ -1,0 +1,182 @@
+import React from "react";
+import { render, screen, fireEvent, act, waitFor } from "@testing-library/react";
+import { ToastProvider } from "../../app/components/shared/ToastProvider";
+import EditMeetingSidebar from "../../app/components/meeting-form/EditMeeting";
+import { IMeeting } from "../../types/models";
+
+// The series' anchor row -- what retrieve/meeting/[id] returns and what the form seeds Date/
+// Time from. A recurring meeting's clicked occurrence is usually weeks away from this date;
+// that gap is exactly what the re-anchoring fix under test corrects for.
+const anchorMeeting: IMeeting = {
+  mid: "m-1",
+  title: "Recurring Series",
+  description: "",
+  creator: "Creator",
+  group: "Group",
+  startDateTime: new Date("2026-07-05T22:00:00.000Z"), // Sun Jul 5, 2026, 6:00 PM ET
+  endDateTime: new Date("2026-07-05T23:00:00.000Z"), // 7:00 PM ET
+  email: "seed@test.icr",
+  calType: ["AA"],
+  modeType: "In Person",
+  room: "Serenity Room",
+  status: "Active",
+  isRecurring: true,
+  recurrencePattern: {
+    mid: "m-1",
+    type: "weekly",
+    startDate: new Date("2026-07-05T00:00:00.000Z"),
+    daysOfWeek: ["Sunday"],
+    firstDayOfWeek: "Sunday",
+    interval: 1,
+    excludedDates: [],
+  },
+};
+
+// The occurrence the user actually clicked on the calendar -- a later Sunday, same time-of-day.
+const occurrenceDate = new Date("2026-08-09T22:00:00.000Z"); // Sun Aug 9, 2026, 6:00 PM ET
+
+// ZoomHostField's useZoomHostPool fires a fetch effect on mount -- stubbed the same way
+// NewMeeting.test.tsx/ViewMeeting.test.tsx do, since nothing here exercises a specific host
+// list. update/meeting itself is mocked per-test via jest.Mock.mockResolvedValueOnce where a
+// distinct response matters.
+beforeEach(() => {
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({ hosts: [], mid: "m-1" }),
+  }) as jest.Mock;
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+const renderEdit = (occurrenceDateProp: Date | null = occurrenceDate) =>
+  render(
+    <ToastProvider>
+      <EditMeetingSidebar
+        meeting={anchorMeeting}
+        onClose={jest.fn()}
+        onUpdateSuccess={jest.fn()}
+        occurrenceDate={occurrenceDateProp}
+      />
+    </ToastProvider>
+  );
+
+function lastUpdateMeetingBody(): Record<string, unknown> {
+  const call = (global.fetch as jest.Mock).mock.calls.find(([url]) => url === "/api/update/meeting");
+  return JSON.parse(call![1].body);
+}
+
+describe("EditMeetingSidebar recurring-scope re-anchoring", () => {
+  it("re-anchors an untouched Date field onto the clicked occurrence for a scoped save", async () => {
+    renderEdit();
+    await act(async () => {});
+
+    fireEvent.click(screen.getByRole("button", { name: "Update Meeting" }));
+    fireEvent.click(screen.getByLabelText("This event"));
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledWith(
+      "/api/update/meeting",
+      expect.objectContaining({ method: "PUT" }),
+    ));
+
+    const body = lastUpdateMeetingBody();
+    // Lands on the occurrence's calendar date (Aug 9), keeping the anchor row's 6 PM ET
+    // time-of-day and 1-hour duration.
+    expect(body.startDateTime).toBe(new Date("2026-08-09T22:00:00.000Z").toISOString());
+    expect(body.endDateTime).toBe(new Date("2026-08-09T23:00:00.000Z").toISOString());
+    expect(body.editScope).toBe("this");
+    expect(body.recurrencePattern).toBeUndefined();
+  });
+
+  it("respects an explicitly edited Date field instead of re-anchoring", async () => {
+    renderEdit();
+    await act(async () => {});
+
+    const dateInput = screen.getByPlaceholderText("MM/DD/YYYY");
+    fireEvent.change(dateInput, { target: { value: "09/01/2026" } });
+    fireEvent.blur(dateInput);
+
+    fireEvent.click(screen.getByRole("button", { name: "Update Meeting" }));
+    fireEvent.click(screen.getByLabelText("This event"));
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+    const body = lastUpdateMeetingBody();
+    expect(new Date(body.startDateTime as string).toISOString().slice(0, 10)).toBe("2026-09-01");
+  });
+
+  it("skips the scope modal and submits whole-series when recurrence is turned off", async () => {
+    renderEdit();
+    await act(async () => {});
+
+    // Unchecks "This meeting is recurring" -- the form now reports isRecurring: false even
+    // though the meeting it opened with was recurring.
+    fireEvent.click(screen.getByText("This meeting is recurring", { exact: true }));
+
+    fireEvent.click(screen.getByRole("button", { name: "Update Meeting" }));
+
+    // No scope modal: the payload carries no recurrencePattern, so 'thisAndFollowing' would
+    // 400 server-side and 'this' is already disabled by the recurrence change -- straight to
+    // submit instead, same as any other non-recurring save.
+    expect(screen.queryByLabelText("This event")).not.toBeInTheDocument();
+
+    await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+    const body = lastUpdateMeetingBody();
+    expect(body.editScope).toBeUndefined();
+    expect(body.occurrenceDate).toBeUndefined();
+    expect(body.recurrencePattern).toBeUndefined();
+    expect(body.isRecurring).toBe(false);
+  });
+
+  it("skips the scope modal entirely when there's no occurrence context (e.g. Diagnostics mount sites)", async () => {
+    renderEdit(null);
+    await act(async () => {});
+
+    fireEvent.click(screen.getByRole("button", { name: "Update Meeting" }));
+
+    expect(screen.queryByLabelText("This event")).not.toBeInTheDocument();
+    await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+    const body = lastUpdateMeetingBody();
+    expect(body.editScope).toBeUndefined();
+  });
+
+  // Regression for a false-positive isRecurrenceDirty: a stored pattern with an empty
+  // daysOfWeek (a real persisted shape -- e.g. tests/factories/meeting.ts's seedRecurringMeeting
+  // default) makes RecurringMeeting.tsx's own "seed a default weekday" effect fire a *second*
+  // mount-time report correcting daysOfWeek from [] to the meeting's actual weekday. Without the
+  // settling window, that self-correction (no user input at all) used to read as a real
+  // recurrence edit, wrongly disabling "This event".
+  it("doesn't treat RecurringMeeting's own default-weekday self-seed as a user recurrence edit", async () => {
+    const meetingWithEmptyDaysOfWeek: IMeeting = {
+      ...anchorMeeting,
+      recurrencePattern: { ...anchorMeeting.recurrencePattern!, daysOfWeek: [] },
+    };
+    render(
+      <ToastProvider>
+        <EditMeetingSidebar
+          meeting={meetingWithEmptyDaysOfWeek}
+          onClose={jest.fn()}
+          onUpdateSuccess={jest.fn()}
+          occurrenceDate={occurrenceDate}
+        />
+      </ToastProvider>,
+    );
+    // Lets both the mount-time report and its self-corrected follow-up (plus the settling
+    // window's real setTimeout(0)) resolve before interacting, same as a real user would only
+    // be able to click after the page has actually settled.
+    await act(async () => { await new Promise((resolve) => setTimeout(resolve, 10)); });
+
+    fireEvent.click(screen.getByRole("button", { name: "Update Meeting" }));
+
+    const thisEventRadio = screen.getByLabelText("This event");
+    expect(thisEventRadio).not.toBeDisabled();
+    fireEvent.click(thisEventRadio);
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+    const body = lastUpdateMeetingBody();
+    expect(body.editScope).toBe("this");
+  });
+});

--- a/frontend/tests/component/EditRecurringModal.test.tsx
+++ b/frontend/tests/component/EditRecurringModal.test.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import EditRecurringModal from "../../app/components/meeting-form/EditRecurringModal";
+
+const baseProps = {
+  title: "Weekly Standup",
+  effectiveDateText: "Aug 15, 2026",
+  onClose: jest.fn(),
+  onSave: jest.fn(),
+};
+
+describe("EditRecurringModal", () => {
+  it("renders nothing when closed", () => {
+    render(<EditRecurringModal isOpen={false} {...baseProps} />);
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("renders accessible dialog semantics and focuses the first radio option on open", () => {
+    render(<EditRecurringModal isOpen {...baseProps} />);
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toHaveAttribute("aria-modal", "true");
+    expect(dialog).toHaveAccessibleName("Edit recurring event");
+    // First focusable in DOM order is the "This event" radio (the options precede the button
+    // row) -- non-destructive, so this is still a safe initial-focus target.
+    expect(screen.getByLabelText("This event")).toHaveFocus();
+  });
+
+  it("calls onClose on Escape", () => {
+    const onClose = jest.fn();
+    render(<EditRecurringModal isOpen {...baseProps} onClose={onClose} />);
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onSave with the selected option, then closes", () => {
+    const onSave = jest.fn();
+    const onClose = jest.fn();
+    render(<EditRecurringModal isOpen {...baseProps} onSave={onSave} onClose={onClose} />);
+    fireEvent.click(screen.getByLabelText("All events"));
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    expect(onSave).toHaveBeenCalledWith("all");
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables the This event option and defaults to This and following when recurrence was changed", () => {
+    render(<EditRecurringModal isOpen {...baseProps} disableThis />);
+    expect(screen.getByLabelText("This event")).toBeDisabled();
+    expect(screen.getByLabelText("This and following events")).toBeChecked();
+    // Initial focus skips the disabled radio and lands on the next focusable option instead.
+    expect(screen.getByLabelText("This and following events")).toHaveFocus();
+  });
+});

--- a/frontend/tests/e2e/03-meeting-editing.spec.ts
+++ b/frontend/tests/e2e/03-meeting-editing.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from "./support/fixtures";
 import { fillTimeRange } from "./support/formHelpers";
-import { seedMeeting } from "../factories/meeting";
+import { seedMeeting, seedRecurringMeeting } from "../factories/meeting";
 import { getTestPrismaClient } from "../factories/db";
 import { convertETToUTC, formatETDateString } from "../../util/date/timeUtils";
 
@@ -60,28 +60,36 @@ test.describe("meeting editing", () => {
     expect(updated).not.toBeNull();
   });
 
-  test("3.5 editing a recurring meeting updates the entire series", async ({ adminPage }) => {
+  test("3.5 editing a recurring meeting opens the edit-recurring dialog", async ({ adminPage }) => {
     const { page } = adminPage;
-    const meeting = await seedMeeting({ title: "Recurring To Edit", isRecurring: true });
-    const prisma = getTestPrismaClient();
-    await prisma.recurrencePattern.create({
-      data: {
-        mid: meeting.mid,
-        type: "weekly",
-        startDate: meeting.startDateTime,
-        daysOfWeek: ["Sunday"],
-        firstDayOfWeek: "Sunday",
-        interval: 1,
-        excludedDates: [],
-      },
-    });
-
+    await seedRecurringMeeting({ title: "Recurring To Edit" });
     await page.goto("/");
     await openMeeting(page, "Recurring To Edit");
     await openEditFromDetails(page);
     await page.getByPlaceholder("Meeting title").fill("Recurring Series Renamed");
-
     await page.getByRole("button", { name: "Update Meeting" }).click();
+
+    await expect(page.getByLabel("This event")).toBeVisible();
+    await expect(page.getByLabel("This and following events")).toBeVisible();
+    await expect(page.getByLabel("All events")).toBeVisible();
+  });
+
+  test("3.5a 'All events' updates the entire series", async ({ adminPage }) => {
+    const { page } = adminPage;
+    const { meeting } = await seedRecurringMeeting({ title: "Recurring To Edit All" });
+    const prisma = getTestPrismaClient();
+
+    await page.goto("/");
+    await openMeeting(page, "Recurring To Edit All");
+    await openEditFromDetails(page);
+    await page.getByPlaceholder("Meeting title").fill("Recurring Series Renamed");
+    await page.getByRole("button", { name: "Update Meeting" }).click();
+    await page.getByLabel("All events").check();
+
+    const updateResponse = page.waitForResponse((r) => r.url().includes("/api/update/meeting"));
+    await page.getByRole("button", { name: "Save", exact: true }).click();
+    await updateResponse;
+
     // The calendar (level-3 heading) picks up the rename immediately via the
     // post-update refresh; the still-open detail panel's own <h1> is a known
     // exception — it keeps showing the pre-edit title until closed and reopened,
@@ -93,6 +101,85 @@ test.describe("meeting editing", () => {
     const all = await prisma.meeting.findMany({ where: { mid: meeting.mid } });
     expect(all).toHaveLength(1);
     expect(all[0].title).toBe("Recurring Series Renamed");
+  });
+
+  test("3.5b 'This event' detaches the clicked occurrence, series keeps other dates", async ({ adminPage }) => {
+    const { page } = adminPage;
+    // seedRecurringMeeting's bare default leaves daysOfWeek empty, which matchesRecurrencePattern
+    // (util/meetings/recurrenceMatch.ts) treats as "matches no date at all" -- not even the
+    // meeting's own start date. A scope 'this'/'thisAndFollowing' save validates occurrenceDate
+    // against that real pattern server-side, so (same as 3.5c below) the day actually clicked
+    // needs to be one the pattern genuinely recurs on.
+    const dayName = new Date().toLocaleDateString("en-US", { weekday: "long", timeZone: "America/New_York" });
+    const { meeting } = await seedRecurringMeeting(
+      { title: "Recurring To Edit This" },
+      { type: "weekly", daysOfWeek: [dayName], interval: 1 },
+    );
+    const prisma = getTestPrismaClient();
+
+    await page.goto("/");
+    await openMeeting(page, "Recurring To Edit This");
+    await openEditFromDetails(page);
+    await page.getByPlaceholder("Meeting title").fill("Occurrence Renamed");
+    await page.getByRole("button", { name: "Update Meeting" }).click();
+    await page.getByLabel("This event").check();
+
+    const updateResponse = page.waitForResponse((r) => r.url().includes("/api/update/meeting"));
+    await page.getByRole("button", { name: "Save", exact: true }).click();
+    await updateResponse;
+    await expect(page.getByText("Meeting updated successfully")).toBeVisible();
+
+    // The series row itself is untouched -- same pattern 04-meeting-deletion.spec.ts's 4.3
+    // asserts for "This event" deletion, mirrored here for an edit.
+    const series = await prisma.meeting.findUnique({ where: { mid: meeting.mid } });
+    expect(series?.title).toBe("Recurring To Edit This");
+    const pattern = await prisma.recurrencePattern.findUnique({ where: { mid: meeting.mid } });
+    expect(pattern?.excludedDates.length).toBeGreaterThan(0);
+
+    // The clicked occurrence becomes its own standalone (non-recurring) meeting.
+    const standalone = await prisma.meeting.findFirst({ where: { title: "Occurrence Renamed" } });
+    expect(standalone).not.toBeNull();
+    expect(standalone?.isRecurring).toBe(false);
+
+    await page.reload();
+    await expect(page.getByText("Occurrence Renamed")).toBeVisible();
+    await expect(page.getByText("Recurring To Edit This")).toHaveCount(0);
+  });
+
+  test("3.5c 'This and following events' splits the series at the clicked date", async ({ adminPage }) => {
+    const { page } = adminPage;
+    const dayName = new Date().toLocaleDateString("en-US", { weekday: "long", timeZone: "America/New_York" });
+    const { meeting } = await seedRecurringMeeting(
+      { title: "Recurring To Split" },
+      { type: "weekly", daysOfWeek: [dayName], interval: 1 },
+    );
+    const prisma = getTestPrismaClient();
+
+    await page.goto("/");
+    await openMeeting(page, "Recurring To Split");
+    await openEditFromDetails(page);
+    await page.getByPlaceholder("Meeting title").fill("Split Series Renamed");
+    await page.getByRole("button", { name: "Update Meeting" }).click();
+    await page.getByLabel("This and following events").check();
+
+    const updateResponse = page.waitForResponse((r) => r.url().includes("/api/update/meeting"));
+    await page.getByRole("button", { name: "Save", exact: true }).click();
+    await updateResponse;
+    await expect(page.getByText("Meeting updated successfully")).toBeVisible();
+
+    // The original series keeps its old title, now bounded to end before the split date.
+    const original = await prisma.meeting.findUnique({ where: { mid: meeting.mid } });
+    expect(original?.title).toBe("Recurring To Split");
+    const originalPattern = await prisma.recurrencePattern.findUnique({ where: { mid: meeting.mid } });
+    expect(originalPattern?.endDate).not.toBeNull();
+
+    // A new tail series picks up the rename from the split date onward.
+    const tail = await prisma.meeting.findFirst({ where: { title: "Split Series Renamed" } });
+    expect(tail).not.toBeNull();
+    expect(tail?.isRecurring).toBe(true);
+
+    await page.reload();
+    await expect(page.getByText("Split Series Renamed")).toBeVisible();
   });
 
   test("3.6 opening a different meeting closes an in-progress edit panel", async ({ adminPage }) => {

--- a/frontend/tests/integration/update-meeting-scoped-edit.test.ts
+++ b/frontend/tests/integration/update-meeting-scoped-edit.test.ts
@@ -1,0 +1,392 @@
+import { randomUUID } from "crypto";
+import type { IMeeting } from "../../types/models";
+import { formatETWeekdayLong } from "../../util/date/timeUtils";
+
+// Same after() shim as update-meeting-route.test.ts -- Next's real after() throws outside a
+// request scope, and the deferred sync promise is already constructed (and running) by the time
+// after() is called either way, so discarding the reference here doesn't change what runs.
+jest.mock("next/server", () => ({
+  ...jest.requireActual("next/server"),
+  after: (task: unknown) => {
+    if (typeof task === "function") void (task as () => unknown)();
+  },
+}));
+
+jest.mock("../../services/auth", () => ({
+  requireRole: jest.fn().mockResolvedValue({
+    user: { role: "ADMIN", email: "session-admin@test.icr" },
+    accessToken: "fake-token",
+  }),
+}));
+
+jest.mock("../../services/googleCalendar", () => ({
+  calendarIdsForMeeting: jest.fn((calType: string[]) =>
+    Object.fromEntries(calType.map((cat) => [cat, `cal-${cat}`]))),
+  createCalendarEvent: jest.fn().mockResolvedValue({ id: `event-${Math.random()}`, error: null }),
+  updateCalendarEvent: jest.fn().mockResolvedValue({ ok: true, error: null }),
+  deleteCalendarEvent: jest.fn().mockResolvedValue(true),
+  // Only exercised by this file's scope-'all' tests, which fall through to the existing
+  // (unmodified) syncUpdatedMeeting path -- an unresolved mock there crashes that function's
+  // destructure of this call's return value.
+  reconcileMeetingCalendars: jest.fn().mockResolvedValue({ updatedEventIds: {}, allSynced: true, googleSyncError: null }),
+  deleteCalendarOccurrence: jest.fn().mockResolvedValue(true),
+  trimCalendarEventSeries: jest.fn().mockResolvedValue(true),
+}));
+
+jest.mock("../../services/zoom", () => ({
+  createZoomMeeting: jest.fn(),
+  updateZoomMeeting: jest.fn(),
+  rehostZoomMeeting: jest.fn(),
+  deleteZoomMeeting: jest.fn(),
+  getZoomMeetingInvitation: jest.fn().mockResolvedValue(null),
+  resolveZoomHost: jest.fn(),
+  getZoomHostCapacities: jest.fn().mockResolvedValue({}),
+  zoomHostPool: ["mock-pool-host-1@icr.test", "mock-pool-host-2@icr.test"],
+  zoomRoomCalendarId: { "Scoped Zoom Room": "zoomroom-cal-id" },
+}));
+
+import { getTestPrismaClient, disconnectTestPrismaClient } from "../factories/db";
+import { seedRecurringMeeting, seedMeeting, seedSuspensionPeriod } from "../factories/meeting";
+import { PUT } from "../../app/api/update/meeting/route";
+import {
+  createCalendarEvent, deleteCalendarOccurrence, trimCalendarEventSeries, deleteCalendarEvent,
+} from "../../services/googleCalendar";
+import { createZoomMeeting, deleteZoomMeeting } from "../../services/zoom";
+
+const mockedCreateCalendarEvent = createCalendarEvent as jest.Mock;
+const mockedDeleteCalendarOccurrence = deleteCalendarOccurrence as jest.Mock;
+const mockedTrimCalendarEventSeries = trimCalendarEventSeries as jest.Mock;
+const mockedDeleteCalendarEvent = deleteCalendarEvent as jest.Mock;
+const mockedCreateZoomMeeting = createZoomMeeting as jest.Mock;
+const mockedDeleteZoomMeeting = deleteZoomMeeting as jest.Mock;
+
+async function waitFor<T>(fn: () => Promise<T | null | undefined>, timeoutMs = 2000): Promise<T> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    const result = await fn();
+    if (result != null) return result;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  throw new Error(`waitFor: condition not met within ${timeoutMs}ms`);
+}
+
+function putMeeting(payload: Partial<IMeeting> & Record<string, unknown>): Promise<Response> {
+  return PUT(new Request("http://localhost/api/update/meeting", { method: "PUT", body: JSON.stringify(payload) }));
+}
+
+// Anchored to a real future Monday so the series' weekly pattern and every occurrenceDate below
+// derive from the same weekday deterministically, instead of hardcoding day names that could
+// silently drift out of sync with the anchor date.
+const SERIES_START = new Date("2026-09-07T18:00:00Z");
+const SERIES_END = new Date("2026-09-07T19:00:00Z");
+const SERIES_WEEKDAY = formatETWeekdayLong(SERIES_START);
+const WEEK_MS = 7 * 24 * 60 * 60 * 1000;
+const occurrence = (weeksLater: number) => ({
+  start: new Date(SERIES_START.getTime() + weeksLater * WEEK_MS),
+  end: new Date(SERIES_END.getTime() + weeksLater * WEEK_MS),
+});
+
+afterAll(async () => {
+  await disconnectTestPrismaClient();
+});
+
+beforeEach(() => {
+  mockedCreateCalendarEvent.mockClear();
+  mockedDeleteCalendarOccurrence.mockClear();
+  mockedTrimCalendarEventSeries.mockClear();
+  mockedDeleteCalendarEvent.mockClear();
+  mockedCreateZoomMeeting.mockClear();
+  mockedDeleteZoomMeeting.mockClear();
+});
+
+// The integration DB is only reset once per file (globalSetup), not per test -- and a weekly,
+// interval-1 pattern recurs on its weekday forever regardless of its own start-date offset, so
+// two tests whose series share the same weekday/time AND the same zoomHost/room would
+// permanently overlap and 409 each other via the very conflict-check this suite is testing.
+// zid/zoomHost default to a fresh value per call so tests stay isolated from each other without
+// having to reason about every other test's schedule; a test asserting a specific shared-Zoom
+// scenario overrides these explicitly.
+async function seedWeeklySeries(overrides: Partial<Parameters<typeof seedRecurringMeeting>[0]> = {}) {
+  return seedRecurringMeeting(
+    {
+      startDateTime: SERIES_START,
+      endDateTime: SERIES_END,
+      zid: `${randomUUID()}`,
+      zoomHost: `zoom-${randomUUID()}@518icr.com`,
+      zoomManaged: true,
+      zoomTopic: "Pinned Scoped-Edit Topic",
+      modeType: "Remote",
+      zoomRoom: null,
+      room: "",
+      calType: ["AA"],
+      ...overrides,
+    },
+    { type: "weekly", daysOfWeek: [SERIES_WEEKDAY], interval: 1 },
+  );
+}
+
+const SERIES_DURATION_MS = SERIES_END.getTime() - SERIES_START.getTime();
+
+function scopedPayload(mid: string, editScope: string, occurrenceDate: Date, extra: Record<string, unknown> = {}) {
+  return {
+    mid,
+    title: "Split-off Occurrence",
+    description: "",
+    creator: "Creator",
+    group: "Group",
+    startDateTime: occurrenceDate,
+    endDateTime: new Date(occurrenceDate.getTime() + SERIES_DURATION_MS),
+    email: "scoped-edit@test.icr",
+    calType: ["AA"],
+    modeType: "Remote",
+    room: "",
+    zoomRoom: null,
+    status: "Active",
+    isRecurring: editScope === "thisAndFollowing",
+    editScope,
+    occurrenceDate,
+    ...extra,
+  };
+}
+
+test("editScope 'this' on a non-recurring meeting is rejected with 400", async () => {
+  const meeting = await seedMeeting();
+  const response = await putMeeting(scopedPayload(meeting.mid, "this", meeting.startDateTime));
+  expect(response.status).toBe(400);
+});
+
+test("editScope 'this' without occurrenceDate is rejected with 400", async () => {
+  const { meeting } = await seedWeeklySeries();
+  const payload = scopedPayload(meeting.mid, "this", occurrence(2).start);
+  delete (payload as Record<string, unknown>).occurrenceDate;
+  const response = await putMeeting(payload);
+  expect(response.status).toBe(400);
+});
+
+test("a recurrencePattern under editScope 'this' is rejected with 400", async () => {
+  const { meeting } = await seedWeeklySeries();
+  const payload = scopedPayload(meeting.mid, "this", occurrence(2).start, {
+    recurrencePattern: { type: "weekly", startDate: occurrence(2).start, daysOfWeek: [SERIES_WEEKDAY], firstDayOfWeek: "Sunday", interval: 1 },
+  });
+  const response = await putMeeting(payload);
+  expect(response.status).toBe(400);
+});
+
+test("editScope 'thisAndFollowing' without a recurrencePattern is rejected with 400", async () => {
+  const { meeting } = await seedWeeklySeries();
+  const response = await putMeeting(scopedPayload(meeting.mid, "thisAndFollowing", occurrence(3).start));
+  expect(response.status).toBe(400);
+});
+
+test("an occurrenceDate that isn't a live occurrence of the pattern is rejected with 400", async () => {
+  const { meeting } = await seedWeeklySeries();
+  // One day off the weekly pattern's day-of-week -- never a live occurrence.
+  const offPattern = new Date(occurrence(2).start.getTime() + 24 * 60 * 60 * 1000);
+  const response = await putMeeting(scopedPayload(meeting.mid, "this", offPattern));
+  expect(response.status).toBe(400);
+});
+
+test("editScope 'this' excludes the occurrence on the parent and creates a detached row inheriting Zoom", async () => {
+  const { meeting } = await seedWeeklySeries({ googleCalendarEventIds: { AA: "parent-event-aa" } });
+  const occurrenceDate = occurrence(2).start;
+
+  const response = await putMeeting(scopedPayload(meeting.mid, "this", occurrenceDate, { title: "Just This Week" }));
+  expect(response.status).toBe(200);
+  const body = await response.json();
+  expect(body.newMid).toBeTruthy();
+
+  const prisma = getTestPrismaClient();
+  const parentPattern = await prisma.recurrencePattern.findUnique({ where: { mid: meeting.mid } });
+  expect(parentPattern?.excludedDates).toHaveLength(1);
+
+  const created = await waitFor(async () => {
+    const row = await prisma.meeting.findUnique({ where: { mid: body.newMid } });
+    return row?.googleSyncStatus != null ? row : null;
+  });
+  expect(created?.isRecurring).toBe(false);
+  expect(created?.splitFromMid).toBe(meeting.mid);
+  expect(created?.title).toBe("Just This Week");
+  expect(created?.zid).toBe(meeting.zid);
+  expect(created?.zoomHost).toBe(meeting.zoomHost);
+  expect(created?.zoomManaged).toBe(meeting.zoomManaged);
+  expect(created?.zoomTopic).toBe(meeting.zoomTopic);
+
+  // No Zoom API call for the split-off row -- the zid/host/link are inherited, not provisioned.
+  expect(mockedCreateZoomMeeting).not.toHaveBeenCalled();
+  expect(mockedDeleteZoomMeeting).not.toHaveBeenCalled();
+  // Parent's calendar event got an EXDATE, not a trim or delete.
+  expect(mockedDeleteCalendarOccurrence).toHaveBeenCalled();
+  expect(mockedTrimCalendarEventSeries).not.toHaveBeenCalled();
+  // The new row got its own calType calendar event created.
+  expect(mockedCreateCalendarEvent).toHaveBeenCalled();
+});
+
+test("editScope 'thisAndFollowing' trims the parent's endDate and creates a new recurring tail series", async () => {
+  const { meeting } = await seedWeeklySeries({ googleCalendarEventIds: { AA: "parent-event-aa" } });
+  const occurrenceDate = occurrence(3).start;
+
+  const payload = scopedPayload(meeting.mid, "thisAndFollowing", occurrenceDate, {
+    title: "New Tail Series",
+    recurrencePattern: {
+      type: "weekly", startDate: occurrenceDate, daysOfWeek: [SERIES_WEEKDAY], firstDayOfWeek: "Sunday", interval: 1,
+    },
+  });
+  const response = await putMeeting(payload);
+  expect(response.status).toBe(200);
+  const body = await response.json();
+  expect(body.newMid).toBeTruthy();
+
+  const prisma = getTestPrismaClient();
+  const parentPattern = await prisma.recurrencePattern.findUnique({ where: { mid: meeting.mid } });
+  expect(parentPattern?.endDate).not.toBeNull();
+  expect(parentPattern!.endDate!.getTime()).toBeLessThan(occurrenceDate.getTime());
+
+  const createdPattern = await waitFor(async () => prisma.recurrencePattern.findUnique({ where: { mid: body.newMid } }));
+  expect(createdPattern?.startDate.getTime()).toBe(occurrenceDate.getTime());
+
+  const created = await prisma.meeting.findUnique({ where: { mid: body.newMid } });
+  expect(created?.isRecurring).toBe(true);
+  expect(created?.splitFromMid).toBe(meeting.mid);
+  expect(created?.zid).toBe(meeting.zid);
+
+  expect(mockedTrimCalendarEventSeries).toHaveBeenCalled();
+  expect(mockedDeleteCalendarOccurrence).not.toHaveBeenCalled();
+});
+
+test("a lineage chain propagates the ROOT mid, not the immediate parent's mid", async () => {
+  const { meeting: root } = await seedWeeklySeries();
+  const firstSplitDate = occurrence(2).start;
+  const firstResponse = await putMeeting(scopedPayload(root.mid, "thisAndFollowing", firstSplitDate, {
+    recurrencePattern: { type: "weekly", startDate: firstSplitDate, daysOfWeek: [SERIES_WEEKDAY], firstDayOfWeek: "Sunday", interval: 1 },
+  }));
+  expect(firstResponse.status).toBe(200);
+  const firstBody = await firstResponse.json();
+
+  // The tail series (weekly, unbounded, starting at week 2) also has a live occurrence at week
+  // 4 -- splitting IT off again must still credit the ORIGINAL root series, not the tail's own
+  // mid, as splitFromMid.
+  const secondSplitDate = occurrence(4).start;
+  const secondResponse = await putMeeting(scopedPayload(firstBody.newMid, "this", secondSplitDate));
+  expect(secondResponse.status).toBe(200);
+  const secondBody = await secondResponse.json();
+
+  const prisma = getTestPrismaClient();
+  const secondSplitRow = await waitFor(async () => prisma.meeting.findUnique({ where: { mid: secondBody.newMid } }));
+  expect(secondSplitRow?.splitFromMid).toBe(root.mid);
+});
+
+test("editScope 'this' produces a 409 when the new occurrence conflicts with another meeting's room, and confirmOverride bypasses it", async () => {
+  const { meeting } = await seedWeeklySeries({ modeType: "In Person", room: "Scoped Conflict Room" });
+  const occ = occurrence(2);
+
+  await seedMeeting({ room: "Scoped Conflict Room", startDateTime: occ.start, endDateTime: occ.end });
+
+  const blocked = await putMeeting(scopedPayload(meeting.mid, "this", occ.start, { modeType: "In Person", room: "Scoped Conflict Room" }));
+  expect(blocked.status).toBe(409);
+  const blockedBody = await blocked.json();
+  expect(blockedBody.conflicts).toBeDefined();
+
+  // The parent's exclusion must not have been written on the aborted attempt.
+  const prisma = getTestPrismaClient();
+  const parentPatternAfterAbort = await prisma.recurrencePattern.findUnique({ where: { mid: meeting.mid } });
+  expect(parentPatternAfterAbort?.excludedDates ?? []).toHaveLength(0);
+
+  const overridden = await putMeeting(scopedPayload(meeting.mid, "this", occ.start, {
+    modeType: "In Person", room: "Scoped Conflict Room", confirmOverride: true,
+  }));
+  expect(overridden.status).toBe(200);
+});
+
+test("a stranded pending-resume series past the trimmed endDate is torn down", async () => {
+  const { meeting } = await seedWeeklySeries();
+  const trimAt = occurrence(2).start;
+  const farFutureResumeDate = occurrence(20).start;
+
+  await seedSuspensionPeriod(meeting.mid, {
+    from: new Date(meeting.startDateTime.getTime() - 24 * 60 * 60 * 1000),
+    to: farFutureResumeDate,
+    promoted: false,
+    resumeEventIds: { AA: "stale-resume-event" },
+  });
+
+  const response = await putMeeting(scopedPayload(meeting.mid, "thisAndFollowing", trimAt, {
+    recurrencePattern: { type: "weekly", startDate: trimAt, daysOfWeek: [SERIES_WEEKDAY], firstDayOfWeek: "Sunday", interval: 1 },
+  }));
+  expect(response.status).toBe(200);
+
+  await waitFor(async () => (mockedDeleteCalendarEvent.mock.calls.length > 0 ? true : null));
+  expect(mockedDeleteCalendarEvent).toHaveBeenCalledWith("fake-token", "stale-resume-event", "cal-AA");
+});
+
+test("excludedDates candidate bug fix: a series with a prior 'this' exclusion can be re-saved (scope 'all') without a false self-conflict", async () => {
+  const { meeting, recurrencePattern } = await seedWeeklySeries({ modeType: "In Person", room: "Regression Room", zid: null, zoomHost: null });
+  const excludedOccurrence = occurrence(2);
+
+  const prisma = getTestPrismaClient();
+  await prisma.recurrencePattern.update({
+    where: { mid: recurrencePattern.mid },
+    data: { excludedDates: { push: excludedOccurrence.start } },
+  });
+
+  // A one-time meeting legitimately booked in the same room, at the exact date/time the series
+  // itself no longer occupies (it's excluded) -- pre-fix, resubmitting the series without its
+  // excludedDates in the payload would expand the candidate as if that date were still live and
+  // falsely 409 against this booking.
+  await seedMeeting({ room: "Regression Room", startDateTime: excludedOccurrence.start, endDateTime: excludedOccurrence.end });
+
+  const editPayload: Record<string, unknown> = {
+    mid: meeting.mid,
+    title: "Resaved Series",
+    description: "",
+    creator: "Creator",
+    group: "Group",
+    startDateTime: meeting.startDateTime,
+    endDateTime: meeting.endDateTime,
+    email: "scoped-edit@test.icr",
+    calType: ["AA"],
+    modeType: "In Person",
+    room: "Regression Room",
+    status: "Active",
+    isRecurring: true,
+    recurrencePattern: {
+      type: "weekly", startDate: meeting.startDateTime, daysOfWeek: [SERIES_WEEKDAY], firstDayOfWeek: "Sunday", interval: 1,
+      // excludedDates deliberately omitted -- the client doesn't resubmit per-occurrence
+      // deletions on a plain field edit.
+    },
+  };
+  const response = await putMeeting(editPayload);
+  expect(response.status).toBe(200);
+});
+
+test("editScope 'all' (omitted) behaves exactly as before -- a single-series in-place edit, no split row", async () => {
+  const { meeting } = await seedWeeklySeries({ modeType: "In Person", room: "Plain Edit Room", zid: null, zoomHost: null });
+
+  const editPayload: Record<string, unknown> = {
+    mid: meeting.mid,
+    title: "Plainly Edited",
+    description: "",
+    creator: "Creator",
+    group: "Group",
+    startDateTime: meeting.startDateTime,
+    endDateTime: meeting.endDateTime,
+    email: "scoped-edit@test.icr",
+    calType: ["AA"],
+    modeType: "In Person",
+    room: "Plain Edit Room",
+    status: "Active",
+    isRecurring: true,
+    recurrencePattern: {
+      type: "weekly", startDate: meeting.startDateTime, daysOfWeek: [SERIES_WEEKDAY], firstDayOfWeek: "Sunday", interval: 1,
+    },
+  };
+  const response = await putMeeting(editPayload);
+  expect(response.status).toBe(200);
+  const body = await response.json();
+  expect(body.newMid).toBeUndefined();
+
+  const prisma = getTestPrismaClient();
+  const rowCount = await prisma.meeting.count({ where: { OR: [{ mid: meeting.mid }, { splitFromMid: meeting.mid }] } });
+  expect(rowCount).toBe(1);
+  const stored = await prisma.meeting.findUnique({ where: { mid: meeting.mid } });
+  expect(stored?.title).toBe("Plainly Edited");
+});

--- a/frontend/tests/unit/editScope.test.ts
+++ b/frontend/tests/unit/editScope.test.ts
@@ -1,0 +1,71 @@
+import { toETDateStr, exclusionInstant, trimmedEndDate, isLiveOccurrence, rootSplitMid } from "../../util/meetings/editScope";
+
+describe("toETDateStr", () => {
+  test("formats a UTC instant as its Eastern-Time calendar date", () => {
+    // 2026-01-15T02:00:00Z is still 2026-01-14 in ET (EST, UTC-5).
+    expect(toETDateStr(new Date("2026-01-15T02:00:00Z"))).toBe("2026-01-14");
+  });
+});
+
+describe("exclusionInstant / trimmedEndDate", () => {
+  test("exclusionInstant is the UTC instant of the occurrence's ET day start", () => {
+    const occurrenceDate = new Date("2026-06-15T22:00:00Z"); // 6pm ET on 2026-06-15 (EDT, UTC-4)
+    const instant = exclusionInstant(occurrenceDate);
+    expect(toETDateStr(instant)).toBe("2026-06-15");
+    // ET midnight of 2026-06-15 is 2026-06-15T04:00:00Z during EDT.
+    expect(instant.toISOString()).toBe("2026-06-15T04:00:00.000Z");
+  });
+
+  test("trimmedEndDate is exactly 1ms before the occurrence's ET day start", () => {
+    const occurrenceDate = new Date("2026-06-15T22:00:00Z");
+    const end = trimmedEndDate(occurrenceDate);
+    expect(end.getTime()).toBe(exclusionInstant(occurrenceDate).getTime() - 1);
+    // So it falls on the PREVIOUS ET calendar day.
+    expect(toETDateStr(end)).toBe("2026-06-14");
+  });
+});
+
+describe("isLiveOccurrence", () => {
+  const weeklyPattern = {
+    type: "weekly",
+    startDate: new Date("2026-06-01T18:00:00Z"), // a Monday
+    endDate: null,
+    interval: 1,
+    daysOfWeek: ["Monday"],
+    weekOfMonth: null,
+    dayOfMonth: null,
+    excludedDates: [] as Date[],
+  };
+
+  test("true for a date the weekly pattern actually produces", () => {
+    expect(isLiveOccurrence(weeklyPattern, new Date("2026-06-15T18:00:00Z"))).toBe(true);
+  });
+
+  test("false for a date off the pattern's day-of-week", () => {
+    expect(isLiveOccurrence(weeklyPattern, new Date("2026-06-16T18:00:00Z"))).toBe(false);
+  });
+
+  test("false for a date before the pattern's start", () => {
+    expect(isLiveOccurrence(weeklyPattern, new Date("2026-05-25T18:00:00Z"))).toBe(false);
+  });
+
+  test("false for a date past the pattern's endDate", () => {
+    const bounded = { ...weeklyPattern, endDate: new Date("2026-06-08T23:59:59Z") };
+    expect(isLiveOccurrence(bounded, new Date("2026-06-15T18:00:00Z"))).toBe(false);
+  });
+
+  test("false for an excluded date even though it otherwise matches", () => {
+    const withExclusion = { ...weeklyPattern, excludedDates: [new Date("2026-06-15T18:00:00Z")] };
+    expect(isLiveOccurrence(withExclusion, new Date("2026-06-15T18:00:00Z"))).toBe(false);
+  });
+});
+
+describe("rootSplitMid", () => {
+  test("returns the meeting's own mid when it has never been split off", () => {
+    expect(rootSplitMid({ mid: "m-1", splitFromMid: null })).toBe("m-1");
+  });
+
+  test("returns the already-recorded root, not the immediate parent's mid, for a lineage chain", () => {
+    expect(rootSplitMid({ mid: "m-2-tail", splitFromMid: "m-1-root" })).toBe("m-1-root");
+  });
+});

--- a/frontend/tests/unit/suspension.test.ts
+++ b/frontend/tests/unit/suspension.test.ts
@@ -77,6 +77,7 @@ function buildMeeting(overrides: Partial<Meeting> = {}): Omit<Meeting, "recurren
     zoomHost: null,
     attemptedZoomHost: null,
     zoomSyncError: null,
+    splitFromMid: null,
     deletedAt: null,
     updatedAt: null,
     ...overrides,

--- a/frontend/util/meetings/editScope.ts
+++ b/frontend/util/meetings/editScope.ts
@@ -1,0 +1,56 @@
+// Pure helpers shared by update/meeting/route.ts for the three-tier recurring-edit scope
+// ('this' / 'thisAndFollowing' / 'all'). Mirrors the ET-day exclusion/trim math delete/meeting/
+// route.ts already uses (its own toETDateStr + getETDayBounds) so both routes agree on exactly
+// which instant an occurrence's ET calendar day starts at.
+import { getETDayBounds } from "../date/timeUtils";
+import { matchesRecurrencePattern } from "./recurrenceMatch";
+
+export type EditScope = 'this' | 'thisAndFollowing' | 'all';
+
+export type RecurrencePatternLike = {
+  type: string;
+  startDate: Date;
+  endDate: Date | null;
+  interval: number;
+  daysOfWeek: string[];
+  weekOfMonth: number | null;
+  dayOfMonth: number | null;
+  excludedDates: Date[];
+};
+
+// Returns "YYYY-MM-DD" in Eastern Time for the given UTC timestamp -- same definition delete/
+// meeting/route.ts keeps locally; duplicated here (not imported from that route) since routes
+// don't export their internals.
+export const toETDateStr = (date: Date): string =>
+  new Intl.DateTimeFormat('en-CA', { timeZone: 'America/New_York' }).format(date);
+
+// The UTC instant of the start of occurrenceDate's ET calendar day -- what gets pushed onto
+// RecurrencePattern.excludedDates for scope 'this' (delete route :144-145's exact math).
+export const exclusionInstant = (occurrenceDate: Date): Date => {
+  const [dayStart] = getETDayBounds(toETDateStr(occurrenceDate));
+  return dayStart;
+};
+
+// 1ms before the start of occurrenceDate's ET calendar day -- the new RecurrencePattern.endDate
+// for scope 'thisAndFollowing', so the trimmed series' last occurrence is the day before
+// occurrenceDate (delete route :160-162's exact math).
+export const trimmedEndDate = (occurrenceDate: Date): Date => {
+  const [dayStart] = getETDayBounds(toETDateStr(occurrenceDate));
+  return new Date(dayStart.getTime() - 1);
+};
+
+// True when occurrenceDate is an actual live occurrence of `pattern` -- not excluded, not past
+// the series end, and on a date/day-of-week/day-of-month the pattern actually produces.
+export const isLiveOccurrence = (pattern: RecurrencePatternLike, occurrenceDate: Date): boolean => {
+  const etDateStr = toETDateStr(occurrenceDate);
+  const [year, month, day] = etDateStr.split('-').map(Number);
+  const localDate = new Date(Date.UTC(year, month - 1, day));
+  return matchesRecurrencePattern(pattern, etDateStr, localDate);
+};
+
+// The root mid a lineage chain shares: a meeting produced by an earlier split already carries
+// its own splitFromMid, which must propagate unchanged rather than being overwritten with the
+// mid of the meeting that was just split again -- otherwise a second split of an
+// already-split-off series would point at the wrong root.
+export const rootSplitMid = (parent: { mid: string; splitFromMid: string | null }): string =>
+  parent.splitFromMid ?? parent.mid;

--- a/frontend/util/meetings/meetingValidation.ts
+++ b/frontend/util/meetings/meetingValidation.ts
@@ -127,6 +127,14 @@ export const meetingSchema = z.object({
     path: ["room"],
   });
 
+// Parsed separately from meetingSchema (not folded into it) so write/meeting -- which shares
+// meetingSchema -- never sees these keys spread into its Prisma create data. update/meeting
+// parses the same raw body through both schemas.
+export const editScopeSchema = z.object({
+  editScope: z.enum(['this', 'thisAndFollowing', 'all']).optional(),
+  occurrenceDate: z.coerce.date().optional(),
+});
+
 // Narrower shape for the Zoom host-availability check — only the fields
 // checkZoomHostPoolAvailability's OccurrenceInput actually needs. The client posts the same
 // full buildMeetingPayload() object the real submit uses (no separate conversion logic), and


### PR DESCRIPTION
Resolves #497

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added scoped editing for recurring meetings: edit this event, this and following events, or the entire series.
  * Single-event edits can detach an occurrence without changing the remaining series.
  * “This and following” edits split the recurring series at the selected occurrence.
  * Added clear confirmation messaging and date-specific handling in the edit flow.

* **Documentation**
  * Updated user guides, quick references, technical decisions, and API documentation to explain recurring-edit behavior and limitations.

* **Bug Fixes**
  * Improved handling of recurring dates, exclusions, conflicts, and calendar synchronization during scoped edits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description
- **frontend/app/api/update/meeting/route.ts**: `PUT` accepts `editScope` (`this` / `thisAndFollowing` / `all`) + `occurrenceDate`. Scoped edits reuse delete's series primitives on the parent (`excludedDates` push, `endDate` trim) and split the edited values into a new `Meeting` row inside one advisory-lock transaction, conflict-checked; response gains `newMid`. Also fixes a pre-existing false-409 bug where the conflict candidate dropped stored `excludedDates`.
- **frontend/prisma/** (`splitFromMid` migration): new nullable lineage column linking split-off rows to their root series' `mid`.
- **frontend/util/meetings/editScope.ts**: pure helpers for the ET-day exclusion/trim math and lineage-root propagation, mirroring the delete route.
- **frontend/app/components/meeting-form/EditRecurringModal.tsx** (+ EditMeeting/ViewMeeting/page.tsx/CalendarSidebarShell threading): save-time scope picker mirroring the delete dialog; clicked occurrence threaded into the edit sidebar; payload re-anchored onto the clicked occurrence when the Date field is untouched; scoped saves poll the created row. Diagnostics mount sites (no occurrence context) degrade to whole-series.
- **frontend/hooks/useMeetingForm.ts**: `isDateDirty`/`isRecurrenceDirty` baselines; also fixes a recurrence-dirty false positive from RecurringMeeting's default-weekday self-seed that could disable scope options and trigger phantom unsaved-changes prompts.
- **Zoom (by design)**: split-off rows inherit the parent's `zid`/link/passcode/host — members keep the link; the shared-`zid` union/schedule-neutral machinery governs later PATCHes. Zoom is never called by a scoped edit, matching delete's contract.
- **docs**: user guide (`why-some-actions-cant-be-undone.md` workaround replaced, `create-edit-delete-meetings.md`, `how-sync-works.md`, quick-reference card), `api-reference.md`, and a new `technical-decisions.md` section recording the split-row model and the Suspend-scopes out-of-scope decision.

## Testing
- [ ] `cd frontend && yarn test:all` (full suite green locally: 301 unit / 304 component / 187 integration / 120 e2e at this branch)
- [ ] Manual: open a recurring meeting from a calendar day → Edit → change the time → Update Meeting → pick **This event** → only that occurrence changes (new standalone entry, same Zoom link); repeat with **This and following** → series splits at that date.
- [ ] Deep-link a meeting (`?mid=`) → Edit → no scope dialog (whole-series behavior preserved).

## Area(s) Touched
**Product areas**
- [ ] auth — sign-in, sessions, NextAuth, role-based access
- [ ] admin — /admin shell (Diagnostics, Users, Import, Export tabs)
- [ ] docs — /docs Resources page (rendering, navigation, search)
- [x] ui/ux — frontend layout/styling not tied to a specific integration

**Integrations**
- [x] google-calendar — Google Calendar sync
- [x] zoom-api — Zoom meeting/host sync

**Engineering**
- [ ] security — auth hardening, data exposure, dependency/security scanning
- [x] testing — test suite (Jest/Playwright) changes
- [ ] github-actions — workflows, Dependabot config, other .github/ CI tooling
- [ ] cleanup — refactor or dead-code removal, no behavior change
- [ ] documentation — docs/ or README changes only

## Pre-merge Checklist
- [x] Code follows current formatting conventions and passes lint (`yarn lint`).
- [x] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
- [ ] All test suites pass, both run locally and green in GitHub CI. **Do not merge if any test suite is failing.**
- [x] A test suite was added or updated for the feature/fix in this PR. **Double-check this if you change a feature and did not update the test suites**.
- [x] Only files relevant to this change are committed — no stray or unrelated files.
- [x] If this branch has a merge conflict with master, master was merged into this branch first (not the other way around).
- [x] The rest of this PR description (Description, Testing) is filled out, not left as template placeholders.
