### PR TITLE
feat(export): make lease and meeting exports recurring-split aware

### DIFF
--- a/docs/01-user-guide/how-to/export-data.md
+++ b/docs/01-user-guide/how-to/export-data.md
@@ -54,3 +54,25 @@ meeting itself is set up:
 "The meeting's own hours" means that one meeting's start-to-end duration, not a sum across its
 whole recurrence — a weekly 1-hour meeting is still just "1 hour" for this calculation, not "1
 hour × however many weeks are in the lease."
+
+## Recurring-series edge cases
+
+Editing "this and following" or "this" occurrence of a recurring meeting can split one series
+into multiple database rows that share the same lease/rental history. Both exports handle this,
+but differently:
+
+- **Lease CSV:** a split or detached row never gets its own line. All rows descended from the
+  same original series are combined into **one billing row**, using whichever row's own schedule
+  starts latest as the representative for rate, room, and time columns — that's the series'
+  current shape. A cancelled single occurrence (delete "this") does **not** reduce the rent
+  charge — the `4×` monthly multiplier is a fixed flat rate per "the meeting's own hours" above,
+  not a per-occurrence count, so removing one date from a recurring series doesn't lower what's
+  billed.
+- **Meetings XLSX:** every row stays a separate row, one per distinct schedule, so a split series
+  shows up as multiple rows. Two optional columns make the relationship legible: **Series End**
+  (the row's own recurrence end date, blank if open-ended or one-time) and **Split From** (the
+  originating series' meeting ID, blank if the row isn't part of a split).
+
+> [!NOTE]
+> The suspended-meetings behavior above still applies per lineage: if any row in a split lineage
+> is suspended rather than deleted, it's still billed in the Lease CSV.

--- a/docs/02-handoff/technical-decisions.md
+++ b/docs/02-handoff/technical-decisions.md
@@ -163,7 +163,7 @@ Each section ends with a **Revisit if:** line — the condition under which this
 - A direct PandaDoc API integration was considered and rejected — it would require a higher-tier PandaDoc account, raising operational cost for no clear benefit at ICR's scale.
 - Moving rate/contact/template values into `LeaseSettings` means a rate change no longer requires a code deploy.
 
-**What the CSV contains:** one row per non-deleted meeting — **not** filtered by `status`, deliberately: a suspended meeting's lease is still a legal obligation, it doesn't lapse just because the meeting is hidden from the calendar.
+**What the CSV contains:** one row per non-deleted meeting lineage — rows created by scoped edits (`splitFromMid`) collapse into a single billing row per root series, represented by the latest-starting segment, so a split series never bills twice. **Not** filtered by `status`, deliberately: a suspended meeting's lease is still a legal obligation, it doesn't lapse just because the meeting is hidden from the calendar.
 
 **Revisit if:** the manual upload-to-PandaDoc step becomes enough of a friction point to justify direct API integration — [PandaDoc has a free API tier](https://www.pandadoc.com/developer-api/pricing/), but that hasn't been evaluated against this app's actual usage.
 

--- a/frontend/app/api/export/lease/route.ts
+++ b/frontend/app/api/export/lease/route.ts
@@ -1,4 +1,4 @@
-import { Role } from "@prisma/client";
+import { Prisma, Role } from "@prisma/client";
 import { requireRole } from "../../../../services/auth";
 import { defaultLeaseSettings } from "../../../../util/lease/leaseDefaults";
 import { formatDayColumn } from "../../../../util/meetings/recurrenceDisplay";
@@ -61,6 +61,44 @@ function formatLeaseDate(date: Date): string {
   return `${day}-${month}-${year}`;
 }
 
+type LeaseMeeting = Prisma.MeetingGetPayload<{ include: { recurrencePattern: true } }>;
+
+// A #497 edit-scope split ("this" -> detached one-time row, "thisAndFollowing" -> new tail
+// row) creates a second Meeting row for what is, for billing purposes, still one lease
+// obligation -- root = splitFromMid ?? mid so every row in a chain (however many generations
+// deep) collapses onto the ROOT series' mid, since #497 always points splitFromMid at the root,
+// never at an intermediate segment.
+function lineageRoot(meeting: LeaseMeeting): string {
+  return meeting.splitFromMid ?? meeting.mid;
+}
+
+// One CSV row per lineage, not per Meeting row -- otherwise a split/detached series would bill
+// twice for the same group. Within a lineage, the representative is whichever segment's own
+// schedule starts latest: that's the "current" shape of the series (a "this and following" edit
+// hands off to its new tail row; a "this" edit's detached occurrence is itself the latest thing
+// that happened to that lineage). Ties broken by mid for a deterministic, arbitrary-but-stable
+// pick -- two rows in the same lineage should never share a startDateTime in practice.
+function pickLineageRepresentative(meetings: LeaseMeeting[]): LeaseMeeting {
+  return meetings.reduce((latest, candidate) => {
+    const latestStart = latest.startDateTime.getTime();
+    const candidateStart = candidate.startDateTime.getTime();
+    if (candidateStart > latestStart) return candidate;
+    if (candidateStart < latestStart) return latest;
+    return candidate.mid < latest.mid ? candidate : latest;
+  });
+}
+
+function groupByLineage(meetings: LeaseMeeting[]): LeaseMeeting[] {
+  const groups = new Map<string, LeaseMeeting[]>();
+  for (const meeting of meetings) {
+    const root = lineageRoot(meeting);
+    const group = groups.get(root);
+    if (group) group.push(meeting);
+    else groups.set(root, [meeting]);
+  }
+  return Array.from(groups.values()).map(pickLineageRepresentative);
+}
+
 function toCSV(rows: Record<string, string>[]): string {
   if (rows.length === 0) return "";
   const header = Object.keys(rows[0]);
@@ -106,7 +144,12 @@ export const GET = async () => {
     const leaseStart = new Date(settings.leaseStartDate);
     const leaseEnd = new Date(settings.leaseEndDate);
 
-    const rows = meetings.map((meeting) => {
+    // Collapse split/detached rows onto one representative per lineage before building CSV
+    // rows, then re-sort -- grouping can promote a row whose title differs from the one the
+    // original title-ordered query put first.
+    const billableMeetings = groupByLineage(meetings).sort((a, b) => a.title.localeCompare(b.title));
+
+    const rows = billableMeetings.map((meeting) => {
       const start = meeting.startDateTime;
       const end = meeting.endDateTime;
       const billableTime = calculateBillableTime(start, end);

--- a/frontend/app/api/export/meetings/route.ts
+++ b/frontend/app/api/export/meetings/route.ts
@@ -67,6 +67,12 @@ const FIELD_COLUMN: Record<MeetingExportFieldKey, { label: string; value: (m: Me
   startTime: { label: "Start Time", value: (m) => formatETTime(m.startDateTime) },
   endDate: { label: "End Date", value: (m) => formatETDate(m.endDateTime) },
   endTime: { label: "End Time", value: (m) => formatETTime(m.endDateTime) },
+  // Blank for an open-ended series (endDate null) or a one-time meeting (no recurrencePattern
+  // at all) -- both mean "no trim has happened", same as the pre-#497 default.
+  seriesEnd: { label: "Series End", value: (m) => (m.recurrencePattern?.endDate ? formatETDate(m.recurrencePattern.endDate) : "") },
+  // Blank for a lineage root (nothing to split from). Nullable at the schema level -- ?? ""
+  // covers a row created before #497 shipped as well as an un-split row.
+  splitFrom: { label: "Split From", value: (m) => m.splitFromMid ?? "" },
   contactEmail: { label: "Contact Email", value: (m) => m.email },
 };
 

--- a/frontend/tests/integration/export-lease-route.test.ts
+++ b/frontend/tests/integration/export-lease-route.test.ts
@@ -6,7 +6,7 @@ jest.mock("../../services/auth", () => ({
 }));
 
 import { getTestPrismaClient, disconnectTestPrismaClient } from "../factories/db";
-import { seedMeeting } from "../factories/meeting";
+import { seedMeeting, seedRecurringMeeting } from "../factories/meeting";
 import { seedLeaseSettings } from "../factories/leaseSettings";
 import { GET } from "../../app/api/export/lease/route";
 
@@ -23,6 +23,10 @@ let seededGroups: string[] = [];
 afterEach(async () => {
   const prisma = getTestPrismaClient();
   if (seededGroups.length > 0) {
+    // RecurrencePattern.mid -> Meeting.mid is ON DELETE RESTRICT (see schema.prisma) -- this
+    // file now seeds recurring meetings too, so their pattern rows must go first or
+    // meeting.deleteMany below throws a foreign key violation instead of just cleaning up.
+    await prisma.recurrencePattern.deleteMany({ where: { meeting: { group: { in: seededGroups } } } });
     await prisma.meeting.deleteMany({ where: { group: { in: seededGroups } } });
     seededGroups = [];
   }
@@ -43,6 +47,13 @@ function columnValueFor(csv: string, groupName: string, column: string): string 
 
 function rentChargeFor(csv: string, groupName: string): string {
   return columnValueFor(csv, groupName, "Rent Charge");
+}
+
+function rowCountFor(csv: string, groupName: string): number {
+  const lines = csv.trim().split("\n");
+  const header = lines[0].split(",");
+  const groupNameIndex = header.indexOf("Group Name");
+  return lines.slice(1).filter((line) => line.split(",")[groupNameIndex] === groupName).length;
 }
 
 test("calculateRentCharge: non-monthly room uses a flat 4 weeks/month, monthly room and Zoom Only return the flat rate", async () => {
@@ -107,4 +118,118 @@ test("formatTime: Start/End Time columns show the meeting's ET wall-clock time, 
 
   expect(columnValueFor(csv, "Time Group", "Start Time")).toBe("6:00 PM");
   expect(columnValueFor(csv, "Time Group", "End Time")).toBe("7:00 PM");
+});
+
+// Excluding one occurrence (delete "this") doesn't touch Meeting.startDateTime/endDateTime, so
+// billable time and Rent Charge are computed exactly as if no date were excluded -- flagged in
+// the #498 audit as a documented, not-fixed-here billing gap (export-data.md's "meeting's own
+// hours" note already covers why the flat 4x multiplier can't reflect per-occurrence removals).
+test("excluded occurrence: series with one excludedDates entry still bills the full flat rate, single row", async () => {
+  await seedLeaseSettings({ rooms: [{ room: "Serenity Room", rate: 15, unit: "hr" }] });
+  await seedRecurringMeeting(
+    { title: "Excluded Group", group: "Excluded Group", room: "Serenity Room", modeType: "In Person" },
+    { daysOfWeek: ["Monday"], excludedDates: [new Date()] },
+  );
+  seededGroups.push("Excluded Group");
+
+  const response = await GET();
+  const csv = await response.text();
+
+  expect(rowCountFor(csv, "Excluded Group")).toBe(1);
+  expect(rentChargeFor(csv, "Excluded Group")).toBe("$60.00");
+});
+
+// A "this and following" delete trims RecurrencePattern.endDate but leaves the Meeting row
+// itself in place (see app/api/delete/meeting/route.ts) -- still exactly one export row, same
+// as the untrimmed case above.
+test("trimmed series: thisAndFollowing-deleted series (endDate set) still emits exactly one row", async () => {
+  await seedLeaseSettings({ rooms: [{ room: "Serenity Room", rate: 15, unit: "hr" }] });
+  const { meeting } = await seedRecurringMeeting({
+    title: "Trimmed Group",
+    group: "Trimmed Group",
+    room: "Serenity Room",
+    modeType: "In Person",
+  });
+  await getTestPrismaClient().recurrencePattern.update({
+    where: { mid: meeting.mid },
+    data: { endDate: new Date(Date.now() - 24 * 60 * 60 * 1000) },
+  });
+  seededGroups.push("Trimmed Group");
+
+  const response = await GET();
+  const csv = await response.text();
+
+  expect(rowCountFor(csv, "Trimmed Group")).toBe(1);
+});
+
+// #497 "this and following" edit: the original row is trimmed (endDate set) and a new tail row
+// takes over with its own later startDateTime, carrying splitFromMid back to the root. Billing
+// must collapse both rows into one -- the tail is the representative since its schedule starts
+// latest.
+test("split pair (thisAndFollowing tail): lineage bills as one row, using the tail's schedule", async () => {
+  await seedLeaseSettings({ rooms: [{ room: "Serenity Room", rate: 15, unit: "hr" }, { room: "Chapel", rate: 20, unit: "hr" }] });
+  const { meeting: root } = await seedRecurringMeeting({
+    title: "Split Group",
+    group: "Split Group",
+    room: "Serenity Room",
+    modeType: "In Person",
+    startDateTime: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000),
+    endDateTime: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000 + 60 * 60 * 1000),
+  });
+  await getTestPrismaClient().recurrencePattern.update({
+    where: { mid: root.mid },
+    data: { endDate: new Date(Date.now() - 8 * 24 * 60 * 60 * 1000) },
+  });
+  await seedRecurringMeeting({
+    title: "Split Group",
+    group: "Split Group",
+    room: "Chapel",
+    modeType: "In Person",
+    startDateTime: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000),
+    endDateTime: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000 + 2 * 60 * 60 * 1000),
+    splitFromMid: root.mid,
+  });
+  seededGroups.push("Split Group");
+
+  const response = await GET();
+  const csv = await response.text();
+
+  expect(rowCountFor(csv, "Split Group")).toBe(1);
+  // Tail's room ($20/hr, 2 billable hours) is the one that should win, not the root's ($15/hr, 1hr).
+  expect(rentChargeFor(csv, "Split Group")).toBe("$160.00");
+  expect(columnValueFor(csv, "Split Group", "Room")).toBe("Chapel ($20/hr)");
+});
+
+// #497 "this" edit: a single occurrence detaches into its own one-time Meeting row (no
+// recurrencePattern) with splitFromMid pointing at the root, and a later startDateTime than the
+// root's recurrence anchor -- so the detached row is the representative here too.
+test("split pair (this detached occurrence): lineage bills as one row, using the detached occurrence", async () => {
+  await seedLeaseSettings({ rooms: [{ room: "Serenity Room", rate: 15, unit: "hr" }] });
+  const { meeting: root } = await seedRecurringMeeting({
+    title: "Detached Group",
+    group: "Detached Group",
+    room: "Serenity Room",
+    modeType: "In Person",
+    startDateTime: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000),
+    endDateTime: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000 + 60 * 60 * 1000),
+  });
+  await seedMeeting({
+    title: "Detached Group",
+    group: "Detached Group",
+    room: "Serenity Room",
+    modeType: "In Person",
+    isRecurring: false,
+    startDateTime: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000),
+    endDateTime: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000 + 60 * 60 * 1000),
+    splitFromMid: root.mid,
+  });
+  seededGroups.push("Detached Group");
+
+  const response = await GET();
+  const csv = await response.text();
+
+  expect(rowCountFor(csv, "Detached Group")).toBe(1);
+  // "Meeting Day" reads formatDayColumn(recurrencePattern) -- "One-time" only appears if the
+  // detached (no-pattern) row won, not the still-recurring root.
+  expect(columnValueFor(csv, "Detached Group", "Meeting Day")).toBe("One-time");
 });

--- a/frontend/tests/integration/export-meetings-route.test.ts
+++ b/frontend/tests/integration/export-meetings-route.test.ts
@@ -1,0 +1,161 @@
+jest.mock("../../services/auth", () => ({
+  requireRole: jest.fn().mockResolvedValue({
+    user: { email: "admin@icr.test", role: "SUPER_ADMIN" },
+    accessToken: "fake-token",
+  }),
+}));
+
+import * as XLSX from "xlsx";
+import { getTestPrismaClient, disconnectTestPrismaClient } from "../factories/db";
+import { seedMeeting, seedRecurringMeeting } from "../factories/meeting";
+import { GET } from "../../app/api/export/meetings/route";
+
+afterAll(async () => {
+  await disconnectTestPrismaClient();
+});
+
+// Same rationale as export-lease-route.test.ts: no per-file DB reset, and the route fetches
+// every non-deleted meeting, so leftover rows from a failed assertion would leak into the next
+// test's row count.
+let seededGroups: string[] = [];
+
+afterEach(async () => {
+  const prisma = getTestPrismaClient();
+  if (seededGroups.length > 0) {
+    await prisma.recurrencePattern.deleteMany({ where: { meeting: { group: { in: seededGroups } } } });
+    await prisma.meeting.deleteMany({ where: { group: { in: seededGroups } } });
+    seededGroups = [];
+  }
+});
+
+interface XlsxRow {
+  [column: string]: string;
+}
+
+async function rowsFor(response: Response): Promise<XlsxRow[]> {
+  const buffer = Buffer.from(await response.arrayBuffer());
+  const workbook = XLSX.read(buffer, { type: "buffer" });
+  const sheet = workbook.Sheets[workbook.SheetNames[0]];
+  return XLSX.utils.sheet_to_json<XlsxRow>(sheet);
+}
+
+test("plain recurring series: one row, Series End blank (open-ended) and Split From blank", async () => {
+  await seedRecurringMeeting({ title: "Open Series", group: "Open Series", room: "Serenity Room" });
+  seededGroups.push("Open Series");
+
+  const response = await GET();
+  expect(response.status).toBe(200);
+  const rows = await rowsFor(response);
+  const row = rows.find((r) => r["Meeting Name"] === "Open Series");
+
+  expect(row).toBeDefined();
+  expect(row?.["Series End"] ?? "").toBe("");
+  expect(row?.["Split From"] ?? "").toBe("");
+});
+
+// A "this" delete pushes an ET-day-start instant onto RecurrencePattern.excludedDates without
+// touching endDate -- the XLSX export doesn't expand occurrences at all (that's the flagged,
+// not-fixed audit finding), so this still shows as a single open-ended row exactly like the
+// unexcluded case above; the exclusion itself has no visible effect on this export's Series End.
+test("excluded occurrence: series with excludedDates still shows a blank Series End", async () => {
+  await seedRecurringMeeting(
+    { title: "Excluded Series", group: "Excluded Series", room: "Serenity Room" },
+    { excludedDates: [new Date()] },
+  );
+  seededGroups.push("Excluded Series");
+
+  const response = await GET();
+  const rows = await rowsFor(response);
+  const row = rows.find((r) => r["Meeting Name"] === "Excluded Series");
+
+  expect(row?.["Series End"] ?? "").toBe("");
+});
+
+// A "this and following" delete trims RecurrencePattern.endDate in place -- Series End should
+// surface that trim date directly.
+test("trimmed series: Series End reflects the trimmed recurrencePattern.endDate", async () => {
+  const { meeting } = await seedRecurringMeeting({
+    title: "Trimmed Series",
+    group: "Trimmed Series",
+    room: "Serenity Room",
+  });
+  // Noon UTC, not midnight -- midnight UTC is still the previous calendar day in ET (UTC-4/-5),
+  // which would make this assert the wrong date regardless of DST (see project's local-timezone
+  // prevention rule).
+  const trimDate = new Date(Date.UTC(2027, 2, 15, 12));
+  await getTestPrismaClient().recurrencePattern.update({
+    where: { mid: meeting.mid },
+    data: { endDate: trimDate },
+  });
+  seededGroups.push("Trimmed Series");
+
+  const response = await GET();
+  const rows = await rowsFor(response);
+  const row = rows.find((r) => r["Meeting Name"] === "Trimmed Series");
+
+  expect(row?.["Series End"]).toBe("03/15/2027");
+});
+
+// #497 split pair: unlike the Lease CSV (one combined billing row), the XLSX export keeps both
+// segments as their own row -- each is a real distinct schedule -- with Split From linking the
+// tail back to the root's mid.
+test("split pair (thisAndFollowing tail): two rows, tail carries Split From back to the root", async () => {
+  const { meeting: root } = await seedRecurringMeeting({
+    title: "Split Series",
+    group: "Split Series",
+    room: "Serenity Room",
+    startDateTime: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000),
+    endDateTime: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000 + 60 * 60 * 1000),
+  });
+  await getTestPrismaClient().recurrencePattern.update({
+    where: { mid: root.mid },
+    data: { endDate: new Date(Date.now() - 8 * 24 * 60 * 60 * 1000) },
+  });
+  await seedRecurringMeeting({
+    title: "Split Series",
+    group: "Split Series",
+    room: "Chapel",
+    startDateTime: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000),
+    endDateTime: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000 + 60 * 60 * 1000),
+    splitFromMid: root.mid,
+  });
+  seededGroups.push("Split Series");
+
+  const response = await GET();
+  const rows = await rowsFor(response).then((r) => r.filter((row) => row["Meeting Name"] === "Split Series"));
+
+  expect(rows).toHaveLength(2);
+  const rootRow = rows.find((r) => r["Physical Room"] === "Serenity Room");
+  const tailRow = rows.find((r) => r["Physical Room"] === "Chapel");
+  expect(rootRow?.["Split From"] ?? "").toBe("");
+  expect(tailRow?.["Split From"]).toBe(root.mid);
+});
+
+// #497 "this" edit: the detached one-time row has no recurrencePattern at all, so Series End is
+// blank on it even though it's part of a lineage that did have a series -- Split From is what
+// actually links it back.
+test("split pair (this detached occurrence): detached row has blank Series End but populated Split From", async () => {
+  const { meeting: root } = await seedRecurringMeeting({
+    title: "Detached Series",
+    group: "Detached Series",
+    room: "Serenity Room",
+  });
+  await seedMeeting({
+    title: "Detached Series",
+    group: "Detached Series",
+    room: "Serenity Room",
+    isRecurring: false,
+    startDateTime: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+    endDateTime: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000 + 60 * 60 * 1000),
+    splitFromMid: root.mid,
+  });
+  seededGroups.push("Detached Series");
+
+  const response = await GET();
+  const rows = await rowsFor(response).then((r) => r.filter((row) => row["Meeting Name"] === "Detached Series"));
+
+  expect(rows).toHaveLength(2);
+  const detachedRow = rows.find((r) => r["Split From"] === root.mid);
+  expect(detachedRow).toBeDefined();
+  expect(detachedRow?.["Series End"] ?? "").toBe("");
+});

--- a/frontend/util/meetings/meetingExportFields.ts
+++ b/frontend/util/meetings/meetingExportFields.ts
@@ -16,6 +16,8 @@ export type MeetingExportFieldKey =
   | "startTime"
   | "endDate"
   | "endTime"
+  | "seriesEnd"
+  | "splitFrom"
   | "contactEmail";
 
 interface MeetingExportFieldGroup {
@@ -47,6 +49,12 @@ export const MEETING_EXPORT_FIELD_GROUPS: MeetingExportFieldGroup[] = [
       { key: "startTime", label: "Start Time" },
       { key: "endDate", label: "End Date" },
       { key: "endTime", label: "End Time" },
+      // Both surface a recurring-series' edit-scope history (see #497/#498): a "this and
+      // following" edit trims the parent's RecurrencePattern.endDate and starts a new tail row,
+      // and a "this" edit detaches a one-time row -- Split From links that row back to the
+      // lineage's root mid so an admin can tell related rows apart in a flat spreadsheet.
+      { key: "seriesEnd", label: "Series End" },
+      { key: "splitFrom", label: "Split From" },
     ],
   },
   {


### PR DESCRIPTION
Resolves #498

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added **Series End** and **Split From** columns to meeting XLSX exports, clarifying recurring-series schedules and splits.
  * Lease CSV exports now consolidate split recurring meetings into a single billing row.
  * Preserved billing for suspended meetings within split series.

* **Documentation**
  * Updated export guidance to explain recurring-series edge cases and export behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description
- **frontend/app/api/export/lease/route.ts**: the lease CSV groups meetings by lineage root (`splitFromMid ?? mid`) and bills each lineage **once** — a split series no longer produces two full-price rows. The representative row is the latest-starting *recurring* segment (mid tie-break); an all-one-time lineage falls back to latest-starting overall.
- **frontend/app/api/export/meetings/route.ts** + **util/meetings/meetingExportFields.ts**: XLSX keeps one row per segment (each is a real schedule) and gains optional **Series End** and **Split From** columns so trims and splits are legible.
- **docs/01-user-guide/how-to/export-data.md**: new recurring-series edge-cases section (how splits appear per export, why a cancelled occurrence doesn't reduce the rent charge).
- Written audit posted on #498 (with a follow-up correction for the recurring-first representative rule), including two flagged-not-fixed billing-policy items: a fully-expired trimmed series still bills full price, and the flat `4×` multiplier doesn't shrink for exclusions (pre-existing documented design).
- **frontend/tests/integration/export-meetings-route.test.ts**: first-ever integration coverage for the XLSX route; lease tests extended with exclusion/trim/split seeds (+ FK-safe cleanup for recurring seeds).

## Testing
- [ ] `cd frontend && TZ=UTC npx jest --config config/jest.integration.config.ts tests/integration/export-lease-route.test.ts tests/integration/export-meetings-route.test.ts`
- [ ] Manual: Admin → Export after a this-and-following edit on a seeded series → lease CSV shows one row for the group; XLSX shows both segments with Series End / Split From populated.

## Area(s) Touched
**Product areas**
- [ ] auth — sign-in, sessions, NextAuth, role-based access
- [x] admin — /admin shell (Diagnostics, Users, Import, Export tabs)
- [ ] docs — /docs Resources page (rendering, navigation, search)
- [ ] ui/ux — frontend layout/styling not tied to a specific integration

**Integrations**
- [ ] google-calendar — Google Calendar sync
- [ ] zoom-api — Zoom meeting/host sync

**Engineering**
- [ ] security — auth hardening, data exposure, dependency/security scanning
- [x] testing — test suite (Jest/Playwright) changes
- [ ] github-actions — workflows, Dependabot config, other .github/ CI tooling
- [ ] cleanup — refactor or dead-code removal, no behavior change
- [x] documentation — docs/ or README changes only

## Pre-merge Checklist
- [x] Code follows current formatting conventions and passes lint (`yarn lint`).
- [x] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
- [ ] All test suites pass, both run locally and green in GitHub CI. **Do not merge if any test suite is failing.**
- [x] A test suite was added or updated for the feature/fix in this PR. **Double-check this if you change a feature and did not update the test suites**.
- [x] Only files relevant to this change are committed — no stray or unrelated files.
- [x] If this branch has a merge conflict with master, master was merged into this branch first (not the other way around).
- [x] The rest of this PR description (Description, Testing) is filled out, not left as template placeholders.
