### PR TITLE
chore(deps): force-patch deepmerge-ts and stop proposing next 16.3.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,11 @@ updates:
       prefix-development: "chore"  # Prefixes dev dependency updates (e.g., chore(deps-dev): ...)
       include: "scope"             # Formats as chore(deps): instead of just chore: 
     open-pull-requests-limit: 10
+    ignore:
+      # Next 16.3.x reintroduces the e2e deep-link hydration regression (#320/#341/#342, §1.5j);
+      # pinned below 16.3.0 until a release passes that suite.
+      - dependency-name: "next"
+        versions: ["16.3.x"]
     groups:
       # Patch and minor bumps (prod or dev) are safe to auto-merge unattended once CI is
       # green (see dependabot-auto-merge.yml) -- only major bumps are left as individual

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -75,7 +75,8 @@
     "postcss": "^8.5.23",
     "sharp": "^0.35.0",
     "**/gaxios/uuid": "^11.1.1",
-    "**/teeny-request/uuid": "^11.1.1"
+    "**/teeny-request/uuid": "^11.1.1",
+    "deepmerge-ts": "^8.0.0"
   },
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e",
   "engines": {

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3541,10 +3541,10 @@ deep-is@^0.1.3:
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.4.tgz#a6f2dce612fadd2ef1f519b73551f17e85199831"
   integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
 
-deepmerge-ts@7.1.5:
-  version "7.1.5"
-  resolved "https://registry.yarnpkg.com/deepmerge-ts/-/deepmerge-ts-7.1.5.tgz#ff818564007f5c150808d2b7b732cac83aa415ab"
-  integrity sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==
+deepmerge-ts@7.1.5, deepmerge-ts@^8.0.0:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/deepmerge-ts/-/deepmerge-ts-8.0.1.tgz#755f118cd798df500bfc0b0aad3861dd89cc904b"
+  integrity sha512-szCXE7YLCvLKR9bFPJcvsezOShdalctSvrgN/LM/QGUEPZQajwjmsMObZ6/DuANT5lxzM/wtO8Feubwdkz8myA==
 
 deepmerge@^4.3.1:
   version "4.3.1"


### PR DESCRIPTION
@coderabbitai summary

## Description
- **frontend/package.json** (+ lockfile): yarn resolution forcing `deepmerge-ts` to 8.x — fixes Dependabot alert 38 (high, stack exhaustion). Transitive via `@prisma/config`, whose latest release still pins 7.1.5, so a resolution is the only fix. Verified: `prisma validate` loads config fine, typecheck + unit suite green.
- **.github/dependabot.yml**: ignore `next` 16.3.x — those releases reintroduce the deep-link hydration e2e regression (#320/#341/#342), which is exactly what's failing on #532.

## Testing
- [ ] `cd frontend && yarn install && yarn typecheck && yarn test:unit && npx prisma validate`

## Area(s) Touched
**Product areas**
- [ ] auth — sign-in, sessions, NextAuth, role-based access
- [ ] admin — /admin shell (Diagnostics, Users, Import, Export tabs)
- [ ] docs — /docs Resources page (rendering, navigation, search)
- [ ] ui/ux — frontend layout/styling not tied to a specific integration

**Integrations**
- [ ] google-calendar — Google Calendar sync
- [ ] zoom-api — Zoom meeting/host sync

**Engineering**
- [x] security — auth hardening, data exposure, dependency/security scanning
- [ ] testing — test suite (Jest/Playwright) changes
- [x] github-actions — workflows, Dependabot config, other .github/ CI tooling
- [ ] cleanup — refactor or dead-code removal, no behavior change
- [ ] documentation — docs/ or README changes only

## Pre-merge Checklist
- [x] Code follows current formatting conventions and passes lint (`yarn lint`).
- [x] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
- [ ] All test suites pass, both run locally and green in GitHub CI. **Do not merge if any test suite is failing.**
- [ ] A test suite was added or updated for the feature/fix in this PR. **Double-check this if you change a feature and did not update the test suites**.
- [x] Only files relevant to this change are committed — no stray or unrelated files.
- [x] If this branch has a merge conflict with master, master was merged into this branch first (not the other way around).
- [x] The rest of this PR description (Description, Testing) is filled out, not left as template placeholders.