### PR TITLE
fix(meetings): stop the meeting-refresh poll from force-closing an open Edit panel

### DIFF
--- a/frontend/app/(main)/page.tsx
+++ b/frontend/app/(main)/page.tsx
@@ -16,6 +16,7 @@ import EditMeetingSidebar from "../components/meeting-form/EditMeeting";
 import { IMeeting } from "../../types/models";
 import { useConflictMids } from "../../hooks/useConflictMids";
 import { useSyncErrorMids } from "../../hooks/useSyncErrorMids";
+import { useMeetingDetailsSync } from "../../hooks/useMeetingDetailsSync";
 import { useViewport } from "../../hooks/useViewport";
 import { PHONE_BREAKPOINT } from "../../util/common/breakpoints";
 import { useCalendarContext } from "../context/CalendarProvider";
@@ -99,43 +100,15 @@ export default function HomePage() {
   // The clicked meeting box, so the View Meeting popup can anchor itself beside it.
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
 
-  const fetchMeetingDetails = useCallback(async (meetingId: string) => {
-    try {
-      const response = await fetch(`/api/retrieve/meeting/${meetingId}`, { method: 'GET' });
-      if (response.ok) {
-        const data: IMeeting = await response.json();
-        // Batched: keeps the old panel on screen until the new meeting is ready.
-        setShowEditMeeting(false);
-        setSelectedMeeting(data);
-        // lastClickedDate is set directly by the calendar box's own click handler (see
-        // setLastClickedDate threaded into DayView/WeekView/DayPortraitView) --
-        // it already knows which specific occurrence's column/row was clicked, which the
-        // globally-selected calendar date does not (e.g. Week view can have a different
-        // selectedDate than the day column actually clicked). Left unset here for the
-        // deep-link (?mid=) path, which has no click to attribute a date to.
-      } else {
-        console.error("Failed to fetch meeting details");
-      }
-    } catch (error) {
-      console.error('Error fetching meeting details:', error);
-    }
-  }, []);
-
-  useEffect(() => {
-    if (selectedMeetingID) {
-      // Async fetch-then-set; the lint rule can't see the setState calls sit after an
-      // await, so this is a false positive for the standard "load on ID change" pattern.
-      // eslint-disable-next-line react-hooks/set-state-in-effect
-      fetchMeetingDetails(selectedMeetingID);
-    } else {
-      setShowEditMeeting(false);
-      setSelectedMeeting(null);
-      setLastClickedDate(null);
-    }
-    // refreshTrigger: a successful retry sync can change the *open* meeting's stored
-    // credentials server-side (Sync from Zoom adopts the live passcode/link) -- the popup must
-    // re-render from the fresh row, not keep showing pre-adoption props with the warning gone.
-  }, [selectedMeetingID, fetchMeetingDetails, refreshTrigger]);
+  // Keeps selectedMeeting in sync with selectedMeetingID and refreshTrigger -- see the hook's
+  // own doc comment for why a background refresh must never force-close an open Edit panel.
+  useMeetingDetailsSync({
+    selectedMeetingID,
+    refreshTrigger,
+    setSelectedMeeting,
+    setShowEditMeeting,
+    setLastClickedDate,
+  });
 
   // Deep-link support for e.g. the Diagnostics conflicts panel's "Edit" button
   // (/?mid=<id>&edit=1) -- read once on mount rather than via useSearchParams, since this

--- a/frontend/hooks/useMeetingDetailsSync.ts
+++ b/frontend/hooks/useMeetingDetailsSync.ts
@@ -1,0 +1,88 @@
+import { useCallback, useEffect, useRef } from "react";
+import { IMeeting } from "../types/models";
+
+export interface UseMeetingDetailsSyncOptions {
+  selectedMeetingID: string | null;
+  // Bumped by the 30s calendar auto-poll (see page.tsx) and by successful writes (delete,
+  // suspend, resume, a meeting update, a sync retry) -- both a genuine selection change and a
+  // background refresh of the same selection flow through here.
+  refreshTrigger: number;
+  setSelectedMeeting: (meeting: IMeeting | null) => void;
+  setShowEditMeeting: (show: boolean) => void;
+  setLastClickedDate: (date: Date | null) => void;
+}
+
+// Keeps `selectedMeeting` in sync with `selectedMeetingID`, refreshing it on every
+// `refreshTrigger` bump too (a successful retry-sync can adopt a live Zoom passcode/link
+// server-side; the popup must re-render from the fresh row). Only a genuine change of *which*
+// meeting is selected resets `showEditMeeting` back to View mode -- a background refresh of the
+// meeting an admin already has open in Edit must never silently discard their in-progress
+// changes by force-closing the panel out from under them.
+export function useMeetingDetailsSync({
+  selectedMeetingID,
+  refreshTrigger,
+  setSelectedMeeting,
+  setShowEditMeeting,
+  setLastClickedDate,
+}: UseMeetingDetailsSyncOptions): void {
+  const fetchMeetingDetails = useCallback(async (meetingId: string, resetEditState: boolean) => {
+    try {
+      const response = await fetch(`/api/retrieve/meeting/${meetingId}`, { method: "GET" });
+      if (response.ok) {
+        const data: IMeeting = await response.json();
+        // Batched: keeps the old panel on screen until the new meeting is ready.
+        if (resetEditState) setShowEditMeeting(false);
+        setSelectedMeeting(data);
+      } else {
+        console.error("Failed to fetch meeting details");
+      }
+    } catch (error) {
+      console.error("Error fetching meeting details:", error);
+    }
+    // setSelectedMeeting/setShowEditMeeting are setState functions from the caller's own
+    // useState -- stable across renders, safe to omit from deps.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Fires only when the *selected meeting itself* changes -- a genuinely new selection
+  // legitimately drops back to View mode rather than silently continuing to edit whatever the
+  // previous selection was.
+  useEffect(() => {
+    if (selectedMeetingID) {
+      // Async fetch-then-set; the lint rule can't see the setState calls sit after an
+      // await, so this is a false positive for the standard "load on ID change" pattern.
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      fetchMeetingDetails(selectedMeetingID, true);
+    } else {
+      setShowEditMeeting(false);
+      setSelectedMeeting(null);
+      // lastClickedDate is set directly by the calendar box's own click handler -- it already
+      // knows which specific occurrence's column/row was clicked, which the globally-selected
+      // calendar date does not. Left unset here for the deep-link (?mid=) path, which has no
+      // click to attribute a date to.
+      setLastClickedDate(null);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedMeetingID, fetchMeetingDetails]);
+
+  // Re-fetches the same open meeting's data on a background refresh (the 30s auto-poll, or a
+  // successful retry-sync) without resetting showEditMeeting -- unlike the effect above, this is
+  // never a new selection, just fresher data for the current one. Guarded on selectedMeetingID
+  // so it doesn't fire before anything is selected.
+  const isFirstRefreshRun = useRef(true);
+  useEffect(() => {
+    // Every effect runs once on mount regardless of its dependency values -- skip that first
+    // run here, since the effect above already fetches on mount (with resetEditState: true).
+    // Without this guard, selecting a meeting would fire two redundant fetches back to back.
+    if (isFirstRefreshRun.current) {
+      isFirstRefreshRun.current = false;
+      return;
+    }
+    if (!selectedMeetingID) return;
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    fetchMeetingDetails(selectedMeetingID, false);
+    // selectedMeetingID/fetchMeetingDetails deliberately excluded -- this effect's only trigger
+    // is refreshTrigger; the effect above already handles a selectedMeetingID change.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [refreshTrigger]);
+}

--- a/frontend/tests/component/EditMeeting.test.tsx
+++ b/frontend/tests/component/EditMeeting.test.tsx
@@ -338,3 +338,51 @@ describe("EditMeetingSidebar recurring-scope re-anchoring", () => {
     expect(screen.getByLabelText("This and following events")).not.toBeDisabled();
   });
 });
+
+describe("EditMeetingSidebar stays open during ordinary field interaction", () => {
+  const renderEditWithOnClose = () => {
+    const onClose = jest.fn();
+    render(
+      <ToastProvider>
+        <EditMeetingSidebar
+          meeting={anchorMeeting}
+          onClose={onClose}
+          onUpdateSuccess={jest.fn()}
+          occurrenceDate={occurrenceDate}
+        />
+      </ToastProvider>,
+    );
+    return onClose;
+  };
+
+  it("keeps the panel open after selecting a Room dropdown option", async () => {
+    const onClose = renderEditWithOnClose();
+    await act(async () => {});
+
+    fireEvent.click(screen.getByRole("button", { name: /Serenity Room/ }));
+    fireEvent.click(screen.getByRole("option", { name: "Unity Room" }));
+
+    expect(screen.getByRole("button", { name: "Update Meeting" })).toBeInTheDocument();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("keeps the panel open while typing digits into the Start time field", async () => {
+    const onClose = renderEditWithOnClose();
+    await act(async () => {});
+
+    fireEvent.change(screen.getByLabelText("Start time"), { target: { value: "09:15" } });
+
+    expect(screen.getByRole("button", { name: "Update Meeting" })).toBeInTheDocument();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("keeps the panel open on a scroll event", async () => {
+    const onClose = renderEditWithOnClose();
+    await act(async () => {});
+
+    fireEvent.scroll(window);
+
+    expect(screen.getByRole("button", { name: "Update Meeting" })).toBeInTheDocument();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/tests/component/useMeetingDetailsSync.test.tsx
+++ b/frontend/tests/component/useMeetingDetailsSync.test.tsx
@@ -1,0 +1,145 @@
+import React from "react";
+import { render, act, waitFor } from "@testing-library/react";
+import { useMeetingDetailsSync } from "../../hooks/useMeetingDetailsSync";
+import { IMeeting } from "../../types/models";
+
+const meeting = (mid: string): IMeeting => ({
+  mid,
+  title: `Meeting ${mid}`,
+  description: "",
+  creator: "Creator",
+  group: "Group",
+  startDateTime: new Date("2026-08-24T18:00:00.000Z"),
+  endDateTime: new Date("2026-08-24T19:00:00.000Z"),
+  email: "seed@test.icr",
+  calType: ["AA"],
+  modeType: "In Person",
+  room: "Serenity Room",
+  status: "Active",
+  isRecurring: false,
+});
+
+const Harness: React.FC<{
+  selectedMeetingID: string | null;
+  refreshTrigger: number;
+  setSelectedMeeting: (meeting: IMeeting | null) => void;
+  setShowEditMeeting: (show: boolean) => void;
+  setLastClickedDate: (date: Date | null) => void;
+}> = (props) => {
+  useMeetingDetailsSync(props);
+  return null;
+};
+
+beforeEach(() => {
+  global.fetch = jest.fn();
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe("useMeetingDetailsSync", () => {
+  it("fetches and resets showEditMeeting when a new meeting is selected", async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => meeting("m-1"),
+    });
+    const setSelectedMeeting = jest.fn();
+    const setShowEditMeeting = jest.fn();
+    const setLastClickedDate = jest.fn();
+
+    render(
+      <Harness
+        selectedMeetingID="m-1"
+        refreshTrigger={0}
+        setSelectedMeeting={setSelectedMeeting}
+        setShowEditMeeting={setShowEditMeeting}
+        setLastClickedDate={setLastClickedDate}
+      />
+    );
+
+    await waitFor(() => expect(setSelectedMeeting).toHaveBeenCalledWith(meeting("m-1")));
+    expect(setShowEditMeeting).toHaveBeenCalledWith(false);
+  });
+
+  it("clears selection state when selectedMeetingID becomes null", () => {
+    const setSelectedMeeting = jest.fn();
+    const setShowEditMeeting = jest.fn();
+    const setLastClickedDate = jest.fn();
+
+    render(
+      <Harness
+        selectedMeetingID={null}
+        refreshTrigger={0}
+        setSelectedMeeting={setSelectedMeeting}
+        setShowEditMeeting={setShowEditMeeting}
+        setLastClickedDate={setLastClickedDate}
+      />
+    );
+
+    expect(setShowEditMeeting).toHaveBeenCalledWith(false);
+    expect(setSelectedMeeting).toHaveBeenCalledWith(null);
+    expect(setLastClickedDate).toHaveBeenCalledWith(null);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  // Regression: a background refresh of the meeting an admin already has open in Edit
+  // (the 30s calendar auto-poll, or a successful retry-sync) must refresh its data without
+  // forcing the panel back to View mode -- that would silently discard an in-progress edit,
+  // bypassing EditMeetingSidebar's own unsaved-changes confirmation entirely.
+  it("refreshes the same meeting's data on a refreshTrigger bump without resetting showEditMeeting", async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => meeting("m-1"),
+    });
+    const setSelectedMeeting = jest.fn();
+    const setShowEditMeeting = jest.fn();
+    const setLastClickedDate = jest.fn();
+
+    const { rerender } = render(
+      <Harness
+        selectedMeetingID="m-1"
+        refreshTrigger={0}
+        setSelectedMeeting={setSelectedMeeting}
+        setShowEditMeeting={setShowEditMeeting}
+        setLastClickedDate={setLastClickedDate}
+      />
+    );
+    await waitFor(() => expect(setSelectedMeeting).toHaveBeenCalledTimes(1));
+    setShowEditMeeting.mockClear();
+    setSelectedMeeting.mockClear();
+
+    await act(async () => {
+      rerender(
+        <Harness
+          selectedMeetingID="m-1"
+          refreshTrigger={1}
+          setSelectedMeeting={setSelectedMeeting}
+          setShowEditMeeting={setShowEditMeeting}
+          setLastClickedDate={setLastClickedDate}
+        />
+      );
+    });
+
+    await waitFor(() => expect(setSelectedMeeting).toHaveBeenCalledWith(meeting("m-1")));
+    expect(setShowEditMeeting).not.toHaveBeenCalled();
+  });
+
+  it("does not fetch on mount before any meeting is selected, even if refreshTrigger is nonzero", () => {
+    const setSelectedMeeting = jest.fn();
+    const setShowEditMeeting = jest.fn();
+    const setLastClickedDate = jest.fn();
+
+    render(
+      <Harness
+        selectedMeetingID={null}
+        refreshTrigger={3}
+        setSelectedMeeting={setSelectedMeeting}
+        setShowEditMeeting={setShowEditMeeting}
+        setLastClickedDate={setLastClickedDate}
+      />
+    );
+
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
@coderabbitai summary

## Description
- **frontend/hooks/useMeetingDetailsSync.ts** (new): extracts `page.tsx`'s meeting-details fetch effect and splits it in two — a genuine `selectedMeetingID` change still resets back to View mode, but a `refreshTrigger` bump (the 30s calendar auto-poll, or a successful delete/suspend/resume/sync-retry) now re-fetches the open meeting *without* touching `showEditMeeting`.
- **frontend/app/(main)/page.tsx**: replaces the inline effect with the hook. Previously every refetch unconditionally called `setShowEditMeeting(false)`, so the next poll tick after an admin opened Edit unmounted the panel mid-edit, silently discarding all changes and bypassing the panel's own unsaved-changes guard (which only covers Cancel/X).
- **frontend/tests/component/useMeetingDetailsSync.test.tsx** (new): regression tests, including the key one — a `refreshTrigger` bump refreshes the same meeting without resetting `showEditMeeting`.
- **frontend/tests/component/EditMeeting.test.tsx**: documents that Room-dropdown selection, typed digits in the time input, and scroll events leave the panel open (these were the reported symptoms; live testing straddled the poll ticks).

## Testing
- [ ] `cd frontend && yarn test:component tests/component/useMeetingDetailsSync.test.tsx`
- [ ] Live repro: `yarn dev`, open a meeting, click Edit, wait 35+ seconds without touching anything — the panel now stays open (previously the 30s poll closed it).
- [ ] Full `yarn test:all` green locally (121/121 e2e).

## Area(s) Touched
**Product areas**
- [ ] auth — sign-in, sessions, NextAuth, role-based access
- [ ] admin — /admin shell (Diagnostics, Users, Import, Export tabs)
- [ ] docs — /docs Resources page (rendering, navigation, search)
- [X] ui/ux — frontend layout/styling not tied to a specific integration

**Integrations**
- [ ] google-calendar — Google Calendar sync
- [ ] zoom-api — Zoom meeting/host sync

**Engineering**
- [ ] security — auth hardening, data exposure, dependency/security scanning
- [X] testing — test suite (Jest/Playwright) changes
- [ ] github-actions — workflows, Dependabot config, other .github/ CI tooling
- [ ] cleanup — refactor or dead-code removal, no behavior change
- [ ] documentation — docs/ or README changes only

## Pre-merge Checklist
- [x] Code follows current formatting conventions and passes lint (`yarn lint`).
- [x] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
- [ ] All test suites pass, both run locally and green in GitHub CI. **Do not merge if any test suite is failing.**
- [x] A test suite was added or updated for the feature/fix in this PR. **Double-check this if you change a feature and did not update the test suites**.
- [x] Only files relevant to this change are committed — no stray or unrelated files.
- [x] If this branch has a merge conflict with master, master was merged into this branch first (not the other way around).
- [x] The rest of this PR description (Description, Testing) is filled out, not left as template placeholders.
