### PR TITLE
fix(meeting-form): require explicit confirmation for whole-series Diagnostics edits

### DIFF
--- a/frontend/app/(main)/page.tsx
+++ b/frontend/app/(main)/page.tsx
@@ -16,6 +16,7 @@ import EditMeetingSidebar from "../components/meeting-form/EditMeeting";
 import { IMeeting } from "../../types/models";
 import { useConflictMids } from "../../hooks/useConflictMids";
 import { useSyncErrorMids } from "../../hooks/useSyncErrorMids";
+import { useMeetingDetailsSync } from "../../hooks/useMeetingDetailsSync";
 import { useViewport } from "../../hooks/useViewport";
 import { PHONE_BREAKPOINT } from "../../util/common/breakpoints";
 import { useCalendarContext } from "../context/CalendarProvider";
@@ -99,43 +100,15 @@ export default function HomePage() {
   // The clicked meeting box, so the View Meeting popup can anchor itself beside it.
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
 
-  const fetchMeetingDetails = useCallback(async (meetingId: string) => {
-    try {
-      const response = await fetch(`/api/retrieve/meeting/${meetingId}`, { method: 'GET' });
-      if (response.ok) {
-        const data: IMeeting = await response.json();
-        // Batched: keeps the old panel on screen until the new meeting is ready.
-        setShowEditMeeting(false);
-        setSelectedMeeting(data);
-        // lastClickedDate is set directly by the calendar box's own click handler (see
-        // setLastClickedDate threaded into DayView/WeekView/DayPortraitView) --
-        // it already knows which specific occurrence's column/row was clicked, which the
-        // globally-selected calendar date does not (e.g. Week view can have a different
-        // selectedDate than the day column actually clicked). Left unset here for the
-        // deep-link (?mid=) path, which has no click to attribute a date to.
-      } else {
-        console.error("Failed to fetch meeting details");
-      }
-    } catch (error) {
-      console.error('Error fetching meeting details:', error);
-    }
-  }, []);
-
-  useEffect(() => {
-    if (selectedMeetingID) {
-      // Async fetch-then-set; the lint rule can't see the setState calls sit after an
-      // await, so this is a false positive for the standard "load on ID change" pattern.
-      // eslint-disable-next-line react-hooks/set-state-in-effect
-      fetchMeetingDetails(selectedMeetingID);
-    } else {
-      setShowEditMeeting(false);
-      setSelectedMeeting(null);
-      setLastClickedDate(null);
-    }
-    // refreshTrigger: a successful retry sync can change the *open* meeting's stored
-    // credentials server-side (Sync from Zoom adopts the live passcode/link) -- the popup must
-    // re-render from the fresh row, not keep showing pre-adoption props with the warning gone.
-  }, [selectedMeetingID, fetchMeetingDetails, refreshTrigger]);
+  // Keeps selectedMeeting in sync with selectedMeetingID and refreshTrigger -- see the hook's
+  // own doc comment for why a background refresh must never force-close an open Edit panel.
+  useMeetingDetailsSync({
+    selectedMeetingID,
+    refreshTrigger,
+    setSelectedMeeting,
+    setShowEditMeeting,
+    setLastClickedDate,
+  });
 
   // Deep-link support for e.g. the Diagnostics conflicts panel's "Edit" button
   // (/?mid=<id>&edit=1) -- read once on mount rather than via useSearchParams, since this

--- a/frontend/app/components/admin/diagnostics/ConflictList.tsx
+++ b/frontend/app/components/admin/diagnostics/ConflictList.tsx
@@ -171,6 +171,11 @@ const ConflictList: React.FC<ConflictListProps> = ({ conflicts, emptyLabel = "No
                             <EditMeetingSidebar
                               layout="wide"
                               meeting={meetingDetails}
+                              // This row's own conflicting occurrence (not the overlap
+                              // intersection) -- a real date this conflict is actually about,
+                              // so a recurring meeting's edit can be scoped to it instead of
+                              // forcing a whole-series rewrite.
+                              occurrenceDate={new Date(meeting.occurrence.start)}
                               onClose={collapse}
                               onUpdateSuccess={() => {
                                 collapse();

--- a/frontend/app/components/admin/diagnostics/SyncIssuesCard.tsx
+++ b/frontend/app/components/admin/diagnostics/SyncIssuesCard.tsx
@@ -229,6 +229,10 @@ const SyncIssuesCard: React.FC = () => {
                         <EditMeetingSidebar
                           layout="wide"
                           meeting={meetingDetails}
+                          // No occurrenceDate: sync status (SyncIssueRow) is series-level, not
+                          // tied to any specific occurrence -- there's no real date to pass.
+                          // A recurring meeting still gets the scope dialog (EditMeeting's
+                          // canScopeEdit), just with 'this'/'thisAndFollowing' disabled.
                           onClose={collapseEdit}
                           onUpdateSuccess={() => {
                             collapseEdit();

--- a/frontend/app/components/meeting-form/EditMeeting.tsx
+++ b/frontend/app/components/meeting-form/EditMeeting.tsx
@@ -48,11 +48,14 @@ interface EditMeetingSidebarProps {
   // "wide" is used when this form is embedded inline in a wider context (e.g. the Diagnostics
   // Conflicts panel) rather than the narrow Main Calendar sidebar. See MeetingForm's layout prop.
   layout?: "sidebar" | "wide";
-  // The specific occurrence the calendar box/popup was clicked on -- same value page.tsx's
-  // handleDelete sends as deleteOption's occurrenceDate (lastClickedDate), kept consistent with
-  // that call site rather than ViewMeeting's re-anchored displayStartDate. Absent at the two
-  // Diagnostics mount sites (ConflictList/SyncIssuesCard), which have no click to attribute a
-  // date to -- absence there means "always scope 'all'", the pre-existing behavior.
+  // The specific occurrence to scope 'this'/'thisAndFollowing' against. Either the calendar
+  // box/popup click date (same value page.tsx's handleDelete sends as deleteOption's
+  // occurrenceDate/lastClickedDate) or, for ConflictList's Diagnostics embed, the conflicting
+  // meeting's own occurrence from the conflict row (ConflictMeetingSummary.occurrence) -- a real
+  // date the row is already about, not a click. Absent at the SyncIssuesCard Diagnostics mount
+  // site, which has no occurrence-specific data at all (sync status is series-level) -- absence
+  // there forces the scope dialog's scoped options off (EditRecurringModal's disableScoped),
+  // requiring an explicit "All events" confirmation instead of silently scoping 'all'.
   occurrenceDate?: Date | null;
 }
 
@@ -106,15 +109,21 @@ const EditMeetingSidebar: React.FC<EditMeetingSidebarProps> =
     // Diagnostics Conflicts panel) has room to spare and keeps full size.
     const compact = layout === "sidebar";
     const [isDiscardPromptOpen, setIsDiscardPromptOpen] = useState(false);
-    // A scope choice only makes sense when the meeting was AND still is recurring, with known
-    // occurrence context (absent at the Diagnostics mount sites). Turning recurrence off in the
-    // form (meeting.isRecurring true, current isRecurring false) is inherently an all-events
-    // restructure -- the payload carries no recurrencePattern, so scope 'thisAndFollowing' would
-    // 400 server-side and 'this' is already disabled by isRecurrenceDirty -- so that case skips
-    // the modal too and submits as today (no editScope, whole-series behavior). Turning
-    // recurrence ON for a previously non-recurring meeting also skips it: there's no existing
-    // series for occurrenceDate to scope against.
-    const canScopeEdit = !!(meeting.isRecurring && isRecurring && occurrenceDate);
+    // A scope choice only makes sense when the meeting was AND still is recurring. Turning
+    // recurrence off in the form (meeting.isRecurring true, current isRecurring false) is
+    // inherently an all-events restructure -- the payload carries no recurrencePattern, so scope
+    // 'thisAndFollowing' would 400 server-side and 'this' is already disabled by
+    // isRecurrenceDirty -- so that case skips the modal too and submits as today (no editScope,
+    // whole-series behavior). Turning recurrence ON for a previously non-recurring meeting also
+    // skips it: there's no existing series for occurrenceDate to scope against.
+    //
+    // Occurrence context (absent at the Diagnostics Sync Issues mount site, which has no click
+    // to attribute a date to -- ConflictList passes the actual conflicting occurrence instead)
+    // still opens the modal, just with 'this'/'thisAndFollowing' disabled -- see
+    // EditRecurringModal's disableScoped, mirroring DeleteRecurringModal's identical gate. This
+    // makes an all-occurrences edit an informed, explicit choice instead of the previous silent
+    // whole-series rewrite.
+    const canScopeEdit = !!(meeting.isRecurring && isRecurring);
     const [isScopeModalOpen, setIsScopeModalOpen] = useState(false);
     // The payload built at the moment Save was pressed -- EditRecurringModal's own choice
     // handler applies the scope onto this rather than rebuilding from current form state, since
@@ -443,7 +452,13 @@ const EditMeetingSidebar: React.FC<EditMeetingSidebarProps> =
           <EditRecurringModal
             isOpen={isScopeModalOpen}
             title={meeting.title}
-            effectiveDateText={formatEffectiveDate(occurrenceDate as Date)}
+            // No occurrence context (Sync Issues panel) falls back to the series' own anchor
+            // date -- mirrors ViewMeeting.tsx's displayStartDate fallback for the same case.
+            // disableScoped forces scope to 'all' whenever this fallback is in play, so this
+            // date is never used to re-anchor a scoped save, only to render the message text.
+            // new Date() wrap: meeting comes off a JSON fetch, so startDateTime is a string at
+            // runtime despite IMeeting's Date type -- Intl.format throws on it unwrapped.
+            effectiveDateText={formatEffectiveDate(new Date(occurrenceDate ?? meeting.startDateTime))}
             onClose={() => {
               setIsScopeModalOpen(false);
               pendingPayloadRef.current = null;
@@ -452,6 +467,7 @@ const EditMeetingSidebar: React.FC<EditMeetingSidebarProps> =
             disableThis={isRecurrenceDirty}
             disableScopedEdits={isModeDirty || isHostDirty}
             disableThisAndFollowing={isDateDirty}
+            disableScoped={!occurrenceDate}
           />
         )}
         <ConflictOverrideModal

--- a/frontend/app/components/meeting-form/EditRecurringModal.tsx
+++ b/frontend/app/components/meeting-form/EditRecurringModal.tsx
@@ -28,6 +28,12 @@ interface EditRecurringModalProps {
   // occurrences belongs in the recurrence editor's daysOfWeek, not the Date field), so only
   // 'thisAndFollowing' is disabled here -- 'this' and 'all' stay available.
   disableThisAndFollowing?: boolean;
+  // True when the caller has no specific occurrence to scope against -- e.g. the Diagnostics
+  // Sync Issues panel, which edits a meeting with no click to attribute a date to.
+  // 'this'/'thisAndFollowing' both need an occurrenceDate the server can validate; without one
+  // they'd 400. Disables both scoped options and forces 'all', mirroring
+  // DeleteRecurringModal's disableScoped gate.
+  disableScoped?: boolean;
 }
 
 const EditRecurringModal: React.FC<EditRecurringModalProps> = ({
@@ -39,11 +45,12 @@ const EditRecurringModal: React.FC<EditRecurringModalProps> = ({
   disableThis = false,
   disableScopedEdits = false,
   disableThisAndFollowing = false,
+  disableScoped = false,
 }) => {
   const [selectedOption, setSelectedOption] = useState<EditScope>('this');
 
-  const isThisDisabled = disableThis || disableScopedEdits;
-  const isThisAndFollowingDisabled = disableScopedEdits || disableThisAndFollowing;
+  const isThisDisabled = disableThis || disableScopedEdits || disableScoped;
+  const isThisAndFollowingDisabled = disableScopedEdits || disableThisAndFollowing || disableScoped;
 
   // Keeps a disabled option from staying selected once a form change makes it unavailable --
   // re-checked each time the modal opens rather than continuously, so it doesn't fight a
@@ -135,12 +142,16 @@ const EditRecurringModal: React.FC<EditRecurringModalProps> = ({
           <label htmlFor="edit-this-and-following" className={styles.radioLabel}>This and following events</label>
         </div>
 
-        {/* Mode/host changes are the broadest constraint (both scoped options unavailable) --
-            shown on its own, in preference to the narrower recurrence/date hints, when it
-            applies: those two are otherwise independent (each disables only its own option)
-            and can legitimately show together (e.g. recurrence-dirty + date-dirty leaves only
-            'all' selectable, for two different reasons). */}
-        {disableScopedEdits ? (
+        {/* disableScoped (no occurrence context at all) and disableScopedEdits (mode/host
+            changes apply to the whole series) each disable both scoped options on their own --
+            shown in preference to the narrower recurrence/date hints below, which can
+            legitimately show together (e.g. recurrence-dirty + date-dirty leaves only 'all'
+            selectable, for two different reasons) once neither of these applies. */}
+        {disableScoped ? (
+          <p className={styles.disabledHint}>
+            Open the meeting from a calendar day to edit specific occurrences.
+          </p>
+        ) : disableScopedEdits ? (
           <p className={styles.disabledHint}>
             Mode and host changes apply to the whole series, so this option isn&apos;t available.
           </p>

--- a/frontend/hooks/useMeetingDetailsSync.ts
+++ b/frontend/hooks/useMeetingDetailsSync.ts
@@ -1,0 +1,88 @@
+import { useCallback, useEffect, useRef } from "react";
+import { IMeeting } from "../types/models";
+
+export interface UseMeetingDetailsSyncOptions {
+  selectedMeetingID: string | null;
+  // Bumped by the 30s calendar auto-poll (see page.tsx) and by successful writes (delete,
+  // suspend, resume, a meeting update, a sync retry) -- both a genuine selection change and a
+  // background refresh of the same selection flow through here.
+  refreshTrigger: number;
+  setSelectedMeeting: (meeting: IMeeting | null) => void;
+  setShowEditMeeting: (show: boolean) => void;
+  setLastClickedDate: (date: Date | null) => void;
+}
+
+// Keeps `selectedMeeting` in sync with `selectedMeetingID`, refreshing it on every
+// `refreshTrigger` bump too (a successful retry-sync can adopt a live Zoom passcode/link
+// server-side; the popup must re-render from the fresh row). Only a genuine change of *which*
+// meeting is selected resets `showEditMeeting` back to View mode -- a background refresh of the
+// meeting an admin already has open in Edit must never silently discard their in-progress
+// changes by force-closing the panel out from under them.
+export function useMeetingDetailsSync({
+  selectedMeetingID,
+  refreshTrigger,
+  setSelectedMeeting,
+  setShowEditMeeting,
+  setLastClickedDate,
+}: UseMeetingDetailsSyncOptions): void {
+  const fetchMeetingDetails = useCallback(async (meetingId: string, resetEditState: boolean) => {
+    try {
+      const response = await fetch(`/api/retrieve/meeting/${meetingId}`, { method: "GET" });
+      if (response.ok) {
+        const data: IMeeting = await response.json();
+        // Batched: keeps the old panel on screen until the new meeting is ready.
+        if (resetEditState) setShowEditMeeting(false);
+        setSelectedMeeting(data);
+      } else {
+        console.error("Failed to fetch meeting details");
+      }
+    } catch (error) {
+      console.error("Error fetching meeting details:", error);
+    }
+    // setSelectedMeeting/setShowEditMeeting are setState functions from the caller's own
+    // useState -- stable across renders, safe to omit from deps.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Fires only when the *selected meeting itself* changes -- a genuinely new selection
+  // legitimately drops back to View mode rather than silently continuing to edit whatever the
+  // previous selection was.
+  useEffect(() => {
+    if (selectedMeetingID) {
+      // Async fetch-then-set; the lint rule can't see the setState calls sit after an
+      // await, so this is a false positive for the standard "load on ID change" pattern.
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      fetchMeetingDetails(selectedMeetingID, true);
+    } else {
+      setShowEditMeeting(false);
+      setSelectedMeeting(null);
+      // lastClickedDate is set directly by the calendar box's own click handler -- it already
+      // knows which specific occurrence's column/row was clicked, which the globally-selected
+      // calendar date does not. Left unset here for the deep-link (?mid=) path, which has no
+      // click to attribute a date to.
+      setLastClickedDate(null);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedMeetingID, fetchMeetingDetails]);
+
+  // Re-fetches the same open meeting's data on a background refresh (the 30s auto-poll, or a
+  // successful retry-sync) without resetting showEditMeeting -- unlike the effect above, this is
+  // never a new selection, just fresher data for the current one. Guarded on selectedMeetingID
+  // so it doesn't fire before anything is selected.
+  const isFirstRefreshRun = useRef(true);
+  useEffect(() => {
+    // Every effect runs once on mount regardless of its dependency values -- skip that first
+    // run here, since the effect above already fetches on mount (with resetEditState: true).
+    // Without this guard, selecting a meeting would fire two redundant fetches back to back.
+    if (isFirstRefreshRun.current) {
+      isFirstRefreshRun.current = false;
+      return;
+    }
+    if (!selectedMeetingID) return;
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    fetchMeetingDetails(selectedMeetingID, false);
+    // selectedMeetingID/fetchMeetingDetails deliberately excluded -- this effect's only trigger
+    // is refreshTrigger; the effect above already handles a selectedMeetingID change.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [refreshTrigger]);
+}

--- a/frontend/tests/component/ConflictList.test.tsx
+++ b/frontend/tests/component/ConflictList.test.tsx
@@ -1,0 +1,99 @@
+import React from "react";
+import { render, screen, fireEvent, act, waitFor } from "@testing-library/react";
+import ConflictList from "../../app/components/admin/diagnostics/ConflictList";
+import { ConflictListRow } from "../../util/meetings/conflictDisplay";
+import { IMeeting } from "../../types/models";
+
+// Stubbed to a prop-capturing shell -- this file is about what occurrenceDate ConflictList
+// hands to the real EditMeetingSidebar, not the sidebar's own edit-scope behavior (covered by
+// EditMeeting.test.tsx).
+jest.mock("../../app/components/meeting-form/EditMeeting", () => ({
+  __esModule: true,
+  default: ({ occurrenceDate }: { occurrenceDate?: Date | null }) => (
+    <div data-testid="edit-meeting-sidebar">
+      occurrenceDate: {occurrenceDate ? occurrenceDate.toISOString() : "none"}
+    </div>
+  ),
+}));
+
+// A room double-booked by two recurring meetings -- each meeting's own conflicting occurrence
+// (not the overlap intersection) is what ConflictList must hand off as occurrenceDate.
+const conflictRow: ConflictListRow = {
+  field: "room",
+  value: "Serenity Room",
+  overlap: { start: "2026-08-09T22:00:00.000Z", end: "2026-08-09T23:00:00.000Z" },
+  meetings: [
+    {
+      mid: "m-1",
+      title: "Recurring Series A",
+      calType: ["AA"],
+      isRecurring: true,
+      recurrencePattern: { type: "weekly", interval: 1, daysOfWeek: ["Sunday"], weekOfMonth: null, dayOfMonth: null },
+      // This meeting's own conflicting occurrence -- weeks after its series anchor date.
+      occurrence: { start: "2026-08-09T22:00:00.000Z", end: "2026-08-09T23:00:00.000Z" },
+    },
+    {
+      mid: "m-2",
+      title: "One-time Meeting B",
+      calType: ["NA"],
+      isRecurring: false,
+      recurrencePattern: null,
+      occurrence: { start: "2026-08-09T22:30:00.000Z", end: "2026-08-09T23:30:00.000Z" },
+    },
+  ],
+};
+
+const meetingDetails: Record<string, IMeeting> = {
+  "m-1": {
+    mid: "m-1",
+    title: "Recurring Series A",
+    description: "",
+    creator: "Creator",
+    group: "Group",
+    startDateTime: new Date("2026-07-05T22:00:00.000Z"),
+    endDateTime: new Date("2026-07-05T23:00:00.000Z"),
+    email: "seed@test.icr",
+    calType: ["AA"],
+    modeType: "In Person",
+    room: "Serenity Room",
+    status: "Active",
+    isRecurring: true,
+    recurrencePattern: {
+      mid: "m-1",
+      type: "weekly",
+      startDate: new Date("2026-07-05T00:00:00.000Z"),
+      daysOfWeek: ["Sunday"],
+      firstDayOfWeek: "Sunday",
+      interval: 1,
+      excludedDates: [],
+    },
+  },
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  global.fetch = jest.fn((url: string) => {
+    if (url === "/api/retrieve/zoom-hosts") {
+      return Promise.resolve({ ok: true, json: async () => ({ hosts: [] }) });
+    }
+    if (url === "/api/retrieve/meeting/m-1") {
+      return Promise.resolve({ ok: true, json: async () => meetingDetails["m-1"] });
+    }
+    return Promise.reject(new Error(`Unexpected fetch: ${url}`));
+  }) as unknown as typeof fetch;
+});
+
+describe("ConflictList edit panel occurrence context", () => {
+  it("passes the conflicting meeting's own occurrence (not the overlap window) as occurrenceDate", async () => {
+    render(<ConflictList conflicts={[conflictRow]} />);
+
+    // Two meetings share this conflict row -- m-1 (the recurring one under test) is first.
+    fireEvent.click(screen.getAllByRole("button", { name: "Edit" })[0]);
+    await act(async () => {});
+
+    await waitFor(() => expect(screen.getByTestId("edit-meeting-sidebar")).toBeInTheDocument());
+    expect(screen.getByTestId("edit-meeting-sidebar")).toHaveTextContent(
+      `occurrenceDate: ${new Date("2026-08-09T22:00:00.000Z").toISOString()}`,
+    );
+  });
+});

--- a/frontend/tests/component/EditMeeting.test.tsx
+++ b/frontend/tests/component/EditMeeting.test.tsx
@@ -219,16 +219,33 @@ describe("EditMeetingSidebar recurring-scope re-anchoring", () => {
     });
   });
 
-  it("skips the scope modal entirely when there's no occurrence context (e.g. Diagnostics mount sites)", async () => {
+  // Regression: editing a recurring meeting from Diagnostics used to skip the scope modal
+  // entirely and silently rewrite the whole series. It must now still show the modal, force an
+  // explicit "All events" confirmation, and only submit once that's confirmed.
+  it("shows the scope modal with scoped options disabled when there's no occurrence context (e.g. Sync Issues panel), and applies scope 'all' only after explicit confirmation", async () => {
     renderEdit(null);
     await act(async () => {});
 
     fireEvent.click(screen.getByRole("button", { name: "Update Meeting" }));
 
-    expect(screen.queryByLabelText("This event")).not.toBeInTheDocument();
-    await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+    const thisEventRadio = await screen.findByLabelText("This event");
+    expect(thisEventRadio).toBeDisabled();
+    expect(screen.getByLabelText("This and following events")).toBeDisabled();
+    expect(screen.getByLabelText("All events")).toBeChecked();
+    expect(screen.getByText(/Open the meeting from a calendar day to edit specific occurrences/)).toBeInTheDocument();
+
+    // No request fired yet -- the modal is a real gate, not just a display.
+    expect(global.fetch).not.toHaveBeenCalledWith("/api/update/meeting", expect.anything());
+
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledWith(
+      "/api/update/meeting",
+      expect.objectContaining({ method: "PUT" }),
+    ));
     const body = lastUpdateMeetingBody();
     expect(body.editScope).toBeUndefined();
+    expect(body.occurrenceDate).toBeUndefined();
   });
 
   // Regression for a false-positive isRecurrenceDirty: a stored pattern with an empty

--- a/frontend/tests/component/EditMeeting.test.tsx
+++ b/frontend/tests/component/EditMeeting.test.tsx
@@ -338,3 +338,51 @@ describe("EditMeetingSidebar recurring-scope re-anchoring", () => {
     expect(screen.getByLabelText("This and following events")).not.toBeDisabled();
   });
 });
+
+describe("EditMeetingSidebar stays open during ordinary field interaction", () => {
+  const renderEditWithOnClose = () => {
+    const onClose = jest.fn();
+    render(
+      <ToastProvider>
+        <EditMeetingSidebar
+          meeting={anchorMeeting}
+          onClose={onClose}
+          onUpdateSuccess={jest.fn()}
+          occurrenceDate={occurrenceDate}
+        />
+      </ToastProvider>,
+    );
+    return onClose;
+  };
+
+  it("keeps the panel open after selecting a Room dropdown option", async () => {
+    const onClose = renderEditWithOnClose();
+    await act(async () => {});
+
+    fireEvent.click(screen.getByRole("button", { name: /Serenity Room/ }));
+    fireEvent.click(screen.getByRole("option", { name: "Unity Room" }));
+
+    expect(screen.getByRole("button", { name: "Update Meeting" })).toBeInTheDocument();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("keeps the panel open while typing digits into the Start time field", async () => {
+    const onClose = renderEditWithOnClose();
+    await act(async () => {});
+
+    fireEvent.change(screen.getByLabelText("Start time"), { target: { value: "09:15" } });
+
+    expect(screen.getByRole("button", { name: "Update Meeting" })).toBeInTheDocument();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("keeps the panel open on a scroll event", async () => {
+    const onClose = renderEditWithOnClose();
+    await act(async () => {});
+
+    fireEvent.scroll(window);
+
+    expect(screen.getByRole("button", { name: "Update Meeting" })).toBeInTheDocument();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/tests/component/EditRecurringModal.test.tsx
+++ b/frontend/tests/component/EditRecurringModal.test.tsx
@@ -120,4 +120,33 @@ describe("EditRecurringModal", () => {
     expect(screen.getByText(/Mode and host changes apply to the whole series/)).toBeInTheDocument();
     expect(screen.queryByText(/Date changes apply to a single event or the whole series/)).not.toBeInTheDocument();
   });
+
+  // disableScoped: the caller has no occurrence context at all (e.g. Diagnostics Sync Issues
+  // panel) -- mirrors DeleteRecurringModal's disableScoped gate. Both scoped options are
+  // disabled and the choice is forced to 'all', but the modal still opens rather than silently
+  // applying scope 'all' behind the admin's back.
+  it("disables both scoped options, forces All events, and explains why when there's no occurrence context", () => {
+    render(<EditRecurringModal isOpen {...baseProps} disableScoped />);
+    expect(screen.getByLabelText("This event")).toBeDisabled();
+    expect(screen.getByLabelText("This and following events")).toBeDisabled();
+    expect(screen.getByLabelText("All events")).toBeChecked();
+    expect(screen.getByLabelText("All events")).toHaveFocus();
+    expect(screen.getByText(/Open the meeting from a calendar day to edit specific occurrences/)).toBeInTheDocument();
+  });
+
+  // disableScoped is the broadest gate (no occurrence context to scope against at all) -- takes
+  // precedence over the mode/host hint the same way that hint takes precedence over the
+  // narrower recurrence/date hints.
+  it("prefers the no-occurrence-context hint over the mode/host hint when both apply", () => {
+    render(<EditRecurringModal isOpen {...baseProps} disableScoped disableScopedEdits />);
+    expect(screen.getByText(/Open the meeting from a calendar day to edit specific occurrences/)).toBeInTheDocument();
+    expect(screen.queryByText(/Mode and host changes apply to the whole series/)).not.toBeInTheDocument();
+  });
+
+  it("only ever calls onSave with 'all' while disableScoped is set", () => {
+    const onSave = jest.fn();
+    render(<EditRecurringModal isOpen {...baseProps} onSave={onSave} disableScoped />);
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    expect(onSave).toHaveBeenCalledWith("all");
+  });
 });

--- a/frontend/tests/component/useMeetingDetailsSync.test.tsx
+++ b/frontend/tests/component/useMeetingDetailsSync.test.tsx
@@ -1,0 +1,145 @@
+import React from "react";
+import { render, act, waitFor } from "@testing-library/react";
+import { useMeetingDetailsSync } from "../../hooks/useMeetingDetailsSync";
+import { IMeeting } from "../../types/models";
+
+const meeting = (mid: string): IMeeting => ({
+  mid,
+  title: `Meeting ${mid}`,
+  description: "",
+  creator: "Creator",
+  group: "Group",
+  startDateTime: new Date("2026-08-24T18:00:00.000Z"),
+  endDateTime: new Date("2026-08-24T19:00:00.000Z"),
+  email: "seed@test.icr",
+  calType: ["AA"],
+  modeType: "In Person",
+  room: "Serenity Room",
+  status: "Active",
+  isRecurring: false,
+});
+
+const Harness: React.FC<{
+  selectedMeetingID: string | null;
+  refreshTrigger: number;
+  setSelectedMeeting: (meeting: IMeeting | null) => void;
+  setShowEditMeeting: (show: boolean) => void;
+  setLastClickedDate: (date: Date | null) => void;
+}> = (props) => {
+  useMeetingDetailsSync(props);
+  return null;
+};
+
+beforeEach(() => {
+  global.fetch = jest.fn();
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe("useMeetingDetailsSync", () => {
+  it("fetches and resets showEditMeeting when a new meeting is selected", async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => meeting("m-1"),
+    });
+    const setSelectedMeeting = jest.fn();
+    const setShowEditMeeting = jest.fn();
+    const setLastClickedDate = jest.fn();
+
+    render(
+      <Harness
+        selectedMeetingID="m-1"
+        refreshTrigger={0}
+        setSelectedMeeting={setSelectedMeeting}
+        setShowEditMeeting={setShowEditMeeting}
+        setLastClickedDate={setLastClickedDate}
+      />
+    );
+
+    await waitFor(() => expect(setSelectedMeeting).toHaveBeenCalledWith(meeting("m-1")));
+    expect(setShowEditMeeting).toHaveBeenCalledWith(false);
+  });
+
+  it("clears selection state when selectedMeetingID becomes null", () => {
+    const setSelectedMeeting = jest.fn();
+    const setShowEditMeeting = jest.fn();
+    const setLastClickedDate = jest.fn();
+
+    render(
+      <Harness
+        selectedMeetingID={null}
+        refreshTrigger={0}
+        setSelectedMeeting={setSelectedMeeting}
+        setShowEditMeeting={setShowEditMeeting}
+        setLastClickedDate={setLastClickedDate}
+      />
+    );
+
+    expect(setShowEditMeeting).toHaveBeenCalledWith(false);
+    expect(setSelectedMeeting).toHaveBeenCalledWith(null);
+    expect(setLastClickedDate).toHaveBeenCalledWith(null);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  // Regression: a background refresh of the meeting an admin already has open in Edit
+  // (the 30s calendar auto-poll, or a successful retry-sync) must refresh its data without
+  // forcing the panel back to View mode -- that would silently discard an in-progress edit,
+  // bypassing EditMeetingSidebar's own unsaved-changes confirmation entirely.
+  it("refreshes the same meeting's data on a refreshTrigger bump without resetting showEditMeeting", async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => meeting("m-1"),
+    });
+    const setSelectedMeeting = jest.fn();
+    const setShowEditMeeting = jest.fn();
+    const setLastClickedDate = jest.fn();
+
+    const { rerender } = render(
+      <Harness
+        selectedMeetingID="m-1"
+        refreshTrigger={0}
+        setSelectedMeeting={setSelectedMeeting}
+        setShowEditMeeting={setShowEditMeeting}
+        setLastClickedDate={setLastClickedDate}
+      />
+    );
+    await waitFor(() => expect(setSelectedMeeting).toHaveBeenCalledTimes(1));
+    setShowEditMeeting.mockClear();
+    setSelectedMeeting.mockClear();
+
+    await act(async () => {
+      rerender(
+        <Harness
+          selectedMeetingID="m-1"
+          refreshTrigger={1}
+          setSelectedMeeting={setSelectedMeeting}
+          setShowEditMeeting={setShowEditMeeting}
+          setLastClickedDate={setLastClickedDate}
+        />
+      );
+    });
+
+    await waitFor(() => expect(setSelectedMeeting).toHaveBeenCalledWith(meeting("m-1")));
+    expect(setShowEditMeeting).not.toHaveBeenCalled();
+  });
+
+  it("does not fetch on mount before any meeting is selected, even if refreshTrigger is nonzero", () => {
+    const setSelectedMeeting = jest.fn();
+    const setShowEditMeeting = jest.fn();
+    const setLastClickedDate = jest.fn();
+
+    render(
+      <Harness
+        selectedMeetingID={null}
+        refreshTrigger={3}
+        setSelectedMeeting={setSelectedMeeting}
+        setShowEditMeeting={setShowEditMeeting}
+        setLastClickedDate={setLastClickedDate}
+      />
+    );
+
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
@coderabbitai summary

## Description
- **frontend/app/components/meeting-form/EditMeeting.tsx**: `canScopeEdit` no longer requires `occurrenceDate`, so saving a recurring meeting always opens the scope dialog. Previously the Diagnostics mount sites (no occurrence context) skipped the dialog entirely and the update route defaulted the missing `editScope` to `'all'` — an admin fixing one occurrence's conflict silently rewrote the whole series.
- **frontend/app/components/meeting-form/EditRecurringModal.tsx**: new `disableScoped` prop mirroring `DeleteRecurringModal`'s existing gate — scoped options disabled, selection forced to "All events", with a hint to open the meeting from a calendar day for occurrence-scoped edits. Whole-series edits from Diagnostics are now an explicit, informed confirmation.
- **frontend/app/components/admin/diagnostics/ConflictList.tsx**: passes the conflict row's own occurrence (`ConflictMeetingSummary.occurrence`) as `occurrenceDate` — a real date the row is already about — so conflict-driven edits get full scoped editing.
- **frontend/app/components/admin/diagnostics/SyncIssuesCard.tsx**: sync status is series-level with no occurrence data, so this site keeps no `occurrenceDate` and gets the disabled-options dialog.
- **frontend/tests/component/** — `EditRecurringModal.test.tsx` (disableScoped behavior), `ConflictList.test.tsx` (new; occurrence pass-through), `EditMeeting.test.tsx` (rewrote the stale test that asserted the old skip-the-modal behavior).

## Testing
- [ ] `cd frontend && yarn test:component tests/component/EditRecurringModal.test.tsx tests/component/EditMeeting.test.tsx tests/component/ConflictList.test.tsx`
- [ ] Live: Admin → Diagnostics → Sync Issues → Edit a recurring meeting → Save: scope dialog appears with scoped options disabled and an explanatory hint; Conflicts-list edits offer full scope choices anchored to the conflicting occurrence.
- [ ] Full `yarn test:all` green locally on the stack.

## Area(s) Touched
**Product areas**
- [ ] auth — sign-in, sessions, NextAuth, role-based access
- [X] admin — /admin shell (Diagnostics, Users, Import, Export tabs)
- [ ] docs — /docs Resources page (rendering, navigation, search)
- [X] ui/ux — frontend layout/styling not tied to a specific integration

**Integrations**
- [ ] google-calendar — Google Calendar sync
- [ ] zoom-api — Zoom meeting/host sync

**Engineering**
- [ ] security — auth hardening, data exposure, dependency/security scanning
- [X] testing — test suite (Jest/Playwright) changes
- [ ] github-actions — workflows, Dependabot config, other .github/ CI tooling
- [ ] cleanup — refactor or dead-code removal, no behavior change
- [ ] documentation — docs/ or README changes only

## Pre-merge Checklist
- [x] Code follows current formatting conventions and passes lint (`yarn lint`).
- [x] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
- [ ] All test suites pass, both run locally and green in GitHub CI. **Do not merge if any test suite is failing.**
- [x] A test suite was added or updated for the feature/fix in this PR. **Double-check this if you change a feature and did not update the test suites**.
- [x] Only files relevant to this change are committed — no stray or unrelated files.
- [x] If this branch has a merge conflict with master, master was merged into this branch first (not the other way around).
- [x] The rest of this PR description (Description, Testing) is filled out, not left as template placeholders.
