### PR TITLE
fix(meetings): correct a count-bounded split's end date and give the child the remaining count

### DIFF
--- a/frontend/app/api/update/meeting/route.ts
+++ b/frontend/app/api/update/meeting/route.ts
@@ -13,7 +13,7 @@ import { lockResourceClaims, ResourceClaim } from "../../../../util/meetings/res
 import { meetingSchema, editScopeSchema } from "../../../../util/meetings/meetingValidation";
 import { reconcilePendingResume, tearDownPendingResumeSeries } from "../../../../util/meetings/suspension";
 import { calculateEndDateFromOccurrences } from "../../../../util/meetings/meetingOccurrences";
-import { EditScope, exclusionInstant, trimmedEndDate, isLiveOccurrence, rootSplitMid, toETDateStr } from "../../../../util/meetings/editScope";
+import { EditScope, countOccurrencesBefore, exclusionInstant, trimmedEndDate, isLiveOccurrence, rootSplitMid, toETDateStr } from "../../../../util/meetings/editScope";
 import { prisma } from "../../../../lib/prisma";
 
 // Runs after the response is sent (see after() call below) — failure updates googleSyncStatus
@@ -477,12 +477,34 @@ async function handleScopedEdit(
   const isRecurringSplit = scope === 'thisAndFollowing';
 
   let calculatedEndDate: Date | null = null;
+  // The count the child row stores for a count-bounded split -- null whenever the payload is
+  // endDate-bounded (or the split isn't recurring), in which case the payload's own value (if
+  // any) is persisted as-is below.
+  let childOccurrenceCount: number | null = null;
   if (isRecurringSplit) {
     const rp = newMeeting.recurrencePattern!;
     calculatedEndDate = rp.endDate ?? null;
     if (rp.numberOfOccurrences && !rp.endDate) {
+      // Remaining-count semantics (matching Google Calendar's this-and-following on a COUNT
+      // rule): an unchanged count-bounded pattern splits into "the rest of the series" -- a
+      // 6-occurrence series split at its 3rd occurrence leaves a 4-occurrence child, keeping
+      // the overall span the admin configured. Only when the admin actually edited the
+      // schedule shape or the count itself does the submitted count run in full from the
+      // split date -- they redefined the series, so their numbers win.
+      const parentRp = existingMeeting.recurrencePattern;
+      const sortedDays = (days: string[] | null | undefined) => [...(days ?? [])].sort().join(',');
+      const shapeUnchanged = !!parentRp &&
+        parentRp.type === rp.type &&
+        (parentRp.interval ?? 1) === (rp.interval ?? 1) &&
+        (parentRp.weekOfMonth ?? null) === (rp.weekOfMonth ?? null) &&
+        (parentRp.dayOfMonth ?? null) === (rp.dayOfMonth ?? null) &&
+        sortedDays(parentRp.daysOfWeek) === sortedDays(rp.daysOfWeek) &&
+        parentRp.numberOfOccurrences === rp.numberOfOccurrences;
+      childOccurrenceCount = shapeUnchanged
+        ? Math.max(1, rp.numberOfOccurrences - countOccurrencesBefore(parentRp!, occurrenceDate))
+        : rp.numberOfOccurrences;
       calculatedEndDate = calculateEndDateFromOccurrences(
-        occurrenceDate, rp.daysOfWeek || [], rp.numberOfOccurrences, rp.interval || 1,
+        occurrenceDate, rp.daysOfWeek || [], childOccurrenceCount, rp.interval || 1,
         rp.type, rp.weekOfMonth ?? null, rp.dayOfMonth ?? null,
       );
     }
@@ -627,7 +649,10 @@ async function handleScopedEdit(
                     type: newMeeting.recurrencePattern!.type,
                     startDate: occurrenceDate,
                     endDate: calculatedEndDate,
-                    numberOfOccurrences: newMeeting.recurrencePattern!.numberOfOccurrences ?? undefined,
+                    // The remaining/child count computed above, so the edit form ("After N
+                    // occurrences") and the endDate-driven popover/expansion agree on the
+                    // child's span instead of contradicting each other.
+                    numberOfOccurrences: childOccurrenceCount ?? newMeeting.recurrencePattern!.numberOfOccurrences ?? undefined,
                     daysOfWeek: newMeeting.recurrencePattern!.daysOfWeek ?? [],
                     firstDayOfWeek: newMeeting.recurrencePattern!.firstDayOfWeek,
                     interval: newMeeting.recurrencePattern!.interval,

--- a/frontend/tests/integration/update-meeting-scoped-edit.test.ts
+++ b/frontend/tests/integration/update-meeting-scoped-edit.test.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "crypto";
 import type { IMeeting } from "../../types/models";
-import { formatETWeekdayLong } from "../../util/date/timeUtils";
+import { formatETDateString, formatETWeekdayLong } from "../../util/date/timeUtils";
 
 // Same after() shim as update-meeting-route.test.ts -- Next's real after() throws outside a
 // request scope, and the deferred sync promise is already constructed (and running) by the time
@@ -429,6 +429,56 @@ test("a 'thisAndFollowing' trim on a count-bounded series survives a later whole
   const afterReEdit = await prisma.recurrencePattern.findUnique({ where: { mid: meeting.mid } });
   expect(afterReEdit?.numberOfOccurrences).toBeNull();
   expect(afterReEdit?.endDate?.getTime()).toBe(trimmedEndDate);
+});
+
+test("'thisAndFollowing' on an unchanged count-bounded series gives the child the REMAINING count, not a fresh full run", async () => {
+  // A 6-occurrence series split at its 4th occurrence leaves a 3-occurrence child (the 4th,
+  // 5th, and 6th), keeping the overall span the admin configured -- Google Calendar's
+  // this-and-following semantics for a COUNT rule.
+  const { meeting } = await seedWeeklySeries();
+  const prisma = getTestPrismaClient();
+  await prisma.recurrencePattern.update({
+    where: { mid: meeting.mid },
+    data: { numberOfOccurrences: 6, endDate: null },
+  });
+
+  const occurrenceDate = occurrence(3).start;
+  const response = await putMeeting(scopedPayload(meeting.mid, "thisAndFollowing", occurrenceDate, {
+    recurrencePattern: {
+      type: "weekly", startDate: occurrenceDate, daysOfWeek: [SERIES_WEEKDAY], firstDayOfWeek: "Sunday", interval: 1,
+      numberOfOccurrences: 6,
+    },
+  }));
+  expect(response.status).toBe(200);
+  const body = await response.json();
+
+  const childPattern = await waitFor(async () => prisma.recurrencePattern.findUnique({ where: { mid: body.newMid } }));
+  expect(childPattern?.numberOfOccurrences).toBe(3);
+  // Last occurrence = the split date + 2 more weeks, i.e. the original series' own 6th slot.
+  expect(formatETDateString(childPattern!.endDate!)).toBe(formatETDateString(occurrence(5).start));
+});
+
+test("'thisAndFollowing' with an admin-changed count runs that count in full from the split date", async () => {
+  const { meeting } = await seedWeeklySeries();
+  const prisma = getTestPrismaClient();
+  await prisma.recurrencePattern.update({
+    where: { mid: meeting.mid },
+    data: { numberOfOccurrences: 6, endDate: null },
+  });
+
+  const occurrenceDate = occurrence(3).start;
+  const response = await putMeeting(scopedPayload(meeting.mid, "thisAndFollowing", occurrenceDate, {
+    recurrencePattern: {
+      type: "weekly", startDate: occurrenceDate, daysOfWeek: [SERIES_WEEKDAY], firstDayOfWeek: "Sunday", interval: 1,
+      numberOfOccurrences: 8,
+    },
+  }));
+  expect(response.status).toBe(200);
+  const body = await response.json();
+
+  const childPattern = await waitFor(async () => prisma.recurrencePattern.findUnique({ where: { mid: body.newMid } }));
+  expect(childPattern?.numberOfOccurrences).toBe(8);
+  expect(formatETDateString(childPattern!.endDate!)).toBe(formatETDateString(new Date(occurrenceDate.getTime() + 7 * WEEK_MS)));
 });
 
 test("a lineage chain propagates the ROOT mid, not the immediate parent's mid", async () => {

--- a/frontend/tests/unit/editScope.test.ts
+++ b/frontend/tests/unit/editScope.test.ts
@@ -1,4 +1,4 @@
-import { toETDateStr, exclusionInstant, trimmedEndDate, isLiveOccurrence, rootSplitMid } from "../../util/meetings/editScope";
+import { toETDateStr, exclusionInstant, trimmedEndDate, isLiveOccurrence, countOccurrencesBefore, rootSplitMid } from "../../util/meetings/editScope";
 
 describe("toETDateStr", () => {
   test("formats a UTC instant as its Eastern-Time calendar date", () => {
@@ -57,6 +57,42 @@ describe("isLiveOccurrence", () => {
   test("false for an excluded date even though it otherwise matches", () => {
     const withExclusion = { ...weeklyPattern, excludedDates: [new Date("2026-06-15T18:00:00Z")] };
     expect(isLiveOccurrence(withExclusion, new Date("2026-06-15T18:00:00Z"))).toBe(false);
+  });
+});
+
+describe("countOccurrencesBefore", () => {
+  const weeklyPattern = {
+    type: "weekly",
+    startDate: new Date("2026-06-01T18:00:00Z"), // a Monday
+    endDate: null,
+    interval: 1,
+    daysOfWeek: ["Monday"],
+    weekOfMonth: null,
+    dayOfMonth: null,
+    excludedDates: [] as Date[],
+  };
+
+  test("zero for the series' first occurrence", () => {
+    expect(countOccurrencesBefore(weeklyPattern, new Date("2026-06-01T18:00:00Z"))).toBe(0);
+  });
+
+  test("counts each prior weekly occurrence", () => {
+    expect(countOccurrencesBefore(weeklyPattern, new Date("2026-06-22T18:00:00Z"))).toBe(3);
+  });
+
+  test("excluded dates still count toward the total (COUNT semantics)", () => {
+    const withExclusion = { ...weeklyPattern, excludedDates: [new Date("2026-06-08T18:00:00Z")] };
+    expect(countOccurrencesBefore(withExclusion, new Date("2026-06-22T18:00:00Z"))).toBe(3);
+  });
+
+  test("a trimmed endDate before the target does not stop the count", () => {
+    const trimmed = { ...weeklyPattern, endDate: new Date("2026-06-08T23:59:59Z") };
+    expect(countOccurrencesBefore(trimmed, new Date("2026-06-22T18:00:00Z"))).toBe(3);
+  });
+
+  test("respects a biweekly interval", () => {
+    const biweekly = { ...weeklyPattern, interval: 2 };
+    expect(countOccurrencesBefore(biweekly, new Date("2026-06-29T18:00:00Z"))).toBe(2);
   });
 });
 

--- a/frontend/tests/unit/meetingOccurrences.test.ts
+++ b/frontend/tests/unit/meetingOccurrences.test.ts
@@ -122,6 +122,36 @@ describe("adjustOccurrenceToDate", () => {
   });
 });
 
+describe("calculateEndDateFromOccurrences — weekly month rollover", () => {
+  // Regression: the weekly loop reused one Date across iterations, so once an intermediate
+  // occurrence rolled into the next month, later setUTCDate offsets were interpreted against
+  // the rolled month — a 6-occurrence Tuesday series from Sept 15, 2026 reported an end of
+  // Dec 20 instead of Oct 20.
+  it("stays week-aligned when intermediate occurrences cross a month boundary", () => {
+    const endDate = calculateEndDateFromOccurrences(
+      new Date("2026-09-15T18:00:00Z"), // a Tuesday, 2 PM ET
+      ["Tuesday"], 6, 1, "weekly", null, null,
+    );
+    expect(formatETDateString(endDate)).toBe("2026-10-20");
+  });
+
+  it("handles a span crossing two month boundaries", () => {
+    const endDate = calculateEndDateFromOccurrences(
+      new Date("2026-09-15T18:00:00Z"),
+      ["Tuesday"], 10, 1, "weekly", null, null,
+    );
+    expect(formatETDateString(endDate)).toBe("2026-11-17");
+  });
+
+  it("is unaffected when only the final occurrence crosses the boundary", () => {
+    const endDate = calculateEndDateFromOccurrences(
+      new Date("2026-09-01T18:00:00Z"), // a Tuesday, 2 PM ET
+      ["Tuesday"], 6, 1, "weekly", null, null,
+    );
+    expect(formatETDateString(endDate)).toBe("2026-10-06");
+  });
+});
+
 describe("calculateEndDateFromOccurrences — monthly day-of-month clamping", () => {
   // Regression: a "day 31" monthly pattern whose Nth occurrence lands in a shorter month (e.g.
   // February) used to build an out-of-range calendar date string like "2026-02-31" -- which

--- a/frontend/util/meetings/editScope.ts
+++ b/frontend/util/meetings/editScope.ts
@@ -3,7 +3,7 @@
 // route.ts already uses (its own toETDateStr + getETDayBounds) so both routes agree on exactly
 // which instant an occurrence's ET calendar day starts at.
 import { getETDayBounds } from "../date/timeUtils";
-import { matchesRecurrencePattern } from "./recurrenceMatch";
+import { addOneETDay, matchesRecurrencePattern } from "./recurrenceMatch";
 
 export type EditScope = 'this' | 'thisAndFollowing' | 'all';
 
@@ -46,6 +46,22 @@ export const isLiveOccurrence = (pattern: RecurrencePatternLike, occurrenceDate:
   const [year, month, day] = etDateStr.split('-').map(Number);
   const localDate = new Date(Date.UTC(year, month - 1, day));
   return matchesRecurrencePattern(pattern, etDateStr, localDate);
+};
+
+// How many occurrences `pattern` produces STRICTLY BEFORE occurrenceDate's ET calendar day.
+// Exclusions and endDate are deliberately ignored: COUNT semantics (RRULE's, and how
+// calculateEndDateFromOccurrences resolves a count into an endDate at create time) allocate one
+// slot per pattern date regardless of later EXDATEs/trims, so a split-off child's remaining
+// count stays anchored to the original allocation.
+export const countOccurrencesBefore = (pattern: RecurrencePatternLike, occurrenceDate: Date): number => {
+  const countingPattern = { ...pattern, endDate: null, excludedDates: [] };
+  const target = toETDateStr(occurrenceDate);
+  let count = 0;
+  for (let etDateStr = toETDateStr(new Date(pattern.startDate)); etDateStr < target; etDateStr = addOneETDay(etDateStr)) {
+    const [year, month, day] = etDateStr.split('-').map(Number);
+    if (matchesRecurrencePattern(countingPattern, etDateStr, new Date(Date.UTC(year, month - 1, day)))) count++;
+  }
+  return count;
 };
 
 // The root mid a lineage chain shares: a meeting produced by an earlier split already carries

--- a/frontend/util/meetings/meetingOccurrences.ts
+++ b/frontend/util/meetings/meetingOccurrences.ts
@@ -288,6 +288,11 @@ export function calculateEndDateFromOccurrences(
             while (nextDayIndex < recurrenceDays.length) {
                 const daysToAdd = (currentWeek * 7) +
                     (recurrenceDays[nextDayIndex] - startDayOfWeek + 7) % 7;
+                // Re-anchor to patternStartDate before the day-offset write: setUTCDate
+                // interprets its argument against endDate's CURRENT month, so once a prior
+                // iteration rolled endDate into the next month, a cumulative offset lands
+                // "day 43 of October" (= Nov 12) instead of Sept 15 + 42 days (= Oct 27).
+                endDate.setTime(patternStartDate.getTime());
                 endDate.setUTCDate(patternStartDate.getUTCDate() + daysToAdd);
                 occurrenceCount++;
                 nextDayIndex++;


### PR DESCRIPTION
@coderabbitai summary

## Description
Found by the 2026-08-21 scoped-edit UX audit: a "This and following" split of a 6-occurrence weekly series reported "Ends December 20" (~11 weeks past the intended end) with a verified 7th occurrence on the calendar, while the same series' edit form said "After 6 occurrences."

- **frontend/util/meetings/meetingOccurrences.ts**: the weekly branch of `calculateEndDateFromOccurrences` reused one `Date` across loop iterations, so once an intermediate occurrence rolled into the next month, later `setUTCDate` offsets were interpreted against the rolled month ("day 50 of November" = Dec 20 instead of Sept 15 + 35 days = Oct 20). Each occurrence now re-anchors to the pattern start first. This also fixes *creating* count-bounded weekly series whose intermediate occurrences straddle a month boundary — the same helper resolves the persisted end date on the write path.
- **frontend/app/api/update/meeting/route.ts**: a `thisAndFollowing` split previously ran the payload's full count from the split date (6-occurrence series split at the 4th → another 6 occurrences). When the admin didn't change the recurrence shape or count, the child now gets the *remaining* count (→ 3), matching Google Calendar's this-and-following semantics for COUNT rules; an explicitly changed count still runs in full from the split date. The child row stores the count actually used, so the edit form ("After N occurrences") and the popover's end date agree.
- **frontend/util/meetings/editScope.ts**: new `countOccurrencesBefore` helper — occurrences strictly before the split date, with exclusions/trims deliberately ignored (RRULE COUNT semantics: an EXDATE consumes its slot).
- **frontend/tests/**: calculator month-rollover regression tests (`meetingOccurrences.test.ts`), `countOccurrencesBefore` unit tests (`editScope.test.ts`), and two integration tests for the remaining-count vs changed-count split semantics (`update-meeting-scoped-edit.test.ts`).

## Testing
- [ ] `cd frontend && yarn test:unit --runTestsByPath tests/unit/meetingOccurrences.test.ts tests/unit/editScope.test.ts`
- [ ] `cd frontend && yarn test:integration --runTestsByPath tests/integration/update-meeting-scoped-edit.test.ts`
- [ ] Live repro: create a weekly meeting ending "after 6 occurrences", edit a middle occurrence → "This and following": the new series' popover end date now matches the original span and the calendar shows no extra occurrences.
- [ ] Full `yarn test:all` green locally (121/121 e2e).

## Area(s) Touched
**Product areas**
- [ ] auth — sign-in, sessions, NextAuth, role-based access
- [ ] admin — /admin shell (Diagnostics, Users, Import, Export tabs)
- [ ] docs — /docs Resources page (rendering, navigation, search)
- [ ] ui/ux — frontend layout/styling not tied to a specific integration

**Integrations**
- [ ] google-calendar — Google Calendar sync
- [ ] zoom-api — Zoom meeting/host sync

**Engineering**
- [ ] security — auth hardening, data exposure, dependency/security scanning
- [X] testing — test suite (Jest/Playwright) changes
- [ ] github-actions — workflows, Dependabot config, other .github/ CI tooling
- [ ] cleanup — refactor or dead-code removal, no behavior change
- [ ] documentation — docs/ or README changes only

## Pre-merge Checklist
- [x] Code follows current formatting conventions and passes lint (`yarn lint`).
- [x] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
- [ ] All test suites pass, both run locally and green in GitHub CI. **Do not merge if any test suite is failing.**
- [x] A test suite was added or updated for the feature/fix in this PR. **Double-check this if you change a feature and did not update the test suites**.
- [x] Only files relevant to this change are committed — no stray or unrelated files.
- [x] If this branch has a merge conflict with master, master was merged into this branch first (not the other way around).
- [x] The rest of this PR description (Description, Testing) is filled out, not left as template placeholders.
