### PR TITLE
fix(meeting-form): keep the occurrence hint's sentence in one flex item

### DIFF
--- a/frontend/app/components/meeting-form/EditMeeting.tsx
+++ b/frontend/app/components/meeting-form/EditMeeting.tsx
@@ -319,8 +319,13 @@ const EditMeetingSidebar: React.FC<EditMeetingSidebarProps> =
         {showOccurrenceDateHint && (
           <p className={styles.occurrenceHint}>
             <Icon name="warning-circle" size={16} />
-            You opened this meeting from its {formatETLongDate(occurrenceDate as Date)} occurrence.
-            The date below is the series&apos; start date, not this occurrence.
+            {/* One span = one flex item: bare text children would each become their own
+                anonymous item, and the whitespace at their boundaries (around the date)
+                collapses away visually. */}
+            <span>
+              You opened this meeting from its {formatETLongDate(occurrenceDate as Date)} occurrence.
+              The date below is the series&apos; start date, not this occurrence.
+            </span>
           </p>
         )}
         <MeetingForm

--- a/frontend/tests/component/EditMeeting.test.tsx
+++ b/frontend/tests/component/EditMeeting.test.tsx
@@ -88,8 +88,11 @@ describe("EditMeetingSidebar mid-series occurrence hint", () => {
   it("shows a hint when the clicked occurrence differs from the series' start date", async () => {
     renderEdit();
     await act(async () => {});
-    expect(screen.getByText(/You opened this meeting from its/)).toBeInTheDocument();
-    expect(screen.getByText(/August 9, 2026/)).toBeInTheDocument();
+    // The whole sentence must be ONE element (a span inside the flex hint): bare text
+    // children of the flex <p> become separate anonymous flex items, and the spaces at
+    // their boundaries (around the date) collapse away visually.
+    const sentence = screen.getByText(/You opened this meeting from its August 9, 2026 occurrence\./);
+    expect(sentence.tagName).toBe("SPAN");
   });
 
   it("shows no hint when there's no occurrence context", async () => {


### PR DESCRIPTION
@coderabbitai summary

## Description
- **frontend/app/components/meeting-form/EditMeeting.tsx**: the occurrence-date hint rendered "August 21, 2026occurrence" — the hint `<p>` is a flex container, so its bare text children become separate anonymous flex items and the whitespace at their boundaries (around the interpolated date) collapses away visually. The sentence is now wrapped in a single `<span>`, one flex item beside the icon. The DOM text always had the spaces; the loss was purely visual, which is why component tests never caught it.
- **frontend/tests/component/EditMeeting.test.tsx**: the hint test now asserts the full sentence (date included) resolves within one SPAN element.

## Testing
- [ ] `cd frontend && yarn test:component --runTestsByPath tests/component/EditMeeting.test.tsx` (16/16)
- [ ] Live: open a recurring meeting from a mid-series occurrence → Edit; the hint reads "…from its August 21, 2026 occurrence." with correct spacing.

## Area(s) Touched
**Product areas**
- [ ] auth — sign-in, sessions, NextAuth, role-based access
- [ ] admin — /admin shell (Diagnostics, Users, Import, Export tabs)
- [ ] docs — /docs Resources page (rendering, navigation, search)
- [X] ui/ux — frontend layout/styling not tied to a specific integration

**Integrations**
- [ ] google-calendar — Google Calendar sync
- [ ] zoom-api — Zoom meeting/host sync

**Engineering**
- [ ] security — auth hardening, data exposure, dependency/security scanning
- [X] testing — test suite (Jest/Playwright) changes
- [ ] github-actions — workflows, Dependabot config, other .github/ CI tooling
- [ ] cleanup — refactor or dead-code removal, no behavior change
- [ ] documentation — docs/ or README changes only

## Pre-merge Checklist
- [x] Code follows current formatting conventions and passes lint (`yarn lint`).
- [x] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
- [ ] All test suites pass, both run locally and green in GitHub CI. **Do not merge if any test suite is failing.**
- [x] A test suite was added or updated for the feature/fix in this PR. **Double-check this if you change a feature and did not update the test suites**.
- [x] Only files relevant to this change are committed — no stray or unrelated files.
- [x] If this branch has a merge conflict with master, master was merged into this branch first (not the other way around).
- [x] The rest of this PR description (Description, Testing) is filled out, not left as template placeholders.
