### PR TITLE
chore(dependabot): drop the next 16.3.x ignore rule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,11 +11,6 @@ updates:
       prefix-development: "chore"  # Prefixes dev dependency updates (e.g., chore(deps-dev): ...)
       include: "scope"             # Formats as chore(deps): instead of just chore: 
     open-pull-requests-limit: 10
-    ignore:
-      # Next 16.3.x reintroduces the e2e deep-link hydration regression (#320/#341/#342, §1.5j);
-      # pinned below 16.3.0 until a release passes that suite.
-      - dependency-name: "next"
-        versions: ["16.3.x"]
     groups:
       # Patch and minor bumps (prod or dev) are safe to auto-merge unattended once CI is
       # green (see dependabot-auto-merge.yml) -- only major bumps are left as individual


### PR DESCRIPTION
@coderabbitai summary

## Description
- **.github/dependabot.yml**: drop the `ignore` rule that blocked `next` 16.3.x updates. The "regression" it guarded against (#320/#341/#342/#378, e2e §1.5j) was root-caused to a replay-unsafe effect guard in our own code — fixed in #544 — and master is already on `next@16.3.2` via #545, so the rule now only silently hides future 16.3.x releases from Dependabot.

## Testing
- [x] YAML-only config change; the rule's removal is verified by master already running `next@16.3.2` green through full CI (#545). Dependabot's next weekly run will confirm 16.3.x/16.4.x bumps flow again.

## Area(s) Touched
**Product areas**
- [ ] auth — sign-in, sessions, NextAuth, role-based access
- [ ] admin — /admin shell (Diagnostics, Users, Import, Export tabs)
- [ ] docs — /docs Resources page (rendering, navigation, search)
- [ ] ui/ux — frontend layout/styling not tied to a specific integration

**Integrations**
- [ ] google-calendar — Google Calendar sync
- [ ] zoom-api — Zoom meeting/host sync

**Engineering**
- [ ] security — auth hardening, data exposure, dependency/security scanning
- [ ] testing — test suite (Jest/Playwright) changes
- [x] github-actions — workflows, Dependabot config, other .github/ CI tooling
- [ ] cleanup — refactor or dead-code removal, no behavior change
- [ ] documentation — docs/ or README changes only

## Pre-merge Checklist
- [x] Code follows current formatting conventions and passes lint (`yarn lint`).
- [x] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
- [x] All test suites pass, both run locally and green in GitHub CI. **Do not merge if any test suite is failing.**
- [ ] A test suite was added or updated for the feature/fix in this PR. <!-- N/A: CI config only, no testable app behavior --> **Double-check this if you change a feature and did not update the test suites**.
- [x] Only files relevant to this change are committed — no stray or unrelated files.
- [ ] If this branch has a merge conflict with master, master was merged into this branch first (not the other way around).
- [x] The rest of this PR description (Description, Testing) is filled out, not left as template placeholders.
