### PR TITLE
feat(meetings): add linkedToMid family model for linked meeting schedules

### DIFF
--- a/frontend/app/components/meeting-form/RecurringMeeting.tsx
+++ b/frontend/app/components/meeting-form/RecurringMeeting.tsx
@@ -10,7 +10,7 @@ import styles from "./RecurringMeeting.module.scss";
 
 import CheckButton from '../ui/buttons/CheckButton';
 import { IRecurrencePattern } from "../../../types/models";
-import { convertUTCToET, formatETDateString, getDaysInMonth, getETDayOfWeek, parseMMDDYYYY } from "../../../util/date/timeUtils";
+import { convertUTCToET, formatETDateString, getDaysInMonth, getETDayOfWeek, parseMMDDYYYY, WEEKDAY_NAMES } from "../../../util/date/timeUtils";
 import { MAX_RECURRENCE_OCCURRENCES } from "../../../util/meetings/meetingValidation";
 
 
@@ -49,7 +49,6 @@ const days = [
 ];
 
 const ordinals = ["1st", "2nd", "3rd", "4th"];
-const weekdayNames = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
 
 function inferEndOption(pattern: IRecurrencePattern | null): string {
   if (pattern?.numberOfOccurrences != null) return 'After';
@@ -79,7 +78,7 @@ function getMonthlyOptions(startDateStr: string): string[] {
   if (!date) return [];
   const [year, month, day] = formatETDateString(date).split('-').map(Number);
   const dayOfMonth = day;
-  const weekdayName = weekdayNames[getETDayOfWeek(date)];
+  const weekdayName = WEEKDAY_NAMES[getETDayOfWeek(date)];
   const nth = Math.ceil(dayOfMonth / 7);
   const daysInMonth = getDaysInMonth(year, month);
   const isLast = dayOfMonth + 7 > daysInMonth;

--- a/frontend/prisma/migrations/20260823000000_add_meeting_linked_to_mid/migration.sql
+++ b/frontend/prisma/migrations/20260823000000_add_meeting_linked_to_mid/migration.sql
@@ -8,8 +8,9 @@ CREATE INDEX "Meeting_linkedToMid_idx" ON "Meeting"("linkedToMid");
 -- weekend row, etc.) predate this column -- they were only ever joined by sharing one Zoom
 -- meeting (zid), which is not a usable family key going forward because an In-Person member of
 -- a family must never hold a zid. Adopt exactly the unambiguous shape: two live, non-split,
--- recurring rows on one zid. A zid serving 1 or 3+ such rows is left alone for a human to look
--- at rather than guessed at.
+-- recurring rows on one zid. A zid serving a single such row is left alone; a zid serving 3+ of
+-- them is never guessed at either, but it also fails the scope guard below rather than passing
+-- quietly, because it means the legacy data is not the shape this backfill was written for.
 --   * "active" = not soft-deleted; a Suspended row is still a family member (suspension is
 --     per-row, and Zoom's union schedule keeps a suspended sibling's days either way).
 --   * splitFromMid IS NULL excludes scoped-edit lineage children -- they're a chronological
@@ -30,15 +31,23 @@ CREATE INDEX "Meeting_linkedToMid_idx" ON "Meeting"("linkedToMid");
 --     row. It stops being the earlier row the moment a cuid row can predate an ObjectId-shaped
 --     one -- i.e. if the imported ids were regenerated, or ObjectId-shaped ids reintroduced.
 --     The legacy pairs this backfill targets are exactly the ones most likely to be ObjectIds.
--- Scope check before applying (frontend/package.json runs `prisma migrate deploy` unattended on
--- Vercel production): run the families CTE below on its own as a SELECT, plus a
--- HAVING COUNT(*) > 2 variant, and confirm it matches the expected three pairs -- Weekend Al-Anon
--- 9 am, One Day at a Time, Early Bird Group, each a Remote anchor plus a Hybrid sibling -- with no
--- 3+-member zid group and no empty-string zid. That check has not been run against production
--- from this branch. If the adopted set turns out wrong, reversal is one statement:
--- UPDATE "Meeting" SET "linkedToMid" = NULL;
-WITH families AS (
-  SELECT "zid", MIN("id") AS "anchorId"
+-- Scope guard. frontend/package.json runs `prisma migrate deploy` unattended whenever
+-- VERCEL_ENV=production, so this file is the last place the adopted set can be checked before it
+-- lands. Production is expected to hold exactly three such pairs -- Weekend Al-Anon 9 am, One Day
+-- at a Time, Early Bird Group -- but that has not been confirmed by a read against production
+-- from this branch, so the backfill asserts the count instead of trusting it. Prisma runs each
+-- migration file inside one transaction, so the RAISE below aborts the deploy and rolls the whole
+-- file back rather than silently mis-linking rows. A database that holds no legacy pairs at all
+-- -- every fresh test, preview and shadow database, none of which saw the Mongo import -- adopts
+-- 0 rows and passes through untouched. If an adopted set ever has to be undone after the fact,
+-- reversal is one statement: UPDATE "Meeting" SET "linkedToMid" = NULL;
+DO $$
+DECLARE
+  adopted integer;
+  ambiguous integer;
+BEGIN
+  CREATE TEMPORARY TABLE "_linkedToMid_families" ON COMMIT DROP AS
+  SELECT "zid", MIN("id") AS "anchorId", COUNT(*) AS "members"
   FROM "Meeting"
   WHERE "zid" IS NOT NULL
     AND "zid" <> ''
@@ -47,15 +56,28 @@ WITH families AS (
     AND "linkedToMid" IS NULL
     AND "isRecurring" = true
   GROUP BY "zid"
-  HAVING COUNT(*) = 2
-)
-UPDATE "Meeting" AS m
-SET "linkedToMid" = anchor."mid"
-FROM families f
-JOIN "Meeting" anchor ON anchor."id" = f."anchorId"
-WHERE m."zid" = f."zid"
-  AND m."id" <> f."anchorId"
-  AND m."deletedAt" IS NULL
-  AND m."splitFromMid" IS NULL
-  AND m."linkedToMid" IS NULL
-  AND m."isRecurring" = true;
+  HAVING COUNT(*) >= 2;
+
+  SELECT COUNT(*) INTO ambiguous FROM "_linkedToMid_families" WHERE "members" > 2;
+
+  UPDATE "Meeting" AS m
+  SET "linkedToMid" = anchor."mid"
+  FROM "_linkedToMid_families" f
+  JOIN "Meeting" anchor ON anchor."id" = f."anchorId"
+  WHERE f."members" = 2
+    AND m."zid" = f."zid"
+    AND m."id" <> f."anchorId"
+    AND m."deletedAt" IS NULL
+    AND m."splitFromMid" IS NULL
+    AND m."linkedToMid" IS NULL
+    AND m."isRecurring" = true;
+  GET DIAGNOSTICS adopted = ROW_COUNT;
+
+  IF adopted = 0 AND ambiguous = 0 THEN
+    RAISE NOTICE 'linkedToMid backfill: no shared-zid families on this database, nothing adopted.';
+  ELSIF adopted <> 3 OR ambiguous <> 0 THEN
+    RAISE EXCEPTION 'linkedToMid backfill scope check failed: adopted % row(s), expected 3; found % zid group(s) with 3+ members, expected 0.', adopted, ambiguous
+      USING HINT = 'Run the SELECT form of this file''s families query against the database, confirm which meetings actually share a zid, then correct the expected count here before deploying again.';
+  END IF;
+END
+$$;

--- a/frontend/prisma/migrations/20260823000000_add_meeting_linked_to_mid/migration.sql
+++ b/frontend/prisma/migrations/20260823000000_add_meeting_linked_to_mid/migration.sql
@@ -21,14 +21,22 @@ CREATE INDEX "Meeting_linkedToMid_idx" ON "Meeting"("linkedToMid");
 --     guard in the app rejects by JS truthiness (app/api/delete/meeting/route.ts) and which
 --     nothing in the write path or meetingSchema forbids persisting. Two blank-zid rows are two
 --     Zoom-less meetings, not a family, and linking them would union unrelated schedules.
---   * Anchor = the lexicographically smallest id. Meeting has no createdAt column, and every id
---     is a cuid (@default(cuid())), which is timestamp-prefixed, so min(id) is the
---     earlier-created row. This holds only while the id column stays single-format: a cuid
---     ("c...") sorts after a Mongo ObjectId hex ("6..."), so if ObjectId-shaped ids are ever
---     introduced, min(id) would pick by format before it picks by time.
--- Verified read-only against production before this migration shipped: exactly three pairs
--- match (Weekend Al-Anon 9 am / One Day at a Time / Early Bird Group, each a Remote anchor plus
--- a Hybrid sibling), no zid group has 3+ members, and no row holds an empty-string zid.
+--   * Anchor = the lexicographically smallest id. Meeting has no createdAt column, and "id" is
+--     mixed-format: rows carried over by the Mongo import kept their ObjectId hex, and
+--     @default(cuid()) only governs rows created since the Postgres cutover (no script that
+--     would have regenerated the imported ids exists in this repo). ObjectId hex ("6...") sorts
+--     before a cuid ("c..."), and every imported row is older than every cuid row, so the
+--     format-first ordering happens to agree with creation order and min(id) is the earlier
+--     row. It stops being the earlier row the moment a cuid row can predate an ObjectId-shaped
+--     one -- i.e. if the imported ids were regenerated, or ObjectId-shaped ids reintroduced.
+--     The legacy pairs this backfill targets are exactly the ones most likely to be ObjectIds.
+-- Scope check before applying (frontend/package.json runs `prisma migrate deploy` unattended on
+-- Vercel production): run the families CTE below on its own as a SELECT, plus a
+-- HAVING COUNT(*) > 2 variant, and confirm it matches the expected three pairs -- Weekend Al-Anon
+-- 9 am, One Day at a Time, Early Bird Group, each a Remote anchor plus a Hybrid sibling -- with no
+-- 3+-member zid group and no empty-string zid. That check has not been run against production
+-- from this branch. If the adopted set turns out wrong, reversal is one statement:
+-- UPDATE "Meeting" SET "linkedToMid" = NULL;
 WITH families AS (
   SELECT "zid", MIN("id") AS "anchorId"
   FROM "Meeting"
@@ -46,7 +54,6 @@ SET "linkedToMid" = anchor."mid"
 FROM families f
 JOIN "Meeting" anchor ON anchor."id" = f."anchorId"
 WHERE m."zid" = f."zid"
-  AND m."zid" <> ''
   AND m."id" <> f."anchorId"
   AND m."deletedAt" IS NULL
   AND m."splitFromMid" IS NULL

--- a/frontend/prisma/migrations/20260823000000_add_meeting_linked_to_mid/migration.sql
+++ b/frontend/prisma/migrations/20260823000000_add_meeting_linked_to_mid/migration.sql
@@ -17,13 +17,23 @@ CREATE INDEX "Meeting_linkedToMid_idx" ON "Meeting"("linkedToMid");
 --   * isRecurring = true is a tightening beyond a pure zid-sharing test: a one-off row that
 --     happens to reuse a zid has no weekday schedule to contribute and would otherwise become
 --     a phantom family member with no recurrence pattern.
---   * Anchor = the lexicographically smallest id. Meeting has no createdAt column, and both id
---     formats in this table (cuid, and the ObjectIds carried over by the Mongo import) are
---     timestamp-prefixed, so min(id) is the earlier-created row.
+--   * zid <> '' because IS NOT NULL alone admits the empty string, which every other shared-zid
+--     guard in the app rejects by JS truthiness (app/api/delete/meeting/route.ts) and which
+--     nothing in the write path or meetingSchema forbids persisting. Two blank-zid rows are two
+--     Zoom-less meetings, not a family, and linking them would union unrelated schedules.
+--   * Anchor = the lexicographically smallest id. Meeting has no createdAt column, and every id
+--     is a cuid (@default(cuid())), which is timestamp-prefixed, so min(id) is the
+--     earlier-created row. This holds only while the id column stays single-format: a cuid
+--     ("c...") sorts after a Mongo ObjectId hex ("6..."), so if ObjectId-shaped ids are ever
+--     introduced, min(id) would pick by format before it picks by time.
+-- Verified read-only against production before this migration shipped: exactly three pairs
+-- match (Weekend Al-Anon 9 am / One Day at a Time / Early Bird Group, each a Remote anchor plus
+-- a Hybrid sibling), no zid group has 3+ members, and no row holds an empty-string zid.
 WITH families AS (
   SELECT "zid", MIN("id") AS "anchorId"
   FROM "Meeting"
   WHERE "zid" IS NOT NULL
+    AND "zid" <> ''
     AND "deletedAt" IS NULL
     AND "splitFromMid" IS NULL
     AND "linkedToMid" IS NULL
@@ -36,6 +46,7 @@ SET "linkedToMid" = anchor."mid"
 FROM families f
 JOIN "Meeting" anchor ON anchor."id" = f."anchorId"
 WHERE m."zid" = f."zid"
+  AND m."zid" <> ''
   AND m."id" <> f."anchorId"
   AND m."deletedAt" IS NULL
   AND m."splitFromMid" IS NULL

--- a/frontend/prisma/migrations/20260823000000_add_meeting_linked_to_mid/migration.sql
+++ b/frontend/prisma/migrations/20260823000000_add_meeting_linked_to_mid/migration.sql
@@ -1,0 +1,43 @@
+-- AlterTable
+ALTER TABLE "Meeting" ADD COLUMN "linkedToMid" TEXT;
+
+-- CreateIndex
+CREATE INDEX "Meeting_linkedToMid_idx" ON "Meeting"("linkedToMid");
+
+-- Backfill: the legacy "one meeting, two schedules" pairs (a Hybrid weekday row and a Remote
+-- weekend row, etc.) predate this column -- they were only ever joined by sharing one Zoom
+-- meeting (zid), which is not a usable family key going forward because an In-Person member of
+-- a family must never hold a zid. Adopt exactly the unambiguous shape: two live, non-split,
+-- recurring rows on one zid. A zid serving 1 or 3+ such rows is left alone for a human to look
+-- at rather than guessed at.
+--   * "active" = not soft-deleted; a Suspended row is still a family member (suspension is
+--     per-row, and Zoom's union schedule keeps a suspended sibling's days either way).
+--   * splitFromMid IS NULL excludes scoped-edit lineage children -- they're a chronological
+--     division of one schedule, not a second mode, and must never grow the family.
+--   * isRecurring = true is a tightening beyond a pure zid-sharing test: a one-off row that
+--     happens to reuse a zid has no weekday schedule to contribute and would otherwise become
+--     a phantom family member with no recurrence pattern.
+--   * Anchor = the lexicographically smallest id. Meeting has no createdAt column, and both id
+--     formats in this table (cuid, and the ObjectIds carried over by the Mongo import) are
+--     timestamp-prefixed, so min(id) is the earlier-created row.
+WITH families AS (
+  SELECT "zid", MIN("id") AS "anchorId"
+  FROM "Meeting"
+  WHERE "zid" IS NOT NULL
+    AND "deletedAt" IS NULL
+    AND "splitFromMid" IS NULL
+    AND "linkedToMid" IS NULL
+    AND "isRecurring" = true
+  GROUP BY "zid"
+  HAVING COUNT(*) = 2
+)
+UPDATE "Meeting" AS m
+SET "linkedToMid" = anchor."mid"
+FROM families f
+JOIN "Meeting" anchor ON anchor."id" = f."anchorId"
+WHERE m."zid" = f."zid"
+  AND m."id" <> f."anchorId"
+  AND m."deletedAt" IS NULL
+  AND m."splitFromMid" IS NULL
+  AND m."linkedToMid" IS NULL
+  AND m."isRecurring" = true;

--- a/frontend/prisma/schema.prisma
+++ b/frontend/prisma/schema.prisma
@@ -83,6 +83,14 @@ model Meeting {
   // of an already-split-off row propagates ITS splitFromMid, not its own mid). Null for a
   // meeting that has never been split off from another series.
   splitFromMid           String?
+  // Set on the non-anchor row of a "linked schedules" family: one meeting the group runs as two
+  // co-existing weekly schedules (same time/duration/interval, different modes on different
+  // weekdays) served by ONE Zoom meeting -- the value is the anchor row's mid, and the family is
+  // { mid = anchor } union { linkedToMid = anchor }. The anchor itself keeps null. Deliberately
+  // a different column from splitFromMid: a split is a chronological division of one series,
+  // linked schedules permanently co-exist. Deliberately not keyed on the shared zid either --
+  // an In-Person family member must never hold a zid/zoomLink (util/meetings/linkedSchedules.ts).
+  linkedToMid            String?
   deletedAt              DateTime?
   updatedAt              DateTime?            @updatedAt
 
@@ -93,6 +101,7 @@ model Meeting {
   @@index([room])
   @@index([zoomRoom])
   @@index([splitFromMid])
+  @@index([linkedToMid])
 }
 
 model RecurrencePattern {

--- a/frontend/tests/integration/diagnostics-route.test.ts
+++ b/frontend/tests/integration/diagnostics-route.test.ts
@@ -36,10 +36,16 @@ afterAll(async () => {
 test("counts a Remote meeting's Zoom sync error even though it has no zoomRoom", async () => {
   const prisma = getTestPrismaClient();
 
+  // Suites share one Postgres instance and run in parallel, so every lookup below has to be
+  // keyed on a mid seeded here -- matching on modeType alone picks up another suite's rows.
+  const remoteMid = `m-${randomUUID()}`;
+  const pendingMid = `m-${randomUUID()}`;
+
   // Regression case: gating this count on zoomRoom truthy (the old behavior) would silently
   // exclude this meeting, since Remote meetings no longer have a zoomRoom.
   await prisma.meeting.create({
     data: buildMeetingData({
+      mid: remoteMid,
       modeType: "Remote",
       room: "",
       zoomSyncStatus: "error",
@@ -48,6 +54,7 @@ test("counts a Remote meeting's Zoom sync error even though it has no zoomRoom",
   });
   await prisma.meeting.create({
     data: buildMeetingData({
+      mid: pendingMid,
       modeType: "Hybrid",
       zoomRoom: "Serenity Room - Zoom",
       googleSyncStatus: "pending",
@@ -66,11 +73,11 @@ test("counts a Remote meeting's Zoom sync error even though it has no zoomRoom",
   const syncIssuesResponse = await getSyncIssues();
   const { syncIssues } = await syncIssuesResponse.json();
 
-  const remoteIssue = syncIssues.find((s: { title: string; modeType: string }) => s.title === "Diagnostics Count Meeting" && s.modeType === "Remote");
+  const remoteIssue = syncIssues.find((s: { mid: string }) => s.mid === remoteMid);
   expect(remoteIssue).toBeDefined();
   expect(remoteIssue.issues.some((i: { text: string }) => i.text.includes("Zoom sync failed"))).toBe(true);
 
-  const pendingIssue = syncIssues.find((s: { modeType: string }) => s.modeType === "Hybrid");
+  const pendingIssue = syncIssues.find((s: { mid: string }) => s.mid === pendingMid);
   expect(pendingIssue).toBeDefined();
   expect(pendingIssue.issues.some((i: { text: string }) => i.text.includes("Waiting on a Zoom host"))).toBe(true);
 });

--- a/frontend/tests/unit/linkedSchedules.test.ts
+++ b/frontend/tests/unit/linkedSchedules.test.ts
@@ -15,14 +15,15 @@ import {
 // --- getLinkedFamily's fake client -------------------------------------------------------
 // A tiny in-memory stand-in for the Prisma delegate, honouring exactly the `where` keys
 // getLinkedFamily uses (mid / mid: { not } / linkedToMid / deletedAt) so a member the query
-// should have filtered out can't slip into a result and pass unnoticed.
+// should have filtered out can't slip into a result and pass unnoticed. findUnique ignores
+// deletedAt exactly like the real key lookup does -- the caller filters soft-deleted rows.
 
 type FakeRow = {
   mid: string;
   modeType: string;
   linkedToMid: string | null;
   deletedAt: Date | null;
-  recurrencePattern?: { daysOfWeek: string[] } | null;
+  recurrencePattern?: { daysOfWeek: string[] | null } | null;
 };
 
 type FakeWhere = {
@@ -42,9 +43,12 @@ const matches = (row: FakeRow, where: FakeWhere): boolean => {
 const fakeClient = (rows: FakeRow[]) =>
   ({
     meeting: {
-      findFirst: async ({ where }: { where: FakeWhere }) => rows.find((row) => matches(row, where)) ?? null,
-      findMany: async ({ where }: { where: FakeWhere }) =>
-        rows.filter((row) => matches(row, where)).sort((a, b) => a.mid.localeCompare(b.mid)),
+      findUnique: async ({ where }: { where: { mid: string } }) =>
+        rows.find((row) => row.mid === where.mid) ?? null,
+      findMany: async ({ where, orderBy }: { where: FakeWhere; orderBy?: { mid: "asc" | "desc" } }) => {
+        const found = rows.filter((row) => matches(row, where));
+        return orderBy?.mid === "asc" ? [...found].sort((a, b) => a.mid.localeCompare(b.mid)) : found;
+      },
     },
   }) as unknown as Prisma.TransactionClient;
 
@@ -91,6 +95,18 @@ describe("getLinkedFamily", () => {
     const family = await getLinkedFamily(fakeClient(rows), "survivor");
     expect(family?.anchor.mid).toBe("survivor");
     expect(family?.linked).toEqual([]);
+  });
+
+  test("returns linked members ordered by mid, not in storage order", async () => {
+    // Defensive beyond today's cap of 2: the Zoom topic's segment order is derived from this
+    // list, so it has to be deterministic no matter what order the rows come back in.
+    const rows = [
+      row("anchor"),
+      row("zulu", { linkedToMid: "anchor" }),
+      row("alpha", { linkedToMid: "anchor" }),
+    ];
+    const family = await getLinkedFamily(fakeClient(rows), "anchor");
+    expect(family?.linked.map((m) => m.mid)).toEqual(["alpha", "zulu"]);
   });
 
   test("the anchor never appears in its own linked list", async () => {
@@ -156,6 +172,14 @@ describe("claimedDaysFor", () => {
 
   test("claims nothing for a member with no recurrence pattern", () => {
     expect(claimedDaysFor(familyOf(schedule("Hybrid")))).toEqual([]);
+  });
+
+  test("claims nothing for a pattern whose daysOfWeek is null", () => {
+    const family = familyOf(
+      { modeType: "Hybrid", recurrencePattern: { daysOfWeek: null } },
+      schedule("Remote", ["Tuesday"]),
+    );
+    expect(claimedDaysFor(family)).toEqual(["Tuesday"]);
   });
 
   test("still reports a day name it doesn't recognise, rather than dropping it", () => {

--- a/frontend/tests/unit/linkedSchedules.test.ts
+++ b/frontend/tests/unit/linkedSchedules.test.ts
@@ -1,0 +1,179 @@
+import type { Prisma } from "@prisma/client";
+import {
+  LINKED_SCHEDULE_CAP,
+  LINKED_SCHEDULE_MODES,
+  availableModesFor,
+  canLinkSchedule,
+  claimedDaysFor,
+  familyMembers,
+  getLinkedFamily,
+  isZoomBearing,
+  type LinkedFamily,
+  type LinkedScheduleRow,
+} from "../../util/meetings/linkedSchedules";
+
+// --- getLinkedFamily's fake client -------------------------------------------------------
+// A tiny in-memory stand-in for the Prisma delegate, honouring exactly the `where` keys
+// getLinkedFamily uses (mid / mid: { not } / linkedToMid / deletedAt) so a member the query
+// should have filtered out can't slip into a result and pass unnoticed.
+
+type FakeRow = {
+  mid: string;
+  modeType: string;
+  linkedToMid: string | null;
+  deletedAt: Date | null;
+  recurrencePattern?: { daysOfWeek: string[] } | null;
+};
+
+type FakeWhere = {
+  mid?: string | { not: string };
+  linkedToMid?: string;
+  deletedAt?: null;
+};
+
+const matches = (row: FakeRow, where: FakeWhere): boolean => {
+  if (where.deletedAt === null && row.deletedAt !== null) return false;
+  if (typeof where.mid === "string" && row.mid !== where.mid) return false;
+  if (where.mid && typeof where.mid === "object" && row.mid === where.mid.not) return false;
+  if (where.linkedToMid !== undefined && row.linkedToMid !== where.linkedToMid) return false;
+  return true;
+};
+
+const fakeClient = (rows: FakeRow[]) =>
+  ({
+    meeting: {
+      findFirst: async ({ where }: { where: FakeWhere }) => rows.find((row) => matches(row, where)) ?? null,
+      findMany: async ({ where }: { where: FakeWhere }) =>
+        rows.filter((row) => matches(row, where)).sort((a, b) => a.mid.localeCompare(b.mid)),
+    },
+  }) as unknown as Prisma.TransactionClient;
+
+const row = (mid: string, over: Partial<FakeRow> = {}): FakeRow => ({
+  mid,
+  modeType: "Hybrid",
+  linkedToMid: null,
+  deletedAt: null,
+  recurrencePattern: null,
+  ...over,
+});
+
+describe("getLinkedFamily", () => {
+  test("a meeting with no linked schedule is a family of one", async () => {
+    const family = await getLinkedFamily(fakeClient([row("solo")]), "solo");
+    expect(family?.anchor.mid).toBe("solo");
+    expect(family?.linked).toEqual([]);
+  });
+
+  test("resolves the same family from either member", async () => {
+    const rows = [row("anchor"), row("second", { linkedToMid: "anchor", modeType: "Remote" })];
+    const fromAnchor = await getLinkedFamily(fakeClient(rows), "anchor");
+    const fromLinked = await getLinkedFamily(fakeClient(rows), "second");
+
+    expect(fromAnchor?.anchor.mid).toBe("anchor");
+    expect(fromAnchor?.linked.map((m) => m.mid)).toEqual(["second"]);
+    expect(fromLinked?.anchor.mid).toBe(fromAnchor?.anchor.mid);
+    expect(fromLinked?.linked.map((m) => m.mid)).toEqual(fromAnchor?.linked.map((m) => m.mid));
+  });
+
+  test("returns null when the mid matches no live meeting", async () => {
+    expect(await getLinkedFamily(fakeClient([row("solo")]), "missing")).toBeNull();
+    expect(await getLinkedFamily(fakeClient([row("gone", { deletedAt: new Date() })]), "gone")).toBeNull();
+  });
+
+  test("excludes a soft-deleted linked schedule from the family", async () => {
+    const rows = [row("anchor"), row("removed", { linkedToMid: "anchor", deletedAt: new Date() })];
+    const family = await getLinkedFamily(fakeClient(rows), "anchor");
+    expect(family?.linked).toEqual([]);
+  });
+
+  test("a survivor still pointing at a soft-deleted anchor becomes its own family", async () => {
+    const rows = [row("anchor", { deletedAt: new Date() }), row("survivor", { linkedToMid: "anchor" })];
+    const family = await getLinkedFamily(fakeClient(rows), "survivor");
+    expect(family?.anchor.mid).toBe("survivor");
+    expect(family?.linked).toEqual([]);
+  });
+
+  test("the anchor never appears in its own linked list", async () => {
+    // Defensive: a row pointing at itself would otherwise be counted twice, pushing a family of
+    // one over the cap.
+    const family = await getLinkedFamily(fakeClient([row("self", { linkedToMid: "self" })]), "self");
+    expect(familyMembers(family!).map((m) => m.mid)).toEqual(["self"]);
+  });
+});
+
+// --- pure predicates ---------------------------------------------------------------------
+
+const familyOf = (...members: LinkedScheduleRow[]): LinkedFamily => ({
+  anchor: members[0],
+  linked: members.slice(1),
+});
+
+const schedule = (modeType: string, daysOfWeek?: string[]): LinkedScheduleRow => ({
+  modeType,
+  recurrencePattern: daysOfWeek ? { daysOfWeek } : null,
+});
+
+describe("canLinkSchedule", () => {
+  test("true while the family is below the cap", () => {
+    expect(canLinkSchedule(familyOf(schedule("Hybrid")))).toBe(true);
+  });
+
+  test("false once the family holds the capped number of schedules", () => {
+    expect(canLinkSchedule(familyOf(schedule("Hybrid"), schedule("Remote")))).toBe(false);
+    expect(LINKED_SCHEDULE_CAP).toBe(2);
+  });
+});
+
+describe("availableModesFor", () => {
+  test("offers every mode no member already holds", () => {
+    expect(availableModesFor(familyOf(schedule("Hybrid")))).toEqual(["In Person", "Remote"]);
+    expect(availableModesFor(familyOf(schedule("Remote")))).toEqual(["Hybrid", "In Person"]);
+  });
+
+  test("returns modes in the fixed Hybrid / In Person / Remote order", () => {
+    expect(LINKED_SCHEDULE_MODES).toEqual(["Hybrid", "In Person", "Remote"]);
+    expect(availableModesFor(familyOf(schedule("Nonsense")))).toEqual([...LINKED_SCHEDULE_MODES]);
+  });
+
+  test("offers nothing once the family is at the cap", () => {
+    expect(availableModesFor(familyOf(schedule("Hybrid"), schedule("Remote")))).toEqual([]);
+  });
+});
+
+describe("claimedDaysFor", () => {
+  test("unions every member's weekdays in week order", () => {
+    const family = familyOf(
+      schedule("Hybrid", ["Monday", "Friday"]),
+      schedule("Remote", ["Saturday", "Sunday"]),
+    );
+    expect(claimedDaysFor(family)).toEqual(["Sunday", "Monday", "Friday", "Saturday"]);
+  });
+
+  test("de-duplicates a day both schedules claim", () => {
+    const family = familyOf(schedule("Hybrid", ["Monday"]), schedule("Remote", ["Monday", "Tuesday"]));
+    expect(claimedDaysFor(family)).toEqual(["Monday", "Tuesday"]);
+  });
+
+  test("claims nothing for a member with no recurrence pattern", () => {
+    expect(claimedDaysFor(familyOf(schedule("Hybrid")))).toEqual([]);
+  });
+
+  test("still reports a day name it doesn't recognise, rather than dropping it", () => {
+    expect(claimedDaysFor(familyOf(schedule("Hybrid", ["Monday", "Funday"])))).toEqual(["Monday", "Funday"]);
+  });
+});
+
+describe("isZoomBearing", () => {
+  test("Hybrid and Remote rows need the family's Zoom meeting", () => {
+    expect(isZoomBearing({ modeType: "Hybrid" })).toBe(true);
+    expect(isZoomBearing({ modeType: "Remote" })).toBe(true);
+  });
+
+  test("an In Person row never holds the family's Zoom identity", () => {
+    expect(isZoomBearing({ modeType: "In Person" })).toBe(false);
+  });
+
+  test("an unrecognised mode is treated as Zoom-free", () => {
+    expect(isZoomBearing({ modeType: "" })).toBe(false);
+  });
+});

--- a/frontend/tests/unit/suspension.test.ts
+++ b/frontend/tests/unit/suspension.test.ts
@@ -78,6 +78,7 @@ function buildMeeting(overrides: Partial<Meeting> = {}): Omit<Meeting, "recurren
     attemptedZoomHost: null,
     zoomSyncError: null,
     splitFromMid: null,
+    linkedToMid: null,
     deletedAt: null,
     updatedAt: null,
     ...overrides,

--- a/frontend/util/date/timeUtils.ts
+++ b/frontend/util/date/timeUtils.ts
@@ -222,6 +222,16 @@ export const getETDayOfWeek = (date: Date): number =>
   new Date(getETCalendarDateMs(formatETDateString(date))).getUTCDay();
 
 /**
+ * Full weekday names, Sunday-first -- both the index<->name mapping for getETDayOfWeek's 0-6
+ * and the canonical sort order for a recurrence pattern's daysOfWeek. The single copy: the
+ * recurrence matcher, the export "Day" column, and the linked-schedules day union all read it,
+ * so they cannot drift on ordering or on the exact spellings stored in daysOfWeek.
+ */
+export const WEEKDAY_NAMES: readonly string[] = [
+  'Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday',
+];
+
+/**
  * Parses a DatePicker field's MM/DD/YYYY value into a UTC Date at ET midnight for that day, or
  * null for an empty/unparseable value. Tolerates unpadded month/day -- DatePicker's onChange
  * can forward the user's raw typed text (e.g. "1/5/2026"), not just its zero-padded output.

--- a/frontend/util/meetings/linkedSchedules.ts
+++ b/frontend/util/meetings/linkedSchedules.ts
@@ -1,0 +1,123 @@
+import type { Prisma } from "@prisma/client";
+
+// A "linked schedules" family is one meeting the group runs as two co-existing weekly
+// schedules -- same time, duration and interval, different modes on different weekdays -- served
+// by ONE Zoom meeting (the shape the "Weekend Al-Anon 9 am" / "One Day at a Time" / "Early Bird
+// Group" legacy meetings already have). The family is keyed by Meeting.linkedToMid, not by the
+// shared zid: an In-Person member must never hold a zid/zoomLink, or the UI and its calendar
+// events would advertise a join link for an in-person meeting and buildZoomRecurrence
+// (services/zoom.ts) would union its weekdays into Zoom's schedule. zid stays the key for the
+// questions it is actually about -- sharedWith/zoomScheduleDiverged, the Zoom recurrence union,
+// and every teardown guard.
+
+// Hard cap on family size. Enforced in one place so the API validator and the form's
+// "Add another mode" gate can never disagree (the same reason isSharedZoomScheduleCompatible is
+// shared between buildZoomRecurrence and the retrieve route).
+export const LINKED_SCHEDULE_CAP = 2;
+
+// Fixed order, also the Zoom-topic segment order: a family's modes always read Hybrid, then
+// In Person, then Remote, regardless of which row was created first.
+export const LINKED_SCHEDULE_MODES = ["Hybrid", "In Person", "Remote"] as const;
+
+export type LinkedScheduleMode = (typeof LINKED_SCHEDULE_MODES)[number];
+
+const WEEK_ORDER = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
+
+// The subset of a meeting row the pure predicates below read -- deliberately structural (same
+// approach as SharedZoomScheduleRow), so a Prisma row, an IMeeting, and a not-yet-created
+// candidate row from a request payload all satisfy it without casting.
+export interface LinkedScheduleRow {
+  modeType: string;
+  recurrencePattern?: { daysOfWeek?: string[] | null } | null;
+}
+
+export interface LinkedFamily<TRow extends LinkedScheduleRow = LinkedScheduleRow> {
+  /** The row holding `linkedToMid: null` -- every other member points at its mid. */
+  anchor: TRow;
+  /** The rows pointing at the anchor. Empty for the overwhelmingly common single-schedule case. */
+  linked: TRow[];
+}
+
+/** A family row as {@link getLinkedFamily} loads it: the full meeting plus its pattern. */
+export type LinkedFamilyMeeting = Prisma.MeetingGetPayload<{ include: { recurrencePattern: true } }>;
+
+const FAMILY_INCLUDE = { recurrencePattern: true } as const;
+
+/** Every member of the family, anchor first. */
+export function familyMembers<TRow extends LinkedScheduleRow>(family: LinkedFamily<TRow>): TRow[] {
+  return [family.anchor, ...family.linked];
+}
+
+/**
+ * Loads the linked-schedule family `mid` belongs to, resolving from either member: given a
+ * linked row, the anchor is followed first, so the returned family is identical whichever mid
+ * the caller happens to hold. Soft-deleted rows are never members (a suspended row still is --
+ * suspension is per-row and Zoom keeps the suspended member's days either way).
+ *
+ * Returns null when `mid` matches no live meeting. A meeting with no linked schedule at all --
+ * almost every meeting -- comes back as a family of one, so callers need no special case.
+ */
+export async function getLinkedFamily(
+  tx: Prisma.TransactionClient,
+  mid: string,
+): Promise<LinkedFamily<LinkedFamilyMeeting> | null> {
+  const row = await tx.meeting.findFirst({ where: { mid, deletedAt: null }, include: FAMILY_INCLUDE });
+  if (!row) return null;
+
+  // Single-level by construction: the cap of 2 means a linked row's anchor is never itself
+  // linked, so there is no pointer chain to walk.
+  const anchor = row.linkedToMid
+    ? await tx.meeting.findFirst({ where: { mid: row.linkedToMid, deletedAt: null }, include: FAMILY_INCLUDE })
+    : row;
+  // Anchor soft-deleted out from under a survivor whose pointer wasn't cleared: treat the
+  // survivor as its own family rather than reporting no family at all, so the row stays
+  // editable and its Zoom topic falls back to the single-schedule form.
+  if (!anchor) return { anchor: row, linked: [] };
+
+  const linked = await tx.meeting.findMany({
+    where: { linkedToMid: anchor.mid, deletedAt: null, mid: { not: anchor.mid } },
+    include: FAMILY_INCLUDE,
+    orderBy: { mid: "asc" },
+  });
+  return { anchor, linked };
+}
+
+/** Whether another schedule may still be added to this family (cap of {@link LINKED_SCHEDULE_CAP}). */
+export function canLinkSchedule(family: LinkedFamily): boolean {
+  return familyMembers(family).length < LINKED_SCHEDULE_CAP;
+}
+
+/**
+ * The modes a new linked schedule may take: every mode no existing member already holds, in
+ * {@link LINKED_SCHEDULE_MODES} order. Empty once the family is at the cap. Drives the form's
+ * mode-button locking, the superset of Room / Zoom Room / Zoom Host fields it mounts, and the
+ * server's rejection of a duplicate mode -- one source of truth for all three.
+ */
+export function availableModesFor(family: LinkedFamily): LinkedScheduleMode[] {
+  if (!canLinkSchedule(family)) return [];
+  const taken = new Set(familyMembers(family).map((row) => row.modeType));
+  return LINKED_SCHEDULE_MODES.filter((mode) => !taken.has(mode));
+}
+
+/**
+ * Every weekday already served by some member, in week order. The family's schedules must be
+ * disjoint -- Zoom holds one union recurrence, so a day claimed twice would silently collapse
+ * into a single occurrence -- so these are exactly the days a new linked schedule may not use.
+ */
+export function claimedDaysFor(family: LinkedFamily): string[] {
+  const claimed = new Set(
+    familyMembers(family).flatMap((row) => row.recurrencePattern?.daysOfWeek ?? []),
+  );
+  const ordered = WEEK_ORDER.filter((day) => claimed.has(day));
+  // Anything not a recognised weekday name still has to be reported as claimed rather than
+  // silently dropped, or the validator would let a second row claim it.
+  return [...ordered, ...[...claimed].filter((day) => !WEEK_ORDER.includes(day))];
+}
+
+/**
+ * Whether this row needs the family's Zoom meeting. An In-Person member is deliberately
+ * Zoom-free: it inherits no zid/zoomLink and is filtered out of the Zoom recurrence union.
+ */
+export function isZoomBearing(row: { modeType: string }): boolean {
+  return row.modeType === "Hybrid" || row.modeType === "Remote";
+}

--- a/frontend/util/meetings/linkedSchedules.ts
+++ b/frontend/util/meetings/linkedSchedules.ts
@@ -17,8 +17,11 @@ import { WEEKDAY_NAMES } from "../date/timeUtils";
 // shared between buildZoomRecurrence and the retrieve route).
 export const LINKED_SCHEDULE_CAP = 2;
 
-// Fixed order, also the Zoom-topic segment order: a family's modes always read Hybrid, then
-// In Person, then Remote, regardless of which row was created first.
+// The authoritative spelling of the three mode names -- util/rooms/modeIcons.ts keys its icon map
+// by LinkedScheduleMode, and meetingValidation's Hybrid/In Person refinements compare against
+// these exact strings. The order is this module's own concern: it is also the Zoom-topic segment
+// order, so a family's modes always read Hybrid, then In Person, then Remote, regardless of which
+// row was created first.
 export const LINKED_SCHEDULE_MODES = ["Hybrid", "In Person", "Remote"] as const;
 
 export type LinkedScheduleMode = (typeof LINKED_SCHEDULE_MODES)[number];

--- a/frontend/util/meetings/linkedSchedules.ts
+++ b/frontend/util/meetings/linkedSchedules.ts
@@ -1,5 +1,7 @@
 import type { Prisma } from "@prisma/client";
 
+import { WEEKDAY_NAMES } from "../date/timeUtils";
+
 // A "linked schedules" family is one meeting the group runs as two co-existing weekly
 // schedules -- same time, duration and interval, different modes on different weekdays -- served
 // by ONE Zoom meeting (the shape the "Weekend Al-Anon 9 am" / "One Day at a Time" / "Early Bird
@@ -20,8 +22,6 @@ export const LINKED_SCHEDULE_CAP = 2;
 export const LINKED_SCHEDULE_MODES = ["Hybrid", "In Person", "Remote"] as const;
 
 export type LinkedScheduleMode = (typeof LINKED_SCHEDULE_MODES)[number];
-
-const WEEK_ORDER = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
 
 // The subset of a meeting row the pure predicates below read -- deliberately structural (same
 // approach as SharedZoomScheduleRow), so a Prisma row, an IMeeting, and a not-yet-created
@@ -61,14 +61,19 @@ export async function getLinkedFamily(
   tx: Prisma.TransactionClient,
   mid: string,
 ): Promise<LinkedFamily<LinkedFamilyMeeting> | null> {
-  const row = await tx.meeting.findFirst({ where: { mid, deletedAt: null }, include: FAMILY_INCLUDE });
+  // findUnique, not findFirst: mid is @unique, so "the row for this mid" is a key lookup and
+  // the soft-delete filter is a property of the row found, not part of what identifies it.
+  const live = async (byMid: string): Promise<LinkedFamilyMeeting | null> => {
+    const found = await tx.meeting.findUnique({ where: { mid: byMid }, include: FAMILY_INCLUDE });
+    return found && found.deletedAt === null ? found : null;
+  };
+
+  const row = await live(mid);
   if (!row) return null;
 
   // Single-level by construction: the cap of 2 means a linked row's anchor is never itself
   // linked, so there is no pointer chain to walk.
-  const anchor = row.linkedToMid
-    ? await tx.meeting.findFirst({ where: { mid: row.linkedToMid, deletedAt: null }, include: FAMILY_INCLUDE })
-    : row;
+  const anchor = row.linkedToMid ? await live(row.linkedToMid) : row;
   // Anchor soft-deleted out from under a survivor whose pointer wasn't cleared: treat the
   // survivor as its own family rather than reporting no family at all, so the row stays
   // editable and its Zoom topic falls back to the single-schedule form.
@@ -108,10 +113,10 @@ export function claimedDaysFor(family: LinkedFamily): string[] {
   const claimed = new Set(
     familyMembers(family).flatMap((row) => row.recurrencePattern?.daysOfWeek ?? []),
   );
-  const ordered = WEEK_ORDER.filter((day) => claimed.has(day));
+  const ordered = WEEKDAY_NAMES.filter((day) => claimed.has(day));
   // Anything not a recognised weekday name still has to be reported as claimed rather than
   // silently dropped, or the validator would let a second row claim it.
-  return [...ordered, ...[...claimed].filter((day) => !WEEK_ORDER.includes(day))];
+  return [...ordered, ...[...claimed].filter((day) => !WEEKDAY_NAMES.includes(day))];
 }
 
 /**

--- a/frontend/util/meetings/meetingValidation.ts
+++ b/frontend/util/meetings/meetingValidation.ts
@@ -115,6 +115,8 @@ export const meetingSchema = z.object({
     message: "At least one calendar type is required.",
     path: ["calType"],
   })
+  // modeType is a free-form string here; these two literals must stay spelled exactly as they are
+  // in LINKED_SCHEDULE_MODES (util/meetings/linkedSchedules.ts), the authoritative mode-name list.
   .refine(
     (meeting) => meeting.modeType !== "Hybrid" || (!!meeting.room && !!meeting.zoomRoom),
     {

--- a/frontend/util/meetings/recurrenceDisplay.ts
+++ b/frontend/util/meetings/recurrenceDisplay.ts
@@ -1,6 +1,8 @@
 // Shared by the meetings XLSX and PandaDocs lease CSV exports so their "Day" columns
 // can never drift apart.
 
+import { WEEKDAY_NAMES } from "../date/timeUtils";
+
 export interface RecurrencePatternLike {
   type: string;
   weekOfMonth: number | null;
@@ -8,7 +10,6 @@ export interface RecurrencePatternLike {
   daysOfWeek: string[];
 }
 
-const DAY_ORDER = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
 const WEEK_OF_MONTH_ORDINALS = ["1st", "2nd", "3rd", "4th"];
 
 const DAY_ABBREVIATIONS: Record<string, string> = {
@@ -24,12 +25,12 @@ const DAY_ABBREVIATIONS: Record<string, string> = {
 // Collapses a set of weekday names into abbreviated ranges in week order, e.g.
 // [Monday, Tuesday, Wednesday, Friday] -> "M-W, F".
 function collapseDayRuns(days: string[]): string {
-  const sorted = [...days].sort((a, b) => DAY_ORDER.indexOf(a) - DAY_ORDER.indexOf(b));
+  const sorted = [...days].sort((a, b) => WEEKDAY_NAMES.indexOf(a) - WEEKDAY_NAMES.indexOf(b));
   const runs: string[][] = [];
   for (const day of sorted) {
-    const dayIndex = DAY_ORDER.indexOf(day);
+    const dayIndex = WEEKDAY_NAMES.indexOf(day);
     const currentRun = runs[runs.length - 1];
-    const runEndIndex = currentRun ? DAY_ORDER.indexOf(currentRun[currentRun.length - 1]) : -2;
+    const runEndIndex = currentRun ? WEEKDAY_NAMES.indexOf(currentRun[currentRun.length - 1]) : -2;
     if (currentRun && dayIndex === runEndIndex + 1) {
       currentRun.push(day);
     } else {

--- a/frontend/util/meetings/recurrenceMatch.ts
+++ b/frontend/util/meetings/recurrenceMatch.ts
@@ -4,9 +4,8 @@
 // See ViewMeeting.tsx's use of matchesRecurrencePattern for why that matters: two independent
 // implementations previously disagreed on monthly patterns, excludedDates, and weekly interval
 // anchoring.
-import { convertETToUTC } from "../date/timeUtils";
+import { convertETToUTC, WEEKDAY_NAMES } from "../date/timeUtils";
 
-const daysOfWeekNames = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
 const etFmt = new Intl.DateTimeFormat('en-CA', { timeZone: 'America/New_York' });
 const etTimeFmt = new Intl.DateTimeFormat('en-GB', {
     timeZone: 'America/New_York',
@@ -61,7 +60,7 @@ export const matchesRecurrencePattern = (
     const patternStartLocalDate = new Date(Date.UTC(startEtYear, startEtMonth - 1, startEtDay));
 
     const dayOfWeek = localDate.getUTCDay();
-    const requestedDayName = daysOfWeekNames[dayOfWeek];
+    const requestedDayName = WEEKDAY_NAMES[dayOfWeek];
 
     if (recurrence.type === "monthly") {
         const interval = recurrence.interval ?? 1;

--- a/frontend/util/rooms/modeIcons.ts
+++ b/frontend/util/rooms/modeIcons.ts
@@ -1,12 +1,19 @@
 import type { IconName } from '../../app/components/ui/displays/Icon';
+import type { LinkedScheduleMode } from '../meetings/linkedSchedules';
 
 // Meeting-mode -> icon mapping, shared by every place a mode ("Hybrid", "In Person",
 // "Remote") is shown as text, so users learn the association before mobile's BoxText
 // drops the label entirely for space (see BoxText.tsx's hideTags prop).
-// Null-prototype so lookups for inherited keys (e.g. "constructor", "toString") come back
-// undefined instead of resolving to an Object.prototype member.
-export const MODE_ICON_NAME: Record<string, IconName> = Object.assign(Object.create(null), {
+// Keyed by LinkedScheduleMode (type-only import, so no runtime coupling) rather than by loose
+// strings: the mode names live in one authoritative list, and adding or renaming one there is a
+// compile error here until this map covers it.
+const MODE_ICONS: Record<LinkedScheduleMode, IconName> = {
   'In Person': 'location',
   Remote: 'video-call',
   Hybrid: 'co-present',
-});
+};
+
+// Null-prototype so lookups for inherited keys (e.g. "constructor", "toString") come back
+// undefined instead of resolving to an Object.prototype member. Widened to Record<string, ...>
+// because callers look modes up by an arbitrary tag string.
+export const MODE_ICON_NAME: Record<string, IconName> = Object.assign(Object.create(null), MODE_ICONS);


### PR DESCRIPTION
@coderabbitai summary

## Description

First PR of the linked meeting modes work: the data model only. Nothing in the app reads `linkedToMid` yet — PR 2 (Zoom topic hierarchy) is the first consumer, at which point the backfilled legacy pairs become live families.

- **frontend/prisma/schema.prisma**: adds `Meeting.linkedToMid String?` plus `@@index([linkedToMid])`, mirroring `splitFromMid`'s shape, nullability and index. The field is deliberately not keyed on `zid` — an In-Person member of a family must never hold a zid, so `zid` cannot be the family key going forward.
- **frontend/prisma/migrations/20260823000000_add_meeting_linked_to_mid/migration.sql**: the `ALTER TABLE` / `CREATE INDEX`, plus the data backfill inline so it rides the normal `prisma migrate deploy` pipeline. Adopts only the unambiguous legacy shape — two live, non-split, non-empty-zid, recurring rows sharing one zid — with `MIN(id)` as the anchor, and asserts its own scope before committing (see Backfill scope below).
- **frontend/util/meetings/linkedSchedules.ts** (new): the family module — `getLinkedFamily`, `familyMembers`, `canLinkSchedule`, `availableModesFor`, `claimedDaysFor`, `isZoomBearing`, and the `LINKED_SCHEDULE_CAP` / `LINKED_SCHEDULE_MODES` constants. `getLinkedFamily` takes a `Prisma.TransactionClient` (a plain `PrismaClient` satisfies it too) and returns the anchor plus its linked rows with `recurrencePattern` included, anchor-first, so a caller can feed the topic builder without a second query.
- **frontend/util/date/timeUtils.ts, util/meetings/recurrenceDisplay.ts, util/meetings/recurrenceMatch.ts, util/rooms/modeIcons.ts, app/components/meeting-form/RecurringMeeting.tsx**: supporting cleanup the new module needs — one shared `WEEKDAY_NAMES` constant across the recurrence utils instead of three private copies, and the mode-icon map keyed by `LinkedScheduleMode`. `util/meetings/meetingValidation.ts` picks up a comment tying its `"Hybrid"`/`"Remote"` literals back to `LINKED_SCHEDULE_MODES` as the authoritative list.
- **frontend/tests/unit/linkedSchedules.test.ts** (new, 18 tests): covers all of the module's functions. `tests/unit/suspension.test.ts`'s `buildMeeting` fixture gained `linkedToMid: null` (required by the new column).
- **frontend/tests/integration/diagnostics-route.test.ts**: unrelated pre-existing flake, fixed in passing. Integration suites run in parallel against one shared Postgres and this test looked its sync issue up by `modeType === "Hybrid"`, which matches Hybrid error rows seeded by `sync-error-mids-route.test.ts`; those sort ahead of this test's own row and carry no pending-host entry. Now keyed on the mid it seeded.

## Backfill scope

`frontend/package.json`'s `build` script runs `prisma migrate deploy` unattended whenever `VERCEL_ENV=production`, so there is no human in the loop between merge and this `UPDATE` landing on production data. The adopted set has **not** been read against production from this branch, so rather than trust it, the migration verifies it:

- The families set is materialised into a temp table, the pair-only `UPDATE` runs, and a `plpgsql` `DO` block raises unless it adopted **exactly 3** rows with **zero** 3+-member zid groups. Prisma runs each migration file in one transaction, so the raise aborts the deploy and rolls the file back rather than silently mis-linking.
- Expected production shape: three pairs — Weekend Al-Anon 9 am, One Day at a Time, Early Bird Group.
- A database holding no shared-zid families at all adopts 0 rows and passes through untouched. That is every fresh test, preview and shadow database (none of them saw the Mongo import), so CI is unaffected.
- If an adopted set ever has to be undone after the fact, reversal is one statement: `UPDATE "Meeting" SET "linkedToMid" = NULL;`
- **If production turns out to hold a different number of pairs, the deploy fails loudly and this migration's expected count has to be corrected before merging again** — that is the intended outcome, not a regression.

## Deviations from the plan

1. **Anchor is `MIN(id)`, not the earlier `createdAt`.** `Meeting` has no `createdAt` column. Both id formats present are timestamp-prefixed and ObjectId hex (`6…`, the Mongo-import rows) sorts before a cuid (`c…`, everything since the Postgres cutover), so lexicographic `MIN(id)` agrees with creation order. The migration comment records exactly when that stops holding.
2. **"Active rows" is `deletedAt IS NULL`, not `status = 'Active'`.** A Suspended row is still a family member: suspension is per-row, and Zoom's union schedule keeps a suspended sibling's days either way. `getLinkedFamily`'s membership filter matches (`deletedAt: null` only), which is also how today's zid-sibling behavior works.
3. **The backfill additionally requires `isRecurring = true`** — a tightening beyond the plan's predicate. A one-off row reusing a zid has no weekday schedule to contribute and would become a phantom family member with a null recurrence pattern that PR 2's topic hierarchy (`formatDayColumn(row.recurrencePattern)`) would then have to special-case.
4. **`zid <> ''` as well as `IS NOT NULL`.** Nothing in the write path or `meetingSchema` forbids persisting an empty-string zid, and every other shared-zid guard in the app rejects it by JS truthiness. Two blank-zid rows are two Zoom-less meetings, not a family.
5. **`linkedToMid IS NULL` on both sides** of the backfill, for idempotency.
6. **`familyMembers` added beyond the plan's five functions** — PR 2 needs the family flattened for `zoomTopicFor`/`buildZoomRecurrence`, and one place that puts the anchor first keeps segment ordering deterministic.
7. **`availableModesFor` returns `[]` at the cap** rather than "modes not taken". It answers "what may a *new* linked schedule be", which is what both the UI gate and the server validator need.

Split children stay out of families by construction: nothing sets a `splitFromMid` row's `linkedToMid`. Making the scoped-edit path actively write `linkedToMid: null` on split children is PR 3's job, not done here.

## Testing

- [x] `cd frontend && yarn lint` — 0 errors, no new warnings.
- [x] `cd frontend && yarn typecheck` — clean.
- [x] `cd frontend && yarn test:unit` — 335/335 across 25 suites, including the 18 new `linkedSchedules` tests.
- [x] `cd frontend && yarn test:integration` — 228/228, 23 suites (this is what exercises `migrate deploy` against a real, empty Postgres, i.e. the backfill's pass-through path).
- [x] Backfill verified against a throwaway `embedded-postgres` instance via `prisma migrate deploy` itself (no remote database contacted at any point), across four seeded scenarios:
  - empty database → applies, adopts 0, passes the guard;
  - three pairs plus decoys (lone-zid row, empty-string-zid pair, soft-deleted sibling, split child, one-off sibling, no-zid rows) → adopts exactly the 3 intended rows and leaves every decoy alone (a Suspended sibling stays linked by construction — `status` is not in the predicate at all);
  - only two pairs → raises `linkedToMid backfill scope check failed: adopted 2 row(s), expected 3` and rolls back, leaving no `linkedToMid` column behind (confirms Prisma's per-file transaction);
  - three pairs plus a 3-member zid group → raises on the ambiguous group and rolls back.

## Area(s) Touched

**Product areas**
- [ ] auth — sign-in, sessions, NextAuth, role-based access
- [ ] admin — /admin shell (Diagnostics, Users, Import, Export tabs)
- [ ] docs — /docs Resources page (rendering, navigation, search)
- [ ] ui/ux — frontend layout/styling not tied to a specific integration

**Integrations**
- [ ] google-calendar — Google Calendar sync
- [ ] zoom-api — Zoom meeting/host sync

**Engineering**
- [ ] security — auth hardening, data exposure, dependency/security scanning
- [x] testing — test suite (Jest/Playwright) changes
- [ ] github-actions — workflows, Dependabot config, other .github/ CI tooling
- [x] cleanup — refactor or dead-code removal, no behavior change
- [ ] documentation — docs/ or README changes only

## Pre-merge Checklist
- [x] Code follows current formatting conventions and passes lint (`yarn lint`).
- [x] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
- [x] All test suites pass, both run locally and green in GitHub CI. **Do not merge if any test suite is failing.**
- [x] A test suite was added or updated for the feature/fix in this PR. **Double-check this if you change a feature and did not update the test suites**.
- [x] Only files relevant to this change are committed — no stray or unrelated files.
- [x] If this branch has a merge conflict with master, master was merged into this branch first (not the other way around).
- [x] The rest of this PR description (Description, Testing) is filled out, not left as template placeholders.

