### PR TITLE
feat(update-meeting): create a linked schedule sharing one Zoom meeting

### DIFF
--- a/frontend/app/api/update/meeting/route.ts
+++ b/frontend/app/api/update/meeting/route.ts
@@ -10,10 +10,15 @@ import {
 import { createZoomMeeting, updateZoomMeeting, deleteZoomMeeting, getZoomHostCapacities, getZoomMeetingInvitation, rehostZoomMeeting, resolveZoomHost, zoomHostPool, zoomRoomCalendarId } from "../../../../services/zoom";
 import { findResourceConflicts, findResourceConflictRows, ConflictRow, ResourceConflictAbort } from "../../../../util/meetings/resourceOverlap";
 import { lockResourceClaims, ResourceClaim } from "../../../../util/meetings/resourceLocks";
-import { meetingSchema, editScopeSchema } from "../../../../util/meetings/meetingValidation";
-import { linkedFamilyLoader, LinkedFamilyLoader } from "../../../../util/meetings/linkedSchedules";
+import { meetingSchema, editScopeSchema, linkedScheduleSchema, LinkedScheduleInput } from "../../../../util/meetings/meetingValidation";
+import {
+  linkedFamilyLoader, LinkedFamilyLoader, LinkedFamilyMeeting, getLinkedFamily, familyMembers,
+  canLinkSchedule, availableModesFor, claimedDaysFor, isZoomBearing, LINKED_SCHEDULE_CAP,
+} from "../../../../util/meetings/linkedSchedules";
+import { isSharedZoomScheduleCompatible } from "../../../../util/meetings/sharedZoomSchedule";
 import { reconcilePendingResume, tearDownPendingResumeSeries } from "../../../../util/meetings/suspension";
-import { calculateEndDateFromOccurrences } from "../../../../util/meetings/meetingOccurrences";
+import { calculateEndDateFromOccurrences, firstOccurrenceOnOrAfter } from "../../../../util/meetings/meetingOccurrences";
+import { convertETToUTC, getETTimeOfDay, isConvertETToUTCValidationError } from "../../../../util/date/timeUtils";
 import { EditScope, countOccurrencesBefore, exclusionInstant, trimmedEndDate, isLiveOccurrence, rootSplitMid, toETDateStr } from "../../../../util/meetings/editScope";
 import { prisma } from "../../../../lib/prisma";
 
@@ -327,8 +332,14 @@ async function syncUpdatedMeeting(
   }
 }
 
-// Runs after the response is sent — parent-side Google Calendar half of a scoped edit: a
-// full-body rewrite of each configured calType event from the parent's POST-WRITE
+// Runs after the response is sent — rewrites one existing meeting's Google Calendar events in
+// place from its current stored state. Two callers, same job: the parent of a scoped edit
+// (whose recurrence was just trimmed/excluded) and every other member of a linked-schedule
+// family a new schedule just joined (whose event TITLE now names a family it didn't before --
+// see handleLinkedScheduleCreate). Described below from the scoped-edit case, which is the one
+// with the subtleties.
+//
+// A full-body rewrite of each configured calType event from the meeting's POST-WRITE
 // RecurrencePattern (buildEventBody regenerates the whole recurrence -- RRULE + EXDATEs -- from
 // it, so a plain events.update is sufficient for both 'this' and 'thisAndFollowing'; no more
 // surgical EXDATE/UNTIL patch), plus the parent's OWN Zoom-Room join-link event (if it has one)
@@ -346,7 +357,7 @@ async function syncUpdatedMeeting(
 // Google write (technical-decisions.md's "API failure ⇒ googleSyncStatus 'error'"). The
 // suspended early-return above deliberately skips this write too -- that deferral is intentional
 // (status stays whatever it already was), not a failure to report.
-async function syncScopedParentCalendar(
+async function republishMeetingCalendars(
   mid: string,
   status: string,
   accessToken: string | undefined,
@@ -422,7 +433,7 @@ async function syncSplitMeeting(
   const meetingForSync: IMeeting = { ...meetingData, isRecurring };
   // The split-off row is a lineage of its parent, not a second mode, so it joins the family only
   // through the zid it inherited -- which is exactly how Zoom already sees it. Read from the
-  // parent's loader: this sync runs concurrently with syncScopedParentCalendar over the same
+  // parent's loader: this sync runs concurrently with republishMeetingCalendars over the same
   // zid group, so the two share one lookup instead of issuing near-identical queries.
   const family = await loadFamily(meetingData.zid ?? null);
 
@@ -710,10 +721,10 @@ async function handleScopedEdit(
   const loadFamily = linkedFamilyLoader(prisma, mid);
 
   after(
-    syncScopedParentCalendar(
+    republishMeetingCalendars(
       mid, existingMeeting.status, auth.accessToken, calendarIds, eventIds, parentForCalendar,
       existingMeeting.zoomCalendarEventId, existingMeeting.zoomRoom, loadFamily,
-    ).catch((error) => console.error("syncScopedParentCalendar threw:", error)),
+    ).catch((error) => console.error("republishMeetingCalendars threw:", error)),
   );
   if (hasStaleResumeSeries) {
     after(tearDownPendingResumeSeries(existingMeeting, auth.accessToken).catch((error) =>
@@ -746,6 +757,440 @@ async function handleScopedEdit(
   return NextResponse.json({ ...updatedParent, newMid: createdMeeting.mid });
 }
 
+// The anchor's ET wall-clock time of day and duration, re-anchored onto the first date its
+// series actually meets on `daysOfWeek`. A linked schedule never gets its start from the client:
+// the family is served by ONE Zoom meeting, which can only hold one series, so every member has
+// to keep the same time of day and duration (isSharedZoomScheduleCompatible) -- and the search
+// runs against the ANCHOR's pattern, so an every-other-week family stays in one week phase
+// instead of the two schedules landing on alternating weeks. Returns null when the requested
+// days produce no occurrence inside the anchor's series at all (e.g. a series that ends first).
+function deriveLinkedScheduleStart(
+  anchor: Meeting & { recurrencePattern: RecurrencePattern | null },
+  daysOfWeek: string[],
+): { startDateTime: Date; endDateTime: Date } | null {
+  const pattern = anchor.recurrencePattern!;
+  const firstETDate = firstOccurrenceOnOrAfter(
+    {
+      type: 'weekly',
+      startDate: pattern.startDate,
+      endDate: pattern.endDate,
+      interval: pattern.interval,
+      daysOfWeek,
+      weekOfMonth: null,
+      dayOfMonth: null,
+      // The anchor's own excluded dates are its alone -- a per-occurrence deletion on the
+      // Monday-Friday schedule says nothing about when the Saturday one starts.
+      excludedDates: [],
+    },
+    toETDateStr(pattern.startDate),
+  );
+  if (!firstETDate) return null;
+  const { hour, minute, second } = getETTimeOfDay(anchor.startDateTime);
+  const pad = (value: number) => String(value).padStart(2, '0');
+  const startDateTime = new Date(convertETToUTC(`${firstETDate}T${pad(hour)}:${pad(minute)}:${pad(second)}`));
+  const durationMs = anchor.endDateTime.getTime() - anchor.startDateTime.getTime();
+  return { startDateTime, endDateTime: new Date(startDateTime.getTime() + durationMs) };
+}
+
+// Runs after the response is sent — the new linked row's own half of the create: its Google
+// Calendar events (and its Zoom-Room event, if any), via the same publish a split-off row gets.
+// The one addition is the In-Person-anchor case: the family had no Zoom meeting to inherit, so
+// this row mints it -- with the family, so it is born holding the union schedule and the
+// family's name -- and becomes the family's zid holder. Every other case inherits the anchor's
+// zid and makes no Zoom API call at all.
+async function syncLinkedSchedule(
+  newMid: string,
+  linkedMeeting: IMeeting,
+  accessToken: string | undefined,
+  loadFamily: LinkedFamilyLoader,
+  // Non-null only when this row mints the family's Zoom meeting; `host` is the pool host already
+  // resolved and persisted synchronously in handleLinkedScheduleCreate (null when the pool was
+  // exhausted, with `syncError` saying so).
+  provision: { host: string | null; syncError: string | null } | null,
+): Promise<void> {
+  let meeting = linkedMeeting;
+
+  if (provision) {
+    if (!provision.host) {
+      // Same contract as every other Zoom-blocked publish: nothing is published with a missing
+      // join link, and "Retry sync" picks this row back up once a host frees up.
+      await prisma.meeting.update({
+        where: { mid: newMid },
+        data: {
+          googleSyncStatus: 'pending',
+          zoomSyncStatus: 'error',
+          zoomSyncError: provision.syncError ?? "No Zoom host available for this meeting's schedule (pool exhausted).",
+        },
+      });
+      return;
+    }
+    const created = await createZoomMeeting(meeting, provision.host, await loadFamily(null));
+    if (!created) {
+      await prisma.meeting.update({
+        where: { mid: newMid },
+        data: { googleSyncStatus: 'pending', zoomSyncStatus: 'error', zoomSyncError: "Failed to create the Zoom meeting." },
+      });
+      return;
+    }
+    const zoomInvitation = await getZoomMeetingInvitation(created.zid);
+    await prisma.meeting.update({
+      where: { mid: newMid },
+      data: { zid: created.zid, zoomLink: created.zoomLink, zoomPasscode: created.zoomPasscode, zoomInvitation },
+    });
+    meeting = { ...meeting, zid: created.zid, zoomLink: created.zoomLink, zoomPasscode: created.zoomPasscode };
+  }
+
+  await syncSplitMeeting(newMid, meeting, true, accessToken, loadFamily);
+}
+
+// Runs after the response is sent — the REST of the family's half of a linked-schedule create.
+// A family's external name is derived from all of its schedules ("Group - Hybrid Mon-Fri - Zoom
+// Only Sat"), so the moment a second schedule joins, every existing member's copy of that name
+// is stale: the shared Zoom meeting needs the widened union schedule and the new topic, and each
+// existing member's Google Calendar events need a full rewrite to pick up the new title. Without
+// this fan-out those events would keep advertising the old single-schedule name until something
+// else happened to touch them.
+async function syncLinkedScheduleFamily(
+  // The family as it stood BEFORE the create -- every member except the new row.
+  members: LinkedFamilyMeeting[],
+  accessToken: string | undefined,
+  loadFamily: LinkedFamilyLoader,
+  // The shared Zoom meeting the new schedule joined, when there is one to widen. Null when the
+  // new row is minting the family's Zoom meeting itself (createZoomMeeting is handed the family
+  // there, so there is nothing left to correct) or when no member uses Zoom at all.
+  patchZid: string | null,
+): Promise<void> {
+  if (patchZid) {
+    // Unmanaged Zoom meetings are never PATCHed -- the stored link is the contract (see
+    // syncUpdatedMeeting).
+    const holder = members.find((member) => member.zid === patchZid && member.zoomManaged);
+    if (holder) {
+      const ok = await updateZoomMeeting(patchZid, holder as unknown as IMeeting, await loadFamily(patchZid));
+      if (!ok) {
+        await prisma.meeting.update({
+          where: { mid: holder.mid },
+          data: {
+            zoomSyncStatus: 'error',
+            zoomSyncError: "Couldn't update the shared Zoom meeting for the newly linked schedule.",
+          },
+        });
+      }
+    }
+  }
+
+  for (const member of members) {
+    await republishMeetingCalendars(
+      member.mid,
+      member.status,
+      accessToken,
+      calendarIdsForMeeting(member.calType ?? []),
+      (member.googleCalendarEventIds ?? {}) as Record<string, string>,
+      member as unknown as IMeeting,
+      member.zoomCalendarEventId,
+      member.zoomRoom,
+      loadFamily,
+    );
+  }
+}
+
+// Handles a `linkedSchedule` block: adds a SECOND weekly schedule -- a different mode on
+// different weekdays -- to an existing recurring meeting, served by the family's one Zoom
+// meeting (util/meetings/linkedSchedules.ts). Modeled on handleScopedEdit, minus the parent
+// trim: the anchor row itself is not touched, only read.
+async function handleLinkedScheduleCreate(
+  auth: { accessToken?: string; user?: { email?: string | null } | null },
+  existingMeeting: Meeting,
+  linkedSchedule: LinkedScheduleInput,
+  confirmOverride: boolean,
+): Promise<Response> {
+  const family = await getLinkedFamily(prisma, existingMeeting.mid);
+  if (!family) {
+    return NextResponse.json({ error: `Meeting with ID ${existingMeeting.mid} not found` }, { status: 404 });
+  }
+  // Resolved from either member, so this is the family's own root even if the request targeted
+  // an already-linked row -- and by the cap check below, the only member whenever this request
+  // goes on to write anything.
+  const anchor = family.anchor;
+
+  if (!anchor.isRecurring || !anchor.recurrencePattern) {
+    return NextResponse.json(
+      { error: "A linked schedule can only be added to a recurring meeting." },
+      { status: 400 },
+    );
+  }
+  if (anchor.recurrencePattern.type !== 'weekly') {
+    return NextResponse.json(
+      { error: "A linked schedule can only be added to a weekly meeting." },
+      { status: 400 },
+    );
+  }
+  if (!canLinkSchedule(family)) {
+    return NextResponse.json(
+      { error: `This meeting already runs ${LINKED_SCHEDULE_CAP} schedules; no more can be linked.` },
+      { status: 400 },
+    );
+  }
+  const availableModes = availableModesFor(family);
+  if (!availableModes.includes(linkedSchedule.modeType)) {
+    return NextResponse.json(
+      { error: `A linked schedule must use a mode this meeting doesn't already run (${availableModes.join(", ")}).` },
+      { status: 400 },
+    );
+  }
+  const linkedDays = linkedSchedule.recurrencePattern.daysOfWeek ?? [];
+  if (linkedDays.length === 0) {
+    return NextResponse.json(
+      { error: "A linked schedule must meet on at least one day of the week." },
+      { status: 400 },
+    );
+  }
+  // Disjoint weekdays are a hard requirement, not a preference: Zoom holds the family's schedules
+  // as ONE union of weekdays, so a day claimed twice silently collapses into a single occurrence.
+  const claimedDays = claimedDaysFor(family);
+  const overlappingDays = linkedDays.filter((day) => claimedDays.includes(day));
+  if (overlappingDays.length > 0) {
+    return NextResponse.json(
+      { error: `This meeting already meets on ${overlappingDays.join(", ")}; a linked schedule must run on other days.` },
+      { status: 400 },
+    );
+  }
+
+  let derived: { startDateTime: Date; endDateTime: Date } | null;
+  try {
+    derived = deriveLinkedScheduleStart(anchor, linkedDays);
+  } catch (error) {
+    // The anchor's time of day doesn't exist on the linked schedule's first date (the DST
+    // spring-forward gap) -- the admin's own input, not a server fault.
+    if (isConvertETToUTCValidationError(error)) {
+      return NextResponse.json({ error: error.message }, { status: 400 });
+    }
+    throw error;
+  }
+  if (!derived) {
+    return NextResponse.json(
+      { error: "The requested days produce no occurrence inside this meeting's series." },
+      { status: 400 },
+    );
+  }
+  const { startDateTime, endDateTime } = derived;
+
+  // Everything below is copied from the anchor, never read from the payload -- see
+  // linkedScheduleBlockSchema's comment. A count-bounded anchor gives the linked schedule the
+  // same count, resolved into its OWN end date because its weekdays reach that count elsewhere.
+  const pattern = anchor.recurrencePattern;
+  const numberOfOccurrences = pattern.endDate ? null : pattern.numberOfOccurrences;
+  const endDate = pattern.endDate ?? (numberOfOccurrences
+    ? calculateEndDateFromOccurrences(startDateTime, linkedDays, numberOfOccurrences, pattern.interval, 'weekly', null, null)
+    : null);
+
+  const needsZoom = isZoomBearing({ modeType: linkedSchedule.modeType });
+  // The family's Zoom identity is inherited whole, never re-provisioned -- one Zoom meeting per
+  // family. An In-Person linked row gets none of it; an In-Person ANCHOR has none to give, so a
+  // Zoom-bearing linked row mints the family's Zoom meeting itself and becomes its zid holder
+  // (linkedToMid still keys the family, which is exactly why the family isn't keyed on zid).
+  const inheritsZoom = needsZoom && isZoomBearing(anchor);
+  const provisionsZoom = needsZoom && !inheritsZoom;
+  const inheritedZoomHost = inheritsZoom ? anchor.zoomHost : null;
+
+  const candidate = {
+    mid: linkedSchedule.mid,
+    title: anchor.title,
+    room: linkedSchedule.room ?? "",
+    zoomRoom: linkedSchedule.zoomRoom ?? null,
+    zoomHost: inheritedZoomHost,
+    status: 'Active',
+    calType: anchor.calType,
+    startDateTime,
+    endDateTime,
+    isRecurring: true,
+    recurrencePattern: {
+      type: 'weekly',
+      startDate: startDateTime,
+      endDate,
+      interval: pattern.interval,
+      daysOfWeek: linkedDays,
+      weekOfMonth: null,
+      dayOfMonth: null,
+      excludedDates: [],
+    },
+  };
+
+  // Backstop for a family Zoom can't hold as one series (a member that diverged in interval,
+  // time of day or duration since it was created). Everything the check reads is derived above,
+  // so a request that reaches here normally passes -- but a family it rejects would have its
+  // Zoom schedule silently frozen from then on, which is worth refusing outright.
+  if (!isSharedZoomScheduleCompatible([...familyMembers(family), candidate])) {
+    return NextResponse.json(
+      { error: "This meeting's schedules can't be served by one Zoom meeting (they must share an interval, time of day and duration)." },
+      { status: 400 },
+    );
+  }
+
+  // License-dependent per-host capacities, resolved before the locked transaction below -- same
+  // reasoning as every other path (a Zoom API round trip while advisory locks are held would
+  // extend lock hold time by an external call's latency; cached 12h, usually a no-op).
+  const hostCapacities = await getZoomHostCapacities();
+
+  let txResult: { createdMeeting: LinkedFamilyMeeting; resolvedHost: string | null; hostSyncError: string | null };
+  try {
+    txResult = await prisma.$transaction(async (tx) => {
+      const claims: ResourceClaim[] = [];
+      if (candidate.room) claims.push({ type: "room", value: candidate.room });
+      if (candidate.zoomRoom) claims.push({ type: "zoomRoom", value: candidate.zoomRoom });
+      if (inheritedZoomHost) claims.push({ type: "zoomHost", value: inheritedZoomHost });
+      // Only the In-Person-anchor case ever picks a host here; every other case reuses the
+      // family's, so no pool lock is needed (or wanted -- see the host-capacity note below).
+      if (provisionsZoom) {
+        for (const host of zoomHostPool) claims.push({ type: "zoomHost", value: host });
+      }
+      await lockResourceClaims(tx, claims);
+
+      if (!confirmOverride) {
+        const conflictRows: ConflictRow[] = [];
+        // room/zoomRoom must NOT exclude the anchor -- same reasoning as handleScopedEdit's: the
+        // anchor's own occurrences are live bookings of that room, and the two schedules only
+        // avoid each other by weekday, which nothing here has verified about the ROOM.
+        if (candidate.room) {
+          conflictRows.push(...await findResourceConflictRows("room", candidate.room, candidate, tx, {}));
+        }
+        if (candidate.zoomRoom) {
+          conflictRows.push(...await findResourceConflictRows("zoomRoom", candidate.zoomRoom, candidate, tx, {}));
+        }
+        // zoomHost DOES exclude the family: the inherited zid is ONE real Zoom booking the two
+        // schedules share, not a second one to flag. The cap makes the anchor the family's only
+        // other member here. Belt-and-braces anyway -- the disjoint-weekday rule above already
+        // means the two schedules' occurrences never overlap.
+        if (inheritedZoomHost) {
+          conflictRows.push(...await findResourceConflictRows(
+            "zoomHost", inheritedZoomHost, candidate, tx,
+            { excludeMid: anchor.mid, includeSuspended: true, capacity: hostCapacities[inheritedZoomHost] ?? 1 },
+          ));
+        }
+        if (conflictRows.length > 0) {
+          throw new ResourceConflictAbort(conflictRows);
+        }
+      }
+
+      // Host capacity is consumed only when this row actually mints a Zoom meeting. An inherited
+      // zid re-uses the family's existing booking, so there is nothing to reserve -- mirrors
+      // handleScopedEdit exactly.
+      let resolvedHost: string | null = null;
+      let hostSyncError: string | null = null;
+      if (provisionsZoom) {
+        resolvedHost = await resolveZoomHost(candidate, tx, { capacities: hostCapacities });
+        hostSyncError = resolvedHost
+          ? null
+          : "No Zoom host available for this meeting's schedule (pool exhausted).";
+      }
+
+      const createdMeeting = await tx.meeting.create({
+        data: {
+          mid: linkedSchedule.mid,
+          title: anchor.title,
+          description: anchor.description,
+          creator: auth.user?.email ?? anchor.creator,
+          lastEditedBy: null,
+          group: anchor.group,
+          startDateTime,
+          endDateTime,
+          email: anchor.email,
+          calType: anchor.calType,
+          modeType: linkedSchedule.modeType,
+          room: candidate.room,
+          zoomRoom: candidate.zoomRoom,
+          // A linked schedule always starts Active -- it has no suspension history of its own,
+          // and must never inherit a suspended anchor's status.
+          status: 'Active',
+          isRecurring: true,
+          linkedToMid: anchor.mid,
+          // A second mode, not a division of the anchor's series -- the two lineage columns are
+          // deliberately distinct (schema.prisma).
+          splitFromMid: null,
+          ...(inheritsZoom
+            ? {
+                zid: anchor.zid,
+                zoomLink: anchor.zoomLink,
+                zoomPasscode: anchor.zoomPasscode,
+                zoomInvitation: anchor.zoomInvitation,
+                zoomHost: anchor.zoomHost,
+                zoomManaged: anchor.zoomManaged,
+                // A pinned family name stays pinned for every member; a null one keeps meaning
+                // "auto, recompute from the current family" (services/zoom.ts).
+                zoomTopic: anchor.zoomTopic,
+              }
+            : {}),
+          ...(provisionsZoom
+            ? {
+                zoomHost: resolvedHost,
+                ...(hostSyncError ? { zoomSyncStatus: 'error', zoomSyncError: hostSyncError } : {}),
+              }
+            : {}),
+          recurrencePattern: {
+            create: {
+              type: 'weekly',
+              startDate: startDateTime,
+              endDate,
+              numberOfOccurrences: numberOfOccurrences ?? undefined,
+              daysOfWeek: linkedDays,
+              firstDayOfWeek: pattern.firstDayOfWeek,
+              interval: pattern.interval,
+              weekOfMonth: null,
+              dayOfMonth: null,
+              excludedDates: [],
+            },
+          },
+        },
+        include: { recurrencePattern: true },
+      });
+
+      return { createdMeeting, resolvedHost, hostSyncError };
+    }, { timeout: 10_000, maxWait: 10_000 });
+  } catch (error) {
+    if (error instanceof ResourceConflictAbort) {
+      return NextResponse.json(
+        { error: "This meeting conflicts with an existing meeting's room, Zoom room, or Zoom host.", conflicts: error.conflicts },
+        { status: 409 },
+      );
+    }
+    throw error;
+  }
+
+  const { createdMeeting, resolvedHost, hostSyncError } = txResult;
+  // One family lookup for both background syncs below -- keyed on the anchor, so it returns the
+  // post-create family (both schedules) whichever of them asks for it first.
+  const loadFamily = linkedFamilyLoader(prisma, anchor.mid);
+
+  after(
+    syncLinkedSchedule(
+      createdMeeting.mid,
+      createdMeeting as unknown as IMeeting,
+      auth.accessToken,
+      loadFamily,
+      provisionsZoom ? { host: resolvedHost, syncError: hostSyncError } : null,
+    ).catch(async (error) => {
+      console.error("syncLinkedSchedule threw:", error);
+      try {
+        await prisma.meeting.update({
+          where: { mid: createdMeeting.mid },
+          data: { googleSyncStatus: 'error', googleSyncError: "Sync job failed unexpectedly." },
+        });
+      } catch (persistError) {
+        console.error("Failed to persist linked-schedule sync failure status:", persistError);
+      }
+    }),
+  );
+  after(
+    syncLinkedScheduleFamily(
+      familyMembers(family),
+      auth.accessToken,
+      loadFamily,
+      inheritsZoom ? anchor.zid : null,
+    ).catch((error) => console.error("syncLinkedScheduleFamily threw:", error)),
+  );
+
+  return NextResponse.json({ ...anchor, linkedMid: createdMeeting.mid });
+}
+
 const updateMeeting = async (request: Request): Promise<Response> => {
   try {
     const auth = await requireRole(Role.ADMIN);
@@ -767,6 +1212,23 @@ const updateMeeting = async (request: Request): Promise<Response> => {
     }
     const editScope: EditScope = scopeParsed.data.editScope ?? 'all';
     const occurrenceDate = scopeParsed.data.occurrenceDate ?? null;
+
+    // Parsed separately from meetingSchema too (see linkedScheduleBlockSchema's comment) --
+    // present only when the request is adding a SECOND schedule to this meeting.
+    const linkedParsed = linkedScheduleSchema.safeParse(rawBody);
+    if (!linkedParsed.success) {
+      return NextResponse.json({ error: "Invalid linked schedule", issues: linkedParsed.error.issues }, { status: 400 });
+    }
+    const linkedSchedule: LinkedScheduleInput | null = linkedParsed.data.linkedSchedule ?? null;
+    // A linked schedule is a property of the whole series (a second weekly schedule of the same
+    // meeting), so there is no coherent meaning for adding one to a single occurrence or to the
+    // tail of a split -- reject the combination instead of silently applying one half of it.
+    if (linkedSchedule && editScope !== 'all') {
+      return NextResponse.json(
+        { error: "A linked schedule applies to the whole series; editScope must be omitted or 'all'." },
+        { status: 400 },
+      );
+    }
 
     // Read before lockResourceClaims acquires anything below -- accepted gap, not covered by
     // this fix: two concurrent edits to this *same* meeting could each compute
@@ -790,6 +1252,10 @@ const updateMeeting = async (request: Request): Promise<Response> => {
     // googleCalendarEventIds if its date has arrived but nothing's promoted it yet, before this
     // edit reads/writes that field below.
     existingMeeting.googleCalendarEventIds = await reconcilePendingResume(existingMeeting);
+
+    if (linkedSchedule) {
+      return handleLinkedScheduleCreate(auth, existingMeeting, linkedSchedule, !!newMeeting.confirmOverride);
+    }
 
     if (editScope !== 'all') {
       if (!existingMeeting.recurrencePattern) {

--- a/frontend/app/api/update/meeting/route.ts
+++ b/frontend/app/api/update/meeting/route.ts
@@ -767,8 +767,17 @@ async function handleScopedEdit(
 function deriveLinkedScheduleStart(
   anchor: Meeting & { recurrencePattern: RecurrencePattern | null },
   daysOfWeek: string[],
-): { startDateTime: Date; endDateTime: Date } | null {
+): { startDateTime: Date; endDateTime: Date; patternStartDate: Date } | null {
   const pattern = anchor.recurrencePattern!;
+  // Never earlier than today: a schedule added to a series that started years ago is a schedule
+  // that starts NOW, not one that retroactively met every week since. Searching from the series
+  // start instead would publish a backdated Google Calendar series (fabricated history on past
+  // calendar views) and, for a count-bounded anchor, could resolve an end date that has already
+  // passed -- a row born dead. The week phase is unaffected: matchesRecurrencePattern measures
+  // the interval from the ANCHOR's own startDate below, whatever date the search begins on.
+  const seriesStartEtDateStr = toETDateStr(pattern.startDate);
+  const todayEtDateStr = toETDateStr(new Date());
+  const searchFromEtDateStr = seriesStartEtDateStr > todayEtDateStr ? seriesStartEtDateStr : todayEtDateStr;
   const firstETDate = firstOccurrenceOnOrAfter(
     {
       type: 'weekly',
@@ -782,14 +791,19 @@ function deriveLinkedScheduleStart(
       // Monday-Friday schedule says nothing about when the Saturday one starts.
       excludedDates: [],
     },
-    toETDateStr(pattern.startDate),
+    searchFromEtDateStr,
   );
   if (!firstETDate) return null;
   const { hour, minute, second } = getETTimeOfDay(anchor.startDateTime);
   const pad = (value: number) => String(value).padStart(2, '0');
   const startDateTime = new Date(convertETToUTC(`${firstETDate}T${pad(hour)}:${pad(minute)}:${pad(second)}`));
   const durationMs = anchor.endDateTime.getTime() - anchor.startDateTime.getTime();
-  return { startDateTime, endDateTime: new Date(startDateTime.getTime() + durationMs) };
+  // INVARIANT: a stored recurrencePattern.startDate is ET-midnight-anchored (parseMMDDYYYY),
+  // never a real meeting-time instant -- calculateEndDateFromOccurrences reads the weekday
+  // anchor straight off getUTCDay(), so a 7 PM-or-later ET start would roll into the next UTC
+  // day and count the occurrences from the wrong weekday.
+  const patternStartDate = new Date(convertETToUTC(`${firstETDate}T00:00:00`));
+  return { startDateTime, endDateTime: new Date(startDateTime.getTime() + durationMs), patternStartDate };
 }
 
 // Runs after the response is sent — the new linked row's own half of the create: its Google
@@ -866,15 +880,18 @@ async function syncLinkedScheduleFamily(
     const holder = members.find((member) => member.zid === patchZid && member.zoomManaged);
     if (holder) {
       const ok = await updateZoomMeeting(patchZid, holder as unknown as IMeeting, await loadFamily(patchZid));
-      if (!ok) {
-        await prisma.meeting.update({
-          where: { mid: holder.mid },
-          data: {
-            zoomSyncStatus: 'error',
-            zoomSyncError: "Couldn't update the shared Zoom meeting for the newly linked schedule.",
-          },
-        });
-      }
+      // Persisted either way, like every other Zoom write: a holder already carrying a stale
+      // zoomSyncStatus 'error' (from an earlier failed sync) would otherwise keep the calendar's
+      // ⚠ badge after this PATCH actually succeeded.
+      await prisma.meeting.update({
+        where: { mid: holder.mid },
+        data: ok
+          ? { zoomSyncStatus: 'synced', zoomSyncError: null }
+          : {
+              zoomSyncStatus: 'error',
+              zoomSyncError: "Couldn't update the shared Zoom meeting for the newly linked schedule.",
+            },
+      });
     }
   }
 
@@ -893,16 +910,82 @@ async function syncLinkedScheduleFamily(
   }
 }
 
+// Whether this payload asks to change the anchor row itself, on top of adding a schedule to it.
+// Compares only what the meeting form can actually edit: `creator` is server-managed and
+// `group` has no input at all (the form posts a placeholder for both), so a difference there is
+// never an admin's edit. A payload with no `recurrencePattern` makes no claim about the
+// recurrence either -- this branch never deletes one, unlike the whole-series path below.
+function submitsAnchorEdits(
+  existing: Meeting & { recurrencePattern: RecurrencePattern | null },
+  submitted: IMeeting,
+): boolean {
+  const text = (value: string | null | undefined) => value ?? "";
+  if (
+    submitted.title !== existing.title ||
+    text(submitted.description) !== text(existing.description) ||
+    text(submitted.email) !== text(existing.email) ||
+    submitted.modeType !== existing.modeType ||
+    text(submitted.room) !== text(existing.room) ||
+    text(submitted.zoomRoom) !== text(existing.zoomRoom) ||
+    text(submitted.status) !== text(existing.status) ||
+    submitted.isRecurring !== existing.isRecurring ||
+    new Date(submitted.startDateTime).getTime() !== existing.startDateTime.getTime() ||
+    new Date(submitted.endDateTime).getTime() !== existing.endDateTime.getTime() ||
+    [...submitted.calType].sort().join("|") !== [...existing.calType].sort().join("|")
+  ) {
+    return true;
+  }
+  // Same definition of "an explicit reassignment" the whole-series path's explicitHostChange
+  // uses: a blank/"Automatic" selection, or resubmitting the meeting's own host, is not one.
+  const submittedHost = (submitted.zoomHost ?? "").trim();
+  if (submittedHost && submittedHost.toLowerCase() !== (existing.zoomHost ?? "").trim().toLowerCase()) return true;
+
+  const pattern = submitted.recurrencePattern;
+  if (!pattern) return false;
+  const stored = existing.recurrencePattern;
+  if (!stored) return true;
+  // A count-bounded pattern is STORED with its count already resolved into a real endDate,
+  // while the form resubmits it as a still-null endDate plus the count -- so the submitted one
+  // has to be resolved the same way the whole-series path resolves it before comparing.
+  const submittedEndDate = pattern.endDate ?? (pattern.numberOfOccurrences
+    ? calculateEndDateFromOccurrences(
+        pattern.startDate, pattern.daysOfWeek ?? [], pattern.numberOfOccurrences,
+        pattern.interval || 1, pattern.type, pattern.weekOfMonth ?? null, pattern.dayOfMonth ?? null,
+      )
+    : null);
+  return (
+    pattern.type !== stored.type ||
+    new Date(pattern.startDate).getTime() !== stored.startDate.getTime() ||
+    (submittedEndDate ? new Date(submittedEndDate).getTime() : null) !== (stored.endDate?.getTime() ?? null) ||
+    (pattern.numberOfOccurrences ?? null) !== (stored.numberOfOccurrences ?? null) ||
+    (pattern.interval || 1) !== stored.interval ||
+    (pattern.weekOfMonth ?? null) !== (stored.weekOfMonth ?? null) ||
+    (pattern.dayOfMonth ?? null) !== (stored.dayOfMonth ?? null) ||
+    (pattern.daysOfWeek ?? []).join("|") !== (stored.daysOfWeek ?? []).join("|")
+  );
+}
+
 // Handles a `linkedSchedule` block: adds a SECOND weekly schedule -- a different mode on
 // different weekdays -- to an existing recurring meeting, served by the family's one Zoom
 // meeting (util/meetings/linkedSchedules.ts). Modeled on handleScopedEdit, minus the parent
 // trim: the anchor row itself is not touched, only read.
 async function handleLinkedScheduleCreate(
   auth: { accessToken?: string; user?: { email?: string | null } | null },
-  existingMeeting: Meeting,
+  existingMeeting: Meeting & { recurrencePattern: RecurrencePattern | null },
+  newMeeting: IMeeting,
   linkedSchedule: LinkedScheduleInput,
-  confirmOverride: boolean,
 ): Promise<Response> {
+  const confirmOverride = !!newMeeting.confirmOverride;
+  // This branch reads the anchor row and never writes it, so any edit to the anchor's own
+  // fields in the same payload would be accepted with a 200 and applied nowhere. Refused
+  // instead of silently dropped -- the two writes are separate requests.
+  if (submitsAnchorEdits(existingMeeting, newMeeting)) {
+    return NextResponse.json(
+      { error: "Save this meeting's own changes before adding a linked schedule -- they can't be submitted together." },
+      { status: 400 },
+    );
+  }
+
   const family = await getLinkedFamily(prisma, existingMeeting.mid);
   if (!family) {
     return NextResponse.json({ error: `Meeting with ID ${existingMeeting.mid} not found` }, { status: 404 });
@@ -955,7 +1038,7 @@ async function handleLinkedScheduleCreate(
     );
   }
 
-  let derived: { startDateTime: Date; endDateTime: Date } | null;
+  let derived: { startDateTime: Date; endDateTime: Date; patternStartDate: Date } | null;
   try {
     derived = deriveLinkedScheduleStart(anchor, linkedDays);
   } catch (error) {
@@ -972,15 +1055,16 @@ async function handleLinkedScheduleCreate(
       { status: 400 },
     );
   }
-  const { startDateTime, endDateTime } = derived;
+  const { startDateTime, endDateTime, patternStartDate } = derived;
 
   // Everything below is copied from the anchor, never read from the payload -- see
   // linkedScheduleBlockSchema's comment. A count-bounded anchor gives the linked schedule the
   // same count, resolved into its OWN end date because its weekdays reach that count elsewhere.
+  // Counted from patternStartDate, not the row's start instant: see deriveLinkedScheduleStart.
   const pattern = anchor.recurrencePattern;
   const numberOfOccurrences = pattern.endDate ? null : pattern.numberOfOccurrences;
   const endDate = pattern.endDate ?? (numberOfOccurrences
-    ? calculateEndDateFromOccurrences(startDateTime, linkedDays, numberOfOccurrences, pattern.interval, 'weekly', null, null)
+    ? calculateEndDateFromOccurrences(patternStartDate, linkedDays, numberOfOccurrences, pattern.interval, 'weekly', null, null)
     : null);
 
   const needsZoom = isZoomBearing({ modeType: linkedSchedule.modeType });
@@ -1005,7 +1089,7 @@ async function handleLinkedScheduleCreate(
     isRecurring: true,
     recurrencePattern: {
       type: 'weekly',
-      startDate: startDateTime,
+      startDate: patternStartDate,
       endDate,
       interval: pattern.interval,
       daysOfWeek: linkedDays,
@@ -1057,13 +1141,19 @@ async function handleLinkedScheduleCreate(
           conflictRows.push(...await findResourceConflictRows("zoomRoom", candidate.zoomRoom, candidate, tx, {}));
         }
         // zoomHost DOES exclude the family: the inherited zid is ONE real Zoom booking the two
-        // schedules share, not a second one to flag. The cap makes the anchor the family's only
-        // other member here. Belt-and-braces anyway -- the disjoint-weekday rule above already
-        // means the two schedules' occurrences never overlap.
+        // schedules share, not a second one to flag. Excluded by zid as well as by the anchor's
+        // mid, because "rows of that one booking" is exactly what a shared zid means -- a
+        // scoped-edit split child of the anchor holds the same zid without being a family
+        // member, and would otherwise be reported as the family colliding with itself.
+        // Belt-and-braces anyway -- the disjoint-weekday rule above already means the two
+        // schedules' occurrences never overlap.
         if (inheritedZoomHost) {
           conflictRows.push(...await findResourceConflictRows(
             "zoomHost", inheritedZoomHost, candidate, tx,
-            { excludeMid: anchor.mid, includeSuspended: true, capacity: hostCapacities[inheritedZoomHost] ?? 1 },
+            {
+              excludeMid: anchor.mid, excludeZid: anchor.zid ?? undefined,
+              includeSuspended: true, capacity: hostCapacities[inheritedZoomHost] ?? 1,
+            },
           ));
         }
         if (conflictRows.length > 0) {
@@ -1128,7 +1218,7 @@ async function handleLinkedScheduleCreate(
           recurrencePattern: {
             create: {
               type: 'weekly',
-              startDate: startDateTime,
+              startDate: patternStartDate,
               endDate,
               numberOfOccurrences: numberOfOccurrences ?? undefined,
               daysOfWeek: linkedDays,
@@ -1156,9 +1246,16 @@ async function handleLinkedScheduleCreate(
   }
 
   const { createdMeeting, resolvedHost, hostSyncError } = txResult;
+  // The zid the family already holds, if any -- the shared Zoom meeting the new schedule joined.
+  const familyZid = familyMembers(family).find((member) => isZoomBearing(member) && member.zid)?.zid ?? null;
   // One family lookup for both background syncs below -- keyed on the anchor, so it returns the
-  // post-create family (both schedules) whichever of them asks for it first.
-  const loadFamily = linkedFamilyLoader(prisma, anchor.mid);
+  // post-create family (both schedules) whichever of them asks for it first. Pinned to the
+  // FAMILY's zid rather than whichever caller gets there first: the loader resolves its zid
+  // argument once, on that first call, and an In-Person linked row would pin it to null --
+  // dropping every other row of the same Zoom meeting (split children, legacy zid groups) from
+  // the union the family PATCH is built from, silently narrowing Zoom's weekly_days (#513).
+  const familyLoader = linkedFamilyLoader(prisma, anchor.mid);
+  const loadFamily: LinkedFamilyLoader = () => familyLoader(familyZid);
 
   after(
     syncLinkedSchedule(
@@ -1179,13 +1276,11 @@ async function handleLinkedScheduleCreate(
       }
     }),
   );
-  // The family's existing shared Zoom meeting, if it has one. It needs the PATCH whether or not
-  // the new schedule is Zoom-bearing: an In-Person member adds no days to the recurrence but
-  // still names itself in the family's topic. Null only when this request just minted it, since
+  // The family's existing shared Zoom meeting needs the PATCH whether or not the new schedule
+  // is Zoom-bearing: an In-Person member adds no days to the recurrence but still names itself
+  // in the family's topic. Null only when this request just minted the Zoom meeting, since
   // createZoomMeeting was already handed the family.
-  const patchZid = provisionsZoom
-    ? null
-    : familyMembers(family).find((member) => isZoomBearing(member) && member.zid)?.zid ?? null;
+  const patchZid = provisionsZoom ? null : familyZid;
 
   after(
     syncLinkedScheduleFamily(familyMembers(family), auth.accessToken, loadFamily, patchZid)
@@ -1258,7 +1353,7 @@ const updateMeeting = async (request: Request): Promise<Response> => {
     existingMeeting.googleCalendarEventIds = await reconcilePendingResume(existingMeeting);
 
     if (linkedSchedule) {
-      return handleLinkedScheduleCreate(auth, existingMeeting, linkedSchedule, !!newMeeting.confirmOverride);
+      return handleLinkedScheduleCreate(auth, existingMeeting, newMeeting, linkedSchedule);
     }
 
     if (editScope !== 'all') {

--- a/frontend/app/api/update/meeting/route.ts
+++ b/frontend/app/api/update/meeting/route.ts
@@ -1179,13 +1179,17 @@ async function handleLinkedScheduleCreate(
       }
     }),
   );
+  // The family's existing shared Zoom meeting, if it has one. It needs the PATCH whether or not
+  // the new schedule is Zoom-bearing: an In-Person member adds no days to the recurrence but
+  // still names itself in the family's topic. Null only when this request just minted it, since
+  // createZoomMeeting was already handed the family.
+  const patchZid = provisionsZoom
+    ? null
+    : familyMembers(family).find((member) => isZoomBearing(member) && member.zid)?.zid ?? null;
+
   after(
-    syncLinkedScheduleFamily(
-      familyMembers(family),
-      auth.accessToken,
-      loadFamily,
-      inheritsZoom ? anchor.zid : null,
-    ).catch((error) => console.error("syncLinkedScheduleFamily threw:", error)),
+    syncLinkedScheduleFamily(familyMembers(family), auth.accessToken, loadFamily, patchZid)
+      .catch((error) => console.error("syncLinkedScheduleFamily threw:", error)),
   );
 
   return NextResponse.json({ ...anchor, linkedMid: createdMeeting.mid });

--- a/frontend/services/googleCalendar.ts
+++ b/frontend/services/googleCalendar.ts
@@ -128,10 +128,12 @@ const CALENDAR_SINGLE_TITLE_SUFFIX = LINKED_SCHEDULE_MODE_LABEL;
 // is also exactly the name the family's shared Zoom meeting carries. Nothing pins a calendar
 // title the way zoomTopic pins a Zoom topic, so there's no verbatim-name escape hatch here.
 //
-// TODO(linked-schedules PR3): the union title is recomputed only for the row being written, so
-// adding or removing a family member leaves the OTHER members' events on their previous title
-// until each is itself edited or retry-synced. PR3's family-wide fan-out has to republish every
-// member's calendar events alongside its updateZoomMeeting, not just the Zoom half.
+// The title is recomputed only for the row being written, so a write that changes the FAMILY's
+// shape has to republish the other members too, or their events keep the name they were last
+// written with. Adding a schedule does exactly that (handleLinkedScheduleCreate's
+// syncLinkedScheduleFamily fan-out, app/api/update/meeting/route.ts).
+// TODO(linked-schedules PR5): removing a linked schedule is a plain row soft-delete, which
+// leaves the SURVIVOR's events on the two-schedule name until it is next written.
 function buildEventTitle(meeting: IMeeting, family: IMeeting[]): string {
     return buildLinkedScheduleLabel(meeting.title, meeting, family, CALENDAR_SINGLE_TITLE_SUFFIX);
 }

--- a/frontend/tests/integration/update-meeting-linked-schedule.test.ts
+++ b/frontend/tests/integration/update-meeting-linked-schedule.test.ts
@@ -1,0 +1,470 @@
+import { randomUUID } from "crypto";
+import type { Meeting } from "@prisma/client";
+import { formatETDateString, formatETWeekdayLong, getETTimeOfDay } from "../../util/date/timeUtils";
+import { buildLinkedScheduleLabel } from "../../util/meetings/linkedSchedules";
+
+// after() tasks are collected rather than discarded (the shim update-meeting-scoped-edit.test.ts
+// uses) so each test can drain them at a known point -- a linked-schedule create fans work out to
+// BOTH the new row and every existing family member, and the assertions are about what those two
+// syncs were handed, not just that they eventually ran.
+const mockCapturedAfterTasks: Promise<unknown>[] = [];
+jest.mock("next/server", () => ({
+  ...jest.requireActual("next/server"),
+  after: (task: unknown) => {
+    mockCapturedAfterTasks.push(Promise.resolve(task));
+  },
+}));
+
+jest.mock("../../services/auth", () => ({
+  requireRole: jest.fn().mockResolvedValue({
+    user: { role: "ADMIN", email: "session-admin@test.icr" },
+    accessToken: "fake-token",
+  }),
+}));
+
+jest.mock("../../services/googleCalendar", () => ({
+  calendarIdsForMeeting: jest.fn((calType: string[]) =>
+    Object.fromEntries(calType.map((cat) => [cat, `cal-${cat}`]))),
+  createCalendarEvent: jest.fn().mockResolvedValue({ id: `event-${Math.random()}`, error: null }),
+  updateCalendarEvent: jest.fn().mockResolvedValue({ ok: true, error: null }),
+  deleteCalendarEvent: jest.fn().mockResolvedValue(true),
+  reconcileMeetingCalendars: jest.fn().mockResolvedValue({ updatedEventIds: {}, allSynced: true, googleSyncError: null }),
+}));
+
+jest.mock("../../services/zoom", () => ({
+  createZoomMeeting: jest.fn(),
+  updateZoomMeeting: jest.fn().mockResolvedValue(true),
+  rehostZoomMeeting: jest.fn(),
+  deleteZoomMeeting: jest.fn(),
+  getZoomMeetingInvitation: jest.fn().mockResolvedValue(null),
+  resolveZoomHost: jest.fn(),
+  getZoomHostCapacities: jest.fn().mockResolvedValue({}),
+  zoomHostPool: ["linked-pool-host-1@icr.test", "linked-pool-host-2@icr.test"],
+  zoomRoomCalendarId: { "Linked Zoom Room": "linked-zoomroom-cal-id" },
+}));
+
+import { getTestPrismaClient, disconnectTestPrismaClient } from "../factories/db";
+import { seedRecurringMeeting, seedMeeting } from "../factories/meeting";
+import { PUT } from "../../app/api/update/meeting/route";
+import { createCalendarEvent, updateCalendarEvent } from "../../services/googleCalendar";
+import { createZoomMeeting, updateZoomMeeting, resolveZoomHost } from "../../services/zoom";
+
+const mockedCreateCalendarEvent = createCalendarEvent as jest.Mock;
+const mockedUpdateCalendarEvent = updateCalendarEvent as jest.Mock;
+const mockedCreateZoomMeeting = createZoomMeeting as jest.Mock;
+const mockedUpdateZoomMeeting = updateZoomMeeting as jest.Mock;
+const mockedResolveZoomHost = resolveZoomHost as jest.Mock;
+
+// A real future Monday, so the anchor's weekday and the linked schedule's Saturday are both
+// derived from the anchor date instead of being hardcoded names that could drift apart.
+const SERIES_START = new Date("2026-09-07T18:00:00Z");
+const SERIES_END = new Date("2026-09-07T19:00:00Z");
+const ANCHOR_WEEKDAY = formatETWeekdayLong(SERIES_START); // Monday
+const LINKED_WEEKDAY = "Saturday";
+const FIRST_LINKED_ET_DATE = "2026-09-12"; // the first Saturday on/after the anchor's start
+
+afterAll(async () => {
+  await disconnectTestPrismaClient();
+});
+
+beforeEach(() => {
+  mockedCreateCalendarEvent.mockClear();
+  mockedUpdateCalendarEvent.mockClear();
+  mockedCreateZoomMeeting.mockClear();
+  mockedUpdateZoomMeeting.mockClear();
+  mockedResolveZoomHost.mockClear();
+  mockCapturedAfterTasks.length = 0;
+});
+
+async function drainAfterTasks(): Promise<void> {
+  await Promise.all(mockCapturedAfterTasks.splice(0, mockCapturedAfterTasks.length));
+}
+
+function putMeeting(payload: Record<string, unknown>): Promise<Response> {
+  return PUT(new Request("http://localhost/api/update/meeting", { method: "PUT", body: JSON.stringify(payload) }));
+}
+
+// The integration DB is reset once per file (globalSetup), not per test, and a weekly interval-1
+// series recurs forever -- so every anchor gets its own room/zid/host unless a test is
+// deliberately about sharing one.
+async function seedAnchor(overrides: Record<string, unknown> = {}, patternOverrides: Record<string, unknown> = {}) {
+  const { meeting } = await seedRecurringMeeting(
+    {
+      title: "Linked Family",
+      startDateTime: SERIES_START,
+      endDateTime: SERIES_END,
+      modeType: "Hybrid",
+      room: `Linked Room ${randomUUID()}`,
+      zoomRoom: "Linked Zoom Room",
+      zid: randomUUID(),
+      zoomLink: "https://zoom.us/j/anchor",
+      zoomPasscode: "anchor-pass",
+      zoomInvitation: "anchor invitation",
+      zoomHost: `linked-${randomUUID()}@518icr.com`,
+      zoomManaged: true,
+      zoomTopic: null,
+      calType: ["AA"],
+      googleCalendarEventIds: { AA: "anchor-event-aa" },
+      ...overrides,
+    },
+    { type: "weekly", daysOfWeek: [ANCHOR_WEEKDAY], interval: 1, ...patternOverrides },
+  );
+  return meeting;
+}
+
+function anchorPayload(anchor: Meeting, extra: Record<string, unknown> = {}) {
+  return {
+    mid: anchor.mid,
+    title: anchor.title,
+    description: anchor.description,
+    creator: anchor.creator,
+    group: anchor.group,
+    startDateTime: anchor.startDateTime,
+    endDateTime: anchor.endDateTime,
+    email: anchor.email,
+    calType: anchor.calType,
+    modeType: anchor.modeType,
+    room: anchor.room,
+    zoomRoom: anchor.zoomRoom,
+    status: anchor.status,
+    isRecurring: anchor.isRecurring,
+    ...extra,
+  };
+}
+
+function linkedBlock(overrides: Record<string, unknown> = {}) {
+  return {
+    mid: `linked-${randomUUID()}`,
+    modeType: "Remote",
+    room: null,
+    zoomRoom: null,
+    recurrencePattern: {
+      type: "weekly",
+      startDate: SERIES_START,
+      daysOfWeek: [LINKED_WEEKDAY],
+      firstDayOfWeek: "Sunday",
+      interval: 1,
+    },
+    ...overrides,
+  };
+}
+
+describe("linked-schedule rejections", () => {
+  test("a non-recurring meeting is rejected with 400", async () => {
+    const anchor = await seedMeeting({ modeType: "Remote", room: "", zoomRoom: null });
+    const response = await putMeeting(anchorPayload(anchor, { linkedSchedule: linkedBlock() }));
+    expect(response.status).toBe(400);
+    expect((await response.json()).error).toMatch(/recurring/i);
+  });
+
+  test("a non-weekly (monthly) meeting is rejected with 400", async () => {
+    const anchor = await seedAnchor({}, { type: "monthly", daysOfWeek: [ANCHOR_WEEKDAY], weekOfMonth: 1 });
+    const response = await putMeeting(anchorPayload(anchor, { linkedSchedule: linkedBlock() }));
+    expect(response.status).toBe(400);
+    expect((await response.json()).error).toMatch(/weekly/i);
+  });
+
+  test("a family already at the cap of 2 is rejected with 400", async () => {
+    const anchor = await seedAnchor();
+    await seedRecurringMeeting(
+      { linkedToMid: anchor.mid, modeType: "Remote", room: "", zoomRoom: null, zid: anchor.zid,
+        startDateTime: SERIES_START, endDateTime: SERIES_END },
+      { type: "weekly", daysOfWeek: [LINKED_WEEKDAY], interval: 1 },
+    );
+
+    const response = await putMeeting(anchorPayload(anchor, {
+      linkedSchedule: linkedBlock({ modeType: "In Person", room: "Some Room", recurrencePattern: {
+        type: "weekly", startDate: SERIES_START, daysOfWeek: ["Sunday"], firstDayOfWeek: "Sunday", interval: 1,
+      } }),
+    }));
+    expect(response.status).toBe(400);
+    expect((await response.json()).error).toMatch(/already runs 2 schedules/i);
+  });
+
+  test("a mode the meeting already runs is rejected with 400", async () => {
+    const anchor = await seedAnchor();
+    const response = await putMeeting(anchorPayload(anchor, {
+      linkedSchedule: linkedBlock({ modeType: "Hybrid", room: "Another Room", zoomRoom: "Linked Zoom Room" }),
+    }));
+    expect(response.status).toBe(400);
+    expect((await response.json()).error).toMatch(/mode this meeting doesn't already run/i);
+  });
+
+  test("weekdays the meeting already meets on are rejected with 400", async () => {
+    const anchor = await seedAnchor();
+    const response = await putMeeting(anchorPayload(anchor, {
+      linkedSchedule: linkedBlock({ recurrencePattern: {
+        type: "weekly", startDate: SERIES_START, daysOfWeek: [ANCHOR_WEEKDAY, LINKED_WEEKDAY],
+        firstDayOfWeek: "Sunday", interval: 1,
+      } }),
+    }));
+    expect(response.status).toBe(400);
+    expect((await response.json()).error).toMatch(new RegExp(`already meets on ${ANCHOR_WEEKDAY}`, "i"));
+  });
+
+  test("a linked schedule with no weekday at all is rejected with 400", async () => {
+    const anchor = await seedAnchor();
+    const response = await putMeeting(anchorPayload(anchor, {
+      linkedSchedule: linkedBlock({ recurrencePattern: {
+        type: "weekly", startDate: SERIES_START, daysOfWeek: [], firstDayOfWeek: "Sunday", interval: 1,
+      } }),
+    }));
+    expect(response.status).toBe(400);
+    expect((await response.json()).error).toMatch(/at least one day/i);
+  });
+
+  test("a Hybrid linked schedule with no room is rejected by the schema with 400", async () => {
+    const anchor = await seedAnchor({ modeType: "Remote", room: "", zoomRoom: null });
+    const response = await putMeeting(anchorPayload(anchor, {
+      linkedSchedule: linkedBlock({ modeType: "Hybrid", room: null, zoomRoom: null }),
+    }));
+    expect(response.status).toBe(400);
+    expect((await response.json()).error).toBe("Invalid linked schedule");
+  });
+
+  test.each(["this", "thisAndFollowing"])(
+    "a linked schedule combined with editScope '%s' is rejected with 400",
+    async (editScope) => {
+      const anchor = await seedAnchor();
+      const response = await putMeeting(anchorPayload(anchor, {
+        editScope,
+        occurrenceDate: SERIES_START,
+        linkedSchedule: linkedBlock(),
+      }));
+      expect(response.status).toBe(400);
+      expect((await response.json()).error).toMatch(/whole series/i);
+    },
+  );
+});
+
+test("a room conflict on the linked schedule's own days is a 409 that writes nothing, and confirmOverride retries it", async () => {
+  const anchor = await seedAnchor();
+  const contestedRoom = `Contested Linked Room ${randomUUID()}`;
+  // A one-time booking of the room on the linked schedule's very first Saturday.
+  await seedMeeting({
+    room: contestedRoom,
+    startDateTime: new Date(`${FIRST_LINKED_ET_DATE}T18:00:00Z`),
+    endDateTime: new Date(`${FIRST_LINKED_ET_DATE}T19:00:00Z`),
+  });
+
+  const linkedMid = `linked-${randomUUID()}`;
+  const blocked = await putMeeting(anchorPayload(anchor, {
+    linkedSchedule: linkedBlock({ mid: linkedMid, modeType: "In Person", room: contestedRoom }),
+  }));
+  expect(blocked.status).toBe(409);
+  expect((await blocked.json()).conflicts).toBeDefined();
+
+  // The whole create is one transaction: an aborted attempt leaves no row behind.
+  const prisma = getTestPrismaClient();
+  expect(await prisma.meeting.findUnique({ where: { mid: linkedMid } })).toBeNull();
+
+  const overridden = await putMeeting(anchorPayload(anchor, {
+    confirmOverride: true,
+    linkedSchedule: linkedBlock({ mid: linkedMid, modeType: "In Person", room: contestedRoom }),
+  }));
+  expect(overridden.status).toBe(200);
+  const created = await prisma.meeting.findUnique({ where: { mid: linkedMid }, include: { recurrencePattern: true } });
+  expect(created?.linkedToMid).toBe(anchor.mid);
+  await drainAfterTasks();
+});
+
+test("a Remote schedule linked to a Hybrid anchor inherits the family's Zoom identity and derives its own schedule", async () => {
+  const anchor = await seedAnchor();
+  const linkedMid = `linked-${randomUUID()}`;
+
+  const response = await putMeeting(anchorPayload(anchor, { linkedSchedule: linkedBlock({ mid: linkedMid }) }));
+  expect(response.status).toBe(200);
+  expect((await response.json()).linkedMid).toBe(linkedMid);
+
+  const prisma = getTestPrismaClient();
+  const created = await prisma.meeting.findUnique({ where: { mid: linkedMid }, include: { recurrencePattern: true } });
+  expect(created?.linkedToMid).toBe(anchor.mid);
+  expect(created?.splitFromMid).toBeNull();
+  expect(created?.status).toBe("Active");
+  expect(created?.isRecurring).toBe(true);
+
+  // Zoom identity inherited whole -- one Zoom meeting serves the family.
+  expect(created?.zid).toBe(anchor.zid);
+  expect(created?.zoomLink).toBe(anchor.zoomLink);
+  expect(created?.zoomPasscode).toBe(anchor.zoomPasscode);
+  expect(created?.zoomInvitation).toBe(anchor.zoomInvitation);
+  expect(created?.zoomHost).toBe(anchor.zoomHost);
+  expect(created?.zoomManaged).toBe(anchor.zoomManaged);
+  // Never re-provisioned, and no fresh host capacity reserved for the inherited booking.
+  expect(mockedCreateZoomMeeting).not.toHaveBeenCalled();
+  expect(mockedResolveZoomHost).not.toHaveBeenCalled();
+
+  // Identity/content copied from the anchor; only the mode and the weekdays are the linked
+  // schedule's own.
+  expect(created?.title).toBe(anchor.title);
+  expect(created?.description).toBe(anchor.description);
+  expect(created?.email).toBe(anchor.email);
+  expect(created?.group).toBe(anchor.group);
+  expect(created?.calType).toEqual(anchor.calType);
+  expect(created?.modeType).toBe("Remote");
+  expect(created?.recurrencePattern?.daysOfWeek).toEqual([LINKED_WEEKDAY]);
+  expect(created?.recurrencePattern?.interval).toBe(1);
+
+  // Re-anchored onto the first Saturday of the anchor's series, keeping its ET time of day and
+  // its duration.
+  expect(formatETDateString(created!.startDateTime)).toBe(FIRST_LINKED_ET_DATE);
+  expect(getETTimeOfDay(created!.startDateTime)).toEqual(getETTimeOfDay(anchor.startDateTime));
+  expect(created!.endDateTime.getTime() - created!.startDateTime.getTime())
+    .toBe(anchor.endDateTime.getTime() - anchor.startDateTime.getTime());
+
+  // The anchor row itself is only read, never rewritten.
+  const anchorAfter = await prisma.meeting.findUnique({ where: { mid: anchor.mid } });
+  expect(anchorAfter?.lastEditedBy).toBeNull();
+  expect(anchorAfter?.modeType).toBe(anchor.modeType);
+});
+
+test("client-supplied schedule values that aren't the linked schedule's own are ignored", async () => {
+  const anchor = await seedAnchor();
+  const linkedMid = `linked-${randomUUID()}`;
+
+  const response = await putMeeting(anchorPayload(anchor, {
+    linkedSchedule: linkedBlock({
+      mid: linkedMid,
+      recurrencePattern: {
+        type: "weekly",
+        // Every one of these is the client trying to define the family's shape: a different
+        // start, a different cadence, and an end of its own.
+        startDate: new Date("2027-01-02T05:00:00Z"),
+        endDate: new Date("2027-03-01T05:00:00Z"),
+        numberOfOccurrences: 3,
+        daysOfWeek: [LINKED_WEEKDAY],
+        firstDayOfWeek: "Sunday",
+        interval: 4,
+      },
+    }),
+  }));
+  expect(response.status).toBe(200);
+
+  const prisma = getTestPrismaClient();
+  const created = await prisma.meeting.findUnique({ where: { mid: linkedMid }, include: { recurrencePattern: true } });
+  expect(created?.recurrencePattern?.interval).toBe(1);
+  expect(created?.recurrencePattern?.endDate).toBeNull();
+  expect(created?.recurrencePattern?.numberOfOccurrences).toBeNull();
+  expect(formatETDateString(created!.recurrencePattern!.startDate)).toBe(FIRST_LINKED_ET_DATE);
+  await drainAfterTasks();
+});
+
+test("the whole family's external name is republished: the shared Zoom meeting and the anchor's calendar events", async () => {
+  const anchor = await seedAnchor();
+  const linkedMid = `linked-${randomUUID()}`;
+
+  const response = await putMeeting(anchorPayload(anchor, { linkedSchedule: linkedBlock({ mid: linkedMid }) }));
+  expect(response.status).toBe(200);
+  await drainAfterTasks();
+
+  // One PATCH of the family's single Zoom meeting, handed BOTH schedules so it can widen its
+  // recurrence to their union and rename itself after the family.
+  expect(mockedUpdateZoomMeeting).toHaveBeenCalledTimes(1);
+  const [patchedZid, patchedMeeting, zoomFamily] = mockedUpdateZoomMeeting.mock.calls[0];
+  expect(patchedZid).toBe(anchor.zid);
+  expect(patchedMeeting.mid).toBe(anchor.mid);
+  expect((zoomFamily as { mid: string }[]).map((row) => row.mid).sort()).toEqual([anchor.mid, linkedMid].sort());
+
+  // The anchor's own calendar event is rewritten too -- its title named a one-schedule meeting
+  // until this fan-out ran. buildEventTitle labels an event with exactly this call.
+  const anchorRewrite = mockedUpdateCalendarEvent.mock.calls.find(([, eventId]) => eventId === "anchor-event-aa");
+  expect(anchorRewrite).toBeDefined();
+  const [, , anchorMeetingArg, anchorCalId, , anchorFamily] = anchorRewrite!;
+  expect(anchorCalId).toBe("cal-AA");
+  expect(buildLinkedScheduleLabel(anchorMeetingArg.title, anchorMeetingArg, anchorFamily))
+    .toBe("Linked Family - Hybrid Mon - Zoom Only Sat");
+
+  // ...and the new row's own event is born with that same family name, never its own lone mode.
+  const linkedCreate = mockedCreateCalendarEvent.mock.calls.find(([, meetingArg]) => meetingArg.mid === linkedMid);
+  expect(linkedCreate).toBeDefined();
+  const [, linkedMeetingArg, , , linkedFamily] = linkedCreate!;
+  expect(buildLinkedScheduleLabel(linkedMeetingArg.title, linkedMeetingArg, linkedFamily))
+    .toBe("Linked Family - Hybrid Mon - Zoom Only Sat");
+});
+
+test("an In-Person schedule linked to a Hybrid anchor inherits no Zoom identity at all", async () => {
+  const anchor = await seedAnchor();
+  const linkedMid = `linked-${randomUUID()}`;
+
+  const response = await putMeeting(anchorPayload(anchor, {
+    linkedSchedule: linkedBlock({ mid: linkedMid, modeType: "In Person", room: `In Person Room ${randomUUID()}` }),
+  }));
+  expect(response.status).toBe(200);
+  await drainAfterTasks();
+
+  const prisma = getTestPrismaClient();
+  const created = await prisma.meeting.findUnique({ where: { mid: linkedMid } });
+  expect(created?.linkedToMid).toBe(anchor.mid);
+  expect(created?.zid).toBeNull();
+  expect(created?.zoomLink).toBeNull();
+  expect(created?.zoomHost).toBeNull();
+  expect(created?.zoomInvitation).toBeNull();
+  expect(mockedCreateZoomMeeting).not.toHaveBeenCalled();
+
+  // The family still has a Zoom meeting (the anchor's), and it still gets renamed -- the
+  // In-Person member names itself in the family's topic even though it holds no zid.
+  expect(mockedUpdateZoomMeeting).toHaveBeenCalledTimes(1);
+  const [, , zoomFamily] = mockedUpdateZoomMeeting.mock.calls[0];
+  expect((zoomFamily as { mid: string }[]).map((row) => row.mid).sort()).toEqual([anchor.mid, linkedMid].sort());
+});
+
+test("a Remote schedule linked to an In-Person anchor provisions the family's Zoom meeting and becomes its zid holder", async () => {
+  const anchor = await seedAnchor({
+    modeType: "In Person",
+    zoomRoom: null,
+    zid: null,
+    zoomLink: null,
+    zoomPasscode: null,
+    zoomInvitation: null,
+    zoomHost: null,
+  });
+  mockedResolveZoomHost.mockResolvedValueOnce("linked-pool-host-1@icr.test");
+  mockedCreateZoomMeeting.mockResolvedValueOnce({
+    zid: "provisioned-zid", zoomLink: "https://zoom.us/j/provisioned", zoomPasscode: "provisioned-pass",
+  });
+  const linkedMid = `linked-${randomUUID()}`;
+
+  const response = await putMeeting(anchorPayload(anchor, { linkedSchedule: linkedBlock({ mid: linkedMid }) }));
+  expect(response.status).toBe(200);
+  await drainAfterTasks();
+
+  // There was no Zoom meeting to inherit, so this row mints the family's -- once, with the whole
+  // family, so it is born holding the union schedule and the family's name.
+  expect(mockedResolveZoomHost).toHaveBeenCalledTimes(1);
+  expect(mockedCreateZoomMeeting).toHaveBeenCalledTimes(1);
+  const [, createdHost, createFamily] = mockedCreateZoomMeeting.mock.calls[0];
+  expect(createdHost).toBe("linked-pool-host-1@icr.test");
+  expect((createFamily as { mid: string }[]).map((row) => row.mid).sort()).toEqual([anchor.mid, linkedMid].sort());
+  // Nothing to widen: the create above already carried the family's schedule.
+  expect(mockedUpdateZoomMeeting).not.toHaveBeenCalled();
+
+  const prisma = getTestPrismaClient();
+  const created = await prisma.meeting.findUnique({ where: { mid: linkedMid } });
+  expect(created?.zid).toBe("provisioned-zid");
+  expect(created?.zoomLink).toBe("https://zoom.us/j/provisioned");
+  expect(created?.zoomHost).toBe("linked-pool-host-1@icr.test");
+  // The family is keyed on linkedToMid, so the Zoom-free anchor is still the root.
+  expect(created?.linkedToMid).toBe(anchor.mid);
+  const anchorAfter = await prisma.meeting.findUnique({ where: { mid: anchor.mid } });
+  expect(anchorAfter?.zid).toBeNull();
+});
+
+test("an exhausted host pool leaves the linked row unpublished rather than half-published", async () => {
+  const anchor = await seedAnchor({
+    modeType: "In Person", zoomRoom: null, zid: null, zoomLink: null, zoomPasscode: null,
+    zoomInvitation: null, zoomHost: null,
+  });
+  mockedResolveZoomHost.mockResolvedValueOnce(null);
+  const linkedMid = `linked-${randomUUID()}`;
+
+  const response = await putMeeting(anchorPayload(anchor, { linkedSchedule: linkedBlock({ mid: linkedMid }) }));
+  expect(response.status).toBe(200);
+  await drainAfterTasks();
+
+  expect(mockedCreateZoomMeeting).not.toHaveBeenCalled();
+  const prisma = getTestPrismaClient();
+  const created = await prisma.meeting.findUnique({ where: { mid: linkedMid } });
+  expect(created?.zoomSyncStatus).toBe("error");
+  expect(created?.googleSyncStatus).toBe("pending");
+  expect(mockedCreateCalendarEvent.mock.calls.some(([, meetingArg]) => meetingArg.mid === linkedMid)).toBe(false);
+});

--- a/frontend/tests/integration/update-meeting-linked-schedule.test.ts
+++ b/frontend/tests/integration/update-meeting-linked-schedule.test.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "crypto";
 import type { Meeting } from "@prisma/client";
-import { formatETDateString, formatETWeekdayLong, getETTimeOfDay } from "../../util/date/timeUtils";
+import { convertETToUTC, formatETDateString, formatETWeekdayLong, getETTimeOfDay } from "../../util/date/timeUtils";
 import { buildLinkedScheduleLabel } from "../../util/meetings/linkedSchedules";
 
 // after() tasks are collected rather than discarded (the shim update-meeting-scoped-edit.test.ts
@@ -62,6 +62,20 @@ const SERIES_END = new Date("2026-09-07T19:00:00Z");
 const ANCHOR_WEEKDAY = formatETWeekdayLong(SERIES_START); // Monday
 const LINKED_WEEKDAY = "Saturday";
 const FIRST_LINKED_ET_DATE = "2026-09-12"; // the first Saturday on/after the anchor's start
+
+// The first `weekday` on/after today in ET -- a linked schedule added to a series that is
+// already running starts now, so its first date can only be expressed relative to the run date.
+function firstETDateOnOrAfterToday(weekday: string): string {
+  const [year, month, day] = formatETDateString(new Date()).split("-").map(Number);
+  // 16:00 UTC is the same ET calendar day under either offset, so stepping in whole UTC days
+  // reads back as consecutive ET dates across a DST change.
+  const cursor = new Date(Date.UTC(year, month - 1, day, 16));
+  for (let i = 0; i < 7; i++) {
+    if (formatETWeekdayLong(cursor) === weekday) return formatETDateString(cursor);
+    cursor.setUTCDate(cursor.getUTCDate() + 1);
+  }
+  throw new Error(`No ${weekday} within a week of today`);
+}
 
 afterAll(async () => {
   await disconnectTestPrismaClient();
@@ -235,6 +249,36 @@ describe("linked-schedule rejections", () => {
       expect((await response.json()).error).toMatch(/whole series/i);
     },
   );
+
+  test("an edit to the anchor's own fields in the same request is rejected rather than dropped", async () => {
+    const anchor = await seedAnchor();
+    const response = await putMeeting(anchorPayload(anchor, {
+      title: "Renamed While Linking",
+      linkedSchedule: linkedBlock(),
+    }));
+    expect(response.status).toBe(400);
+    expect((await response.json()).error).toMatch(/before adding a linked schedule/i);
+
+    const prisma = getTestPrismaClient();
+    const anchorAfter = await prisma.meeting.findUnique({ where: { mid: anchor.mid } });
+    expect(anchorAfter?.title).toBe(anchor.title);
+  });
+
+  test("resubmitting the anchor's own stored values, recurrence included, is not an edit", async () => {
+    const anchor = await seedAnchor();
+    const response = await putMeeting(anchorPayload(anchor, {
+      recurrencePattern: {
+        type: "weekly",
+        startDate: anchor.startDateTime,
+        daysOfWeek: [ANCHOR_WEEKDAY],
+        firstDayOfWeek: "Sunday",
+        interval: 1,
+      },
+      linkedSchedule: linkedBlock(),
+    }));
+    expect(response.status).toBe(200);
+    await drainAfterTasks();
+  });
 });
 
 test("a room conflict on the linked schedule's own days is a 409 that writes nothing, and confirmOverride retries it", async () => {
@@ -447,6 +491,133 @@ test("a Remote schedule linked to an In-Person anchor provisions the family's Zo
   expect(created?.linkedToMid).toBe(anchor.mid);
   const anchorAfter = await prisma.meeting.findUnique({ where: { mid: anchor.mid } });
   expect(anchorAfter?.zid).toBeNull();
+});
+
+test("a count-bounded anchor with an evening start counts the linked schedule's occurrences from the right weekday", async () => {
+  // 8 PM ET on a Wednesday: the instant's UTC calendar date is already Thursday, which is
+  // exactly what an ET-midnight-anchored pattern startDate keeps out of the occurrence count.
+  const anchor = await seedAnchor(
+    {
+      startDateTime: new Date(convertETToUTC("2026-09-09T20:00:00")),
+      endDateTime: new Date(convertETToUTC("2026-09-09T21:00:00")),
+    },
+    {
+      daysOfWeek: ["Wednesday"],
+      startDate: new Date(convertETToUTC("2026-09-09T00:00:00")),
+      numberOfOccurrences: 2,
+    },
+  );
+  const linkedMid = `linked-${randomUUID()}`;
+
+  const response = await putMeeting(anchorPayload(anchor, {
+    linkedSchedule: linkedBlock({
+      mid: linkedMid,
+      recurrencePattern: {
+        type: "weekly", startDate: SERIES_START, daysOfWeek: ["Monday", "Tuesday"],
+        firstDayOfWeek: "Sunday", interval: 1,
+      },
+    }),
+  }));
+  expect(response.status).toBe(200);
+
+  const prisma = getTestPrismaClient();
+  const created = await prisma.meeting.findUnique({ where: { mid: linkedMid }, include: { recurrencePattern: true } });
+  // The pattern's start is ET midnight of the first date, not the row's 8 PM start instant.
+  expect(formatETDateString(created!.recurrencePattern!.startDate)).toBe("2026-09-14");
+  expect(getETTimeOfDay(created!.recurrencePattern!.startDate)).toEqual({ hour: 0, minute: 0, second: 0 });
+  // Two occurrences on Mon+Tue is that same week's Tuesday -- not a week later, which is what a
+  // weekday anchor read off the UTC date would produce.
+  expect(created?.recurrencePattern?.numberOfOccurrences).toBe(2);
+  expect(formatETDateString(created!.recurrencePattern!.endDate!)).toBe("2026-09-15");
+  await drainAfterTasks();
+});
+
+test("a schedule added to an already-running series starts now, not at the series' original start", async () => {
+  const anchor = await seedAnchor(
+    {
+      startDateTime: new Date(convertETToUTC("2019-01-07T18:00:00")), // a Monday, years ago
+      endDateTime: new Date(convertETToUTC("2019-01-07T19:00:00")),
+    },
+    { daysOfWeek: [ANCHOR_WEEKDAY], startDate: new Date(convertETToUTC("2019-01-07T00:00:00")) },
+  );
+  const linkedMid = `linked-${randomUUID()}`;
+
+  const response = await putMeeting(anchorPayload(anchor, { linkedSchedule: linkedBlock({ mid: linkedMid }) }));
+  expect(response.status).toBe(200);
+
+  const prisma = getTestPrismaClient();
+  const created = await prisma.meeting.findUnique({ where: { mid: linkedMid }, include: { recurrencePattern: true } });
+  const expectedFirstDate = firstETDateOnOrAfterToday(LINKED_WEEKDAY);
+  // Backdating this row to 2019 would publish a Google Calendar series with years of meetings
+  // that never happened.
+  expect(formatETDateString(created!.startDateTime)).toBe(expectedFirstDate);
+  expect(formatETDateString(created!.recurrencePattern!.startDate)).toBe(expectedFirstDate);
+  // The anchor's ET time of day still carries over -- one Zoom meeting, one time of day.
+  expect(getETTimeOfDay(created!.startDateTime)).toEqual(getETTimeOfDay(anchor.startDateTime));
+  await drainAfterTasks();
+});
+
+// A scoped edit's split child: not a family member (its linkedToMid stays null), but a real row
+// of the family's ONE Zoom booking, sitting on the linked schedule's very first Saturday.
+async function seedZidSharingSplitChild(anchor: Meeting) {
+  return seedMeeting({
+    modeType: "Remote",
+    room: "",
+    zoomRoom: null,
+    zid: anchor.zid,
+    zoomLink: anchor.zoomLink,
+    zoomHost: anchor.zoomHost,
+    splitFromMid: anchor.mid,
+    startDateTime: new Date(`${FIRST_LINKED_ET_DATE}T18:00:00Z`),
+    endDateTime: new Date(`${FIRST_LINKED_ET_DATE}T19:00:00Z`),
+  });
+}
+
+test("a Zoom-free linked schedule still leaves every row of the shared Zoom meeting in its schedule", async () => {
+  const anchor = await seedAnchor();
+  const splitChild = await seedZidSharingSplitChild(anchor);
+  const linkedMid = `linked-${randomUUID()}`;
+
+  // In Person deliberately: this row holds no zid of its own, so the family's zid has to come
+  // from the family rather than from whichever background sync asks for it first.
+  const response = await putMeeting(anchorPayload(anchor, {
+    linkedSchedule: linkedBlock({ mid: linkedMid, modeType: "In Person", room: `Linked In Person ${randomUUID()}` }),
+  }));
+  expect(response.status).toBe(200);
+  await drainAfterTasks();
+
+  const [, , zoomFamily] = mockedUpdateZoomMeeting.mock.calls[0];
+  expect((zoomFamily as { mid: string }[]).map((row) => row.mid).sort())
+    .toEqual([anchor.mid, splitChild.mid, linkedMid].sort());
+});
+
+test("another row of the family's own Zoom booking is not a host conflict", async () => {
+  const anchor = await seedAnchor();
+  await seedZidSharingSplitChild(anchor);
+  const linkedMid = `linked-${randomUUID()}`;
+
+  // The inherited host is booked at that hour by the split child -- which is the family's own
+  // single Zoom meeting, not a second booking to flag.
+  const response = await putMeeting(anchorPayload(anchor, { linkedSchedule: linkedBlock({ mid: linkedMid }) }));
+  expect(response.status).toBe(200);
+  await drainAfterTasks();
+});
+
+test("a successful family Zoom update clears the holder's stale error status", async () => {
+  const anchor = await seedAnchor({
+    zoomSyncStatus: "error",
+    zoomSyncError: "An earlier sync failed.",
+  });
+  const linkedMid = `linked-${randomUUID()}`;
+
+  const response = await putMeeting(anchorPayload(anchor, { linkedSchedule: linkedBlock({ mid: linkedMid }) }));
+  expect(response.status).toBe(200);
+  await drainAfterTasks();
+
+  const prisma = getTestPrismaClient();
+  const anchorAfter = await prisma.meeting.findUnique({ where: { mid: anchor.mid } });
+  expect(anchorAfter?.zoomSyncStatus).toBe("synced");
+  expect(anchorAfter?.zoomSyncError).toBeNull();
 });
 
 test("an exhausted host pool leaves the linked row unpublished rather than half-published", async () => {

--- a/frontend/tests/unit/linkedScheduleSchema.test.ts
+++ b/frontend/tests/unit/linkedScheduleSchema.test.ts
@@ -67,6 +67,15 @@ describe("linkedScheduleSchema", () => {
     ).success).toBe(true);
   });
 
+  // Only the weekdays are read from the block's pattern, so a non-weekly type would otherwise be
+  // silently served as a weekly schedule.
+  it("rejects a non-weekly recurrence type", () => {
+    const parsed = linkedScheduleSchema.safeParse(
+      linkedSchedule({ recurrencePattern: { ...weeklyPattern, type: "monthly" } }),
+    );
+    expect(parsed.success).toBe(false);
+  });
+
   it("requires an In Person schedule to carry a room", () => {
     expect(linkedScheduleSchema.safeParse(linkedSchedule({ modeType: "In Person" })).success).toBe(false);
     expect(linkedScheduleSchema.safeParse(linkedSchedule({ modeType: "In Person", room: "Serenity Room" })).success)

--- a/frontend/tests/unit/linkedScheduleSchema.test.ts
+++ b/frontend/tests/unit/linkedScheduleSchema.test.ts
@@ -1,0 +1,75 @@
+import { linkedScheduleSchema } from "../../util/meetings/meetingValidation";
+
+const weeklyPattern = {
+  type: "weekly",
+  startDate: "2026-09-12T18:00:00.000Z",
+  daysOfWeek: ["Saturday"],
+  firstDayOfWeek: "Sunday",
+  interval: 1,
+};
+
+const linkedSchedule = (overrides: Record<string, unknown> = {}) => ({
+  linkedSchedule: {
+    mid: "linked-mid",
+    modeType: "Remote",
+    room: null,
+    zoomRoom: null,
+    recurrencePattern: weeklyPattern,
+    ...overrides,
+  },
+});
+
+describe("linkedScheduleSchema", () => {
+  it("accepts a Remote schedule with no rooms at all", () => {
+    const parsed = linkedScheduleSchema.safeParse(linkedSchedule());
+    expect(parsed.success).toBe(true);
+  });
+
+  // The block is parsed from the same raw body as meetingSchema, so a request without one has
+  // to read as "no linked schedule", not as invalid input.
+  it("treats a body with no linkedSchedule as absent, not invalid", () => {
+    const parsed = linkedScheduleSchema.safeParse({ mid: "m-1", title: "Meeting" });
+    expect(parsed.success).toBe(true);
+    expect(parsed.success && parsed.data.linkedSchedule).toBeUndefined();
+  });
+
+  // Nothing the two schedules must agree on is accepted from the client (the route derives it
+  // from the anchor), so keys like title or startDateTime are simply not part of the contract.
+  it("strips fields the linked schedule doesn't own", () => {
+    const parsed = linkedScheduleSchema.safeParse(
+      linkedSchedule({ title: "Renamed", startDateTime: "2026-09-12T18:00:00.000Z" }),
+    );
+    expect(parsed.success).toBe(true);
+    expect(parsed.success && parsed.data.linkedSchedule).not.toHaveProperty("title");
+    expect(parsed.success && parsed.data.linkedSchedule).not.toHaveProperty("startDateTime");
+  });
+
+  it("rejects a mode outside the three the family model knows", () => {
+    expect(linkedScheduleSchema.safeParse(linkedSchedule({ modeType: "Hyflex" })).success).toBe(false);
+  });
+
+  it("rejects a client-generated mid that is empty", () => {
+    expect(linkedScheduleSchema.safeParse(linkedSchedule({ mid: "" })).success).toBe(false);
+  });
+
+  it("rejects a block with no recurrence pattern -- a linked schedule is always recurring", () => {
+    const parsed = linkedScheduleSchema.safeParse(linkedSchedule({ recurrencePattern: undefined }));
+    expect(parsed.success).toBe(false);
+  });
+
+  // Same room requirements meetingSchema puts on the primary schedule -- the linked row is an
+  // ordinary Meeting row once written.
+  it("requires a Hybrid schedule to carry both a room and a Zoom room", () => {
+    expect(linkedScheduleSchema.safeParse(linkedSchedule({ modeType: "Hybrid", room: "Serenity Room" })).success)
+      .toBe(false);
+    expect(linkedScheduleSchema.safeParse(
+      linkedSchedule({ modeType: "Hybrid", room: "Serenity Room", zoomRoom: "Zoom Room A" }),
+    ).success).toBe(true);
+  });
+
+  it("requires an In Person schedule to carry a room", () => {
+    expect(linkedScheduleSchema.safeParse(linkedSchedule({ modeType: "In Person" })).success).toBe(false);
+    expect(linkedScheduleSchema.safeParse(linkedSchedule({ modeType: "In Person", room: "Serenity Room" })).success)
+      .toBe(true);
+  });
+});

--- a/frontend/util/meetings/meetingValidation.ts
+++ b/frontend/util/meetings/meetingValidation.ts
@@ -1,5 +1,7 @@
 import { z } from "zod";
 
+import { LINKED_SCHEDULE_MODES } from "./linkedSchedules";
+
 // Zoom's `agenda` field (which the description is sent as, see services/zoom.ts's
 // buildZoomMeetingBody) hard-caps at 1024 chars -- lower than Google Calendar's description
 // limit, so a too-long description silently fails only the Zoom half of the sync. The form UI
@@ -136,6 +138,43 @@ export const editScopeSchema = z.object({
   editScope: z.enum(['this', 'thisAndFollowing', 'all']).optional(),
   occurrenceDate: z.coerce.date().optional(),
 });
+
+// A second weekly schedule to create alongside the meeting being updated -- a different mode on
+// different weekdays, sharing the family's one Zoom meeting (util/meetings/linkedSchedules.ts).
+// Parsed separately from meetingSchema for the same reason editScopeSchema is: these keys
+// describe a whole other Meeting row, and must never be spread into the anchor's update data.
+//
+// Deliberately narrow. Everything the two schedules must agree on -- title, description, email,
+// group, calType, time of day, duration, interval, and where the series ends -- is derived
+// server-side from the anchor row and never read from here, because a family whose rows disagree
+// on any of them has no single-series representation on Zoom (isSharedZoomScheduleCompatible)
+// and would silently stop reaching Zoom at all. Only the mode, the room(s) that mode needs, and
+// the weekdays are genuinely this schedule's own.
+export const linkedScheduleBlockSchema = z.object({
+  // Client-generated, like NewMeeting's -- so both rows are known before the write and the
+  // create can stay inside the same transaction as the rest of the request.
+  mid: z.string().min(1),
+  modeType: z.enum(LINKED_SCHEDULE_MODES),
+  room: z.string().nullable().optional(),
+  zoomRoom: z.string().nullable().optional(),
+  recurrencePattern: recurrencePatternSchema,
+})
+  // Same room requirements meetingSchema puts on the primary schedule -- the linked row is an
+  // ordinary Meeting row and gets rendered, conflict-checked and published exactly like one.
+  .refine((linked) => linked.modeType !== "Hybrid" || (!!linked.room && !!linked.zoomRoom), {
+    message: "Hybrid meetings require both a physical room and a Zoom room.",
+    path: ["room"],
+  })
+  .refine((linked) => linked.modeType !== "In Person" || !!linked.room, {
+    message: "In Person meetings require a physical room.",
+    path: ["room"],
+  });
+
+export const linkedScheduleSchema = z.object({
+  linkedSchedule: linkedScheduleBlockSchema.optional(),
+});
+
+export type LinkedScheduleInput = z.infer<typeof linkedScheduleBlockSchema>;
 
 // Narrower shape for the Zoom host-availability check — only the fields
 // checkZoomHostPoolAvailability's OccurrenceInput actually needs. The client posts the same

--- a/frontend/util/meetings/meetingValidation.ts
+++ b/frontend/util/meetings/meetingValidation.ts
@@ -150,6 +150,16 @@ export const editScopeSchema = z.object({
 // on any of them has no single-series representation on Zoom (isSharedZoomScheduleCompatible)
 // and would silently stop reaching Zoom at all. Only the mode, the room(s) that mode needs, and
 // the weekdays are genuinely this schedule's own.
+//
+// RULE: that derivation is a create-time snapshot, and drift afterwards is accepted, not
+// guarded. Editing either row's title/description/email/group/calType propagates to neither the
+// other row nor the family's external name (buildLinkedScheduleLabel builds each member's name
+// from that member's OWN title), so the two members' calendar events can end up reading
+// differently. Nothing detects or reconciles it; re-saving both rows with the same values is the
+// fix. The schedule fields above are the ones that would actually break Zoom, and those are
+// re-checked on every write.
+// TODO(linked-schedules PR6): if the form grows a single submit that edits the anchor and its
+// linked schedules together, propagate the shared identity fields there instead.
 export const linkedScheduleBlockSchema = z.object({
   // Client-generated, like NewMeeting's -- so both rows are known before the write and the
   // create can stay inside the same transaction as the rest of the request.
@@ -168,6 +178,13 @@ export const linkedScheduleBlockSchema = z.object({
   .refine((linked) => linked.modeType !== "In Person" || !!linked.room, {
     message: "In Person meetings require a physical room.",
     path: ["room"],
+  })
+  // The weekdays are read from this pattern but its frequency is not: the anchor must already be
+  // weekly, and Zoom holds the family as one weekly union. Rejected rather than silently coerced,
+  // so a client asking for a monthly schedule is told no instead of getting a weekly one.
+  .refine((linked) => linked.recurrencePattern.type === "weekly", {
+    message: "A linked schedule must be weekly.",
+    path: ["recurrencePattern", "type"],
   });
 
 export const linkedScheduleSchema = z.object({

--- a/frontend/util/meetings/resourceOverlap.ts
+++ b/frontend/util/meetings/resourceOverlap.ts
@@ -246,6 +246,11 @@ export type FindConflictsOptions = {
   // Exclude this meeting (by mid) from the query — used when re-checking a meeting against
   // itself during an update.
   excludeMid?: string;
+  // Exclude every row sharing this zid — one Zoom meeting is ONE real booking of its host, no
+  // matter how many rows point at it (a linked-schedule family, a scoped edit's split children,
+  // a legacy zid group), so a zoomHost check for a candidate joining that meeting must not
+  // report it as colliding with itself. Rows with no zid at all are never excluded.
+  excludeZid?: string;
   // Suspended meetings still occupy their Zoom host (sync is skipped while suspended, not
   // torn down) but shouldn't nag admins on the room/zoomRoom conflicts panel. Default false.
   includeSuspended?: boolean;
@@ -281,6 +286,9 @@ export async function findResourceConflicts(
       notDeleted,
       fieldWhere(field, value),
       ...(opts.excludeMid ? [{ mid: { not: opts.excludeMid } }] : []),
+      // Spelled with the explicit null branch rather than a bare `not`: a SQL inequality never
+      // matches NULL, and the Zoom-free rows are exactly the ones this check must keep seeing.
+      ...(opts.excludeZid ? [{ OR: [{ zid: null }, { zid: { not: opts.excludeZid } }] }] : []),
     ],
   };
 
@@ -438,6 +446,9 @@ export async function getPoolHostLoads(
       notDeleted,
       { zoomHost: { in: pool, mode: "insensitive" } },
       ...(opts.excludeMid ? [{ mid: { not: opts.excludeMid } }] : []),
+      // Spelled with the explicit null branch rather than a bare `not`: a SQL inequality never
+      // matches NULL, and the Zoom-free rows are exactly the ones this check must keep seeing.
+      ...(opts.excludeZid ? [{ OR: [{ zid: null }, { zid: { not: opts.excludeZid } }] }] : []),
     ],
   };
 
@@ -750,6 +761,9 @@ export async function findResourceConflictRows(
       notDeleted,
       fieldWhere(field, value),
       ...(opts.excludeMid ? [{ mid: { not: opts.excludeMid } }] : []),
+      // Spelled with the explicit null branch rather than a bare `not`: a SQL inequality never
+      // matches NULL, and the Zoom-free rows are exactly the ones this check must keep seeing.
+      ...(opts.excludeZid ? [{ OR: [{ zid: null }, { zid: { not: opts.excludeZid } }] }] : []),
     ],
   };
 


### PR DESCRIPTION
@coderabbitai summary

## Description

Third PR of the linked meeting modes work, stacked on #552. PR 1 added the `linkedToMid` family model and PR 2 taught Zoom and Google Calendar to name a family; this one is the first write path that **creates** a family. `PUT /api/update/meeting` gains an optional `linkedSchedule` block that adds a *second weekly schedule* — a different mode on different weekdays — to an existing recurring meeting, sharing the family's **one** Zoom meeting instead of minting a second, and fans the family's new name out to the existing member's Zoom topic and Google Calendar events.

No UI posts this block yet (PR 6), and `POST /api/write/meeting`'s two-row create is PR 4 — this PR is API + tests only, and every existing request shape is untouched (`linkedSchedule` absent ⇒ byte-identical control flow).

- **frontend/util/meetings/meetingValidation.ts**: `linkedScheduleBlockSchema` / `linkedScheduleSchema` (`{ mid, modeType, room, zoomRoom, recurrencePattern }`), parsed *separately* from `meetingSchema` for the same reason `editScopeSchema` is — these keys describe a whole other Meeting row and must never be spread into the anchor's update data. Deliberately narrow: the schema carries only the mode, the room(s) that mode needs, and the weekdays. Everything the two schedules must agree on — title, description, email, group, calType, time of day, duration, interval, where the series ends — is derived server-side from the anchor and never read from the payload, because a family whose rows disagree on any of them has no single-series representation on Zoom (`isSharedZoomScheduleCompatible`) and would silently stop reaching Zoom at all. Zod-level rules mirror `meetingSchema`'s room requirements (Hybrid needs both rooms, In Person needs a room) and reject a non-`weekly` pattern rather than coercing it.
  - **The title de-sync decision carried over from PR 2's review: accepted, not guarded.** The derivation is a create-time snapshot. Editing either row's title/description/email/group/calType afterwards propagates to neither the sibling nor the family's external name (`buildLinkedScheduleLabel` builds each member's name from that member's *own* title), so the two events can end up reading differently; nothing detects or reconciles it, and re-saving both rows is the fix. The schedule fields are the ones that would actually break Zoom, and those are re-checked on every write. Recorded as a `RULE:` in the schema's own comment, with a `TODO(linked-schedules PR6)` if the form later grows a combined submit.
- **frontend/app/api/update/meeting/route.ts**: `handleLinkedScheduleCreate`, modeled on `handleScopedEdit` minus the parent trim — the anchor row is read, never written.
  - **Validation (all 400s):** anchor not recurring; anchor not `weekly`; family already at `LINKED_SCHEDULE_CAP` (`canLinkSchedule`); a mode the family already runs (`availableModesFor`); no weekdays at all; weekdays overlapping any existing member's (`claimedDaysFor` — disjoint days are a hard requirement, since Zoom holds the family as ONE union of weekdays and a day claimed twice silently collapses into a single occurrence); the requested days producing no occurrence inside the anchor's series; a prospective family `isSharedZoomScheduleCompatible` rejects; and `linkedSchedule` combined with a non-`all` `editScope`. Plus one that isn't in the plan: **a payload that also edits the anchor's own fields is refused** (`submitsAnchorEdits`) rather than 200'd and applied nowhere — this branch never writes the anchor, so a silently-dropped edit would be the worst outcome. The comparison covers only what the form can actually edit (`creator`/`group` are placeholders), and resolves a count-bounded pattern's `endDate` the same way the whole-series path does before comparing, so resubmitting the meeting's own stored values is correctly *not* an edit.
  - **Derived series (`deriveLinkedScheduleStart`):** the anchor's ET wall-clock time of day and duration re-anchored onto the first date the anchor's own pattern meets on the requested weekdays, searched from **today or the series start, whichever is later** — a schedule added to a series that began years ago starts now, not retroactively (a backdated Google series is fabricated history, and a count-bounded anchor could otherwise resolve an already-passed end date, i.e. a row born dead). Searching against the *anchor's* pattern keeps an every-other-week family in one week phase. `recurrencePattern.startDate` is ET-midnight-anchored per the existing invariant, so `calculateEndDateFromOccurrences` reads the weekday off the right day for an evening meeting. A DST spring-forward gap surfaces as a 400 with `convertETToUTC`'s own message, not a 500.
  - **Zoom identity is inherited whole, never re-provisioned.** `inheritsZoom` copies `zid`/`zoomLink`/`zoomPasscode`/`zoomInvitation`/`zoomHost`/`zoomManaged`/`zoomTopic` from the anchor (a pinned topic stays pinned for every member; a null one keeps meaning "auto, recompute"). An In-Person linked row gets none of it. The **In-Person-anchor** case is the inverse: there is no Zoom meeting to inherit, so the Zoom-bearing linked row provisions one (`resolveZoomHost` + `createZoomMeeting` *with the family*, so it is born holding the union schedule and the family name) and becomes the family's zid holder — which is precisely why the family is keyed on `linkedToMid` and not on `zid`. Host capacity is consumed only in that case; an inherited zid re-uses the family's existing booking, mirroring `handleScopedEdit`.
  - **Transaction and conflicts:** one `$transaction` + `lockResourceClaims` over the linked row's own `room`/`zoomRoom` and the inherited `zoomHost` (the whole pool only when this row provisions). `room`/`zoomRoom` are conflict-checked against the whole calendar and do **not** exclude the anchor — the anchor's occurrences are live bookings of that room, and the two schedules only avoid each other by weekday, which says nothing about the room. `zoomHost` **does** exclude the family, by `excludeZid` as well as by mid. 409 + `confirmOverride` retry, unchanged shape. Response gains `linkedMid`.
  - **`after(...)` fan-out — this closes PR 2's deferred calendar gap.** `syncLinkedSchedule` publishes the new row's own calendar events through the same path a split-off row gets (plus the provisioning branch above). `syncLinkedScheduleFamily` then does what `handleScopedEdit` never had to: PATCHes the shared Zoom meeting for the widened union schedule and new topic, and calls `republishMeetingCalendars` on **every pre-existing member** so their events pick up the new title instead of advertising the old single-schedule name until something else happened to touch them. The Zoom PATCH is keyed on the family *holding a zid at all*, not on the new schedule needing one — an In-Person member adds no days to the recurrence but does name itself in the family's topic. Its result is persisted either way, so a holder carrying a stale `zoomSyncStatus: 'error'` doesn't keep the calendar's ⚠ badge after a PATCH that actually succeeded. Both syncs share one `linkedFamilyLoader`, pinned to the **family's** zid rather than whichever caller resolves it first — an In-Person linked row would otherwise pin it to `null` and drop split children and legacy zid rows from the union, silently re-narrowing Zoom's `weekly_days` (the bug fixed in #513).
  - `syncScopedParentCalendar` → **`republishMeetingCalendars`**: same function, now with two callers (a scoped edit's parent, and every family member a new schedule just joined). Rename only.
- **frontend/util/meetings/resourceOverlap.ts**: `FindConflictsOptions.excludeZid`, honored by `findResourceConflicts`, `getPoolHostLoads` and `findResourceConflictRows`. One Zoom meeting is ONE real booking of its host no matter how many rows point at it (a linked family, a scoped edit's split children, a legacy zid group), so a `zoomHost` check for a candidate joining that meeting must not report it as colliding with itself. Spelled `{ OR: [{ zid: null }, { zid: { not } }] }` rather than a bare `not`, because a SQL inequality never matches NULL and the Zoom-free rows are exactly the ones the check must keep seeing.
- **frontend/services/googleCalendar.ts**: PR 2's `TODO(linked-schedules PR3)` at `buildEventTitle` retired — it now points at this PR's fan-out, with a narrowed `TODO(linked-schedules PR5)` for the remaining half (removing a linked schedule is a plain row soft-delete, which still leaves the survivor's events on the two-schedule name until it is next written; the delete-route cleanup is PR 5's).
- **frontend/tests/integration/update-meeting-linked-schedule.test.ts** (22 tests) and **frontend/tests/unit/linkedScheduleSchema.test.ts** (9): every 400 rule and the `editScope` combination; 409-writes-nothing then `confirmOverride` retries; Zoom identity inherited for Remote-on-Hybrid and *not* inherited for In-Person-on-Hybrid; the In-Person-anchor provisioning case incl. an exhausted pool leaving the row unpublished rather than half-published; client-supplied fields that aren't the schedule's own being ignored; the family-wide republish (Zoom topic + anchor's calendar events) and the stale-error clear; an evening count-bounded anchor's occurrence counting; a schedule added to an already-running series starting now; a Zoom-free schedule still leaving every row of the shared booking in the union; and the family's own zid not being a host conflict.

## Testing

- [x] `cd frontend && yarn test:all` — green (lint, lint:css, typecheck, unit, component, integration, e2e), run against a clear port 3000.
- [x] `yarn test:integration --testPathPattern update-meeting-linked-schedule` — the 22 route tests above.
- [x] `yarn test:unit --testPathPattern linkedScheduleSchema` — the 9 schema tests.
- [x] Pre-existing-test sweep (`pr_convention.md`): the existing `update-meeting-route.test.ts` / `update-meeting-scoped-edit.test.ts` suites still pass unchanged, which is the assertion that a request without `linkedSchedule` reaches exactly the same code as before; `syncScopedParentCalendar`'s rename is covered by `yarn typecheck`.
- [ ] Reviewer check: `git diff feat/linked-zoom-topic...feat/linked-schedule-update-api -- frontend/app/api/update/meeting/route.ts` — confirm `handleLinkedScheduleCreate` never writes the anchor row, and that no derived topic is written back into `Meeting.zoomTopic`.
- [ ] Reviewer check: POST a `linkedSchedule` block against a local recurring Hybrid meeting (e.g. Mon–Fri) with `modeType: "Remote"` on Saturday and confirm one Zoom meeting is shared, the topic reads `"<title> - Hybrid Mon-Fri - Zoom Only Sat"`, and both rows' Google Calendar events carry that same title.

## Area(s) Touched

**Product areas**
- [ ] auth — sign-in, sessions, NextAuth, role-based access
- [ ] admin — /admin shell (Diagnostics, Users, Import, Export tabs)
- [ ] docs — /docs Resources page (rendering, navigation, search)
- [ ] ui/ux — frontend layout/styling not tied to a specific integration

**Integrations**
- [x] google-calendar — Google Calendar sync
- [x] zoom-api — Zoom meeting/host sync

**Engineering**
- [ ] security — auth hardening, data exposure, dependency/security scanning
- [x] testing — test suite (Jest/Playwright) changes
- [ ] github-actions — workflows, Dependabot config, other .github/ CI tooling
- [ ] cleanup — refactor or dead-code removal, no behavior change
- [ ] documentation — docs/ or README changes only

## Pre-merge Checklist
- [x] Code follows current formatting conventions and passes lint (`yarn lint`).
- [x] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
- [ ] All test suites pass, both run locally and green in GitHub CI. **Do not merge if any test suite is failing.**
- [x] A test suite was added or updated for the feature/fix in this PR. **Double-check this if you change a feature and did not update the test suites**.
- [x] Only files relevant to this change are committed — no stray or unrelated files.
- [x] If this branch has a merge conflict with master, master was merged into this branch first (not the other way around).
- [x] The rest of this PR description (Description, Testing) is filled out, not left as template placeholders.
