### PR TITLE
feat(write-meeting): create a meeting with two linked schedules

### DIFF
--- a/frontend/app/api/update/meeting/route.ts
+++ b/frontend/app/api/update/meeting/route.ts
@@ -13,12 +13,13 @@ import { lockResourceClaims, ResourceClaim } from "../../../../util/meetings/res
 import { meetingSchema, editScopeSchema, linkedScheduleSchema, LinkedScheduleInput } from "../../../../util/meetings/meetingValidation";
 import {
   linkedFamilyLoader, LinkedFamilyLoader, LinkedFamilyMeeting, getLinkedFamily, familyMembers,
-  canLinkSchedule, availableModesFor, claimedDaysFor, isZoomBearing, LINKED_SCHEDULE_CAP,
+  canLinkSchedule, availableModesFor, claimedDaysFor, isZoomBearing, deriveLinkedScheduleStart,
+  LINKED_SCHEDULE_CAP,
 } from "../../../../util/meetings/linkedSchedules";
 import { isSharedZoomScheduleCompatible } from "../../../../util/meetings/sharedZoomSchedule";
 import { reconcilePendingResume, tearDownPendingResumeSeries } from "../../../../util/meetings/suspension";
-import { calculateEndDateFromOccurrences, firstOccurrenceOnOrAfter } from "../../../../util/meetings/meetingOccurrences";
-import { convertETToUTC, getETTimeOfDay, isConvertETToUTCValidationError } from "../../../../util/date/timeUtils";
+import { calculateEndDateFromOccurrences } from "../../../../util/meetings/meetingOccurrences";
+import { isConvertETToUTCValidationError } from "../../../../util/date/timeUtils";
 import { EditScope, countOccurrencesBefore, exclusionInstant, trimmedEndDate, isLiveOccurrence, rootSplitMid, toETDateStr } from "../../../../util/meetings/editScope";
 import { prisma } from "../../../../lib/prisma";
 
@@ -755,55 +756,6 @@ async function handleScopedEdit(
   );
 
   return NextResponse.json({ ...updatedParent, newMid: createdMeeting.mid });
-}
-
-// The anchor's ET wall-clock time of day and duration, re-anchored onto the first date its
-// series actually meets on `daysOfWeek`. A linked schedule never gets its start from the client:
-// the family is served by ONE Zoom meeting, which can only hold one series, so every member has
-// to keep the same time of day and duration (isSharedZoomScheduleCompatible) -- and the search
-// runs against the ANCHOR's pattern, so an every-other-week family stays in one week phase
-// instead of the two schedules landing on alternating weeks. Returns null when the requested
-// days produce no occurrence inside the anchor's series at all (e.g. a series that ends first).
-function deriveLinkedScheduleStart(
-  anchor: Meeting & { recurrencePattern: RecurrencePattern | null },
-  daysOfWeek: string[],
-): { startDateTime: Date; endDateTime: Date; patternStartDate: Date } | null {
-  const pattern = anchor.recurrencePattern!;
-  // Never earlier than today: a schedule added to a series that started years ago is a schedule
-  // that starts NOW, not one that retroactively met every week since. Searching from the series
-  // start instead would publish a backdated Google Calendar series (fabricated history on past
-  // calendar views) and, for a count-bounded anchor, could resolve an end date that has already
-  // passed -- a row born dead. The week phase is unaffected: matchesRecurrencePattern measures
-  // the interval from the ANCHOR's own startDate below, whatever date the search begins on.
-  const seriesStartEtDateStr = toETDateStr(pattern.startDate);
-  const todayEtDateStr = toETDateStr(new Date());
-  const searchFromEtDateStr = seriesStartEtDateStr > todayEtDateStr ? seriesStartEtDateStr : todayEtDateStr;
-  const firstETDate = firstOccurrenceOnOrAfter(
-    {
-      type: 'weekly',
-      startDate: pattern.startDate,
-      endDate: pattern.endDate,
-      interval: pattern.interval,
-      daysOfWeek,
-      weekOfMonth: null,
-      dayOfMonth: null,
-      // The anchor's own excluded dates are its alone -- a per-occurrence deletion on the
-      // Monday-Friday schedule says nothing about when the Saturday one starts.
-      excludedDates: [],
-    },
-    searchFromEtDateStr,
-  );
-  if (!firstETDate) return null;
-  const { hour, minute, second } = getETTimeOfDay(anchor.startDateTime);
-  const pad = (value: number) => String(value).padStart(2, '0');
-  const startDateTime = new Date(convertETToUTC(`${firstETDate}T${pad(hour)}:${pad(minute)}:${pad(second)}`));
-  const durationMs = anchor.endDateTime.getTime() - anchor.startDateTime.getTime();
-  // INVARIANT: a stored recurrencePattern.startDate is ET-midnight-anchored (parseMMDDYYYY),
-  // never a real meeting-time instant -- calculateEndDateFromOccurrences reads the weekday
-  // anchor straight off getUTCDay(), so a 7 PM-or-later ET start would roll into the next UTC
-  // day and count the occurrences from the wrong weekday.
-  const patternStartDate = new Date(convertETToUTC(`${firstETDate}T00:00:00`));
-  return { startDateTime, endDateTime: new Date(startDateTime.getTime() + durationMs), patternStartDate };
 }
 
 // Runs after the response is sent — the new linked row's own half of the create: its Google

--- a/frontend/app/api/update/meeting/sync/route.ts
+++ b/frontend/app/api/update/meeting/sync/route.ts
@@ -5,7 +5,7 @@ import { IMeeting } from "../../../../../types/models";
 import { createCalendarEvent, updateCalendarEvent, reconcileMeetingCalendars } from "../../../../../services/googleCalendar";
 import { createZoomMeeting, getZoomHostCapacities, getZoomMeetingCredentials, updateZoomMeeting, getZoomMeetingInvitation, resolveZoomHost, zoomHostPool, zoomRoomCalendarId } from "../../../../../services/zoom";
 import { lockResourceClaims } from "../../../../../util/meetings/resourceLocks";
-import { linkedFamilyLoader } from "../../../../../util/meetings/linkedSchedules";
+import { familyMembers, getLinkedFamily, isZoomBearing, linkedFamilyLoader } from "../../../../../util/meetings/linkedSchedules";
 import { prisma } from "../../../../../lib/prisma";
 
 const syncMeeting = async (request: Request): Promise<Response> => {
@@ -64,6 +64,13 @@ const syncMeeting = async (request: Request): Promise<Response> => {
             let zoomCalendarEventId = meeting.zoomCalendarEventId;
             let zoomSynced = true;
             let liveCredentialsFetched = false;
+            // The Zoom-bearing family members this retry has to hand its freshly-minted Zoom
+            // identity to (see the mint branch below). Empty for every other path.
+            let fanOutMids: string[] = [];
+            // What a failed invitation fetch falls back to. This row's own stored value, except
+            // when it adopts a sibling's Zoom meeting -- then the family's invitation is the one
+            // it should be carrying.
+            let storedInvitation = meeting.zoomInvitation;
             zoomSyncError = null;
 
             if (zid) {
@@ -101,46 +108,87 @@ const syncMeeting = async (request: Request): Promise<Response> => {
                 // deliberate choice -- a retry must not auto-provision an app-owned meeting
                 // under a flag that says the app doesn't own it.
             } else {
-                // Reserve a pool host under lock BEFORE ever calling the external Zoom API below
-                // -- closes #360's TOCTOU gap: two retries of this same meeting (or a retry
-                // racing a fresh write/meeting create) could otherwise both read the same
-                // last-free host before either persisted it. The reservation transaction only
-                // ever writes `zoomHost` and stays DB-only; the external API call happens
-                // afterward, outside the lock -- a Postgres advisory lock can't stay held across
-                // a network call the way it can across another DB query (see write/meeting and
-                // update/meeting's transactions, which don't make external calls either).
-                // Resolved BEFORE the locked transaction, same as write/update -- a Zoom API
-                // round trip while pool locks are held would extend lock hold time (cached 12h).
-                const hostCapacities = await getZoomHostCapacities();
-                const host = await prisma.$transaction(async (tx) => {
-                    await lockResourceClaims(tx, zoomHostPool.map((h) => ({ type: "zoomHost" as const, value: h })));
-                    const resolved = await resolveZoomHost(meetingForCalendar, tx, { excludeMid: mid, capacities: hostCapacities });
-                    if (resolved) {
-                        await tx.meeting.update({ where: { mid }, data: { zoomHost: resolved } });
-                    }
-                    return resolved;
-                }, { timeout: 10_000 });
+                // A linked-schedule family is served by ONE Zoom meeting and holds ONE host slot
+                // (util/meetings/linkedSchedules.ts), so what the rest of the family already has
+                // decides this retry entirely. Two Zoom-bearing members can be zid-less at the
+                // same time (a create whose host pool was exhausted), and retrying each of them
+                // in turn would otherwise mint a second Zoom meeting for one meeting.
+                const linkedFamily = await getLinkedFamily(prisma, mid);
+                const familySiblings = (linkedFamily ? familyMembers(linkedFamily) : [])
+                    .filter((row) => row.mid !== mid && isZoomBearing(row));
+                const holder = familySiblings.find((row) => row.zid);
+                const holderZid = holder?.zid ?? null;
 
-                if (!host) {
-                    zoomSynced = false;
-                    zoomSyncError = "No Zoom host available for this meeting's schedule (pool exhausted).";
+                if (holder && holderZid) {
+                    // The family's Zoom meeting already exists: adopt its identity and widen its
+                    // schedule to cover this row's days, rather than provisioning a second one.
+                    zid = holderZid;
+                    zoomLink = holder.zoomLink;
+                    zoomPasscode = holder.zoomPasscode;
+                    zoomHost = holder.zoomHost;
+                    storedInvitation = holder.zoomInvitation;
+                    // Unmanaged (adopted/external) Zoom meetings are never PATCHed -- same
+                    // contract as the zid branch above; the stored link is all this row adopts.
+                    if (holder.zoomManaged) {
+                        const ok = await updateZoomMeeting(holderZid, meetingForCalendar, await loadFamily(holderZid));
+                        if (!ok) {
+                            zoomSynced = false;
+                            zoomSyncError = "Couldn't update the shared Zoom meeting for this schedule.";
+                        }
+                    }
                 } else {
-                    // Reserved above regardless of what happens next -- a createZoomMeeting
-                    // failure below must not roll back the reservation (the final
-                    // prisma.meeting.update further down re-persists this same value either way).
-                    zoomHost = host;
-                    // Same family lookup as the PATCH branch above, minus the zid this row
-                    // doesn't have yet -- the fresh Zoom meeting is minted with the family's
-                    // union schedule and Zoom name from the start.
-                    const family = await loadFamily(null);
-                    const created = await createZoomMeeting(meetingForCalendar, host, family);
-                    if (created) {
-                        zid = created.zid;
-                        zoomLink = created.zoomLink;
-                        zoomPasscode = created.zoomPasscode;
-                    } else {
+                    // A sibling that reserved a pool host but never got its Zoom meeting minted
+                    // already holds the family's one host slot -- join that reservation instead
+                    // of resolving a second host for the same booking.
+                    let host = familySiblings.find((row) => row.zoomHost)?.zoomHost ?? null;
+                    if (!host) {
+                        // Reserve a pool host under lock BEFORE ever calling the external Zoom API
+                        // below -- closes #360's TOCTOU gap: two retries of this same meeting (or a
+                        // retry racing a fresh write/meeting create) could otherwise both read the
+                        // same last-free host before either persisted it. The reservation
+                        // transaction only ever writes `zoomHost` and stays DB-only; the external
+                        // API call happens afterward, outside the lock -- a Postgres advisory lock
+                        // can't stay held across a network call the way it can across another DB
+                        // query (see write/meeting and update/meeting's transactions, which don't
+                        // make external calls either).
+                        // Resolved BEFORE the locked transaction, same as write/update -- a Zoom
+                        // API round trip while pool locks are held would extend lock hold time
+                        // (cached 12h).
+                        const hostCapacities = await getZoomHostCapacities();
+                        host = await prisma.$transaction(async (tx) => {
+                            await lockResourceClaims(tx, zoomHostPool.map((h) => ({ type: "zoomHost" as const, value: h })));
+                            const resolved = await resolveZoomHost(meetingForCalendar, tx, { excludeMid: mid, capacities: hostCapacities });
+                            if (resolved) {
+                                await tx.meeting.update({ where: { mid }, data: { zoomHost: resolved } });
+                            }
+                            return resolved;
+                        }, { timeout: 10_000 });
+                    }
+
+                    if (!host) {
                         zoomSynced = false;
-                        zoomSyncError = "Failed to create the Zoom meeting.";
+                        zoomSyncError = "No Zoom host available for this meeting's schedule (pool exhausted).";
+                    } else {
+                        // Reserved above regardless of what happens next -- a createZoomMeeting
+                        // failure below must not roll back the reservation (the final
+                        // prisma.meeting.update further down re-persists this same value either way).
+                        zoomHost = host;
+                        // Same family lookup as the PATCH branch above, minus the zid this row
+                        // doesn't have yet -- the fresh Zoom meeting is minted with the family's
+                        // union schedule and Zoom name from the start.
+                        const family = await loadFamily(null);
+                        const created = await createZoomMeeting(meetingForCalendar, host, family);
+                        if (created) {
+                            zid = created.zid;
+                            zoomLink = created.zoomLink;
+                            zoomPasscode = created.zoomPasscode;
+                            // The minted meeting belongs to the whole family, not to the row the
+                            // admin happened to retry -- see the fan-out below.
+                            fanOutMids = familySiblings.map((row) => row.mid);
+                        } else {
+                            zoomSynced = false;
+                            zoomSyncError = "Failed to create the Zoom meeting.";
+                        }
                     }
                 }
             }
@@ -174,7 +222,7 @@ const syncMeeting = async (request: Request): Promise<Response> => {
             zoomSyncError = zoomSynced ? null : zoomSyncError;
             // See the comment in app/api/update/meeting/route.ts's syncUpdatedMeeting: a fetch
             // failure here (collapsed to null) shouldn't overwrite an already-stored invitation.
-            const zoomInvitation = zid ? (await getZoomMeetingInvitation(zid)) ?? meeting.zoomInvitation : null;
+            const zoomInvitation = zid ? (await getZoomMeetingInvitation(zid)) ?? storedInvitation : null;
             await prisma.meeting.update({
                 where: { mid },
                 data: {
@@ -185,6 +233,17 @@ const syncMeeting = async (request: Request): Promise<Response> => {
                     ...(zid && meeting.zid && !liveCredentialsFetched ? {} : { zoomDriftDetectedAt: null }),
                 },
             });
+            // The Zoom identity this retry minted is the FAMILY's, so every Zoom-bearing member
+            // gets it -- a sibling left zid-less would look unprovisioned to its own "Retry sync"
+            // and mint a second Zoom meeting (and reserve a second host) for one meeting. Only
+            // the shared identity is fanned out: each sibling keeps its own sync statuses, so its
+            // still-unpublished calendar events stay flagged until it is retried in turn.
+            if (fanOutMids.length > 0) {
+                await prisma.meeting.updateMany({
+                    where: { mid: { in: fanOutMids } },
+                    data: { zid, zoomLink, zoomPasscode, zoomInvitation, zoomHost },
+                });
+            }
         }
 
         // True when this meeting needs Zoom but doesn't currently have a healthy Zoom sync --

--- a/frontend/app/api/write/meeting/route.ts
+++ b/frontend/app/api/write/meeting/route.ts
@@ -125,8 +125,11 @@ async function syncNewMeeting(
       isRecurring: row.isRecurring,
       // Only a Zoom-bearing row carries the family's link: buildEventBody writes
       // "Zoom: {link}" into the description whenever one is present, and an In-Person schedule
-      // must never advertise a join link.
-      ...(row.zoomBearing ? { zid, zoomLink, zoomPasscode } : {}),
+      // must never advertise a join link -- including one the payload itself supplied, which is
+      // why the else arm clears rather than omits.
+      ...(row.zoomBearing
+        ? { zid, zoomLink, zoomPasscode }
+        : { zid: null, zoomLink: null, zoomPasscode: null, zoomInvitation: null }),
     };
 
     // Accumulated instead of written immediately -- these used to be two separate
@@ -601,6 +604,13 @@ const createMeeting = async (request: Request) => {
           // sentinel for a real SQL NULL) -- Mongo's connector accepted plain `null` here directly.
           googleCalendarEventIds: meetingDetails.googleCalendarEventIds ?? Prisma.DbNull,
           isRecurring,
+          // An In-Person schedule must never hold a zid/zoomLink, whoever supplied it: its
+          // calendar event would advertise a join link for a meeting that never meets online,
+          // and buildZoomRecurrence would union its weekdays into Zoom's single schedule (the
+          // invariant in util/meetings/linkedSchedules.ts). Keyed on the MODE, not on
+          // primaryZoomBearing, so a suspended Hybrid schedule still keeps the adopted Zoom
+          // meeting it was created with.
+          ...(isZoomBearing(meetingData) ? {} : { zid: null, zoomLink: null, zoomPasscode: null, zoomInvitation: null }),
           // Never the family's host on a schedule that doesn't use Zoom: an In-Person primary
           // schedule whose linked schedule is Remote holds no Zoom identity at all.
           zoomHost: primaryZoomBearing ? resolvedHost : null,
@@ -738,7 +748,14 @@ const createMeeting = async (request: Request) => {
           console.error("syncNewMeeting threw:", error);
           try {
             await prisma.meeting.updateMany({
-              where: { mid: { in: syncRows.map((row) => row.mid) } },
+              // Never a row that already finished: the two schedules publish one after the
+              // other, so the second one throwing must not flip the first back to 'error' while
+              // its calendar events are live. The explicit null arm is load-bearing -- a plain
+              // `not` filter on a nullable column can't be relied on to match SQL NULLs.
+              where: {
+                mid: { in: syncRows.map((row) => row.mid) },
+                OR: [{ googleSyncStatus: null }, { googleSyncStatus: { not: 'synced' } }],
+              },
               data: { googleSyncStatus: 'error', googleSyncError: "Sync job failed unexpectedly." },
             });
           } catch (persistError) {

--- a/frontend/app/api/write/meeting/route.ts
+++ b/frontend/app/api/write/meeting/route.ts
@@ -6,10 +6,27 @@ import { createCalendarEvent, calendarIdsForMeeting } from "../../../../services
 import { createZoomMeeting, getZoomHostCapacities, getZoomMeetingInvitation, resolveZoomHost, zoomHostPool, zoomRoomCalendarId } from "../../../../services/zoom";
 import { findResourceConflicts, findResourceConflictRows, ConflictRow, ResourceConflictAbort } from "../../../../util/meetings/resourceOverlap";
 import { lockResourceClaims, ResourceClaim } from "../../../../util/meetings/resourceLocks";
-import { meetingSchema } from "../../../../util/meetings/meetingValidation";
-import { linkedFamilyLoader } from "../../../../util/meetings/linkedSchedules";
+import { meetingSchema, linkedScheduleSchema, LinkedScheduleInput } from "../../../../util/meetings/meetingValidation";
+import {
+  linkedFamilyLoader, availableModesFor, claimedDaysFor, deriveLinkedScheduleStart, isZoomBearing,
+} from "../../../../util/meetings/linkedSchedules";
+import { isSharedZoomScheduleCompatible } from "../../../../util/meetings/sharedZoomSchedule";
+import { isConvertETToUTCValidationError } from "../../../../util/date/timeUtils";
 import { calculateEndDateFromOccurrences } from "../../../../util/meetings/meetingOccurrences";
 import { prisma } from "../../../../lib/prisma";
+
+// One schedule of the meeting being created, as the deferred sync below has to publish it. A
+// plain create has exactly one of these; a create carrying a `linkedSchedule` block has two --
+// the same meeting run as two weekly schedules, served by ONE Zoom meeting
+// (util/meetings/linkedSchedules.ts).
+type NewMeetingSyncRow = {
+  mid: string;
+  meeting: IMeeting;
+  isRecurring: boolean;
+  // Whether this row needs the family's Zoom meeting. An In-Person member is deliberately
+  // Zoom-free: it holds no zid/zoomLink and its weekdays never reach Zoom's recurrence.
+  zoomBearing: boolean;
+};
 
 // Runs after the response is sent (see after() call below) — failure sets googleSyncStatus but
 // does not fail the request, which has already returned by the time this runs. `resolvedHost`
@@ -24,10 +41,13 @@ import { prisma } from "../../../../lib/prisma";
 // Zoom API call failed) can skip the calendar publish entirely this run rather than
 // publishing "fully scheduled" with a missing link -- a later "Retry sync"
 // (update/meeting/sync/route.ts) picks this back up once a host becomes available.
+//
+// A family is served by ONE Zoom meeting: it is created once, from whichever row bears Zoom
+// first (the anchor unless the anchor is In Person), and its identity is then fanned out to
+// every Zoom-bearing row. Each row still publishes its OWN Google Calendar events -- same
+// family, same union title, but its own dates, room and calendars.
 async function syncNewMeeting(
-  mid: string,
-  meetingData: IMeeting,
-  isRecurring: boolean,
+  rows: NewMeetingSyncRow[],
   accessToken: string | undefined,
   resolvedHost: string | null,
   // The specific reason resolvedHost is null (pool exhausted vs. a manually-picked host that
@@ -35,32 +55,40 @@ async function syncNewMeeting(
   // both reasons collapsed to the same generic "pool exhausted" message below.
   hostSyncError: string | null,
 ): Promise<void> {
-  if (meetingData.status === 'Suspended') return;
+  const [primary] = rows;
+  if (primary.meeting.status === 'Suspended') return;
 
-  const zoomEnabled = meetingData.modeType === 'Hybrid' || meetingData.modeType === 'Remote';
-
-  let zid = meetingData.zid ?? null;
-  let zoomLink = meetingData.zoomLink ?? null;
-  let zoomPasscode = meetingData.zoomPasscode ?? null;
-  const zoomHost = resolvedHost;
-  let zoomCalendarEventId: string | null = null;
-  let zoomSynced = true;
-  let zoomSyncError: string | null = null;
   // One family lookup for this whole sync, shared by the Zoom create and every calendar publish
   // below -- the family names the Zoom meeting and each member's calendar event alike, so a
   // second lookup could only disagree with the first.
-  const loadFamily = linkedFamilyLoader(prisma, mid);
+  const loadFamily = linkedFamilyLoader(prisma, primary.mid);
 
-  if (zoomEnabled && !zid && !zoomLink) {
-    if (!zoomHost) {
+  const zoomRows = rows.filter((row) => row.zoomBearing);
+  // The row the family's single Zoom meeting is minted from: the anchor whenever it needs Zoom,
+  // otherwise the linked schedule (an In-Person anchor has no Zoom meeting to give, so its
+  // Zoom-bearing sibling becomes the family's zid holder -- which is exactly why the family is
+  // keyed on linkedToMid rather than on zid).
+  const mintingRow = zoomRows[0] ?? null;
+
+  let zid = mintingRow?.meeting.zid ?? null;
+  let zoomLink = mintingRow?.meeting.zoomLink ?? null;
+  let zoomPasscode = mintingRow?.meeting.zoomPasscode ?? null;
+  let zoomInvitation: string | null = null;
+  let zoomSynced = true;
+  let zoomSyncError: string | null = null;
+
+  if (mintingRow && !zid && !zoomLink) {
+    if (!resolvedHost) {
       zoomSynced = false;
       zoomSyncError = hostSyncError ?? "No Zoom host available for this meeting's schedule (pool exhausted).";
     } else {
-      // The row is already committed by the time this runs, so the family lookup sees every
+      // The rows are already committed by the time this runs, so the family lookup sees every
       // schedule this meeting was created with -- one Zoom meeting is minted for the whole
-      // family, with its union schedule and its family Zoom name.
+      // family, with its union schedule and its family Zoom name, never one per schedule.
       const family = await loadFamily(null);
-      const created = await createZoomMeeting({ ...meetingData, isRecurring }, zoomHost, family);
+      const created = await createZoomMeeting(
+        { ...mintingRow.meeting, isRecurring: mintingRow.isRecurring }, resolvedHost, family,
+      );
       if (created) {
         zid = created.zid;
         zoomLink = created.zoomLink;
@@ -72,96 +100,287 @@ async function syncNewMeeting(
     }
   }
 
-  // True when this meeting needs Zoom but doesn't have a working Zoom meeting after the
-  // attempt above -- the calendar publish below is deferred, not attempted with a missing link.
-  // Matches the creation gate above (!zid && !zoomLink), not just !zid -- a payload that
-  // already carried a zoomLink (no zid) skips creation at that gate and would otherwise be
-  // misclassified as blocking despite already having a working link to publish.
-  const zoomBlocking = zoomEnabled && !zid && !zoomLink;
-  const meetingForSync: IMeeting = { ...meetingData, isRecurring, zoomLink };
-
-  // Accumulated instead of written immediately -- these used to be two separate
-  // prisma.meeting.update calls (this block, then the zoom block below), leaving a real window
-  // where a poller could observe googleSyncStatus turn non-null before the zid/zoomHost write
-  // landed. `undefined` here means "this run never touched this field," same as omitting it
-  // from a Prisma update -- the single combined write below makes every field that *did* change
-  // visible atomically, in one row version. googleSyncStatus itself is always assigned by one
-  // of the three branches below (zoomBlocking/accessToken/no-token), unlike the other two.
-  let googleCalendarEventIds: Record<string, string> | undefined;
-  let googleSyncStatus: string | undefined;
-  let googleSyncError: string | null | undefined;
-
-  if (zoomBlocking) {
-    googleSyncStatus = 'pending';
-  } else if (accessToken) {
-    const requestedCalTypes = meetingData.calType ?? [];
-    const calendarIds = calendarIdsForMeeting(requestedCalTypes);
-    const eventIds: Record<string, string> = {};
-    // A category missing from calendarIds never gets visited by the loop below, so without
-    // this its GOOGLE_CALENDAR_* misconfiguration would count against `synced` (see the
-    // comment below) but leave the error null -- an "error" status with no error text.
-    const unconfiguredCat = requestedCalTypes.find((cat) => !calendarIds[cat]);
-    let syncError: string | null = unconfiguredCat
-      ? `Calendar for "${unconfiguredCat}" is not configured.`
-      : null;
-    const family = await loadFamily(zid);
-    for (const [cat, calId] of Object.entries(calendarIds)) {
-      const { id, error } = await createCalendarEvent(accessToken, meetingForSync, calId, undefined, family);
-      if (id) eventIds[cat] = id;
-      else syncError = syncError ?? error;
-    }
-    // Checked against requestedCalTypes, not calendarIds -- a category missing from calendarIds
-    // (its GOOGLE_CALENDAR_* env var isn't configured) must still count against `synced`, same
-    // as one whose event failed to create. Comparing against calendarIds alone would silently
-    // report success whenever some (or all) requested categories never even attempted to sync.
-    const synced = requestedCalTypes.length > 0 && requestedCalTypes.every((cat) => eventIds[cat]);
-    googleCalendarEventIds = eventIds;
-    googleSyncStatus = synced ? 'synced' : 'error';
-    googleSyncError = synced ? null : syncError;
-  } else {
-    // No accessToken and not zoomBlocking -- without this branch googleSyncStatus stays
-    // `undefined` forever (never assigned, never persisted), and for a non-Zoom meeting the
-    // write below is skipped entirely (see the `googleSyncStatus !== undefined` gate), leaving
-    // the row at googleSyncStatus: null indefinitely with nothing surfacing the failure.
-    googleSyncStatus = 'error';
-    googleSyncError = "No Google Calendar access token available for this sync.";
+  if (zid || zoomLink) {
+    zoomInvitation = zid ? await getZoomMeetingInvitation(zid) : null;
+    // The Zoom identity is a family-wide set, fanned out to EVERY Zoom-bearing row rather than
+    // to the minting row alone -- both schedules are the same one Zoom booking, and a row left
+    // without the zid would look unprovisioned to Retry sync and mint a second meeting.
+    // Written before the calendar publishes below, so a throw mid-publish can't strand a real
+    // Zoom meeting with nothing in the database pointing at it.
+    await prisma.meeting.updateMany({
+      where: { mid: { in: zoomRows.map((row) => row.mid) } },
+      data: { zid, zoomLink, zoomPasscode, zoomInvitation, zoomHost: resolvedHost },
+    });
   }
 
-  if (zoomEnabled) {
-    const zoomInvitation = zid ? await getZoomMeetingInvitation(zid) : null;
+  for (const row of rows) {
+    // True when this row needs Zoom but doesn't have a working Zoom meeting after the attempt
+    // above -- its calendar publish is deferred, not attempted with a missing link. Matches the
+    // creation gate above (!zid && !zoomLink), not just !zid -- a payload that already carried a
+    // zoomLink (no zid) skips creation at that gate and would otherwise be misclassified as
+    // blocking despite already having a working link to publish.
+    const zoomBlocking = row.zoomBearing && !zid && !zoomLink;
+    const meetingForSync: IMeeting = {
+      ...row.meeting,
+      isRecurring: row.isRecurring,
+      // Only a Zoom-bearing row carries the family's link: buildEventBody writes
+      // "Zoom: {link}" into the description whenever one is present, and an In-Person schedule
+      // must never advertise a join link.
+      ...(row.zoomBearing ? { zid, zoomLink, zoomPasscode } : {}),
+    };
 
-    // Only Hybrid meetings have a zoomRoom -- Remote's dedicated per-room Zoom-Room calendar
-    // publish naturally no-ops here (zoomRoomCalendarId[""] is undefined); its Zoom link is
-    // carried by the main calType-calendar event above instead.
-    if (accessToken && zoomLink && meetingData.zoomRoom) {
-      const calId = zoomRoomCalendarId[meetingData.zoomRoom];
-      if (calId) {
-        const { id: eventId, error } = await createCalendarEvent(accessToken, { ...meetingForSync, zoomLink }, calId, zoomLink, await loadFamily(zid));
-        if (eventId) zoomCalendarEventId = eventId;
-        else {
-          zoomSynced = false;
-          zoomSyncError = zoomSyncError ?? error ?? "Zoom meeting created but its calendar event failed to sync.";
+    // Accumulated instead of written immediately -- these used to be two separate
+    // prisma.meeting.update calls (this block, then the zoom block below), leaving a real window
+    // where a poller could observe googleSyncStatus turn non-null before the zid/zoomHost write
+    // landed. `undefined` here means "this run never touched this field," same as omitting it
+    // from a Prisma update -- the single combined write below makes every field that *did* change
+    // visible atomically, in one row version. googleSyncStatus itself is always assigned by one
+    // of the three branches below (zoomBlocking/accessToken/no-token), unlike the other two.
+    let googleCalendarEventIds: Record<string, string> | undefined;
+    let googleSyncStatus: string | undefined;
+    let googleSyncError: string | null | undefined;
+
+    if (zoomBlocking) {
+      googleSyncStatus = 'pending';
+    } else if (accessToken) {
+      const requestedCalTypes = row.meeting.calType ?? [];
+      const calendarIds = calendarIdsForMeeting(requestedCalTypes);
+      const eventIds: Record<string, string> = {};
+      // A category missing from calendarIds never gets visited by the loop below, so without
+      // this its GOOGLE_CALENDAR_* misconfiguration would count against `synced` (see the
+      // comment below) but leave the error null -- an "error" status with no error text.
+      const unconfiguredCat = requestedCalTypes.find((cat) => !calendarIds[cat]);
+      let syncError: string | null = unconfiguredCat
+        ? `Calendar for "${unconfiguredCat}" is not configured.`
+        : null;
+      // The same family every other publish in this request gets -- so both schedules' events
+      // are born with the family's union title, never their own lone-mode one.
+      const family = await loadFamily(zid);
+      for (const [cat, calId] of Object.entries(calendarIds)) {
+        const { id, error } = await createCalendarEvent(accessToken, meetingForSync, calId, undefined, family);
+        if (id) eventIds[cat] = id;
+        else syncError = syncError ?? error;
+      }
+      // Checked against requestedCalTypes, not calendarIds -- a category missing from calendarIds
+      // (its GOOGLE_CALENDAR_* env var isn't configured) must still count against `synced`, same
+      // as one whose event failed to create. Comparing against calendarIds alone would silently
+      // report success whenever some (or all) requested categories never even attempted to sync.
+      const synced = requestedCalTypes.length > 0 && requestedCalTypes.every((cat) => eventIds[cat]);
+      googleCalendarEventIds = eventIds;
+      googleSyncStatus = synced ? 'synced' : 'error';
+      googleSyncError = synced ? null : syncError;
+    } else {
+      // No accessToken and not zoomBlocking -- without this branch googleSyncStatus stays
+      // `undefined` forever (never assigned, never persisted), and for a non-Zoom meeting the
+      // write below is skipped entirely (see the `googleSyncStatus !== undefined` gate), leaving
+      // the row at googleSyncStatus: null indefinitely with nothing surfacing the failure.
+      googleSyncStatus = 'error';
+      googleSyncError = "No Google Calendar access token available for this sync.";
+    }
+
+    if (row.zoomBearing) {
+      // The family's Zoom outcome is shared by every Zoom-bearing row; only the Zoom-Room
+      // calendar event below is this row's own.
+      let zoomCalendarEventId: string | null = null;
+      let rowZoomSynced = zoomSynced;
+      let rowZoomSyncError = zoomSyncError;
+
+      // Only Hybrid meetings have a zoomRoom -- Remote's dedicated per-room Zoom-Room calendar
+      // publish naturally no-ops here (zoomRoomCalendarId[""] is undefined); its Zoom link is
+      // carried by the main calType-calendar event above instead.
+      if (accessToken && zoomLink && row.meeting.zoomRoom) {
+        const calId = zoomRoomCalendarId[row.meeting.zoomRoom];
+        if (calId) {
+          const { id: eventId, error } = await createCalendarEvent(
+            accessToken, { ...meetingForSync, zoomLink }, calId, zoomLink, await loadFamily(zid),
+          );
+          if (eventId) zoomCalendarEventId = eventId;
+          else {
+            rowZoomSynced = false;
+            rowZoomSyncError = rowZoomSyncError ?? error ?? "Zoom meeting created but its calendar event failed to sync.";
+          }
         }
       }
-    }
 
-    await prisma.meeting.update({
-      where: { mid },
-      data: {
-        zid, zoomLink, zoomPasscode, zoomInvitation, zoomHost, zoomCalendarEventId,
-        zoomSyncStatus: zoomSynced ? 'synced' : 'error',
-        zoomSyncError: zoomSynced ? null : zoomSyncError,
-        googleCalendarEventIds, googleSyncStatus, googleSyncError,
-      },
-    });
-  } else {
-    // googleSyncStatus is always assigned by this point (see the accumulator comment above),
-    // so this write always has something to persist.
-    await prisma.meeting.update({
-      where: { mid },
-      data: { googleCalendarEventIds, googleSyncStatus, googleSyncError },
-    });
+      await prisma.meeting.update({
+        where: { mid: row.mid },
+        data: {
+          zoomCalendarEventId,
+          zoomSyncStatus: rowZoomSynced ? 'synced' : 'error',
+          zoomSyncError: rowZoomSynced ? null : rowZoomSyncError,
+          googleCalendarEventIds, googleSyncStatus, googleSyncError,
+        },
+      });
+    } else {
+      // googleSyncStatus is always assigned by this point (see the accumulator comment above),
+      // so this write always has something to persist.
+      await prisma.meeting.update({
+        where: { mid: row.mid },
+        data: { googleCalendarEventIds, googleSyncStatus, googleSyncError },
+      });
+    }
   }
+}
+
+// Everything the linked schedule's own Meeting + RecurrencePattern rows are written from, once
+// the payload has been validated against the primary schedule it is derived from.
+type LinkedSchedulePlan = {
+  mid: string;
+  modeType: string;
+  room: string;
+  zoomRoom: string | null;
+  startDateTime: Date;
+  endDateTime: Date;
+  patternStartDate: Date;
+  endDate: Date | null;
+  numberOfOccurrences: number | null;
+  daysOfWeek: string[];
+  interval: number;
+  firstDayOfWeek: string;
+  zoomBearing: boolean;
+  // The occurrence-expansion shape the conflict checks read.
+  candidate: {
+    mid: string;
+    title: string;
+    room: string;
+    zoomRoom: string | null;
+    zoomHost: string | null;
+    status: string;
+    calType: string[];
+    startDateTime: Date;
+    endDateTime: Date;
+    isRecurring: boolean;
+    recurrencePattern: {
+      type: string; startDate: Date; endDate: Date | null; interval: number;
+      daysOfWeek: string[]; weekOfMonth: number | null; dayOfMonth: number | null; excludedDates: Date[];
+    };
+  };
+};
+
+// Validates a `linkedSchedule` block against the primary schedule in the same payload and derives
+// the second row's whole series from it. Mirrors handleLinkedScheduleCreate (update/meeting/
+// route.ts), whose anchor is a stored row rather than the request's own primary schedule -- the
+// rules are the same because the resulting families have to be: one Zoom meeting can only hold
+// one series, so the two schedules may differ in mode, weekdays and rooms and in nothing else.
+// Returns an error message for a 400, or the plan to write.
+function planLinkedSchedule(
+  meetingData: IMeeting,
+  recurrencePattern: IMeeting['recurrencePattern'],
+  calculatedEndDate: Date | null,
+  linkedSchedule: LinkedScheduleInput,
+): { error: string } | { plan: LinkedSchedulePlan } {
+  if (!recurrencePattern) {
+    return { error: "A linked schedule can only be added to a recurring meeting." };
+  }
+  if (recurrencePattern.type !== 'weekly') {
+    return { error: "A linked schedule can only be added to a weekly meeting." };
+  }
+  // The primary schedule as the shared family predicates read it -- the family this request is
+  // about to create is exactly {primary, linked}, so the same availableModesFor/claimedDaysFor
+  // that gate an added schedule (and the form's mode/day locking) gate this one.
+  const family = {
+    anchor: { modeType: meetingData.modeType, recurrencePattern: { daysOfWeek: recurrencePattern.daysOfWeek ?? [] } },
+    linked: [],
+  };
+  const availableModes = availableModesFor(family);
+  if (!availableModes.includes(linkedSchedule.modeType)) {
+    return { error: `A linked schedule must use a mode this meeting doesn't already run (${availableModes.join(", ")}).` };
+  }
+  const daysOfWeek = linkedSchedule.recurrencePattern.daysOfWeek ?? [];
+  if (daysOfWeek.length === 0) {
+    return { error: "A linked schedule must meet on at least one day of the week." };
+  }
+  // Disjoint weekdays are a hard requirement, not a preference: Zoom holds the family's schedules
+  // as ONE union of weekdays, so a day claimed twice silently collapses into a single occurrence.
+  const claimedDays = claimedDaysFor(family);
+  const overlappingDays = daysOfWeek.filter((day) => claimedDays.includes(day));
+  if (overlappingDays.length > 0) {
+    return { error: `This meeting already meets on ${overlappingDays.join(", ")}; a linked schedule must run on other days.` };
+  }
+
+  const interval = recurrencePattern.interval || 1;
+  let derived: ReturnType<typeof deriveLinkedScheduleStart>;
+  try {
+    derived = deriveLinkedScheduleStart(
+      {
+        startDateTime: new Date(meetingData.startDateTime),
+        endDateTime: new Date(meetingData.endDateTime),
+        // endDate normalized to calculatedEndDate, so a count-bounded primary schedule doesn't
+        // look unbounded while the first linked occurrence is searched for.
+        recurrencePattern: { startDate: new Date(recurrencePattern.startDate), endDate: calculatedEndDate, interval },
+      },
+      daysOfWeek,
+    );
+  } catch (error) {
+    // The primary schedule's time of day doesn't exist on the linked schedule's first date (the
+    // DST spring-forward gap) -- the admin's own input, not a server fault.
+    if (isConvertETToUTCValidationError(error)) return { error: error.message };
+    throw error;
+  }
+  if (!derived) {
+    return { error: "The requested days produce no occurrence inside this meeting's series." };
+  }
+  const { startDateTime, endDateTime, patternStartDate } = derived;
+
+  // Where the series ends is the primary schedule's to decide, never the linked block's: a
+  // count-bounded meeting gives the linked schedule the same COUNT, resolved into its own end
+  // date because its weekdays reach that count elsewhere. Counted from patternStartDate, not the
+  // row's start instant -- see deriveLinkedScheduleStart.
+  const numberOfOccurrences = recurrencePattern.endDate ? null : (recurrencePattern.numberOfOccurrences ?? null);
+  const endDate = recurrencePattern.endDate
+    ? new Date(recurrencePattern.endDate)
+    : (numberOfOccurrences
+      ? calculateEndDateFromOccurrences(patternStartDate, daysOfWeek, numberOfOccurrences, interval, 'weekly', null, null)
+      : null);
+
+  const plan: LinkedSchedulePlan = {
+    mid: linkedSchedule.mid,
+    modeType: linkedSchedule.modeType,
+    room: linkedSchedule.room ?? "",
+    zoomRoom: linkedSchedule.zoomRoom ?? null,
+    startDateTime,
+    endDateTime,
+    patternStartDate,
+    endDate,
+    numberOfOccurrences,
+    daysOfWeek,
+    interval,
+    firstDayOfWeek: recurrencePattern.firstDayOfWeek || "Sunday",
+    zoomBearing: isZoomBearing({ modeType: linkedSchedule.modeType }),
+    candidate: {
+      mid: linkedSchedule.mid,
+      title: meetingData.title,
+      room: linkedSchedule.room ?? "",
+      zoomRoom: linkedSchedule.zoomRoom ?? null,
+      // Whatever host the family ends up on is resolved inside the write transaction; the
+      // conflict checks read this candidate for its occurrences, never for its host.
+      zoomHost: null,
+      status: meetingData.status ?? 'Active',
+      calType: meetingData.calType,
+      startDateTime,
+      endDateTime,
+      isRecurring: true,
+      recurrencePattern: {
+        type: 'weekly', startDate: patternStartDate, endDate, interval,
+        daysOfWeek, weekOfMonth: null, dayOfMonth: null, excludedDates: [],
+      },
+    },
+  };
+
+  // Backstop for a family Zoom couldn't hold as one series. Everything the check reads is derived
+  // above, so a request that reaches here normally passes -- but a family it rejects would have
+  // its Zoom schedule silently frozen from creation, which is worth refusing outright.
+  const primaryRow = {
+    isRecurring: true,
+    startDateTime: new Date(meetingData.startDateTime),
+    endDateTime: new Date(meetingData.endDateTime),
+    recurrencePattern: { type: recurrencePattern.type, interval },
+  };
+  if (!isSharedZoomScheduleCompatible([primaryRow, { ...plan.candidate, recurrencePattern: { type: 'weekly', interval } }])) {
+    return { error: "This meeting's schedules can't be served by one Zoom meeting (they must share an interval, time of day and duration)." };
+  }
+
+  return { plan };
 }
 
 const createMeeting = async (request: Request) => {
@@ -169,7 +388,8 @@ const createMeeting = async (request: Request) => {
     const auth = await requireRole(Role.ADMIN);
     if (auth instanceof Response) return auth;
 
-    const parsed = meetingSchema.safeParse(await request.json());
+    const rawBody = await request.json();
+    const parsed = meetingSchema.safeParse(rawBody);
     if (!parsed.success) {
       return NextResponse.json({ error: "Invalid meeting data", issues: parsed.error.issues }, { status: 400 });
     }
@@ -177,6 +397,14 @@ const createMeeting = async (request: Request) => {
     // The form doesn't collect a creator (it sends a placeholder) -- record the signed-in admin
     // who actually created the meeting, server-side, so the value can't be spoofed either.
     meetingData.creator = auth.user?.email ?? meetingData.creator;
+
+    // Parsed separately from meetingSchema (see linkedScheduleBlockSchema's comment) -- present
+    // only when the meeting is being created with a SECOND weekly schedule of its own.
+    const linkedParsed = linkedScheduleSchema.safeParse(rawBody);
+    if (!linkedParsed.success) {
+      return NextResponse.json({ error: "Invalid linked schedule", issues: linkedParsed.error.issues }, { status: 400 });
+    }
+    const linkedSchedule: LinkedScheduleInput | null = linkedParsed.data.linkedSchedule ?? null;
 
     const { recurrencePattern, confirmOverride, ...meetingDetails } = meetingData;
     const isRecurring = !!recurrencePattern;
@@ -199,8 +427,19 @@ const createMeeting = async (request: Request) => {
       );
     }
 
-    const zoomEnabled = (meetingData.modeType === 'Hybrid' || meetingData.modeType === 'Remote')
-      && meetingData.status !== 'Suspended';
+    let linkedPlan: LinkedSchedulePlan | null = null;
+    if (linkedSchedule) {
+      const planned = planLinkedSchedule(meetingData, recurrencePattern ?? null, calculatedEndDate, linkedSchedule);
+      if ('error' in planned) return NextResponse.json({ error: planned.error }, { status: 400 });
+      linkedPlan = planned.plan;
+    }
+
+    // Zoom is provisioned for the FAMILY, not per row: a Hybrid/Remote schedule needs it whether
+    // it is the primary schedule or the linked one, and either way there is exactly one Zoom
+    // meeting, one host reservation, and one set of Zoom credentials.
+    const primaryZoomBearing = isZoomBearing(meetingData) && meetingData.status !== 'Suspended';
+    const linkedZoomBearing = !!linkedPlan?.zoomBearing && meetingData.status !== 'Suspended';
+    const zoomEnabled = primaryZoomBearing || linkedZoomBearing;
 
     // Built once, reused for every conflict/candidate check below (the blocking check, the
     // zoomHost re-check on override, and the pool-auto-assign call) -- endDate normalized to
@@ -211,6 +450,24 @@ const createMeeting = async (request: Request) => {
       isRecurring,
       recurrencePattern: recurrencePattern ? { ...recurrencePattern, endDate: calculatedEndDate } : null,
     };
+
+    // The host is booked ONCE for the whole family, so it is checked against everything that one
+    // Zoom booking has to cover: the union of the Zoom-bearing schedules' weekdays, at the time
+    // of day and duration they share (isSharedZoomScheduleCompatible, enforced above). Checking
+    // the two rows separately would instead count the family's single booking twice against the
+    // host's capacity. Identical to `candidate` whenever there is no linked schedule.
+    const zoomCandidate = (() => {
+      if (!linkedPlan || !linkedZoomBearing) return candidate;
+      // An In-Person primary schedule holds no Zoom booking at all -- the linked schedule's own
+      // occurrences are the whole of what the family's Zoom meeting covers.
+      if (!primaryZoomBearing) return linkedPlan.candidate;
+      if (!candidate.recurrencePattern) return candidate;
+      const unionDays = [...new Set([
+        ...(candidate.recurrencePattern.daysOfWeek ?? []),
+        ...linkedPlan.daysOfWeek,
+      ])];
+      return { ...candidate, recurrencePattern: { ...candidate.recurrencePattern, daysOfWeek: unionDays } };
+    })();
 
     let resolvedHost: string | null = null;
     let zoomSyncError: string | null = null;
@@ -246,12 +503,18 @@ const createMeeting = async (request: Request) => {
     // capacity an Active meeting would get.
     const hostCapacities = await getZoomHostCapacities();
 
-    let result: { createdMeeting: Meeting; createdPattern: Awaited<ReturnType<typeof prisma.recurrencePattern.create>> | null };
+    let result: {
+      createdMeeting: Meeting;
+      createdPattern: Awaited<ReturnType<typeof prisma.recurrencePattern.create>> | null;
+      createdLinked: (Meeting & { recurrencePattern: Awaited<ReturnType<typeof prisma.recurrencePattern.create>> | null }) | null;
+    };
     try {
       result = await prisma.$transaction(async (tx) => {
         const claims: ResourceClaim[] = [];
         if (meetingData.room) claims.push({ type: "room", value: meetingData.room });
         if (meetingData.zoomRoom) claims.push({ type: "zoomRoom", value: meetingData.zoomRoom });
+        if (linkedPlan?.room) claims.push({ type: "room", value: linkedPlan.room });
+        if (linkedPlan?.zoomRoom) claims.push({ type: "zoomRoom", value: linkedPlan.zoomRoom });
         if (meetingData.zoomHost) claims.push({ type: "zoomHost", value: meetingData.zoomHost });
         if (needsAutoHost) {
           for (const host of zoomHostPool) claims.push({ type: "zoomHost", value: host });
@@ -277,9 +540,19 @@ const createMeeting = async (request: Request) => {
           if (meetingData.zoomRoom) {
             conflictRows.push(...await findResourceConflictRows("zoomRoom", meetingData.zoomRoom, candidate, tx, { excludeMid: meetingData.mid }));
           }
+          // The linked schedule's own rooms get the same full check against the rest of the
+          // calendar. Neither new row is in the database yet, so nothing here can report the two
+          // schedules as colliding with each other -- and they cannot in any case, since their
+          // weekdays are disjoint.
+          if (linkedPlan?.room) {
+            conflictRows.push(...await findResourceConflictRows("room", linkedPlan.room, linkedPlan.candidate, tx, { excludeMid: linkedPlan.mid }));
+          }
+          if (linkedPlan?.zoomRoom) {
+            conflictRows.push(...await findResourceConflictRows("zoomRoom", linkedPlan.zoomRoom, linkedPlan.candidate, tx, { excludeMid: linkedPlan.mid }));
+          }
           if (meetingData.zoomHost) {
             zoomHostConflictRows = await findResourceConflictRows(
-              "zoomHost", meetingData.zoomHost, candidate, tx,
+              "zoomHost", meetingData.zoomHost, zoomCandidate, tx,
               { excludeMid: meetingData.mid, includeSuspended: true, capacity: hostCapacities[meetingData.zoomHost] ?? 1 },
             );
             conflictRows.push(...zoomHostConflictRows);
@@ -301,7 +574,7 @@ const createMeeting = async (request: Request) => {
             // the block entirely) needs a fresh check here.
             const conflicts = confirmOverride
               ? await findResourceConflicts(
-                  "zoomHost", meetingData.zoomHost, candidate, tx,
+                  "zoomHost", meetingData.zoomHost, zoomCandidate, tx,
                   { excludeMid: meetingData.mid, includeSuspended: true, capacity: hostCapacities[meetingData.zoomHost] ?? 1 },
                 )
               : [];
@@ -312,7 +585,9 @@ const createMeeting = async (request: Request) => {
               attemptedZoomHost = meetingData.zoomHost;
             }
           } else {
-            const poolResolvedHost = await resolveZoomHost(candidate, tx, { excludeMid: meetingData.mid, capacities: hostCapacities });
+            // Resolved once, against the family's whole booking -- one host reservation for one
+            // Zoom meeting, never one per schedule.
+            const poolResolvedHost = await resolveZoomHost(zoomCandidate, tx, { excludeMid: meetingData.mid, capacities: hostCapacities });
             resolvedHost = poolResolvedHost;
             zoomSyncError = poolResolvedHost
               ? null
@@ -326,15 +601,19 @@ const createMeeting = async (request: Request) => {
           // sentinel for a real SQL NULL) -- Mongo's connector accepted plain `null` here directly.
           googleCalendarEventIds: meetingDetails.googleCalendarEventIds ?? Prisma.DbNull,
           isRecurring,
-          zoomHost: resolvedHost,
-          attemptedZoomHost,
-          ...(zoomSyncError ? { zoomSyncStatus: 'error', zoomSyncError } : {}),
+          // Never the family's host on a schedule that doesn't use Zoom: an In-Person primary
+          // schedule whose linked schedule is Remote holds no Zoom identity at all.
+          zoomHost: primaryZoomBearing ? resolvedHost : null,
+          attemptedZoomHost: primaryZoomBearing ? attemptedZoomHost : null,
+          ...(primaryZoomBearing && zoomSyncError ? { zoomSyncStatus: 'error', zoomSyncError } : {}),
         };
 
         // meetingDetails.mid is client-generated (see NewMeeting.tsx's uuidv4()) and known
         // before either write, so both creates stay part of this same transaction instead of a
         // create-then-create sequence an interrupted request could leave half-done (a Meeting
-        // with isRecurring: true and no RecurrencePattern row).
+        // with isRecurring: true and no RecurrencePattern row). The linked schedule's mid is
+        // client-generated for the same reason, so its row joins this transaction too -- a
+        // family that exists half-written is not a shape any later request could repair.
         const createdMeeting = await tx.meeting.create({ data: meetingCreateData });
         const createdPattern = recurrencePattern
           ? await tx.recurrencePattern.create({
@@ -353,7 +632,70 @@ const createMeeting = async (request: Request) => {
             })
           : null;
 
-        return { createdMeeting, createdPattern };
+        const createdLinked = linkedPlan
+          ? await tx.meeting.create({
+              data: {
+                mid: linkedPlan.mid,
+                // Identity, content and calendars are the family's, copied from the primary
+                // schedule -- only the mode, the rooms that mode needs and the weekdays are the
+                // linked schedule's own (see linkedScheduleBlockSchema's RULE comment).
+                title: meetingData.title,
+                description: meetingData.description,
+                creator: meetingData.creator,
+                lastEditedBy: null,
+                group: meetingData.group,
+                email: meetingData.email,
+                calType: meetingData.calType,
+                // Mirrors the primary schedule's status rather than being pinned Active: both
+                // rows are born here, together, so there is no prior suspension for this row to
+                // wrongly inherit -- and a family whose halves disagreed would have one schedule
+                // publishing calendar events while the other stayed dark.
+                status: meetingData.status,
+                startDateTime: linkedPlan.startDateTime,
+                endDateTime: linkedPlan.endDateTime,
+                modeType: linkedPlan.modeType,
+                room: linkedPlan.room,
+                zoomRoom: linkedPlan.zoomRoom,
+                isRecurring: true,
+                linkedToMid: meetingDetails.mid,
+                // A second mode, not a division of the primary schedule's series -- the two
+                // lineage columns are deliberately distinct (schema.prisma).
+                splitFromMid: null,
+                googleCalendarEventIds: Prisma.DbNull,
+                // The family's one Zoom identity, whether it was supplied with the payload (an
+                // adopted meeting) or is about to be minted by the deferred sync. An In-Person
+                // linked schedule gets none of it.
+                ...(linkedPlan.zoomBearing
+                  ? {
+                      zid: meetingData.zid ?? null,
+                      zoomLink: meetingData.zoomLink ?? null,
+                      zoomPasscode: meetingData.zoomPasscode ?? null,
+                      zoomInvitation: meetingData.zoomInvitation ?? null,
+                      zoomHost: resolvedHost,
+                      attemptedZoomHost,
+                      ...(zoomSyncError ? { zoomSyncStatus: 'error', zoomSyncError } : {}),
+                    }
+                  : {}),
+                recurrencePattern: {
+                  create: {
+                    type: 'weekly',
+                    startDate: linkedPlan.patternStartDate,
+                    endDate: linkedPlan.endDate,
+                    numberOfOccurrences: linkedPlan.numberOfOccurrences ?? undefined,
+                    daysOfWeek: linkedPlan.daysOfWeek,
+                    firstDayOfWeek: linkedPlan.firstDayOfWeek,
+                    interval: linkedPlan.interval,
+                    weekOfMonth: null,
+                    dayOfMonth: null,
+                    excludedDates: [],
+                  },
+                },
+              },
+              include: { recurrencePattern: true },
+            })
+          : null;
+
+        return { createdMeeting, createdPattern, createdLinked };
       }, { timeout: 10_000, maxWait: 10_000 });
     } catch (error) {
       if (error instanceof ResourceConflictAbort) {
@@ -366,21 +708,37 @@ const createMeeting = async (request: Request) => {
     }
 
     const newMeeting = result.createdMeeting;
-    const responseMeeting = result.createdPattern
-      ? { ...newMeeting, recurrencePattern: result.createdPattern }
-      : newMeeting;
+    const responseMeeting = {
+      ...newMeeting,
+      ...(result.createdPattern ? { recurrencePattern: result.createdPattern } : {}),
+      ...(result.createdLinked ? { linkedMid: result.createdLinked.mid } : {}),
+    };
+
+    // The rows the deferred sync publishes, primary first -- the family's Zoom meeting is minted
+    // from the first Zoom-bearing one.
+    const syncRows: NewMeetingSyncRow[] = [
+      { mid: newMeeting.mid, meeting: meetingData, isRecurring, zoomBearing: primaryZoomBearing },
+      ...(result.createdLinked
+        ? [{
+            mid: result.createdLinked.mid,
+            meeting: result.createdLinked as unknown as IMeeting,
+            isRecurring: true,
+            zoomBearing: linkedZoomBearing,
+          }]
+        : []),
+    ];
 
     // GCal/Zoom sync runs after the response is sent — see syncNewMeeting above. Caught here so
     // a throw mid-sync (as opposed to a handled failure, which syncNewMeeting already persists
     // as an error status itself) doesn't vanish as a silent unhandled rejection, leaving the
     // meeting's sync status at whatever it was before this run.
     after(
-      syncNewMeeting(newMeeting.mid, meetingData, isRecurring, auth.accessToken, resolvedHost, zoomSyncError)
+      syncNewMeeting(syncRows, auth.accessToken, resolvedHost, zoomSyncError)
         .catch(async (error) => {
           console.error("syncNewMeeting threw:", error);
           try {
-            await prisma.meeting.update({
-              where: { mid: newMeeting.mid },
+            await prisma.meeting.updateMany({
+              where: { mid: { in: syncRows.map((row) => row.mid) } },
               data: { googleSyncStatus: 'error', googleSyncError: "Sync job failed unexpectedly." },
             });
           } catch (persistError) {

--- a/frontend/tests/integration/update-meeting-sync-route.test.ts
+++ b/frontend/tests/integration/update-meeting-sync-route.test.ts
@@ -382,3 +382,123 @@ describe("retrying an already-synced meeting (existing zid)", () => {
     expect(mockedReconcileMeetingCalendars).not.toHaveBeenCalled();
   });
 });
+
+// A linked-schedule family is served by ONE Zoom meeting and holds ONE pool host slot
+// (util/meetings/linkedSchedules.ts). Retry sync provisions Zoom, so it is a place that
+// invariant can be broken one row at a time.
+describe("retrying a linked-schedule family", () => {
+  function syncRequest(mid: string): Request {
+    return new Request("http://localhost/api/update/meeting/sync", {
+      method: "POST",
+      body: JSON.stringify({ mid }),
+    });
+  }
+
+  // Exactly the state a two-schedule create leaves behind when the host pool was exhausted:
+  // both Zoom-bearing rows committed, neither provisioned.
+  async function seedZidlessFamily(prefix: string) {
+    const prisma = getTestPrismaClient();
+    const anchor = buildMeetingData({ title: `${prefix} Anchor`, modeType: "Hybrid", room: `${prefix} Room` });
+    const linked = buildMeetingData({ title: `${prefix} Linked`, linkedToMid: anchor.mid });
+    await prisma.meeting.create({ data: anchor });
+    await prisma.meeting.create({ data: linked });
+    return { anchor, linked };
+  }
+
+  test("retrying both zid-less schedules of one family mints ONE Zoom meeting, shared by both", async () => {
+    mockedResolveZoomHost.mockResolvedValue("family-host@icr.test");
+    mockedCreateZoomMeeting.mockResolvedValue({
+      zid: "one-family-zid", zoomLink: "http://zoom.test/one-family", zoomPasscode: "family-pass",
+    });
+    mockedUpdateZoomMeeting.mockResolvedValue(true);
+    mockedGetZoomMeetingCredentials.mockResolvedValue(null);
+    mockedReconcileMeetingCalendars.mockResolvedValue({ updatedEventIds: {}, allSynced: true, googleSyncError: null });
+
+    const { anchor, linked } = await seedZidlessFamily("Pool Exhausted");
+
+    expect((await POST(syncRequest(anchor.mid))).status).toBe(200);
+    expect((await POST(syncRequest(linked.mid))).status).toBe(200);
+
+    // The second retry finds the family already provisioned and PATCHes that meeting instead of
+    // minting its own -- two Zoom meetings (and two host reservations) for one meeting is exactly
+    // what the family exists to prevent.
+    expect(mockedCreateZoomMeeting).toHaveBeenCalledTimes(1);
+    expect(mockedResolveZoomHost).toHaveBeenCalledTimes(1);
+    expect(mockedUpdateZoomMeeting).toHaveBeenCalledWith("one-family-zid", expect.anything(), expect.any(Array));
+
+    const prisma = getTestPrismaClient();
+    for (const mid of [anchor.mid, linked.mid]) {
+      const row = await prisma.meeting.findUnique({ where: { mid } });
+      expect(row?.zid).toBe("one-family-zid");
+      expect(row?.zoomLink).toBe("http://zoom.test/one-family");
+      expect(row?.zoomPasscode).toBe("family-pass");
+      expect(row?.zoomHost).toBe("family-host@icr.test");
+    }
+  });
+
+  test("the sibling of a just-provisioned schedule keeps its own pending sync status until it is retried", async () => {
+    mockedResolveZoomHost.mockResolvedValue("family-host-2@icr.test");
+    mockedCreateZoomMeeting.mockResolvedValue({
+      zid: "sibling-fanout-zid", zoomLink: "http://zoom.test/sibling-fanout", zoomPasscode: null,
+    });
+    mockedReconcileMeetingCalendars.mockResolvedValue({ updatedEventIds: {}, allSynced: true, googleSyncError: null });
+
+    const { anchor, linked } = await seedZidlessFamily("Fan Out");
+    expect((await POST(syncRequest(anchor.mid))).status).toBe(200);
+
+    const prisma = getTestPrismaClient();
+    const sibling = await prisma.meeting.findUnique({ where: { mid: linked.mid } });
+    // Only the shared Zoom identity is fanned out: this row's own calendar events were never
+    // published by the anchor's retry, so its statuses must keep saying so.
+    expect(sibling?.zid).toBe("sibling-fanout-zid");
+    expect(sibling?.googleSyncStatus).toBe("pending");
+    expect(sibling?.zoomSyncStatus).toBe("error");
+    expect(mockedReconcileMeetingCalendars).toHaveBeenCalledTimes(1);
+  });
+
+  test("retrying a zid-less schedule whose family already has a Zoom meeting adopts it instead of minting a second", async () => {
+    mockedUpdateZoomMeeting.mockResolvedValue(true);
+    mockedReconcileMeetingCalendars.mockResolvedValue({ updatedEventIds: {}, allSynced: true, googleSyncError: null });
+
+    const prisma = getTestPrismaClient();
+    const anchor = buildMeetingData({
+      title: "Adopting Anchor",
+      modeType: "Hybrid",
+      room: "Adopting Room",
+      zid: "already-held-zid",
+      zoomLink: "http://zoom.test/already-held",
+      zoomPasscode: "held-pass",
+      zoomInvitation: "held invitation",
+      zoomHost: "held-host@icr.test",
+      googleSyncStatus: "synced",
+      zoomSyncStatus: "synced",
+      zoomSyncError: null,
+    });
+    const linked = buildMeetingData({ title: "Adopting Linked", linkedToMid: anchor.mid });
+    await prisma.meeting.create({ data: anchor });
+    await prisma.meeting.create({ data: linked });
+
+    const response = await POST(syncRequest(linked.mid));
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.zoomSyncStatus).toBe("synced");
+
+    expect(mockedCreateZoomMeeting).not.toHaveBeenCalled();
+    // No second host slot either -- the family's booking already has one.
+    expect(mockedResolveZoomHost).not.toHaveBeenCalled();
+    // The shared meeting is re-PATCHed so its schedule widens to cover the adopting row's days.
+    expect(mockedUpdateZoomMeeting).toHaveBeenCalledWith("already-held-zid", expect.anything(), expect.any(Array));
+
+    const adopted = await prisma.meeting.findUnique({ where: { mid: linked.mid } });
+    expect(adopted?.zid).toBe("already-held-zid");
+    expect(adopted?.zoomLink).toBe("http://zoom.test/already-held");
+    expect(adopted?.zoomPasscode).toBe("held-pass");
+    expect(adopted?.zoomInvitation).toBe("held invitation");
+    expect(adopted?.zoomHost).toBe("held-host@icr.test");
+
+    // The holder itself is left exactly as it was.
+    const holder = await prisma.meeting.findUnique({ where: { mid: anchor.mid } });
+    expect(holder?.zid).toBe("already-held-zid");
+    expect(holder?.googleSyncStatus).toBe("synced");
+  });
+});

--- a/frontend/tests/integration/write-meeting-linked-schedule.test.ts
+++ b/frontend/tests/integration/write-meeting-linked-schedule.test.ts
@@ -448,6 +448,75 @@ test("an exhausted host pool leaves BOTH schedules unpublished rather than half-
   expect(mockedCreateCalendarEvent).not.toHaveBeenCalled();
 });
 
+test("an In-Person primary schedule holds no client-supplied Zoom identity", async () => {
+  const linked = linkedBlock();
+  const payload = meetingPayload({
+    modeType: "In Person",
+    room: `In Person Adopting ${randomUUID()}`,
+    zoomRoom: null,
+    // The whole Zoom identity of an adopted meeting, supplied by the client for a schedule that
+    // never meets online.
+    zid: "adopted-zid",
+    zoomLink: "https://zoom.us/j/adopted",
+    zoomPasscode: "adopted-pass",
+    zoomInvitation: "adopted invitation",
+    linkedSchedule: linked,
+  });
+
+  expect((await postMeeting(payload)).status).toBe(201);
+  await drainAfterTasks();
+
+  const prisma = getTestPrismaClient();
+  const primary = await prisma.meeting.findUnique({ where: { mid: payload.mid } });
+  const created = await prisma.meeting.findUnique({ where: { mid: linked.mid } });
+
+  // Every Zoom field, not just the host: a row holding a zid/zoomLink would advertise a join
+  // link on its calendar event and union its weekdays into the family's Zoom recurrence.
+  expect(primary?.zid).toBeNull();
+  expect(primary?.zoomLink).toBeNull();
+  expect(primary?.zoomPasscode).toBeNull();
+  expect(primary?.zoomInvitation).toBeNull();
+  expect(primary?.zoomHost).toBeNull();
+  // The Remote schedule is where the adopted Zoom meeting actually lives.
+  expect(created?.zid).toBe("adopted-zid");
+  expect(created?.zoomLink).toBe("https://zoom.us/j/adopted");
+
+  // ...and the in-person schedule's calendar event is published with no join link either --
+  // buildEventBody writes "Zoom: {link}" from exactly this argument.
+  const primaryCall = mockedCreateCalendarEvent.mock.calls.find(([, meetingArg]) => meetingArg.mid === payload.mid);
+  expect(primaryCall).toBeDefined();
+  expect(primaryCall![1].zid).toBeNull();
+  expect(primaryCall![1].zoomLink).toBeNull();
+  // The payload already carried a Zoom meeting, so none is minted for the family.
+  expect(mockedCreateZoomMeeting).not.toHaveBeenCalled();
+});
+
+test("a deferred sync that throws on the second schedule leaves the first schedule's synced status standing", async () => {
+  mockedResolveZoomHost.mockResolvedValue("create-pool-host-1@icr.test");
+  mockedCreateZoomMeeting.mockResolvedValue({ zid: `zid-${randomUUID()}`, zoomLink: "https://zoom.us/j/throws", zoomPasscode: null });
+  const linked = linkedBlock();
+  const payload = meetingPayload({ linkedSchedule: linked });
+  // A throw, not a handled publish failure: the linked row's publish takes down the whole
+  // deferred sync after the primary row has already committed its own success.
+  mockedCreateCalendarEvent.mockImplementation(async (_token: string, meetingArg: { mid: string }) => {
+    if (meetingArg.mid === linked.mid) throw new Error("calendar publish exploded");
+    return { id: `event-${randomUUID()}`, error: null };
+  });
+
+  expect((await postMeeting(payload)).status).toBe(201);
+  await drainAfterTasks();
+
+  const prisma = getTestPrismaClient();
+  const primary = await prisma.meeting.findUnique({ where: { mid: payload.mid } });
+  const created = await prisma.meeting.findUnique({ where: { mid: linked.mid } });
+
+  // The primary schedule's events are live on Google -- the catch-all must not flip it to error.
+  expect(primary?.googleSyncStatus).toBe("synced");
+  expect(primary?.googleSyncError).toBeNull();
+  expect(created?.googleSyncStatus).toBe("error");
+  expect(created?.googleSyncError).toBe("Sync job failed unexpectedly.");
+});
+
 test("the linked schedule's own series is derived, never taken from the client", async () => {
   mockedResolveZoomHost.mockResolvedValue("create-pool-host-1@icr.test");
   mockedCreateZoomMeeting.mockResolvedValue({ zid: `zid-${randomUUID()}`, zoomLink: "https://zoom.us/j/derived", zoomPasscode: null });

--- a/frontend/tests/integration/write-meeting-linked-schedule.test.ts
+++ b/frontend/tests/integration/write-meeting-linked-schedule.test.ts
@@ -1,0 +1,501 @@
+import { randomUUID } from "crypto";
+import { formatETDateString, formatETWeekdayLong, getETTimeOfDay } from "../../util/date/timeUtils";
+import { buildLinkedScheduleLabel } from "../../util/meetings/linkedSchedules";
+
+// after() tasks are collected rather than discarded, so each test can drain them at a known
+// point -- creating a meeting with two schedules fans one deferred sync out across BOTH rows,
+// and the assertions are about what that sync was handed, not just that it eventually ran.
+const mockCapturedAfterTasks: Promise<unknown>[] = [];
+jest.mock("next/server", () => ({
+  ...jest.requireActual("next/server"),
+  after: (task: unknown) => {
+    mockCapturedAfterTasks.push(Promise.resolve(typeof task === "function" ? (task as () => unknown)() : task));
+  },
+}));
+
+jest.mock("../../services/auth", () => ({
+  requireRole: jest.fn().mockResolvedValue({
+    user: { role: "ADMIN", email: "session-admin@test.icr" },
+    accessToken: "fake-token",
+  }),
+}));
+
+jest.mock("../../services/googleCalendar", () => ({
+  calendarIdsForMeeting: jest.fn((calType: string[]) =>
+    Object.fromEntries(calType.map((cat) => [cat, `cal-${cat}`]))),
+  createCalendarEvent: jest.fn().mockResolvedValue({ id: `event-${Math.random()}`, error: null }),
+}));
+
+jest.mock("../../services/zoom", () => ({
+  createZoomMeeting: jest.fn(),
+  getZoomMeetingInvitation: jest.fn().mockResolvedValue("family invitation"),
+  resolveZoomHost: jest.fn(),
+  getZoomHostCapacities: jest.fn().mockResolvedValue({}),
+  // The route locks every pool host through the real lockResourceClaims before resolving one,
+  // so these need to be real strings even though resolveZoomHost itself is mocked.
+  zoomHostPool: ["create-pool-host-1@icr.test", "create-pool-host-2@icr.test"],
+  // Left empty on purpose: every test here gives its rows a unique zoomRoom (so the room
+  // conflict check can't make tests order-dependent), and an unmapped zoomRoom publishes no
+  // Zoom-Room calendar event.
+  zoomRoomCalendarId: {},
+}));
+
+import { getTestPrismaClient, disconnectTestPrismaClient } from "../factories/db";
+import { seedMeeting } from "../factories/meeting";
+import { POST } from "../../app/api/write/meeting/route";
+import { createCalendarEvent } from "../../services/googleCalendar";
+import { createZoomMeeting, resolveZoomHost } from "../../services/zoom";
+
+const mockedCreateCalendarEvent = createCalendarEvent as jest.Mock;
+const mockedCreateZoomMeeting = createZoomMeeting as jest.Mock;
+const mockedResolveZoomHost = resolveZoomHost as jest.Mock;
+
+// A real future Monday at 2 PM ET, so both schedules' weekdays are derived from one date rather
+// than hardcoded names that could drift apart.
+const SERIES_START = new Date("2026-09-07T18:00:00Z");
+const SERIES_END = new Date("2026-09-07T19:00:00Z");
+const PRIMARY_WEEKDAY = formatETWeekdayLong(SERIES_START); // Monday
+const LINKED_WEEKDAY = "Saturday";
+const FIRST_LINKED_ET_DATE = "2026-09-12"; // the first Saturday on/after the series start
+
+afterAll(async () => {
+  await disconnectTestPrismaClient();
+});
+
+beforeEach(() => {
+  mockedCreateCalendarEvent.mockClear();
+  mockedCreateCalendarEvent.mockResolvedValue({ id: `event-${randomUUID()}`, error: null });
+  mockedCreateZoomMeeting.mockReset();
+  mockedResolveZoomHost.mockReset();
+  mockCapturedAfterTasks.length = 0;
+});
+
+async function drainAfterTasks(): Promise<void> {
+  await Promise.all(mockCapturedAfterTasks.splice(0, mockCapturedAfterTasks.length));
+}
+
+function postMeeting(payload: Record<string, unknown>): Promise<Response> {
+  return POST(new Request("http://localhost/api/write/meeting", { method: "POST", body: JSON.stringify(payload) }));
+}
+
+// The integration database is reset once per file, not per test, and a weekly interval-1 series
+// recurs forever -- so every payload gets its own room/zoomRoom unless a test is deliberately
+// about sharing one.
+function meetingPayload(overrides: Record<string, unknown> = {}) {
+  return {
+    mid: `primary-${randomUUID()}`,
+    title: "Linked Create",
+    description: "A meeting with two schedules",
+    creator: "Spoofed Creator",
+    group: "Group",
+    startDateTime: SERIES_START,
+    endDateTime: SERIES_END,
+    email: "linked-create@test.icr",
+    calType: ["AA"],
+    modeType: "Hybrid",
+    room: `Primary Room ${randomUUID()}`,
+    zoomRoom: `Primary Zoom Room ${randomUUID()}`,
+    status: "Active",
+    isRecurring: true,
+    recurrencePattern: {
+      type: "weekly",
+      startDate: SERIES_START,
+      daysOfWeek: [PRIMARY_WEEKDAY],
+      firstDayOfWeek: "Sunday",
+      interval: 1,
+    },
+    ...overrides,
+  };
+}
+
+function linkedBlock(overrides: Record<string, unknown> = {}) {
+  return {
+    mid: `linked-${randomUUID()}`,
+    modeType: "Remote",
+    room: null,
+    zoomRoom: null,
+    recurrencePattern: {
+      type: "weekly",
+      startDate: SERIES_START,
+      daysOfWeek: [LINKED_WEEKDAY],
+      firstDayOfWeek: "Sunday",
+      interval: 1,
+    },
+    ...overrides,
+  };
+}
+
+describe("linked-schedule rejections", () => {
+  test("a non-recurring meeting is rejected with 400", async () => {
+    const response = await postMeeting(meetingPayload({
+      isRecurring: false,
+      recurrencePattern: null,
+      linkedSchedule: linkedBlock(),
+    }));
+    expect(response.status).toBe(400);
+    expect((await response.json()).error).toMatch(/recurring/i);
+  });
+
+  test("a non-weekly (monthly) meeting is rejected with 400", async () => {
+    const response = await postMeeting(meetingPayload({
+      recurrencePattern: {
+        type: "monthly", startDate: SERIES_START, daysOfWeek: [PRIMARY_WEEKDAY],
+        firstDayOfWeek: "Sunday", interval: 1, weekOfMonth: 1,
+      },
+      linkedSchedule: linkedBlock(),
+    }));
+    expect(response.status).toBe(400);
+    expect((await response.json()).error).toMatch(/weekly/i);
+  });
+
+  test("a linked schedule in the meeting's own mode is rejected with 400", async () => {
+    const response = await postMeeting(meetingPayload({
+      linkedSchedule: linkedBlock({ modeType: "Hybrid", room: "Another Room", zoomRoom: "Another Zoom Room" }),
+    }));
+    expect(response.status).toBe(400);
+    expect((await response.json()).error).toMatch(/mode this meeting doesn't already run/i);
+  });
+
+  test("weekdays the meeting already meets on are rejected with 400", async () => {
+    const response = await postMeeting(meetingPayload({
+      linkedSchedule: linkedBlock({ recurrencePattern: {
+        type: "weekly", startDate: SERIES_START, daysOfWeek: [PRIMARY_WEEKDAY, LINKED_WEEKDAY],
+        firstDayOfWeek: "Sunday", interval: 1,
+      } }),
+    }));
+    expect(response.status).toBe(400);
+    expect((await response.json()).error).toMatch(new RegExp(`already meets on ${PRIMARY_WEEKDAY}`, "i"));
+  });
+
+  test("a linked schedule with no weekday at all is rejected with 400", async () => {
+    const response = await postMeeting(meetingPayload({
+      linkedSchedule: linkedBlock({ recurrencePattern: {
+        type: "weekly", startDate: SERIES_START, daysOfWeek: [],
+        firstDayOfWeek: "Sunday", interval: 1,
+      } }),
+    }));
+    expect(response.status).toBe(400);
+    expect((await response.json()).error).toMatch(/at least one day/i);
+  });
+
+  test("a monthly linked schedule is rejected by the schema with 400", async () => {
+    const response = await postMeeting(meetingPayload({
+      linkedSchedule: linkedBlock({ recurrencePattern: {
+        type: "monthly", startDate: SERIES_START, daysOfWeek: [LINKED_WEEKDAY],
+        firstDayOfWeek: "Sunday", interval: 1, weekOfMonth: 1,
+      } }),
+    }));
+    expect(response.status).toBe(400);
+    expect((await response.json()).error).toBe("Invalid linked schedule");
+  });
+
+  test("a Hybrid linked schedule with no room is rejected by the schema with 400", async () => {
+    const response = await postMeeting(meetingPayload({
+      modeType: "Remote", room: "", zoomRoom: null,
+      linkedSchedule: linkedBlock({ modeType: "Hybrid", room: null, zoomRoom: null }),
+    }));
+    expect(response.status).toBe(400);
+    expect((await response.json()).error).toBe("Invalid linked schedule");
+  });
+
+  test("nothing is written when the linked schedule is rejected", async () => {
+    const payload = meetingPayload({ linkedSchedule: linkedBlock({ modeType: "Hybrid", room: "R", zoomRoom: "ZR" }) });
+    expect((await postMeeting(payload)).status).toBe(400);
+
+    const prisma = getTestPrismaClient();
+    expect(await prisma.meeting.findUnique({ where: { mid: payload.mid } })).toBeNull();
+  });
+});
+
+test("a Hybrid meeting and its Remote linked schedule are created together, sharing one Zoom meeting", async () => {
+  mockedResolveZoomHost.mockResolvedValue("create-pool-host-1@icr.test");
+  mockedCreateZoomMeeting.mockResolvedValue({
+    zid: "family-zid", zoomLink: "https://zoom.us/j/family", zoomPasscode: "family-pass",
+  });
+  const linked = linkedBlock();
+  const payload = meetingPayload({ linkedSchedule: linked });
+
+  const response = await postMeeting(payload);
+  expect(response.status).toBe(201);
+  expect((await response.json()).linkedMid).toBe(linked.mid);
+  await drainAfterTasks();
+
+  const prisma = getTestPrismaClient();
+  const primary = await prisma.meeting.findUnique({ where: { mid: payload.mid }, include: { recurrencePattern: true } });
+  const created = await prisma.meeting.findUnique({ where: { mid: linked.mid }, include: { recurrencePattern: true } });
+
+  // The linked row is a second schedule of the same meeting, not a division of its series.
+  expect(created?.linkedToMid).toBe(payload.mid);
+  expect(created?.splitFromMid).toBeNull();
+  expect(created?.status).toBe("Active");
+  expect(created?.isRecurring).toBe(true);
+  expect(created?.modeType).toBe("Remote");
+
+  // Identity and content are the family's, copied from the primary schedule.
+  expect(created?.title).toBe(primary?.title);
+  expect(created?.description).toBe(primary?.description);
+  expect(created?.email).toBe(primary?.email);
+  expect(created?.group).toBe(primary?.group);
+  expect(created?.calType).toEqual(primary?.calType);
+  expect(created?.creator).toBe("session-admin@test.icr");
+
+  // Re-anchored onto the first Saturday of the primary schedule's series, keeping its ET time of
+  // day and its duration -- one Zoom meeting can only hold one time of day.
+  expect(formatETDateString(created!.startDateTime)).toBe(FIRST_LINKED_ET_DATE);
+  expect(getETTimeOfDay(created!.startDateTime)).toEqual(getETTimeOfDay(primary!.startDateTime));
+  expect(created!.endDateTime.getTime() - created!.startDateTime.getTime())
+    .toBe(primary!.endDateTime.getTime() - primary!.startDateTime.getTime());
+  expect(created?.recurrencePattern?.daysOfWeek).toEqual([LINKED_WEEKDAY]);
+  expect(created?.recurrencePattern?.interval).toBe(1);
+
+  // ONE Zoom meeting for the whole family, minted from the primary schedule and handed both
+  // rows so its recurrence is their union from the very first write.
+  expect(mockedCreateZoomMeeting).toHaveBeenCalledTimes(1);
+  const [mintedFrom, mintedHost, zoomFamily] = mockedCreateZoomMeeting.mock.calls[0];
+  expect(mintedFrom.mid).toBe(payload.mid);
+  expect(mintedHost).toBe("create-pool-host-1@icr.test");
+  expect((zoomFamily as { mid: string }[]).map((row) => row.mid).sort()).toEqual([payload.mid, linked.mid].sort());
+
+  // ...and its identity is fanned out to every Zoom-bearing row, not just the one it was minted
+  // from -- a row without the zid would look unprovisioned and mint a second meeting on retry.
+  for (const row of [primary, created]) {
+    expect(row?.zid).toBe("family-zid");
+    expect(row?.zoomLink).toBe("https://zoom.us/j/family");
+    expect(row?.zoomPasscode).toBe("family-pass");
+    expect(row?.zoomInvitation).toBe("family invitation");
+    expect(row?.zoomHost).toBe("create-pool-host-1@icr.test");
+    expect(row?.zoomSyncStatus).toBe("synced");
+    expect(row?.googleSyncStatus).toBe("synced");
+  }
+});
+
+test("the family's host is reserved once, against both schedules' days together", async () => {
+  mockedResolveZoomHost.mockResolvedValue("create-pool-host-1@icr.test");
+  mockedCreateZoomMeeting.mockResolvedValue({ zid: `zid-${randomUUID()}`, zoomLink: "https://zoom.us/j/once", zoomPasscode: null });
+  const payload = meetingPayload({ linkedSchedule: linkedBlock() });
+
+  expect((await postMeeting(payload)).status).toBe(201);
+  await drainAfterTasks();
+
+  // One reservation for one Zoom booking: resolving per schedule would charge the pool twice for
+  // a meeting Zoom only ever sees once.
+  expect(mockedResolveZoomHost).toHaveBeenCalledTimes(1);
+  const [hostCandidate] = mockedResolveZoomHost.mock.calls[0];
+  // ...and that one reservation covers everything the booking has to serve: the union of the
+  // Zoom-bearing schedules' weekdays.
+  expect([...hostCandidate.recurrencePattern.daysOfWeek].sort())
+    .toEqual([PRIMARY_WEEKDAY, LINKED_WEEKDAY].sort());
+});
+
+test("a manually-picked host busy on the LINKED schedule's day is a 409 that writes neither row", async () => {
+  const contestedHost = `contested-${randomUUID()}@icr.test`;
+  // A booking of that host on the linked schedule's very first Saturday -- a day the primary
+  // schedule never meets on, so only a host check over the family's union can see it.
+  await seedMeeting({
+    zoomHost: contestedHost,
+    modeType: "Remote",
+    room: "",
+    zid: `zid-busy-${randomUUID()}`,
+    startDateTime: new Date(`${FIRST_LINKED_ET_DATE}T18:00:00Z`),
+    endDateTime: new Date(`${FIRST_LINKED_ET_DATE}T19:00:00Z`),
+  });
+  const linked = linkedBlock();
+  const payload = meetingPayload({ zoomHost: contestedHost, linkedSchedule: linked });
+
+  const response = await postMeeting(payload);
+  expect(response.status).toBe(409);
+  expect((await response.json()).conflicts).toBeDefined();
+
+  const prisma = getTestPrismaClient();
+  expect(await prisma.meeting.findUnique({ where: { mid: payload.mid } })).toBeNull();
+  expect(await prisma.meeting.findUnique({ where: { mid: linked.mid } })).toBeNull();
+  expect(mockedCreateZoomMeeting).not.toHaveBeenCalled();
+});
+
+test("a room conflict on the linked schedule's own room is a 409 that writes neither row", async () => {
+  const contestedRoom = `Contested Linked Room ${randomUUID()}`;
+  await seedMeeting({
+    room: contestedRoom,
+    startDateTime: new Date(`${FIRST_LINKED_ET_DATE}T18:00:00Z`),
+    endDateTime: new Date(`${FIRST_LINKED_ET_DATE}T19:00:00Z`),
+  });
+  const linked = linkedBlock({ modeType: "In Person", room: contestedRoom });
+  const payload = meetingPayload({ linkedSchedule: linked });
+
+  const response = await postMeeting(payload);
+  expect(response.status).toBe(409);
+
+  const prisma = getTestPrismaClient();
+  expect(await prisma.meeting.findUnique({ where: { mid: payload.mid } })).toBeNull();
+  expect(await prisma.meeting.findUnique({ where: { mid: linked.mid } })).toBeNull();
+
+  // ...and confirmOverride retries the whole two-row create.
+  mockedResolveZoomHost.mockResolvedValue("create-pool-host-1@icr.test");
+  mockedCreateZoomMeeting.mockResolvedValue({ zid: `zid-${randomUUID()}`, zoomLink: "https://zoom.us/j/override", zoomPasscode: null });
+  const retried = await postMeeting({ ...payload, confirmOverride: true });
+  expect(retried.status).toBe(201);
+  expect((await prisma.meeting.findUnique({ where: { mid: linked.mid } }))?.linkedToMid).toBe(payload.mid);
+  await drainAfterTasks();
+});
+
+test("both schedules' calendar events are born with the family's union title", async () => {
+  mockedResolveZoomHost.mockResolvedValue("create-pool-host-1@icr.test");
+  mockedCreateZoomMeeting.mockResolvedValue({ zid: `zid-${randomUUID()}`, zoomLink: "https://zoom.us/j/title", zoomPasscode: null });
+  const linked = linkedBlock();
+  const payload = meetingPayload({ linkedSchedule: linked });
+
+  expect((await postMeeting(payload)).status).toBe(201);
+  await drainAfterTasks();
+
+  // buildEventTitle names an event with exactly this call, so asserting on the arguments each
+  // publish was handed is asserting on the title Google receives.
+  for (const mid of [payload.mid, linked.mid]) {
+    const call = mockedCreateCalendarEvent.mock.calls.find(([, meetingArg]) => meetingArg.mid === mid);
+    expect(call).toBeDefined();
+    const [, meetingArg, calId, , family] = call!;
+    expect(calId).toBe("cal-AA");
+    expect(buildLinkedScheduleLabel(meetingArg.title, meetingArg, family))
+      .toBe("Linked Create - Hybrid Mon - Zoom Only Sat");
+  }
+});
+
+test("an In-Person linked schedule inherits no Zoom identity at all", async () => {
+  mockedResolveZoomHost.mockResolvedValue("create-pool-host-1@icr.test");
+  mockedCreateZoomMeeting.mockResolvedValue({ zid: "hybrid-only-zid", zoomLink: "https://zoom.us/j/hybridonly", zoomPasscode: null });
+  const linked = linkedBlock({ modeType: "In Person", room: `In Person Room ${randomUUID()}`, zoomRoom: null });
+  const payload = meetingPayload({ linkedSchedule: linked });
+
+  expect((await postMeeting(payload)).status).toBe(201);
+  await drainAfterTasks();
+
+  const prisma = getTestPrismaClient();
+  const created = await prisma.meeting.findUnique({ where: { mid: linked.mid } });
+  expect(created?.linkedToMid).toBe(payload.mid);
+  expect(created?.zid).toBeNull();
+  expect(created?.zoomLink).toBeNull();
+  expect(created?.zoomPasscode).toBeNull();
+  expect(created?.zoomInvitation).toBeNull();
+  expect(created?.zoomHost).toBeNull();
+  // Its own calendar events still publish -- an in-person schedule needs no Zoom meeting.
+  expect(created?.googleSyncStatus).toBe("synced");
+
+  // Still one Zoom meeting, minted from the Hybrid schedule, and the In-Person row is part of
+  // the family it is named after even though it holds no zid.
+  expect(mockedCreateZoomMeeting).toHaveBeenCalledTimes(1);
+  const [mintedFrom, , zoomFamily] = mockedCreateZoomMeeting.mock.calls[0];
+  expect(mintedFrom.mid).toBe(payload.mid);
+  expect((zoomFamily as { mid: string }[]).map((row) => row.mid).sort()).toEqual([payload.mid, linked.mid].sort());
+
+  // The host is reserved for the Hybrid schedule's days alone -- the In-Person schedule's
+  // weekdays never reach Zoom's recurrence, so they must not charge the pool either.
+  const [hostCandidate] = mockedResolveZoomHost.mock.calls[0];
+  expect(hostCandidate.recurrencePattern.daysOfWeek).toEqual([PRIMARY_WEEKDAY]);
+});
+
+test("an In-Person meeting with a Remote linked schedule: the linked row holds the family's Zoom identity", async () => {
+  mockedResolveZoomHost.mockResolvedValue("create-pool-host-2@icr.test");
+  mockedCreateZoomMeeting.mockResolvedValue({ zid: "linked-held-zid", zoomLink: "https://zoom.us/j/linkedheld", zoomPasscode: null });
+  const linked = linkedBlock();
+  const payload = meetingPayload({
+    modeType: "In Person",
+    room: `In Person Primary ${randomUUID()}`,
+    zoomRoom: null,
+    linkedSchedule: linked,
+  });
+
+  expect((await postMeeting(payload)).status).toBe(201);
+  await drainAfterTasks();
+
+  const prisma = getTestPrismaClient();
+  const primary = await prisma.meeting.findUnique({ where: { mid: payload.mid } });
+  const created = await prisma.meeting.findUnique({ where: { mid: linked.mid } });
+
+  // There is no Zoom meeting on the in-person schedule to inherit, so the linked schedule mints
+  // the family's and becomes its zid holder -- linkedToMid still keys the family, which is
+  // exactly why the family isn't keyed on zid.
+  expect(mockedCreateZoomMeeting).toHaveBeenCalledTimes(1);
+  const [mintedFrom] = mockedCreateZoomMeeting.mock.calls[0];
+  expect(mintedFrom.mid).toBe(linked.mid);
+  expect(created?.zid).toBe("linked-held-zid");
+  expect(created?.zoomHost).toBe("create-pool-host-2@icr.test");
+  expect(primary?.zid).toBeNull();
+  expect(primary?.zoomHost).toBeNull();
+  expect(created?.linkedToMid).toBe(payload.mid);
+
+  // The reservation covers the schedule that actually meets online.
+  const [hostCandidate] = mockedResolveZoomHost.mock.calls[0];
+  expect(hostCandidate.recurrencePattern.daysOfWeek).toEqual([LINKED_WEEKDAY]);
+});
+
+test("an exhausted host pool leaves BOTH schedules unpublished rather than half-published", async () => {
+  mockedResolveZoomHost.mockResolvedValue(null);
+  const linked = linkedBlock();
+  const payload = meetingPayload({ linkedSchedule: linked });
+
+  expect((await postMeeting(payload)).status).toBe(201);
+  await drainAfterTasks();
+
+  expect(mockedCreateZoomMeeting).not.toHaveBeenCalled();
+  const prisma = getTestPrismaClient();
+  for (const mid of [payload.mid, linked.mid]) {
+    const row = await prisma.meeting.findUnique({ where: { mid } });
+    expect(row?.zoomSyncStatus).toBe("error");
+    expect(row?.zoomSyncError).toMatch(/pool exhausted/i);
+    // Nothing is published with a missing join link; "Retry sync" picks both rows back up once a
+    // host frees up.
+    expect(row?.googleSyncStatus).toBe("pending");
+  }
+  expect(mockedCreateCalendarEvent).not.toHaveBeenCalled();
+});
+
+test("the linked schedule's own series is derived, never taken from the client", async () => {
+  mockedResolveZoomHost.mockResolvedValue("create-pool-host-1@icr.test");
+  mockedCreateZoomMeeting.mockResolvedValue({ zid: `zid-${randomUUID()}`, zoomLink: "https://zoom.us/j/derived", zoomPasscode: null });
+  const linked = linkedBlock({
+    recurrencePattern: {
+      type: "weekly",
+      // Every one of these is the client trying to define the family's shape: a different start,
+      // a different cadence, and an end of its own.
+      startDate: new Date("2027-01-02T05:00:00Z"),
+      endDate: new Date("2027-03-01T05:00:00Z"),
+      numberOfOccurrences: 3,
+      daysOfWeek: [LINKED_WEEKDAY],
+      firstDayOfWeek: "Sunday",
+      interval: 4,
+    },
+  });
+  const payload = meetingPayload({ linkedSchedule: linked });
+
+  expect((await postMeeting(payload)).status).toBe(201);
+  await drainAfterTasks();
+
+  const prisma = getTestPrismaClient();
+  const created = await prisma.meeting.findUnique({ where: { mid: linked.mid }, include: { recurrencePattern: true } });
+  expect(created?.recurrencePattern?.interval).toBe(1);
+  expect(created?.recurrencePattern?.endDate).toBeNull();
+  expect(created?.recurrencePattern?.numberOfOccurrences).toBeNull();
+  expect(formatETDateString(created!.recurrencePattern!.startDate)).toBe(FIRST_LINKED_ET_DATE);
+});
+
+test("a count-bounded meeting gives its linked schedule the same count, resolved into its own end date", async () => {
+  mockedResolveZoomHost.mockResolvedValue("create-pool-host-1@icr.test");
+  mockedCreateZoomMeeting.mockResolvedValue({ zid: `zid-${randomUUID()}`, zoomLink: "https://zoom.us/j/counted", zoomPasscode: null });
+  const linked = linkedBlock();
+  const payload = meetingPayload({
+    recurrencePattern: {
+      type: "weekly", startDate: SERIES_START, daysOfWeek: [PRIMARY_WEEKDAY],
+      firstDayOfWeek: "Sunday", interval: 1, numberOfOccurrences: 3,
+    },
+    linkedSchedule: linked,
+  });
+
+  expect((await postMeeting(payload)).status).toBe(201);
+  await drainAfterTasks();
+
+  const prisma = getTestPrismaClient();
+  const created = await prisma.meeting.findUnique({ where: { mid: linked.mid }, include: { recurrencePattern: true } });
+  // Three Saturdays from its own first one, not the primary schedule's three Mondays.
+  expect(created?.recurrencePattern?.numberOfOccurrences).toBe(3);
+  expect(formatETDateString(created!.recurrencePattern!.startDate)).toBe(FIRST_LINKED_ET_DATE);
+  expect(formatETDateString(created!.recurrencePattern!.endDate!)).toBe("2026-09-26");
+});

--- a/frontend/util/meetings/linkedSchedules.ts
+++ b/frontend/util/meetings/linkedSchedules.ts
@@ -1,8 +1,12 @@
 import type { Prisma } from "@prisma/client";
 
 import type { IMeeting } from "../../types/models";
-import { WEEKDAY_NAMES } from "../date/timeUtils";
+import { convertETToUTC, formatETDateString, getETTimeOfDay, WEEKDAY_NAMES } from "../date/timeUtils";
 import { formatDayColumn } from "./recurrenceDisplay";
+// recurrenceMatch, not meetingOccurrences: this module is reached from the client through
+// meetingValidation.ts (hooks/useMeetingForm.ts), and meetingOccurrences' `server-only`/Prisma
+// imports would break that build. The two export the same function.
+import { firstOccurrenceOnOrAfter } from "./recurrenceMatch";
 
 // A "linked schedules" family is one meeting the group runs as two co-existing weekly
 // schedules -- same time, duration and interval, different modes on different weekdays -- served
@@ -196,6 +200,71 @@ export function claimedDaysFor(family: LinkedFamily): string[] {
  */
 export function isZoomBearing(row: { modeType: string }): boolean {
   return row.modeType === "Hybrid" || row.modeType === "Remote";
+}
+
+// --- deriving a linked schedule's own series from the anchor's -----------------------------
+
+/** The anchor fields {@link deriveLinkedScheduleStart} re-anchors a linked schedule onto. */
+export interface LinkedScheduleAnchor {
+  startDateTime: Date;
+  endDateTime: Date;
+  recurrencePattern?: { startDate: Date; endDate?: Date | null; interval: number } | null;
+}
+
+/**
+ * The anchor's ET wall-clock time of day and duration, re-anchored onto the first date its
+ * series actually meets on `daysOfWeek`. A linked schedule never gets its start from the client:
+ * the family is served by ONE Zoom meeting, which can only hold one series, so every member has
+ * to keep the same time of day and duration ({@link isSharedZoomScheduleCompatible}) -- and the
+ * search runs against the ANCHOR's pattern, so an every-other-week family stays in one week phase
+ * instead of the two schedules landing on alternating weeks.
+ *
+ * Returns null when the requested days produce no occurrence inside the anchor's series at all
+ * (e.g. a series that ends first), or when the anchor carries no pattern to re-anchor onto.
+ * Throws convertETToUTC's validation error when the anchor's time of day doesn't exist on the
+ * derived date (the DST spring-forward gap) -- callers turn that into a 400.
+ */
+export function deriveLinkedScheduleStart(
+  anchor: LinkedScheduleAnchor,
+  daysOfWeek: string[],
+): { startDateTime: Date; endDateTime: Date; patternStartDate: Date } | null {
+  const pattern = anchor.recurrencePattern;
+  if (!pattern) return null;
+  // Never earlier than today: a schedule added to a series that started years ago is a schedule
+  // that starts NOW, not one that retroactively met every week since. Searching from the series
+  // start instead would publish a backdated Google Calendar series (fabricated history on past
+  // calendar views) and, for a count-bounded anchor, could resolve an end date that has already
+  // passed -- a row born dead. The week phase is unaffected: matchesRecurrencePattern measures
+  // the interval from the ANCHOR's own startDate below, whatever date the search begins on.
+  const seriesStartEtDateStr = formatETDateString(pattern.startDate);
+  const todayEtDateStr = formatETDateString(new Date());
+  const searchFromEtDateStr = seriesStartEtDateStr > todayEtDateStr ? seriesStartEtDateStr : todayEtDateStr;
+  const firstETDate = firstOccurrenceOnOrAfter(
+    {
+      type: 'weekly',
+      startDate: pattern.startDate,
+      endDate: pattern.endDate ?? null,
+      interval: pattern.interval,
+      daysOfWeek,
+      weekOfMonth: null,
+      dayOfMonth: null,
+      // The anchor's own excluded dates are its alone -- a per-occurrence deletion on the
+      // Monday-Friday schedule says nothing about when the Saturday one starts.
+      excludedDates: [],
+    },
+    searchFromEtDateStr,
+  );
+  if (!firstETDate) return null;
+  const { hour, minute, second } = getETTimeOfDay(anchor.startDateTime);
+  const pad = (value: number) => String(value).padStart(2, '0');
+  const startDateTime = new Date(convertETToUTC(`${firstETDate}T${pad(hour)}:${pad(minute)}:${pad(second)}`));
+  const durationMs = anchor.endDateTime.getTime() - anchor.startDateTime.getTime();
+  // INVARIANT: a stored recurrencePattern.startDate is ET-midnight-anchored (parseMMDDYYYY),
+  // never a real meeting-time instant -- calculateEndDateFromOccurrences reads the weekday
+  // anchor straight off getUTCDay(), so a 7 PM-or-later ET start would roll into the next UTC
+  // day and count the occurrences from the wrong weekday.
+  const patternStartDate = new Date(convertETToUTC(`${firstETDate}T00:00:00`));
+  return { startDateTime, endDateTime: new Date(startDateTime.getTime() + durationMs), patternStartDate };
 }
 
 // --- the family's display name, shared by every external service --------------------------

--- a/frontend/util/meetings/meetingOccurrences.ts
+++ b/frontend/util/meetings/meetingOccurrences.ts
@@ -2,7 +2,7 @@ import "server-only";
 import { getETDayBounds, convertETToUTC, addDaysToETDateString, getDaysInMonth, isDstGapError } from "../date/timeUtils";
 import { prisma } from "../../lib/prisma";
 import { PublicMeeting, toPublicMeeting } from "./publicMeeting";
-import { isDateSuspended, isAfterSeriesEnd, matchesRecurrencePattern, addOneETDay, adjustOccurrenceToDate } from "./recurrenceMatch";
+import { isDateSuspended, isAfterSeriesEnd, matchesRecurrencePattern, addOneETDay, adjustOccurrenceToDate, firstOccurrenceOnOrAfter } from "./recurrenceMatch";
 
 const notDeleted = { deletedAt: null };
 const etFmt = new Intl.DateTimeFormat('en-CA', { timeZone: 'America/New_York' });
@@ -15,27 +15,7 @@ const isDateExcluded = (excludedDates: Date[], dateStr: string): boolean =>
 // importing these from meetingOccurrences.ts unchanged -- the pure logic itself now lives in
 // recurrenceMatch.ts, which ViewMeeting.tsx (client) also imports directly since this file's
 // `server-only`/Prisma imports make it unusable from client components.
-export { isDateSuspended, matchesRecurrencePattern, addOneETDay, adjustOccurrenceToDate };
-
-// Walks forward day-by-day from `fromEtDateStr` (inclusive) and returns the first ET date
-// string on/after it that the recurrence pattern actually produces an occurrence on. Bounded to
-// ~370 days so a pattern that (mis)matches nothing near `fromEtDateStr` can't loop forever.
-export const firstOccurrenceOnOrAfter = (
-    recurrence: { type: string; startDate: Date; endDate: Date | null; interval: number; daysOfWeek: string[]; weekOfMonth: number | null; dayOfMonth: number | null; excludedDates: Date[] },
-    fromEtDateStr: string,
-): string | null => {
-    const [year, month, day] = fromEtDateStr.split('-').map(Number);
-    let cursor = Date.UTC(year, month - 1, day);
-    const msPerDay = 24 * 60 * 60 * 1000;
-    for (let i = 0; i < 370; i++) {
-        const localDate = new Date(cursor);
-        const etDateStr = `${localDate.getUTCFullYear()}-${String(localDate.getUTCMonth() + 1).padStart(2, '0')}-${String(localDate.getUTCDate()).padStart(2, '0')}`;
-        if (isAfterSeriesEnd(recurrence.endDate, etDateStr)) return null;
-        if (matchesRecurrencePattern(recurrence, etDateStr, localDate)) return etDateStr;
-        cursor += msPerDay;
-    }
-    return null;
-};
+export { isDateSuspended, matchesRecurrencePattern, addOneETDay, adjustOccurrenceToDate, firstOccurrenceOnOrAfter };
 
 /**
  * Returns every meeting occurrence (one-time + recurring, expanded) that falls within

--- a/frontend/util/meetings/recurrenceMatch.ts
+++ b/frontend/util/meetings/recurrenceMatch.ts
@@ -116,6 +116,26 @@ export const matchesRecurrencePattern = (
     return false;
 };
 
+// Walks forward day-by-day from `fromEtDateStr` (inclusive) and returns the first ET date
+// string on/after it that the recurrence pattern actually produces an occurrence on. Bounded to
+// ~370 days so a pattern that (mis)matches nothing near `fromEtDateStr` can't loop forever.
+export const firstOccurrenceOnOrAfter = (
+    recurrence: { type: string; startDate: Date; endDate: Date | null; interval: number; daysOfWeek: string[]; weekOfMonth: number | null; dayOfMonth: number | null; excludedDates: Date[] },
+    fromEtDateStr: string,
+): string | null => {
+    const [year, month, day] = fromEtDateStr.split('-').map(Number);
+    let cursor = Date.UTC(year, month - 1, day);
+    const msPerDay = 24 * 60 * 60 * 1000;
+    for (let i = 0; i < 370; i++) {
+        const localDate = new Date(cursor);
+        const etDateStr = `${localDate.getUTCFullYear()}-${String(localDate.getUTCMonth() + 1).padStart(2, '0')}-${String(localDate.getUTCDate()).padStart(2, '0')}`;
+        if (isAfterSeriesEnd(recurrence.endDate, etDateStr)) return null;
+        if (matchesRecurrencePattern(recurrence, etDateStr, localDate)) return etDateStr;
+        cursor += msPerDay;
+    }
+    return null;
+};
+
 // Adds one calendar day to an ET date string ("YYYY-MM-DD"), via UTC-anchored date-component
 // arithmetic (not a real elapsed-time addition), so this can't be thrown off by DST.
 export const addOneETDay = (etDateStr: string): string => {


### PR DESCRIPTION
@coderabbitai summary

## Description

Fourth PR of the linked meeting modes work, stacked on #554. PR 3 taught `PUT /api/update/meeting` to add a second weekly schedule to an *existing* meeting; this one does the same thing at birth — `POST /api/write/meeting` gains the same optional `linkedSchedule` block, so a meeting can be created as **two schedules in one write**: a different mode on different weekdays, served by **one** Zoom meeting, one host reservation, and one set of Zoom credentials.

No UI posts this block yet (PR 6) — this PR is API + tests only, and every existing request shape is untouched (`linkedSchedule` absent ⇒ byte-identical control flow, same single-row sync, same single `prisma.meeting.update`).

- **frontend/app/api/write/meeting/route.ts**: the two-row create and the family-aware deferred sync.
  - **`planLinkedSchedule`** validates the block against the primary schedule *in the same payload* and derives the second row's whole series from it. It mirrors `handleLinkedScheduleCreate`'s rules deliberately — the update route's anchor is a stored row, this one's is the request's own primary schedule, but the resulting families have to be identical, so the same shared predicates (`availableModesFor`, `claimedDaysFor`, `deriveLinkedScheduleStart`, `isSharedZoomScheduleCompatible`) gate both. **400s:** not recurring; not `weekly`; a mode the meeting already runs; no weekdays at all; weekdays the primary schedule already claims (disjoint days are a hard requirement — Zoom holds the family as ONE union of weekdays, so a day claimed twice silently collapses into a single occurrence); requested days producing no occurrence inside the series; a DST spring-forward gap (surfaced as `convertETToUTC`'s own message, not a 500); and the `isSharedZoomScheduleCompatible` backstop. Everything the two schedules must agree on — title, description, email, group, calType, status, time of day, duration, interval, where the series ends — is derived from the primary schedule and never read from the block, which carries only the mode, the room(s) that mode needs, and the weekdays.
  - **Both rows are written in the one existing `$transaction`.** Both mids are client-generated (the route's own comment at `:324-327` already relied on this for the Meeting + RecurrencePattern pair), so the linked row's create joins that transaction with no restructuring — a family that exists half-written is not a shape any later request could repair. The linked row gets `linkedToMid: <primary mid>` and `splitFromMid: null`: a second mode, not a division of the primary schedule's series.
  - **The host is booked once, for the whole family.** A new `zoomCandidate` — the union of the Zoom-bearing schedules' weekdays at the time of day and duration they share — is what `resolveZoomHost` and both `zoomHost` conflict checks read. Checking the two rows separately would count the family's single booking twice against the host's capacity. When the primary schedule is In Person, the linked schedule's own occurrences are the entire booking. `room`/`zoomRoom` still get the full per-row check against the rest of the calendar; neither new row is in the database yet, so nothing can report the two schedules as colliding with each other.
  - **`syncNewMeeting` now takes rows, not one meeting.** It mints the family's Zoom meeting **once**, from the first Zoom-bearing row, with the family (so the initial recurrence is the union and the topic is the family name from the very first write), then fans `zid`/`zoomLink`/`zoomPasscode`/`zoomInvitation`/`zoomHost` out to **every** Zoom-bearing row via `updateMany` — the old single-row `prisma.meeting.update` was the gap the plan called out, and a row left without the zid would look unprovisioned to Retry sync and mint a second meeting. That write lands *before* the calendar publishes, so a throw mid-publish can't strand a real Zoom meeting with nothing in the database pointing at it. Each row then publishes its **own** calendar events with its own room, calType and mode — same family, same union title, its own dates. An exhausted host pool leaves *both* rows `googleSyncStatus: 'pending'` rather than half-published.
  - **The In-Person-primary case** is the inverse of the usual one: there is no Zoom identity on the primary schedule to give, so the Zoom-bearing linked row becomes the family's zid holder and the primary row holds no `zid`/`zoomHost`/`attemptedZoomHost` at all — which is precisely why the family is keyed on `linkedToMid` and not on `zid`. Symmetrically, an In-Person *linked* row inherits none of the family's Zoom identity and never advertises a join link in its calendar events.
  - Response gains `linkedMid`, matching PR 3's shape. The `after(...)` failure handler widens to `updateMany` over both mids so a thrown sync can't leave the sibling's status untouched.
- **frontend/util/meetings/linkedSchedules.ts, frontend/app/api/update/meeting/route.ts**: `deriveLinkedScheduleStart` moves out of the update route (where it was module-private) into the shared linked-schedules module — the create route needs the identical anchor-relative derivation, and two copies of "never earlier than today, searched against the anchor's own pattern, ET-midnight-anchored pattern start" is exactly the kind of duplication that drifts. Behavior is unchanged; the anchor parameter is loosened to a structural type so a not-yet-written payload can be passed as well as a stored row.
- **frontend/util/meetings/recurrenceMatch.ts, frontend/util/meetings/meetingOccurrences.ts**: `firstOccurrenceOnOrAfter` moves alongside the other pure recurrence predicates in `recurrenceMatch.ts`, re-exported from `meetingOccurrences.ts` for its existing importers. `linkedSchedules.ts` is reached from the client through `meetingValidation.ts` (`hooks/useMeetingForm.ts`), and `meetingOccurrences.ts`'s `server-only`/Prisma imports would break that build.
- **frontend/tests/integration/write-meeting-linked-schedule.test.ts** (18 tests): every 400 rule plus "nothing is written when the linked schedule is rejected"; both rows created together sharing one Zoom meeting with no second `createZoomMeeting`; the host reserved once against both schedules' days together; a manually-picked host busy on the *linked* schedule's day being a 409 that writes neither row; a room conflict on the linked schedule's own room likewise; both rows' calendar events born with the family's union title; an In-Person linked schedule inheriting no Zoom identity; the In-Person-primary case where the linked row holds it instead; an exhausted pool leaving both rows unpublished; the linked series being derived rather than taken from the client; and a count-bounded meeting giving its linked schedule the same count resolved into its own end date.

**Out of scope for v1** (unchanged from PR 1): 3+ schedules — the cap is one predicate in the shared validator, and `linkedSchedule` is a single block, so the create path can't express a third either.

## Testing

- [x] `cd frontend && yarn test:all` — green (lint, lint:css, typecheck, unit, component, integration, e2e), run against a clear port 3000.
- [x] `yarn test:integration --testPathPattern write-meeting-linked-schedule` — the 18 route tests above.
- [x] Pre-existing-test sweep (`pr_convention.md`): `syncNewMeeting`'s signature change and the single-`update`→`updateMany` swap are the behavior-altering edits, so the existing `write-meeting-route.test.ts` suite passing unchanged is the assertion that a request without `linkedSchedule` still produces exactly the same writes and sync statuses as before; delegated to a subagent rather than run from the implementing context.
- [ ] Reviewer check: `git diff feat/linked-schedule-update-api...feat/linked-schedule-create-api -- frontend/app/api/write/meeting/route.ts` — confirm `createZoomMeeting` is called at most once per request and that no second host reservation is taken for the linked row.
- [ ] Reviewer check: POST a create with a Hybrid Mon–Fri primary schedule and a `linkedSchedule` of `modeType: "Remote"` on Saturday; confirm two rows, one `zid` shared by both, one Zoom recurrence covering Mon–Sat, and both rows' Google Calendar events carrying the family's union title.

## Area(s) Touched

**Product areas**
- [ ] auth — sign-in, sessions, NextAuth, role-based access
- [ ] admin — /admin shell (Diagnostics, Users, Import, Export tabs)
- [ ] docs — /docs Resources page (rendering, navigation, search)
- [ ] ui/ux — frontend layout/styling not tied to a specific integration

**Integrations**
- [x] google-calendar — Google Calendar sync
- [x] zoom-api — Zoom meeting/host sync

**Engineering**
- [ ] security — auth hardening, data exposure, dependency/security scanning
- [x] testing — test suite (Jest/Playwright) changes
- [ ] github-actions — workflows, Dependabot config, other .github/ CI tooling
- [ ] cleanup — refactor or dead-code removal, no behavior change
- [ ] documentation — docs/ or README changes only

## Pre-merge Checklist
- [x] Code follows current formatting conventions and passes lint (`yarn lint`).
- [x] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
- [ ] All test suites pass, both run locally and green in GitHub CI. **Do not merge if any test suite is failing.**
- [x] A test suite was added or updated for the feature/fix in this PR. **Double-check this if you change a feature and did not update the test suites**.
- [x] Only files relevant to this change are committed — no stray or unrelated files.
- [x] If this branch has a merge conflict with master, master was merged into this branch first (not the other way around).
- [x] The rest of this PR description (Description, Testing) is filled out, not left as template placeholders.
