### PR TITLE
feat(edit-meeting): show and remove a meeting's linked schedule

### DIFF
--- a/frontend/app/(main)/page.tsx
+++ b/frontend/app/(main)/page.tsx
@@ -351,6 +351,7 @@ export default function HomePage() {
           zoomManaged={selectedMeeting.zoomManaged}
           sharedWith={selectedMeeting.sharedWith}
           zoomScheduleDiverged={selectedMeeting.zoomScheduleDiverged}
+          linkedSchedules={selectedMeeting.linkedSchedules}
           group={selectedMeeting.group}
 
           /* ViewMeetingDetails formats for ET display internally (formatETDateString, etTimeFmt,

--- a/frontend/app/api/delete/meeting/route.ts
+++ b/frontend/app/api/delete/meeting/route.ts
@@ -175,9 +175,10 @@ const deleteMeeting = async (request: Request) => {
     const calendarIds = calendarIdsForMeeting(meeting.calType ?? []);
     const eventIds = (meeting.googleCalendarEventIds ?? {}) as Record<string, string>;
 
-    // Verified atomic: each branch below is exactly one top-level Mongo write (recurrencePattern
-    // update, recurrencePattern update, or meeting update) -- no unwrapped multi-write gap to
-    // fix here, unlike write/meeting/route.ts's create path.
+    // Verified atomic: the two partial-delete branches below are each exactly one top-level
+    // write (a recurrencePattern update), and the 'all' branch wraps its soft delete and the
+    // linked-family pointer cleanup in one transaction -- no unwrapped multi-write gap to fix
+    // here, unlike write/meeting/route.ts's create path.
     if (deleteOption === 'this') {
       if (!meeting.recurrencePattern) {
         return new Response(JSON.stringify({ error: "Meeting has no recurrence pattern" }), {
@@ -236,11 +237,25 @@ const deleteMeeting = async (request: Request) => {
         meeting.zoomCalendarEventId, meeting.zoomRoom,
       ));
     } else {
-      // 'all' or non-recurring: soft-delete the master meeting record
-      await prisma.meeting.update({
-        where: { mid },
-        data: { deletedAt: new Date() },
-      });
+      // 'all' or non-recurring: soft-delete the master meeting record. Deleting the ANCHOR of a
+      // linked-schedule family also releases its surviving members, so a lone row never dangles
+      // a linkedToMid at a soft-deleted mid -- its family drops to one and its Zoom topic and
+      // calendar titles fall back to the single-schedule name on the next write. Nothing to do
+      // when the deleted row was the linked member instead: the anchor's own linkedToMid was
+      // never set. The shared Zoom meeting itself is untouched either way -- syncDeleteAll's
+      // zid guard keeps it alive for whichever member is left.
+      await prisma.$transaction([
+        prisma.meeting.update({
+          where: { mid },
+          data: { deletedAt: new Date() },
+        }),
+        ...(meeting.linkedToMid === null
+          ? [prisma.meeting.updateMany({
+              where: { linkedToMid: mid, deletedAt: null },
+              data: { linkedToMid: null },
+            })]
+          : []),
+      ]);
       // Google Calendar + Zoom: whole-series delete — 'this'/'thisAndFollowing' leave Zoom untouched
       after(syncDeleteAll(accessToken, calendarIds, eventIds, meeting));
     }

--- a/frontend/app/api/retrieve/meeting/[id]/route.ts
+++ b/frontend/app/api/retrieve/meeting/[id]/route.ts
@@ -4,7 +4,7 @@ import { prisma } from "../../../../../lib/prisma";
 import { toPublicMeeting } from "../../../../../util/meetings/publicMeeting";
 import { getUnresolvedSuspension } from "../../../../../util/meetings/suspension";
 import { isSharedZoomScheduleCompatible } from "../../../../../util/meetings/sharedZoomSchedule";
-import { isDetachedSplitChild } from "../../../../../util/meetings/linkedSchedules";
+import { familyMembers, getLinkedFamily, isDetachedSplitChild } from "../../../../../util/meetings/linkedSchedules";
 import { formatETDateString } from "../../../../../util/date/timeUtils";
 const getMeeting = async(request: NextRequest) => {
   try {
@@ -83,6 +83,32 @@ const getMeeting = async(request: NextRequest) => {
         }
       : {};
 
+    // The OTHER schedules of this one meeting (Meeting.linkedToMid), e.g. the Saturday Zoom-only
+    // half of a meeting whose weekday half is Hybrid. Deliberately separate from sharedWith
+    // above: that one is keyed on zid and answers whether this Zoom LINK feeds another row,
+    // which an In-Person family member (no zid at all) would never appear in. Admin-only for the
+    // same reason (BUG-022) -- it names rooms, hosts and schedules a public viewer never sees.
+    const family = isAdminSession ? await getLinkedFamily(prisma, meeting.mid) : null;
+    const linkedSchedules = family
+      ? familyMembers(family)
+          .filter((row) => row.mid !== meeting.mid)
+          .map((row) => ({
+            mid: row.mid,
+            modeType: row.modeType,
+            room: row.room,
+            zoomRoom: row.zoomRoom,
+            zoomHost: row.zoomHost,
+            recurrencePattern: row.recurrencePattern,
+            startDateTime: row.startDateTime,
+            endDateTime: row.endDateTime,
+            // A family member can be sitting at 'pending'/'error' with no calendar events yet
+            // (the Zoom host pool was exhausted when it was created, and it's waiting on a retry
+            // sync) -- the card says so rather than presenting the schedule as already live.
+            googleSyncStatus: row.googleSyncStatus,
+            zoomSyncStatus: row.zoomSyncStatus,
+          }))
+      : [];
+
     const body = isAdminSession
       ? {
           ...meetingWithoutSuspensions,
@@ -90,6 +116,9 @@ const getMeeting = async(request: NextRequest) => {
           suspendedSince: relevantSuspension?.from ?? null,
           suspensionActive,
           ...sharedZoom,
+          // Omitted entirely, not sent as [], for the overwhelmingly common single-schedule
+          // meeting -- same shape as sharedZoom above.
+          ...(linkedSchedules.length > 0 ? { linkedSchedules } : {}),
         }
       : toPublicMeeting({ ...meeting, recurrencePattern: meeting.recurrencePattern ?? null });
 

--- a/frontend/app/components/meeting-form/EditMeeting.tsx
+++ b/frontend/app/components/meeting-form/EditMeeting.tsx
@@ -15,8 +15,11 @@ import DiscardChangesModal from './DiscardChangesModal';
 import FormValidationBanner from './FormValidationBanner';
 import EditRecurringModal, { EditScope } from './EditRecurringModal';
 import IconButton from '../ui/buttons/IconButton';
+import ScheduleSummaryCard, { formatScheduleLine } from './ScheduleSummaryCard';
+import RemoveLinkedScheduleModal from './RemoveLinkedScheduleModal';
 
-import { IMeeting } from '../../../types/models'
+import { ILinkedSchedule, IMeeting } from '../../../types/models'
+import { isZoomBearing } from '../../../util/meetings/linkedSchedules';
 import { physicalRoomOptions, zoomRoomOptions } from "../../../util/rooms/rooms";
 import { useMeetingForm, CAL_TYPE_OPTIONS, CAL_TYPE_COLOR, DESCRIPTION_MAX_LENGTH } from '../../../hooks/useMeetingForm';
 import { ConflictListRow } from '../../../util/meetings/conflictDisplay';
@@ -97,6 +100,13 @@ const EditMeetingSidebar: React.FC<EditMeetingSidebarProps> =
     const sharedWithText = (meeting.sharedWith ?? [])
       .map((row) => `${row.title} (${row.modeType})`)
       .join(', ');
+
+    // This meeting's OTHER schedules, if it runs as a linked family. Read-only here: a linked
+    // schedule's own mode/days/room are edited from its own form (it's an ordinary meeting row
+    // with its own mid), so this form only shows what it is and offers to remove it.
+    const linkedSchedules = meeting.linkedSchedules ?? [];
+    const [scheduleToRemove, setScheduleToRemove] = useState<ILinkedSchedule | null>(null);
+    const [isRemovingSchedule, setIsRemovingSchedule] = useState(false);
 
     const { showToast } = useToast();
     const [isSubmitting, setIsSubmitting] = useState(false);
@@ -225,6 +235,38 @@ const EditMeetingSidebar: React.FC<EditMeetingSidebarProps> =
       }
     };
 
+    // Removing a linked schedule is a whole-series delete of that row through the ordinary
+    // delete route -- it's a normal Meeting row, and that route already keeps the family's one
+    // shared Zoom meeting alive for whichever schedule is left. Nothing about the form's own
+    // in-progress edits is submitted or discarded here; the refresh onUpdateSuccess triggers
+    // re-reads the meeting (and so the remaining schedules) without closing the panel.
+    const confirmRemoveSchedule = async () => {
+      if (!scheduleToRemove || isRemovingSchedule) return;
+      setIsRemovingSchedule(true);
+      try {
+        const response = await fetch('/api/delete/meeting', {
+          method: 'DELETE',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ mid: scheduleToRemove.mid, deleteOption: 'all' }),
+        });
+        if (!response.ok) {
+          const body = await response.json().catch(() => null);
+          throw new Error(body?.error || `HTTP error! status: ${response.status}`);
+        }
+        setScheduleToRemove(null);
+        showToast({ variant: "success", title: "Linked schedule removed." });
+        onUpdateSuccess();
+      } catch (error) {
+        console.error('Could not remove the linked schedule:', error);
+        showToast({
+          variant: "error",
+          title: error instanceof Error ? error.message : "Could not remove the linked schedule.",
+        });
+      } finally {
+        setIsRemovingSchedule(false);
+      }
+    };
+
     // Scope: 'all' (or no occurrence context) submits the payload untouched -- current,
     // unscoped whole-series behavior. Scope 'this'/'thisAndFollowing' stamps editScope +
     // occurrenceDate on for the server, and strips recurrencePattern under 'this' specifically
@@ -327,6 +369,28 @@ const EditMeetingSidebar: React.FC<EditMeetingSidebarProps> =
               The date below is the series&apos; start date, not this occurrence.
             </span>
           </p>
+        )}
+        {linkedSchedules.length > 0 && (
+          <section className={styles.linkedSchedules} aria-labelledby="linked-schedules-heading">
+            <h4 id="linked-schedules-heading" className={styles.linkedSchedulesHeading}>
+              {linkedSchedules.length === 1 ? 'Linked schedule' : 'Linked schedules'}
+            </h4>
+            <p className={styles.linkedSchedulesNote}>
+              This meeting also runs on other days in a different mode. The form below edits the
+              schedule you opened — a linked schedule is edited from its own form.
+            </p>
+            {linkedSchedules.map((schedule) => (
+              <ScheduleSummaryCard
+                key={schedule.mid}
+                schedule={schedule}
+                // A full navigation, not a client-side route change: page.tsx reads ?mid= once
+                // on mount to resolve a deep link.
+                editHref={`/?mid=${encodeURIComponent(schedule.mid)}&edit=1`}
+                onRemove={() => setScheduleToRemove(schedule)}
+                removeDisabled={isRemovingSchedule}
+              />
+            ))}
+          </section>
         )}
         <MeetingForm
           meetingTitleTextField={<TextField
@@ -489,6 +553,25 @@ const EditMeetingSidebar: React.FC<EditMeetingSidebarProps> =
             disableScopedEdits={isModeDirty || isHostDirty}
             disableThisAndFollowing={isDateDirty}
             disableScoped={!occurrenceDate}
+          />
+        )}
+        {scheduleToRemove && (
+          <RemoveLinkedScheduleModal
+            isOpen
+            title={meeting.title}
+            modeType={scheduleToRemove.modeType}
+            scheduleText={formatScheduleLine(scheduleToRemove)}
+            // Whether the family's one Zoom meeting survives comes down to whether the schedule
+            // left behind is on it: the delete route only tears a Zoom meeting down once no live
+            // row still points at its zid (delete/meeting/route.ts's siblingCount guard). An
+            // In-Person schedule was never on it in the first place.
+            zoomImpact={
+              !isZoomBearing(scheduleToRemove)
+                ? 'none'
+                : meeting.zid ? 'kept' : 'deleted'
+            }
+            onCancel={() => setScheduleToRemove(null)}
+            onConfirm={confirmRemoveSchedule}
           />
         )}
         <ConflictOverrideModal

--- a/frontend/app/components/meeting-form/MeetingForm.module.scss
+++ b/frontend/app/components/meeting-form/MeetingForm.module.scss
@@ -202,6 +202,30 @@
   }
 }
 
+// Read-only summary of the meeting's other schedules, above the form that edits this one.
+.linkedSchedules {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin: 0 0 16px;
+}
+
+.linkedSchedulesHeading {
+  margin: 0;
+  color: $navy-color;
+  font-family: 'Source Sans Pro', sans-serif;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.linkedSchedulesNote {
+  margin: 0;
+  color: $text-secondary-color;
+  font-family: 'Source Sans Pro', sans-serif;
+  font-size: 12.5px;
+  line-height: 1.4;
+}
+
 .meetingHeader {
   display: flex;
   flex-direction: row;

--- a/frontend/app/components/meeting-form/RemoveLinkedScheduleModal.module.scss
+++ b/frontend/app/components/meeting-form/RemoveLinkedScheduleModal.module.scss
@@ -1,0 +1,124 @@
+@import '../../../styles/Variables.module';
+
+.modalOverlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgb(0 0 0 / 50%);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  // Same tier as DeleteMeetingModal's overlay, and for the same reason: Modal portals itself to
+  // document.body, so it has to beat ViewMeeting's own already-portaled .popupAnchor (2000).
+  z-index: 2001;
+}
+
+.modalContent {
+  background-color: $white-color;
+  border-radius: $radius-md;
+  width: 400px;
+  max-width: 90%;
+  padding: 24px;
+  font-family: "Source Sans Pro", sans-serif;
+  color: $black-color;
+  box-shadow: 0 4px 12px rgb(0 0 0 / 15%);
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 8px;
+}
+
+.iconCircle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background-color: #FEE4E2;
+  color: $danger-color;
+  flex-shrink: 0;
+}
+
+.title {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 600;
+}
+
+// Left-indented to align under the title text (36px icon circle + 12px header gap), matching
+// DeleteMeetingModal's message column.
+.message {
+  margin: 0 0 16px;
+  padding-left: 48px;
+  font-size: 15px;
+  line-height: 1.5;
+  color: #444;
+}
+
+.scheduleText {
+  color: $danger-color;
+}
+
+.zoomNote {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  margin: 0 0 16px;
+  padding: 10px 12px;
+  border-radius: 6px;
+  background-color: $warning-bg-color;
+  color: #444;
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.noteIcon {
+  flex-shrink: 0;
+  margin-top: 1px;
+  color: $warning-text-color;
+}
+
+.buttonContainer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.cancelButton {
+  padding: 8px 16px;
+  border-radius: 6px;
+  border: 1.5px solid $light-grey-color;
+  background-color: $white-color;
+  color: $black-color;
+  font-size: 14px;
+  font-weight: 600;
+  text-align: center;
+  cursor: pointer;
+
+  &:hover {
+    background-color: #F5F5F5;
+  }
+}
+
+.deleteButton {
+  padding: 8px 16px;
+  border-radius: 6px;
+  border: none;
+  background-color: $danger-color;
+  color: $white-color;
+  font-size: 14px;
+  font-weight: 600;
+  text-align: center;
+  cursor: pointer;
+
+  &:hover {
+    background-color: #A32020;
+  }
+}

--- a/frontend/app/components/meeting-form/RemoveLinkedScheduleModal.tsx
+++ b/frontend/app/components/meeting-form/RemoveLinkedScheduleModal.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import Icon from '../ui/displays/Icon';
+import Modal from '../ui/overlays/Modal';
+import styles from './RemoveLinkedScheduleModal.module.scss';
+
+interface RemoveLinkedScheduleModalProps {
+  isOpen: boolean;
+  /** The meeting both schedules belong to. */
+  title: string;
+  /** The schedule being removed, e.g. "Zoom Only" / "Hybrid". */
+  modeType: string;
+  /** Its days and time, as the card shows them ("Sat · 9 - 10 AM"). */
+  scheduleText: string;
+  /**
+   * What removing this schedule does to the meeting's one shared Zoom meeting: nothing at all
+   * (an In-Person schedule was never part of it), 'kept' (the remaining schedule still runs on
+   * it), or 'deleted' (this was the last schedule pointing at it).
+   */
+  zoomImpact: 'none' | 'kept' | 'deleted';
+  onCancel: () => void;
+  onConfirm: () => void;
+}
+
+// Confirms removing one schedule from a meeting that runs as two. Same shell, header treatment
+// and button layout as DeleteMeetingModal -- this deletes a real Meeting row, so it gets the
+// same weight as any other delete, not an inline "x".
+const RemoveLinkedScheduleModal: React.FC<RemoveLinkedScheduleModalProps> = ({
+  isOpen,
+  title,
+  modeType,
+  scheduleText,
+  zoomImpact,
+  onCancel,
+  onConfirm,
+}) => (
+  <Modal
+    isOpen={isOpen}
+    onClose={onCancel}
+    overlayClassName={styles.modalOverlay}
+    contentClassName={styles.modalContent}
+    labelledBy="remove-linked-schedule-title"
+  >
+    <div className={styles.header}>
+      <span className={styles.iconCircle}>
+        <Icon name="delete" size={20} />
+      </span>
+      <h2 id="remove-linked-schedule-title" className={styles.title}>Remove this schedule?</h2>
+    </div>
+
+    <p className={styles.message}>
+      <strong>{title}</strong>&apos;s <strong>{modeType}</strong> schedule
+      (<strong className={styles.scheduleText}>{scheduleText}</strong>) will be permanently removed
+      from the calendar. The meeting keeps its other schedule. This can&apos;t be undone.
+    </p>
+
+    {zoomImpact !== 'none' && (
+      <div className={styles.zoomNote}>
+        <Icon name="warning-circle" size={16} className={styles.noteIcon} />
+        <span>
+          {zoomImpact === 'kept'
+            ? 'The shared Zoom meeting stays. Its schedule narrows to the remaining days the next time this meeting is saved.'
+            : 'This is the only schedule using the meeting’s Zoom link, so that Zoom meeting is deleted too.'}
+        </span>
+      </div>
+    )}
+
+    <div className={styles.buttonContainer}>
+      <button className={styles.cancelButton} onClick={onCancel}>Cancel</button>
+      <button className={styles.deleteButton} onClick={onConfirm}>Remove schedule</button>
+    </div>
+  </Modal>
+);
+
+export default RemoveLinkedScheduleModal;

--- a/frontend/app/components/meeting-form/ScheduleSummaryCard.module.scss
+++ b/frontend/app/components/meeting-form/ScheduleSummaryCard.module.scss
@@ -1,0 +1,75 @@
+@import '../../../styles/Variables.module';
+
+.card {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 10px 12px;
+  border: 1px solid $grey-border-color;
+  border-radius: $radius-lg;
+  background: $white-color;
+}
+
+.headerRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.mode {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: $black-color;
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.removeButton {
+  border: 1px solid $danger-color;
+  background: $white-color;
+  color: $danger-color;
+  border-radius: $radius-md;
+  padding: 2px 10px;
+  font-size: 12.5px;
+  font-weight: 600;
+  cursor: pointer;
+
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.6;
+  }
+}
+
+.scheduleLine,
+.waitingNote,
+.editHint {
+  display: flex;
+  align-items: flex-start;
+  gap: 6px;
+  margin: 0;
+  font-size: 12.5px;
+  line-height: 1.4;
+  color: $text-secondary-color;
+
+  img,
+  svg {
+    flex-shrink: 0;
+    margin-top: 1px;
+  }
+
+  span {
+    flex: 1;
+  }
+}
+
+.waitingNote {
+  color: $warning-text-color;
+  font-weight: 600;
+}
+
+.editLink {
+  color: $link-color;
+  text-decoration: underline;
+}

--- a/frontend/app/components/meeting-form/ScheduleSummaryCard.tsx
+++ b/frontend/app/components/meeting-form/ScheduleSummaryCard.tsx
@@ -1,0 +1,161 @@
+import React from 'react';
+
+import Icon from '../ui/displays/Icon';
+import { MODE_ICON_NAME } from '../../../util/rooms/modeIcons';
+import { formatDayColumn } from '../../../util/meetings/recurrenceDisplay';
+import { formatCompactTimeRange } from '../../../util/date/timeFormat';
+
+import styles from './ScheduleSummaryCard.module.scss';
+
+// Extracts ET wall-clock time as "HH:MM" (24hr), which is what formatCompactTimeRange expects
+// -- mirrors ViewMeeting.tsx's etTimeFmt.
+const etTimeFmt = new Intl.DateTimeFormat('en-GB', {
+  timeZone: 'America/New_York', hour: '2-digit', minute: '2-digit', hour12: false,
+});
+
+const stripZoomSuffix = (name: string): string => name.replace(/ - Zoom$/, '');
+
+/** The pattern fields the card's Day line reads -- structurally satisfied by IRecurrencePattern. */
+export interface ScheduleSummaryPattern {
+  type: string;
+  weekOfMonth?: number | null;
+  dayOfMonth?: number | null;
+  daysOfWeek?: string[] | null;
+}
+
+/**
+ * One schedule of a meeting, as the card displays it. Deliberately structural rather than
+ * `ILinkedSchedule`: the same card renders a saved family member (from
+ * retrieve/meeting/[id]'s `linkedSchedules`) and a schedule that only exists in form state and
+ * has no mid or sync status yet.
+ *
+ * Dates are accepted as strings too -- a saved schedule arrives over JSON, so its
+ * `startDateTime` is a string at runtime whatever the declared type says.
+ */
+export interface ScheduleSummary {
+  modeType: string;
+  recurrencePattern?: ScheduleSummaryPattern | null;
+  startDateTime: Date | string;
+  endDateTime: Date | string;
+  room?: string | null;
+  zoomRoom?: string | null;
+  googleSyncStatus?: string | null;
+  zoomSyncStatus?: string | null;
+}
+
+/**
+ * A schedule's own line: the days it meets and its ET time range, e.g. `"Sat · 9 - 10 AM"`
+ * (just the time range for a one-time schedule). Exported so anything referring to a schedule
+ * outside the card -- the removal confirmation, a toast -- names it the same way the card does.
+ */
+export function formatScheduleLine(schedule: ScheduleSummary): string {
+  const { recurrencePattern } = schedule;
+  const dayText = formatDayColumn(
+    recurrencePattern
+      ? {
+          type: recurrencePattern.type,
+          weekOfMonth: recurrencePattern.weekOfMonth ?? null,
+          dayOfMonth: recurrencePattern.dayOfMonth ?? null,
+          daysOfWeek: recurrencePattern.daysOfWeek ?? [],
+        }
+      : null,
+  );
+  // new Date() wrap: a saved schedule comes off a JSON fetch, so these are strings at runtime
+  // despite the Date type -- Intl.format throws on one unwrapped.
+  const timeText = formatCompactTimeRange(
+    etTimeFmt.format(new Date(schedule.startDateTime)),
+    etTimeFmt.format(new Date(schedule.endDateTime)),
+  );
+  return dayText ? `${dayText} · ${timeText}` : timeText;
+}
+
+export interface ScheduleSummaryCardProps {
+  schedule: ScheduleSummary;
+  /**
+   * Where this schedule's own meeting form lives (`/?mid=<mid>&edit=1`). Renders the line
+   * pointing the admin at it -- a linked schedule's own mode, days, room and host are edited
+   * there, never from inside the meeting it's linked to.
+   */
+  editHref?: string;
+  /** Omitted entirely (not rendered disabled) when the host has no removal action wired up. */
+  onRemove?: () => void;
+  /** Blocks a second click while a removal already in flight finishes. */
+  removeDisabled?: boolean;
+}
+
+// Read-only summary of one of a meeting's schedules: mode, the days it meets, its time range,
+// and where it happens. The host owns every action and all state -- this renders what it is
+// handed, so the same card serves an already-saved linked schedule and (from the create flow) a
+// schedule that hasn't been written yet.
+const ScheduleSummaryCard: React.FC<ScheduleSummaryCardProps> = ({
+  schedule,
+  editHref,
+  onRemove,
+  removeDisabled = false,
+}) => {
+  const { modeType, room, zoomRoom, googleSyncStatus, zoomSyncStatus } = schedule;
+  const locationText = [room, zoomRoom ? stripZoomSuffix(zoomRoom) : null].filter(Boolean).join(' · ');
+
+  // Not yet live on the service in question. 'error' counts as waiting rather than broken: a
+  // schedule created while the Zoom host pool was exhausted lands here with no calendar events
+  // at all, and the fix is the same retry sync either way. A null status is a row that never
+  // reported one (legacy/backfilled rows) -- not a claim that anything is outstanding.
+  const isWaiting = (status: string | null | undefined): boolean => status === 'pending' || status === 'error';
+  const waitingOn = [
+    isWaiting(googleSyncStatus) ? 'Google Calendar' : null,
+    isWaiting(zoomSyncStatus) ? 'Zoom' : null,
+  ].filter(Boolean);
+
+  return (
+    <div className={styles.card}>
+      <div className={styles.headerRow}>
+        <span className={styles.mode}>
+          {MODE_ICON_NAME[modeType] && <Icon name={MODE_ICON_NAME[modeType]} size={16} />}
+          {modeType}
+        </span>
+        {onRemove && (
+          <button
+            type="button"
+            className={styles.removeButton}
+            onClick={onRemove}
+            disabled={removeDisabled}
+            aria-label={`Remove the ${modeType} schedule`}
+          >
+            Remove
+          </button>
+        )}
+      </div>
+
+      <p className={styles.scheduleLine}>
+        <Icon name="clock" size={16} />
+        <span>{formatScheduleLine(schedule)}</span>
+      </p>
+
+      {locationText && (
+        <p className={styles.scheduleLine}>
+          <Icon name="location" size={16} />
+          <span>{locationText}</span>
+        </p>
+      )}
+
+      {waitingOn.length > 0 && (
+        <p className={styles.waitingNote}>
+          <Icon name="warning-circle" size={16} />
+          <span>Waiting to sync with {waitingOn.join(' and ')} — this schedule isn&apos;t live there yet.</span>
+        </p>
+      )}
+
+      {editHref && (
+        <p className={styles.editHint}>
+          <Icon name="link" size={16} />
+          <span>
+            <a href={editHref} className={styles.editLink}>Open this schedule</a> to change its
+            mode, days, room, or host.
+          </span>
+        </p>
+      )}
+    </div>
+  );
+};
+
+export default ScheduleSummaryCard;

--- a/frontend/app/components/meeting-form/ViewMeeting.module.scss
+++ b/frontend/app/components/meeting-form/ViewMeeting.module.scss
@@ -213,6 +213,21 @@
       }
     }
 
+    // The meeting's other schedules (its linked family), each rendered by ScheduleSummaryCard
+    // with its own border -- so this group only supplies the label and the spacing between them.
+    .linkedScheduleGroup {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+
+    .linkedScheduleHeading {
+      margin: 0;
+      font-size: 13px;
+      font-weight: 600;
+      color: $text-secondary-color;
+    }
+
     // Zoom block -- one tinted card instead of four stacked rows. No margin of its own --
     // it's a direct flex child of .details, so the container's gap already spaces it.
     .zoomBlock {

--- a/frontend/app/components/meeting-form/ViewMeeting.tsx
+++ b/frontend/app/components/meeting-form/ViewMeeting.tsx
@@ -10,7 +10,9 @@ import TagList from '../ui/displays/TagList';
 import BottomSheet from '../ui/overlays/BottomSheet';
 import Icon from '../ui/displays/Icon';
 
-import { IRecurrencePattern, ISharedZoomRow } from '../../../types/models';
+import ScheduleSummaryCard from './ScheduleSummaryCard';
+
+import { ILinkedSchedule, IRecurrencePattern, ISharedZoomRow } from '../../../types/models';
 import { formatCompactTimeRange, formatMeetingDateLine } from "../../../util/date/timeFormat";
 import {
   convertETToUTC,
@@ -77,6 +79,10 @@ type ViewMeetingDetailsProps = {
   // Those rows' schedules disagree, so Zoom is holding its current schedule until they match.
   // A pending state, not a failure: the app and Google calendars already follow this row.
   zoomScheduleDiverged?: boolean;
+  // The meeting's OTHER schedules -- one meeting the group runs on different days in a
+  // different mode. Admin-only, like sharedWith. Read-only here: removing one is an Edit
+  // action, and each is edited from its own form.
+  linkedSchedules?: ILinkedSchedule[];
   googleSyncStatus?: string | null;
   googleSyncError?: string | null;
   zoomSyncStatus?: string | null;
@@ -125,6 +131,7 @@ const ViewMeetingDetails: React.FC<ViewMeetingDetailsProps> = ({
   zoomManaged,
   sharedWith,
   zoomScheduleDiverged = false,
+  linkedSchedules,
   startDateTime,
   endDateTime,
   email,
@@ -414,6 +421,7 @@ const ViewMeetingDetails: React.FC<ViewMeetingDetailsProps> = ({
   const primaryLocation = room || (zoomRoom ? stripZoomSuffix(zoomRoom) : '');
   const showZoomMismatchRow = !!(room && zoomRoom && isZoomRoomMismatched(room, zoomRoom));
   const sharedRows = sharedWith ?? [];
+  const linkedRows = linkedSchedules ?? [];
   const sharedWithText = sharedRows.map((row) => `${row.title} (${row.modeType})`).join(', ');
 
   const content = (
@@ -504,6 +512,21 @@ const ViewMeetingDetails: React.FC<ViewMeetingDetailsProps> = ({
             </p>
           )}
         </div>
+
+        {isAdmin && linkedRows.length > 0 && (
+          <div className={styles.linkedScheduleGroup}>
+            <p className={styles.linkedScheduleHeading}>Also meets</p>
+            {linkedRows.map((schedule) => (
+              <ScheduleSummaryCard
+                key={schedule.mid}
+                schedule={schedule}
+                // A full navigation, not a client-side route change: page.tsx reads ?mid= once
+                // on mount to resolve a deep link.
+                editHref={`/?mid=${encodeURIComponent(schedule.mid)}&edit=1`}
+              />
+            ))}
+          </div>
+        )}
 
         {zoomLink && zid && (
           <div className={styles.zoomBlock}>

--- a/frontend/tests/component/EditMeeting.test.tsx
+++ b/frontend/tests/component/EditMeeting.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen, fireEvent, act, waitFor } from "@testing-library/react";
+import { render, screen, fireEvent, act, waitFor, within } from "@testing-library/react";
 import { ToastProvider } from "../../app/components/shared/ToastProvider";
 import EditMeetingSidebar from "../../app/components/meeting-form/EditMeeting";
 import { IMeeting } from "../../types/models";
@@ -436,5 +436,131 @@ describe("EditMeetingSidebar stays open during ordinary field interaction", () =
 
     expect(screen.getByRole("button", { name: "Update Meeting" })).toBeInTheDocument();
     expect(onClose).not.toHaveBeenCalled();
+  });
+});
+
+// A meeting the group runs as two schedules (retrieve/meeting/[id]'s admin-only
+// linkedSchedules). The form edits the schedule that was opened; the other one is read-only
+// here and can only be removed.
+describe("EditMeetingSidebar linked schedules", () => {
+  const linkedMeeting: IMeeting = {
+    ...anchorMeeting,
+    modeType: "Hybrid",
+    zid: "89296128710",
+    linkedSchedules: [
+      {
+        mid: "m-linked",
+        modeType: "Remote",
+        room: "",
+        zoomRoom: "Unity Room - Zoom",
+        zoomHost: "pool-host-1@icr.test",
+        recurrencePattern: {
+          type: "weekly",
+          startDate: new Date("2026-07-11T00:00:00.000Z"),
+          daysOfWeek: ["Saturday"],
+          firstDayOfWeek: "Sunday",
+          interval: 1,
+        },
+        startDateTime: new Date("2026-07-11T22:00:00.000Z"), // 6:00 PM ET
+        endDateTime: new Date("2026-07-11T23:00:00.000Z"),
+        googleSyncStatus: "synced",
+        zoomSyncStatus: "synced",
+      },
+    ],
+  };
+
+  const renderWithLinked = (meeting: IMeeting = linkedMeeting) => {
+    const onUpdateSuccess = jest.fn();
+    render(
+      <ToastProvider>
+        <EditMeetingSidebar
+          meeting={meeting}
+          onClose={jest.fn()}
+          onUpdateSuccess={onUpdateSuccess}
+          occurrenceDate={null}
+        />
+      </ToastProvider>,
+    );
+    return onUpdateSuccess;
+  };
+
+  const deleteCalls = () =>
+    (global.fetch as jest.Mock).mock.calls.filter(([url]) => url === "/api/delete/meeting");
+
+  it("renders the other schedule read-only, with a link to its own form", async () => {
+    renderWithLinked();
+    await act(async () => {});
+
+    // Scoped to the section: the form's own Mode buttons name every mode too, so "Remote"
+    // alone is ambiguous on this page.
+    const section = screen.getByRole("region", { name: "Linked schedule" });
+    expect(within(section).getByText("Remote")).toBeInTheDocument();
+    expect(within(section).getByText("Sat · 6 - 7 PM")).toBeInTheDocument();
+    expect(within(section).getByRole("link", { name: "Open this schedule" })).toHaveAttribute(
+      "href",
+      "/?mid=m-linked&edit=1",
+    );
+  });
+
+  it("says nothing about linked schedules for an ordinary single-schedule meeting", async () => {
+    renderWithLinked(anchorMeeting);
+    await act(async () => {});
+
+    expect(screen.queryByRole("region", { name: /Linked schedule/ })).not.toBeInTheDocument();
+  });
+
+  it("asks for confirmation before removing, and deletes nothing if the admin cancels", async () => {
+    renderWithLinked();
+    await act(async () => {});
+
+    fireEvent.click(screen.getByRole("button", { name: /Remove/ }));
+    expect(screen.getByRole("heading", { name: "Remove this schedule?" })).toBeInTheDocument();
+    // The surviving schedule is Hybrid and holds the family's zid, so the Zoom meeting stays.
+    expect(screen.getByText(/The shared Zoom meeting stays/)).toBeInTheDocument();
+
+    // The form has a Cancel button of its own -- this is the modal's.
+    fireEvent.click(within(screen.getByRole("dialog")).getByRole("button", { name: "Cancel" }));
+    expect(deleteCalls()).toHaveLength(0);
+  });
+
+  it("soft-deletes the whole linked row through the delete route once confirmed", async () => {
+    const onUpdateSuccess = renderWithLinked();
+    await act(async () => {});
+
+    fireEvent.click(screen.getByRole("button", { name: /Remove/ }));
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Remove schedule" }));
+    });
+
+    expect(deleteCalls()).toHaveLength(1);
+    const [, init] = deleteCalls()[0];
+    expect(init.method).toBe("DELETE");
+    expect(JSON.parse(init.body)).toEqual({ mid: "m-linked", deleteOption: "all" });
+    // The panel stays open -- the refresh re-reads the meeting (and its remaining schedules)
+    // without discarding whatever edit is in progress in the form.
+    await waitFor(() => expect(onUpdateSuccess).toHaveBeenCalled());
+    expect(screen.getByRole("button", { name: "Update Meeting" })).toBeInTheDocument();
+  });
+
+  // The delete route only tears a Zoom meeting down once no live row still points at its zid,
+  // so what the confirmation promises depends on whether the schedule left behind is on it.
+  it("warns that the Zoom meeting goes too when the surviving schedule has none", async () => {
+    renderWithLinked({ ...linkedMeeting, modeType: "In Person", zid: null });
+    await act(async () => {});
+
+    fireEvent.click(screen.getByRole("button", { name: /Remove/ }));
+    expect(screen.getByText(/that Zoom meeting is deleted too/)).toBeInTheDocument();
+  });
+
+  it("says nothing about Zoom when removing an In-Person schedule", async () => {
+    renderWithLinked({
+      ...linkedMeeting,
+      linkedSchedules: [{ ...linkedMeeting.linkedSchedules![0], modeType: "In Person", room: "Serenity Room", zoomRoom: null }],
+    });
+    await act(async () => {});
+
+    fireEvent.click(screen.getByRole("button", { name: /Remove/ }));
+    expect(screen.getByRole("heading", { name: "Remove this schedule?" })).toBeInTheDocument();
+    expect(screen.queryByText(/Zoom meeting/)).not.toBeInTheDocument();
   });
 });

--- a/frontend/tests/component/ScheduleSummaryCard.test.tsx
+++ b/frontend/tests/component/ScheduleSummaryCard.test.tsx
@@ -1,0 +1,113 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import ScheduleSummaryCard, { ScheduleSummary, formatScheduleLine } from "../../app/components/meeting-form/ScheduleSummaryCard";
+
+// A Saturday Zoom-only half of a linked family: 9-10 AM ET, one weekday, its own Zoom room.
+const saturdaySchedule: ScheduleSummary = {
+  modeType: "Remote",
+  recurrencePattern: {
+    type: "weekly",
+    weekOfMonth: null,
+    dayOfMonth: null,
+    daysOfWeek: ["Saturday"],
+  },
+  startDateTime: new Date("2026-09-12T13:00:00.000Z"), // 9:00 AM ET
+  endDateTime: new Date("2026-09-12T14:00:00.000Z"), // 10:00 AM ET
+  room: "",
+  zoomRoom: "Unity Room - Zoom",
+  googleSyncStatus: "synced",
+  zoomSyncStatus: "synced",
+};
+
+describe("ScheduleSummaryCard", () => {
+  it("names the mode, its icon, the days it meets and its ET time range", () => {
+    render(<ScheduleSummaryCard schedule={saturdaySchedule} />);
+
+    expect(screen.getByText("Remote")).toBeInTheDocument();
+    expect(document.querySelector('[data-icon-name="video-call"]')).toBeInTheDocument();
+    expect(screen.getByText("Sat · 9 - 10 AM")).toBeInTheDocument();
+  });
+
+  it("shows the schedule's own room and Zoom room, without the Zoom room's ' - Zoom' suffix", () => {
+    render(<ScheduleSummaryCard schedule={{ ...saturdaySchedule, modeType: "Hybrid", room: "Serenity Room" }} />);
+
+    expect(screen.getByText("Serenity Room · Unity Room")).toBeInTheDocument();
+  });
+
+  // A schedule created while the Zoom host pool was exhausted has no calendar events at all
+  // yet and is waiting on a retry sync -- the card has to say so rather than presenting it as
+  // a live schedule.
+  it("reports a schedule that is still waiting on both services", () => {
+    render(
+      <ScheduleSummaryCard
+        schedule={{ ...saturdaySchedule, googleSyncStatus: "pending", zoomSyncStatus: "error" }}
+      />,
+    );
+
+    expect(screen.getByText(/Waiting to sync with Google Calendar and Zoom/)).toBeInTheDocument();
+  });
+
+  it("names only the service that is actually outstanding", () => {
+    render(
+      <ScheduleSummaryCard
+        schedule={{ ...saturdaySchedule, googleSyncStatus: "synced", zoomSyncStatus: "pending" }}
+      />,
+    );
+
+    expect(screen.getByText(/Waiting to sync with Zoom —/)).toBeInTheDocument();
+    expect(screen.queryByText(/Google Calendar/)).not.toBeInTheDocument();
+  });
+
+  // A backfilled legacy row reports no sync status at all -- that's silence, not an
+  // outstanding write.
+  it("says nothing about syncing for a fully synced schedule, or one with no status at all", () => {
+    const { rerender } = render(<ScheduleSummaryCard schedule={saturdaySchedule} />);
+    expect(screen.queryByText(/Waiting to sync/)).not.toBeInTheDocument();
+
+    rerender(
+      <ScheduleSummaryCard
+        schedule={{ ...saturdaySchedule, googleSyncStatus: null, zoomSyncStatus: null }}
+      />,
+    );
+    expect(screen.queryByText(/Waiting to sync/)).not.toBeInTheDocument();
+  });
+
+  it("links to the schedule's own form when given one, and omits the line otherwise", () => {
+    const { rerender } = render(
+      <ScheduleSummaryCard schedule={saturdaySchedule} editHref="/?mid=m-linked&edit=1" />,
+    );
+
+    expect(screen.getByRole("link", { name: "Open this schedule" })).toHaveAttribute(
+      "href",
+      "/?mid=m-linked&edit=1",
+    );
+
+    rerender(<ScheduleSummaryCard schedule={saturdaySchedule} />);
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+  });
+
+  it("offers Remove only when the host wired an action up, and blocks a second click while one is in flight", () => {
+    const onRemove = jest.fn();
+    const { rerender } = render(<ScheduleSummaryCard schedule={saturdaySchedule} />);
+    expect(screen.queryByRole("button", { name: /Remove/ })).not.toBeInTheDocument();
+
+    rerender(<ScheduleSummaryCard schedule={saturdaySchedule} onRemove={onRemove} />);
+    fireEvent.click(screen.getByRole("button", { name: /Remove/ }));
+    expect(onRemove).toHaveBeenCalledTimes(1);
+
+    rerender(<ScheduleSummaryCard schedule={saturdaySchedule} onRemove={onRemove} removeDisabled />);
+    expect(screen.getByRole("button", { name: /Remove/ })).toBeDisabled();
+  });
+
+  it("falls back to the time range alone for a schedule with no recurrence", () => {
+    render(<ScheduleSummaryCard schedule={{ ...saturdaySchedule, recurrencePattern: null }} />);
+
+    // formatDayColumn calls an absent pattern "One-time" rather than blank, so the line still
+    // says what kind of schedule this is.
+    expect(screen.getByText("One-time · 9 - 10 AM")).toBeInTheDocument();
+  });
+
+  it("formats the same line the card shows for callers outside it", () => {
+    expect(formatScheduleLine(saturdaySchedule)).toBe("Sat · 9 - 10 AM");
+  });
+});

--- a/frontend/tests/component/ViewMeeting.test.tsx
+++ b/frontend/tests/component/ViewMeeting.test.tsx
@@ -455,3 +455,50 @@ describe("ViewMeeting", () => {
     });
   });
 });
+
+// The meeting's other schedules (retrieve/meeting/[id]'s admin-only linkedSchedules), shown
+// here read-only -- removing one is an Edit action.
+describe("ViewMeeting linked schedules", () => {
+  const linkedSchedule = {
+    mid: "m-linked",
+    modeType: "Remote",
+    room: "",
+    zoomRoom: "Unity Room - Zoom",
+    zoomHost: "pool-host-1@icr.test",
+    recurrencePattern: {
+      type: "weekly",
+      startDate: new Date("2026-08-01T00:00:00Z"),
+      daysOfWeek: ["Saturday"],
+      firstDayOfWeek: "Sunday",
+      interval: 1,
+    },
+    startDateTime: new Date("2026-08-01T18:00:00Z"),
+    endDateTime: new Date("2026-08-01T19:00:00Z"),
+    googleSyncStatus: "synced",
+    zoomSyncStatus: "synced",
+  };
+
+  it("shows an admin the other schedule and where to edit it, with no Remove action here", async () => {
+    renderViewMeeting({
+      ...baseProps, anchorEl: makeAnchorEl(), isPhone: false, linkedSchedules: [linkedSchedule],
+    });
+
+    expect(await screen.findByText("Also meets")).toBeInTheDocument();
+    expect(screen.getByText("Sat · 2 - 3 PM")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Open this schedule" })).toHaveAttribute(
+      "href", "/?mid=m-linked&edit=1",
+    );
+    expect(screen.queryByRole("button", { name: /Remove/ })).not.toBeInTheDocument();
+  });
+
+  // BUG-022: the API never sends this to a non-admin, and the UI doesn't offer it either.
+  it("never renders the section for a non-admin viewer", async () => {
+    renderViewMeeting({
+      ...baseProps, anchorEl: makeAnchorEl(), isPhone: false, isAdmin: false,
+      linkedSchedules: [linkedSchedule],
+    });
+
+    await screen.findByText("Serenity Group");
+    expect(screen.queryByText("Also meets")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/tests/integration/delete-meeting-route.test.ts
+++ b/frontend/tests/integration/delete-meeting-route.test.ts
@@ -1,5 +1,6 @@
 import { getTestPrismaClient, disconnectTestPrismaClient } from "../factories/db";
 import { seedMeeting, seedRecurringMeeting, seedSuspensionPeriod } from "../factories/meeting";
+import { buildLinkedScheduleLabel, familyMembers, getLinkedFamily } from "../../util/meetings/linkedSchedules";
 
 // The route always passes an already-started promise to after() (syncDeleteAll etc. are invoked
 // eagerly as part of constructing the argument, before after() ever sees it) -- capturing that
@@ -398,5 +399,107 @@ describe("deleteOption 'this' / 'thisAndFollowing'", () => {
     // to buildEventBody's street-address default, breaking Zoom Room one-touch join) is skipped.
     expect(mockedUpdate).toHaveBeenCalledTimes(1);
     expect(mockedUpdate).not.toHaveBeenCalledWith(expect.anything(), "live-room-event-id-3", expect.anything(), expect.anything(), expect.anything());
+  });
+});
+
+// One meeting run as two linked schedules (Meeting.linkedToMid). Deleting one of them is an
+// ordinary whole-series delete of an ordinary row -- what's specific to a family is that the
+// survivor must not be left pointing at a soft-deleted anchor, and that the Zoom meeting the
+// two share has to outlive whichever of them goes first.
+describe("linked schedules", () => {
+  const seedFamily = async (overrides: { zid?: string | null; linkedModeType?: string } = {}) => {
+    const { zid = null, linkedModeType = "Remote" } = overrides;
+    const { meeting: anchor } = await seedRecurringMeeting(
+      { title: "One Day at a Time", modeType: "Hybrid", room: "Serenity Room",
+        zoomRoom: "Delete Route Zoom Room", zid, zoomManaged: true },
+      { daysOfWeek: ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"] },
+    );
+    const { meeting: linked } = await seedRecurringMeeting(
+      { title: "One Day at a Time", modeType: linkedModeType, room: "", zoomRoom: null,
+        zid: linkedModeType === "In Person" ? null : zid, zoomManaged: true, linkedToMid: anchor.mid },
+      { daysOfWeek: ["Saturday"] },
+    );
+    return { anchor, linked };
+  };
+
+  const deleteMeeting = (mid: string) => DELETE(new Request("http://localhost/api/delete/meeting", {
+    method: "DELETE", body: JSON.stringify({ mid, deleteOption: "all" }),
+  }));
+
+  test("deleting the anchor releases the surviving schedule instead of leaving it pointing at a deleted mid", async () => {
+    const { anchor, linked } = await seedFamily();
+
+    expect((await deleteMeeting(anchor.mid)).status).toBe(200);
+    await drainAfterTasks();
+
+    const survivor = await getTestPrismaClient().meeting.findUnique({ where: { mid: linked.mid } });
+    expect(survivor?.linkedToMid).toBeNull();
+    expect(survivor?.deletedAt).toBeNull();
+  });
+
+  test("deleting the linked schedule leaves the anchor untouched -- it never held a pointer", async () => {
+    const { anchor, linked } = await seedFamily();
+
+    expect((await deleteMeeting(linked.mid)).status).toBe(200);
+    await drainAfterTasks();
+
+    const survivor = await getTestPrismaClient().meeting.findUnique({ where: { mid: anchor.mid } });
+    expect(survivor?.linkedToMid).toBeNull();
+    expect(survivor?.deletedAt).toBeNull();
+  });
+
+  // The family's ONE Zoom meeting still serves whichever schedule is left -- the existing
+  // shared-zid guard is what keeps it alive, and it has to keep holding for a linked family.
+  test("the family's shared Zoom meeting survives the first deletion and only goes with the last", async () => {
+    const zid = "70000000901";
+    const { anchor, linked } = await seedFamily({ zid });
+
+    await deleteMeeting(anchor.mid);
+    await drainAfterTasks();
+    expect(mockedDeleteZoom).not.toHaveBeenCalled();
+
+    await deleteMeeting(linked.mid);
+    await drainAfterTasks();
+    expect(mockedDeleteZoom).toHaveBeenCalledWith(zid);
+  });
+
+  // An In-Person schedule holds no zid, so once it's the only row left there is nothing sharing
+  // the deleted row's zid -- the Zoom meeting goes with the schedule that was actually on it.
+  test("removing the only Zoom-bearing schedule tears the Zoom meeting down, In-Person survivor and all", async () => {
+    const zid = "70000000902";
+    const { meeting: anchor } = await seedRecurringMeeting(
+      { title: "Early Bird", modeType: "In Person", room: "Serenity Room", zid: null, zoomManaged: true },
+      { daysOfWeek: ["Monday"] },
+    );
+    const { meeting: linked } = await seedRecurringMeeting(
+      { title: "Early Bird", modeType: "Remote", room: "", zid, zoomManaged: true, linkedToMid: anchor.mid },
+      { daysOfWeek: ["Saturday"] },
+    );
+
+    await deleteMeeting(linked.mid);
+    await drainAfterTasks();
+
+    expect(mockedDeleteZoom).toHaveBeenCalledWith(zid);
+    const survivor = await getTestPrismaClient().meeting.findUnique({ where: { mid: anchor.mid } });
+    expect(survivor?.deletedAt).toBeNull();
+  });
+
+  // The survivor's family drops to one, so the name every external service shows it falls back
+  // from the two-schedule hierarchy to its own single-schedule suffix on the next write.
+  test("the survivor's external name falls back to the single-schedule form", async () => {
+    const prisma = getTestPrismaClient();
+    const { anchor, linked } = await seedFamily({ zid: "70000000903" });
+
+    const before = await getLinkedFamily(prisma, linked.mid);
+    expect(buildLinkedScheduleLabel(linked.title, before!.anchor, familyMembers(before!)))
+      .toBe("One Day at a Time - Hybrid Mon-Fri - Zoom Only Sat");
+
+    await deleteMeeting(anchor.mid);
+    await drainAfterTasks();
+
+    const after = await getLinkedFamily(prisma, linked.mid);
+    expect(familyMembers(after!)).toHaveLength(1);
+    expect(buildLinkedScheduleLabel(linked.title, after!.anchor, familyMembers(after!)))
+      .toBe("One Day at a Time - Zoom Only");
   });
 });

--- a/frontend/tests/integration/retrieve-meeting-detail-route.test.ts
+++ b/frontend/tests/integration/retrieve-meeting-detail-route.test.ts
@@ -1,6 +1,6 @@
 import { NextRequest } from "next/server";
 import { seedMeeting, seedRecurringMeeting } from "../factories/meeting";
-import { disconnectTestPrismaClient } from "../factories/db";
+import { getTestPrismaClient, disconnectTestPrismaClient } from "../factories/db";
 import { convertETToUTC, formatETDateString } from "../../util/date/timeUtils";
 
 jest.mock("../../services/auth", () => ({
@@ -169,5 +169,117 @@ describe("shared Zoom link siblings", () => {
     expect(Object.keys(body).sort()).toEqual(PUBLIC_MEETING_FIELDS);
     expect(body).not.toHaveProperty("sharedWith");
     expect(body).not.toHaveProperty("zoomScheduleDiverged");
+  });
+});
+
+// One meeting the group runs as two schedules (Meeting.linkedToMid) -- e.g. Hybrid on weekdays
+// and Zoom-only on Saturday. Keyed on linkedToMid, never on zid: an In-Person member holds no
+// zid at all, so a zid lookup would miss it entirely.
+describe("linked schedules", () => {
+  const seedFamily = async (
+    anchorOverrides: Record<string, unknown> = {},
+    linkedOverrides: Record<string, unknown> = {},
+  ) => {
+    const { meeting: anchor } = await seedRecurringMeeting(
+      { title: "One Day at a Time", modeType: "Hybrid", room: "Serenity Room",
+        zoomRoom: "Unity Room - Zoom", zoomHost: "pool-host-1@icr.test", ...anchorOverrides },
+      { daysOfWeek: ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"] },
+    );
+    const { meeting: linked } = await seedRecurringMeeting(
+      { title: "One Day at a Time", modeType: "Remote", room: "", zoomRoom: null,
+        zoomHost: "pool-host-1@icr.test", linkedToMid: anchor.mid,
+        googleSyncStatus: "synced", zoomSyncStatus: "synced", ...linkedOverrides },
+      { daysOfWeek: ["Saturday"] },
+    );
+    return { anchor, linked };
+  };
+
+  test("an admin gets the other schedule, with everything the schedule card renders", async () => {
+    mockedGetAuth.mockResolvedValue({ user: { role: "ADMIN" } });
+    const { anchor, linked } = await seedFamily();
+
+    const body = await getMeetingDetail(anchor.mid);
+    expect(body.linkedSchedules).toHaveLength(1);
+    const [schedule] = body.linkedSchedules;
+    expect(Object.keys(schedule).sort()).toEqual([
+      "endDateTime", "googleSyncStatus", "mid", "modeType", "recurrencePattern", "room",
+      "startDateTime", "zoomRoom", "zoomSyncStatus", "zoomHost",
+    ].sort());
+    expect(schedule.mid).toBe(linked.mid);
+    expect(schedule.modeType).toBe("Remote");
+    expect(schedule.zoomHost).toBe("pool-host-1@icr.test");
+    expect(schedule.recurrencePattern.daysOfWeek).toEqual(["Saturday"]);
+    expect(schedule.googleSyncStatus).toBe("synced");
+    expect(new Date(schedule.startDateTime)).toEqual(linked.startDateTime);
+  });
+
+  // The family resolves from either member, so opening the Saturday row reports the weekday
+  // one -- never itself.
+  test("opening the linked row reports the anchor, not itself", async () => {
+    mockedGetAuth.mockResolvedValue({ user: { role: "ADMIN" } });
+    const { anchor, linked } = await seedFamily();
+
+    const body = await getMeetingDetail(linked.mid);
+    expect(body.linkedSchedules.map((row: { mid: string }) => row.mid)).toEqual([anchor.mid]);
+    expect(body.linkedSchedules[0].modeType).toBe("Hybrid");
+  });
+
+  // The whole reason the family is keyed on linkedToMid: an In-Person schedule must never hold
+  // a zid, so sharedWith (a zid question) can't see this pair at all.
+  test("a Zoom-free family member is reported even though the two share no zid", async () => {
+    mockedGetAuth.mockResolvedValue({ user: { role: "ADMIN" } });
+    const { anchor, linked } = await seedFamily(
+      { modeType: "In Person", zid: null, zoomRoom: null, zoomHost: null },
+      { modeType: "Remote", zid: "70000002101", room: "" },
+    );
+
+    const body = await getMeetingDetail(anchor.mid);
+    expect(body.linkedSchedules.map((row: { mid: string }) => row.mid)).toEqual([linked.mid]);
+    expect(body).not.toHaveProperty("sharedWith");
+  });
+
+  // Pool exhaustion leaves a just-created Zoom-bearing member at pending/error with no calendar
+  // events yet -- the card has to be able to say the schedule isn't live, so the statuses are
+  // part of the payload.
+  test("a member still waiting on its first sync reports its raw statuses", async () => {
+    mockedGetAuth.mockResolvedValue({ user: { role: "ADMIN" } });
+    const { anchor } = await seedFamily({}, { googleSyncStatus: "pending", zoomSyncStatus: "error" });
+
+    const body = await getMeetingDetail(anchor.mid);
+    expect(body.linkedSchedules[0].googleSyncStatus).toBe("pending");
+    expect(body.linkedSchedules[0].zoomSyncStatus).toBe("error");
+  });
+
+  test("a soft-deleted member is no longer part of the family", async () => {
+    mockedGetAuth.mockResolvedValue({ user: { role: "ADMIN" } });
+    const { anchor, linked } = await seedFamily();
+    await getTestPrismaClient().meeting.update({
+      where: { mid: linked.mid }, data: { deletedAt: new Date() },
+    });
+
+    const body = await getMeetingDetail(anchor.mid);
+    expect(body).not.toHaveProperty("linkedSchedules");
+  });
+
+  test("a single-schedule meeting carries no linkedSchedules at all", async () => {
+    mockedGetAuth.mockResolvedValue({ user: { role: "ADMIN" } });
+    const meeting = await seedMeeting();
+
+    const body = await getMeetingDetail(meeting.mid);
+    expect(body).not.toHaveProperty("linkedSchedules");
+  });
+
+  // BUG-022: rooms, hosts and schedules of another row are admin-only, exactly like sharedWith.
+  test("a USER-role session and a public caller both get nothing", async () => {
+    const { anchor } = await seedFamily();
+
+    mockedGetAuth.mockResolvedValue({ user: { role: "USER" } });
+    const userBody = await getMeetingDetail(anchor.mid);
+    expect(Object.keys(userBody).sort()).toEqual(PUBLIC_MEETING_FIELDS);
+    expect(userBody).not.toHaveProperty("linkedSchedules");
+
+    mockedGetAuth.mockResolvedValue(null);
+    const publicBody = await getMeetingDetail(anchor.mid);
+    expect(publicBody).not.toHaveProperty("linkedSchedules");
   });
 });

--- a/frontend/types/models.ts
+++ b/frontend/types/models.ts
@@ -48,6 +48,11 @@ interface IMeeting {
   // Those rows' schedules can't currently be expressed as one Zoom series, so Zoom keeps the
   // schedule it already has until they match again. Same population rules as sharedWith.
   zoomScheduleDiverged?: boolean;
+  // This meeting's OTHER schedules in its linked family (Meeting.linkedToMid) -- same
+  // population rules as sharedWith, and absent whenever the meeting has no linked schedule.
+  // A different question from sharedWith: that one asks whether this Zoom LINK feeds another
+  // row (a zid question), this one asks which schedules make up this one meeting.
+  linkedSchedules?: ILinkedSchedule[];
   isRecurring: boolean;
   recurrencePattern?: IRecurrencePattern | null;
   googleCalendarEventId?: string | null;
@@ -68,6 +73,24 @@ interface IMeeting {
 interface ISharedZoomRow {
   title: string;
   modeType: string;
+}
+
+// One member of a meeting's linked-schedule family, as retrieve/meeting/[id] returns it to an
+// admin -- everything ScheduleSummaryCard needs to render that schedule read-only, and nothing
+// else. The sync statuses are part of it because a family member can legitimately still be
+// waiting on Zoom host capacity when the card first renders (its calendar events don't exist
+// yet), which the card has to say rather than showing the schedule as already live.
+interface ILinkedSchedule {
+  mid: string;
+  modeType: string;
+  room: string;
+  zoomRoom: string | null;
+  zoomHost: string | null;
+  recurrencePattern: IRecurrencePattern | null;
+  startDateTime: Date;
+  endDateTime: Date;
+  googleSyncStatus: string | null;
+  zoomSyncStatus: string | null;
 }
 
 interface IRecurrencePattern {
@@ -106,4 +129,4 @@ interface ILeaseSettings {
   emailTemplate: string;
 }
 
-export type { IAdmin, IMeeting, ISharedZoomRow, IRecurrencePattern, IRoomRate, ILeaseSettings };
+export type { IAdmin, IMeeting, ISharedZoomRow, ILinkedSchedule, IRecurrencePattern, IRoomRate, ILeaseSettings };


### PR DESCRIPTION
@coderabbitai summary

## Description

Fifth PR of the linked meeting modes work, stacked on #555. PRs 3 and 4 taught the update and create routes to *write* a linked schedule; this one is the first that lets an admin **see** one. After it, the three legacy production meetings that were backfilled into families in PR 1 are visible and manageable in the app — read-only, plus a Remove action. There is still no create UI (PR 6).

- **frontend/app/api/retrieve/meeting/[id]/route.ts, frontend/types/models.ts**: an admin response gains `linkedSchedules` — this meeting's *other* schedules (`Meeting.linkedToMid`), each carrying only what the card renders: mode, room, Zoom room, host, recurrence pattern, start/end, and the two sync statuses. Deliberately a separate field from the existing `sharedWith`: that one is keyed on `zid` and answers "does another row use this Zoom **link**", which an In-Person family member — no `zid` at all — can never appear in, whereas this one answers "which schedules make up this one meeting". Admin-only for the BUG-022 reason (it names rooms, hosts and schedules a public viewer never sees), and omitted entirely rather than sent as `[]` for the overwhelmingly common single-schedule meeting, matching `sharedZoom`'s shape.
- **frontend/app/components/meeting-form/ScheduleSummaryCard.tsx** (new): the read-only summary of one schedule — mode icon + name, the days it meets and its ET time range, where it happens, a "waiting to sync" note, and a link to that schedule's own form. Two details worth a reviewer's eye:
  - Its prop type is **structural, not `ILinkedSchedule`**, so PR 6 can hand it a schedule that only exists in form state with no mid or sync status yet. `startDateTime`/`endDateTime` accept a string as well as a `Date` because a saved schedule arrives over JSON and is a string at runtime whatever the declared type says — `Intl.format` throws on an unwrapped one.
  - `'error'` counts as **waiting**, not broken: a schedule created while the Zoom host pool was exhausted lands there with no calendar events at all, and the fix is the same retry sync as `'pending'`. A `null` status is a legacy/backfilled row that never reported one, and claims nothing.
  - `formatScheduleLine` is exported so the removal confirmation names the schedule exactly the way the card does.
- **frontend/app/components/meeting-form/EditMeeting.tsx**: a "Linked schedule(s)" section above the form, one card per member, each with a **Remove** action. The section says plainly that the form below edits the schedule you opened — a linked schedule's mode, days, room and host are edited from its own form, since it is an ordinary Meeting row with its own mid, and offering to edit it in-place here would be a second, subtly different editor for the same row.
- **frontend/app/components/meeting-form/RemoveLinkedScheduleModal.tsx** (new): removal goes through the ordinary `DELETE /api/delete/meeting` with `deleteOption: 'all'` — it *is* a whole-series delete of a real Meeting row, so it gets the same modal weight as any other delete rather than an inline "×". The modal states the Zoom consequence up front, which is not the same in all three cases: nothing at all for an In-Person schedule (it was never on the Zoom meeting), *kept* when the surviving schedule still runs on it, *deleted* when this was the last row pointing at that `zid`. None of the form's in-progress edits are submitted or discarded; the existing `onUpdateSuccess` refresh re-reads the meeting without closing the panel.
- **frontend/app/components/meeting-form/ViewMeeting.tsx, frontend/app/(main)/page.tsx**: the same card, under an "Also meets" heading, in the read-only detail panel — admin-gated there too, and with **no** Remove action: removing a schedule is an Edit action.
- **frontend/app/api/delete/meeting/route.ts**: deleting the **anchor** of a family now clears `linkedToMid` on its surviving members, inside the same transaction as the soft delete, so a lone row never dangles a pointer at a soft-deleted mid — its family drops to one and its Zoom topic and calendar titles fall back to the single-schedule name on the next write. Nothing to do when the deleted row was the linked member instead: the anchor's own `linkedToMid` was never set. The shared Zoom meeting is untouched either way — `syncDeleteAll`'s existing sibling/zid guard keeps it alive for whichever schedule is left, and only tears it down with the last one.
- **Tests** — 6 new `EditMeeting` cases (the read-only card and its link, silence for a single-schedule meeting, cancel deletes nothing, confirm hits the delete route, and both Zoom-consequence wordings), a new 9-case `ScheduleSummaryCard.test.tsx`, 2 new `ViewMeeting` cases (admin sees it with no Remove; a non-admin never does), 5 new `delete-meeting-route` cases (anchor-vs-member deletion, the shared Zoom meeting surviving the first delete and going with the last, and the survivor's external name falling back), and 6 new `retrieve-meeting-detail-route` cases (including a Zoom-free member reported despite sharing no `zid`, a soft-deleted member dropping out of the family, and a USER-role session plus a public caller both getting nothing).

## Testing

- [x] `cd frontend && yarn test:all` — green (lint, lint:css, typecheck, unit, component, integration, e2e), run against a clear port 3000.
- [x] `yarn test:component --testPathPattern "ScheduleSummaryCard|EditMeeting|ViewMeeting"` and `yarn test:integration --testPathPattern "retrieve-meeting-detail-route|delete-meeting-route"` — the new cases above.
- [x] Pre-existing-test sweep (`pr_convention.md`): the behavior-altering edits are the delete route's single `update` → `$transaction` and the retrieve route's admin body gaining a field, so the existing `delete-meeting-route.test.ts` and `retrieve-meeting-detail-route.test.ts` suites passing unchanged is the assertion that a single-schedule meeting deletes and reads back exactly as before; delegated to a subagent rather than run from the implementing context.
- [ ] Reviewer check: open one of the backfilled legacy meetings as an admin — the detail panel shows an "Also meets" card for its other schedule, and Edit shows the same card with a Remove action. Open it as a non-admin: neither appears.
- [ ] Reviewer check: remove the linked schedule of a Hybrid + Zoom-Only family and confirm the modal says the Zoom meeting *stays*, that only the linked row is soft-deleted, and that the survivor's `linkedToMid` is cleared when the anchor is the one removed.

## Area(s) Touched

**Product areas**
- [ ] auth — sign-in, sessions, NextAuth, role-based access
- [ ] admin — /admin shell (Diagnostics, Users, Import, Export tabs)
- [ ] docs — /docs Resources page (rendering, navigation, search)
- [x] ui/ux — frontend layout/styling not tied to a specific integration

**Integrations**
- [x] google-calendar — Google Calendar sync
- [x] zoom-api — Zoom meeting/host sync

**Engineering**
- [ ] security — auth hardening, data exposure, dependency/security scanning
- [x] testing — test suite (Jest/Playwright) changes
- [ ] github-actions — workflows, Dependabot config, other .github/ CI tooling
- [ ] cleanup — refactor or dead-code removal, no behavior change
- [ ] documentation — docs/ or README changes only

## Pre-merge Checklist
- [x] Code follows current formatting conventions and passes lint (`yarn lint`).
- [x] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
- [ ] All test suites pass, both run locally and green in GitHub CI. **Do not merge if any test suite is failing.**
- [x] A test suite was added or updated for the feature/fix in this PR. **Double-check this if you change a feature and did not update the test suites**.
- [x] Only files relevant to this change are committed — no stray or unrelated files.
- [x] If this branch has a merge conflict with master, master was merged into this branch first (not the other way around).
- [x] The rest of this PR description (Description, Testing) is filled out, not left as template placeholders.
