### PR TITLE
fix(meetings): skip a fellowship prefix the title already names

### DIFF
--- a/frontend/tests/unit/linkedSchedules.test.ts
+++ b/frontend/tests/unit/linkedSchedules.test.ts
@@ -363,3 +363,31 @@ describe("fellowshipPrefixedTitle", () => {
     expect(titled([])).toBe("Serenity Now");
   });
 });
+
+describe("fellowshipPrefixedTitle redundancy skip", () => {
+  const prefixed = (title: string, calType: string[], fellowship: string | null = null) =>
+    fellowshipPrefixedTitle({ title, calType, fellowship });
+
+  test("skips a fellowship the title already names as a word", () => {
+    expect(prefixed("AA District", ["AA"])).toBe("AA District");
+    expect(prefixed("Al-Anon Intergroup", ["Al-Anon"])).toBe("Al-Anon Intergroup");
+    expect(prefixed("Tuesday Noon Al-Anon", ["Al-Anon"])).toBe("Tuesday Noon Al-Anon");
+    expect(prefixed("Friday Al-Anon (AFG)", ["Al-Anon"])).toBe("Friday Al-Anon (AFG)");
+  });
+
+  test("skips only the redundant part of a multi-fellowship prefix", () => {
+    expect(prefixed("AA District", ["AA", "Al-Anon"])).toBe("Al-Anon AA District");
+  });
+
+  test("matching is whole-word and case-insensitive -- substrings never suppress a prefix", () => {
+    expect(prefixed("Thursday AFG", ["Al-Anon"])).toBe("Al-Anon Thursday AFG");
+    expect(prefixed("Noon Brown Baggers", ["AA"])).toBe("AA Noon Brown Baggers");
+    expect(prefixed("aa district", ["AA"])).toBe("aa district");
+  });
+
+  test("applies to the custom Other fellowship too, with regex metacharacters escaped", () => {
+    expect(prefixed("NA Spiritual Foundations", ["Other"], "NA")).toBe("NA Spiritual Foundations");
+    expect(prefixed("Spiritual Foundation", ["Other"], "NA")).toBe("NA Spiritual Foundation");
+    expect(prefixed("C+ Group Meeting", ["Other"], "C+")).toBe("C+ Group Meeting");
+  });
+});

--- a/frontend/tests/unit/zoom.test.ts
+++ b/frontend/tests/unit/zoom.test.ts
@@ -132,7 +132,7 @@ describe("toZoomStartTime / buildZoomMeetingBody (via createZoomMeeting's reques
     await createZoomMeeting(meeting, "host@test.icr");
 
     const body = getCapturedBody();
-    expect(body?.topic).toBe("AA Wednesday AA");
+    expect(body?.topic).toBe("Wednesday AA");
     expect(body?.agenda).toBe("Weekly meeting");
     expect(body?.type).toBe(2);
   });

--- a/frontend/util/meetings/linkedSchedules.ts
+++ b/frontend/util/meetings/linkedSchedules.ts
@@ -286,13 +286,23 @@ export function resolveFamilyRows<TRow extends { mid: string }>(meeting: TRow, f
 // category checkboxes were clicked in.
 const FELLOWSHIP_CAL_TYPES = ["AA", "Al-Anon"] as const;
 
+const escapeRegExp = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+// Whether the title already names this fellowship as a whole word ("AA District",
+// "Tuesday Noon Al-Anon") -- a prefix would then just stutter ("AA AA District").
+// Whole-word so "AA" inside e.g. "AFG" or "Baggers" can never suppress a genuine prefix.
+function titleAlreadyNames(title: string, name: string): boolean {
+  return new RegExp(`(^|[^A-Za-z0-9])${escapeRegExp(name)}([^A-Za-z0-9]|$)`, "i").test(title);
+}
+
 /**
  * The fellowship-prefixed base title external services display:
  * `"AA/Al-Anon Serenity Now"`. AA and Al-Anon come straight from calType; a calType of
- * "Other" contributes the custom `fellowship` text instead (nothing when it's empty). With no
- * fellowship at all the title passes through unchanged. Like {@link buildLinkedScheduleLabel},
- * the prefix uses the caller's own row, so family members' names agree only while their
- * calType/fellowship columns do.
+ * "Other" contributes the custom `fellowship` text instead (nothing when it's empty). A
+ * fellowship the title already names as a word is skipped rather than stuttered
+ * ("AA District", not "AA AA District"). With no fellowship left the title passes through
+ * unchanged. Like {@link buildLinkedScheduleLabel}, the prefix uses the caller's own row, so
+ * family members' names agree only while their calType/fellowship columns do.
  */
 export function fellowshipPrefixedTitle(
   meeting: Pick<IMeeting, "title" | "calType" | "fellowship">,
@@ -301,7 +311,8 @@ export function fellowshipPrefixedTitle(
   const parts: string[] = FELLOWSHIP_CAL_TYPES.filter((name) => calType.includes(name));
   const custom = calType.includes("Other") ? meeting.fellowship?.trim() : "";
   if (custom) parts.push(custom);
-  return parts.length ? `${parts.join("/")} ${meeting.title}` : meeting.title;
+  const needed = parts.filter((name) => !titleAlreadyNames(meeting.title, name));
+  return needed.length ? `${needed.join("/")} ${meeting.title}` : meeting.title;
 }
 
 // How each mode names itself inside a family label. Only Remote is renamed ("Zoom Only") --


### PR DESCRIPTION
@coderabbitai summary

## Description
- **util/meetings/linkedSchedules.ts**: `fellowshipPrefixedTitle` now skips a fellowship the title already names as a whole word, so the sweep produces "AA District" / "Al-Anon Intergroup" instead of "AA AA District" / "Al-Anon Al-Anon Intergroup" (5 production meetings affected, surfaced by the resync-titles dry run). Whole-word, case-insensitive matching so a substring ("AFG", "Baggers") never suppresses a genuine prefix; applies to the custom Other fellowship too, with regex metacharacters escaped.
- **tests/unit/linkedSchedules.test.ts / zoom.test.ts**: skip-rule cases (redundant, partial multi-fellowship, substring non-matches, custom text); the one topic assertion whose fixture title contained "AA" updated to the new non-stuttered output.

## Testing
- [ ] `cd frontend && yarn test:unit tests/unit/linkedSchedules.test.ts tests/unit/zoom.test.ts`
- [ ] Dry-run check: `POST /api/admin/resync-titles {"dryRun":true}` — no `newTitle` repeats its fellowship word.

## Area(s) Touched
**Product areas**
- [ ] auth — sign-in, sessions, NextAuth, role-based access
- [ ] admin — /admin shell (Diagnostics, Users, Import, Export tabs)
- [ ] docs — /docs Resources page (rendering, navigation, search)
- [ ] ui/ux — frontend layout/styling not tied to a specific integration

**Integrations**
- [x] google-calendar — Google Calendar sync
- [x] zoom-api — Zoom meeting/host sync

**Engineering**
- [ ] security — auth hardening, data exposure, dependency/security scanning
- [x] testing — test suite (Jest/Playwright) changes
- [ ] github-actions — workflows, Dependabot config, other .github/ CI tooling
- [ ] cleanup — refactor or dead-code removal, no behavior change
- [ ] documentation — docs/ or README changes only

## Pre-merge Checklist
- [x] Code follows current formatting conventions and passes lint (`yarn lint`).
- [x] Comments are appropriate — only where genuinely non-obvious, not restating what the code already says.
- [x] All test suites pass, both run locally and green in GitHub CI. **Do not merge if any test suite is failing.**
- [x] A test suite was added or updated for the feature/fix in this PR. **Double-check this if you change a feature and did not update the test suites**.
- [x] Only files relevant to this change are committed — no stray or unrelated files.
- [ ] If this branch has a merge conflict with master, master was merged into this branch first (not the other way around).
- [x] The rest of this PR description (Description, Testing) is filled out, not left as template placeholders.
